### PR TITLE
separate linting and runtests pipelines

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,12 +1,10 @@
-name: Python application
+name: Lint
 
 on: [push]
 
 jobs:
-  build:
-
+  flake8-py3:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -21,10 +19,5 @@ jobs:
       run: |
         pip install flake8
         pip install pep8-naming
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings.
+        flake8 --version
         flake8 . --count --statistics
-    - name: Test and coverage
-      run: |
-        ./runtests.sh --coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,13 +7,7 @@ stages:
    - python -m pip install --upgrade pip
    - pip uninstall -y torch torchvision
    - pip install -r requirements.txt
-   - pip list
-   - pip install flake8
-   - pip install pep8-naming
-   # stop the build if there are Python syntax errors or undefined names
-   # - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --config ./.flake8
-   # exit-zero treats all errors as warnings.
-   - flake8 . --count --statistics --config ./.flake8
+   # - pip list
    - ./runtests.sh --net
    - echo "Done with runtests.sh"
 


### PR DESCRIPTION
This PR resolves the current CI issues in #49 #52 by
decoupling the CI tasks:
- running the linting job with github app (https://github.com/Project-MONAI/MONAI/actions)
- running unit/integration tests with gitlab (https://gitlab.com/project-monai/MONAI/pipelines/)

(This PR is a follow-up of #19 #46 )