### PR TITLE
Add script to run unit tests in GPU runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,17 @@ stages:
 
 .base_template : &BASE
    script:
-   - cat README.md
+   - nvidia-smi
+   - python -m pip install --upgrade pip
+   - pip install -r requirements.txt
+   - pip install flake8
+   - pip install pep8-naming
+   # stop the build if there are Python syntax errors or undefined names
+   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --config ./.flake8
+   # exit-zero treats all errors as warnings.
+   # - flake8 . --count --statistics --config ./.flake8
+   - ./runtests.sh --quick
+   - echo "Done with runtests.sh"
 
 build-ci-test:
     stage: build


### PR DESCRIPTION
A GPU runner in gitlab-master.nvidia.com was setup to run CI jobs.  The runner pulls nvcr.io/nvidia/pytorch:19.10-py3, installs dependencies and run unit tests (w/ --quick).

The CI status shall be reported back to github.  The log details are not viewable outside nvidia, which we are still working on.