### PR TITLE
120 fix MeanDice Nan issue for all zero data

### DIFF
--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -73,9 +73,11 @@ class MeanDice(Metric):
         average = compute_meandice(y_pred, y, self.include_background, self.to_onehot_y, self.mutually_exclusive,
                                    self.add_sigmoid, self.logit_thresh)
 
-        batch_size = len(y)
-        self._sum += average.item() * batch_size
-        self._num_examples += batch_size
+        # add all items in current batch
+        for v in average:
+            if torch.isnan(v) == torch.tensor(False):
+                self._sum += v.item()
+                self._num_examples += 1
 
     @sync_all_reduce("_sum", "_num_examples")
     def compute(self):

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -9,42 +9,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, Optional, Sequence, Union
+
 import torch
-from typing import Callable, Union, Optional, Sequence
 from ignite.exceptions import NotComputableError
 from ignite.metrics import Metric
-from ignite.metrics.metric import sync_all_reduce, reinit__is_reduced
+from ignite.metrics.metric import reinit__is_reduced, sync_all_reduce
+
 from monai.metrics.compute_meandice import compute_meandice
 
-__all__ = [
-    'MeanDice'
-]
+__all__ = ['MeanDice']
 
 
 class MeanDice(Metric):
     """Computes dice score metric from full size Tensor and collects average over batch, class-channels, iterations.
     """
-    def __init__(
-        self,
-        include_background=True,
-        to_onehot_y=True,
-        logit_thresh=None,
-        add_sigmoid=False,
-        mutually_exclusive=True,
-        output_transform: Callable = lambda x: x,
-        device: Optional[Union[str, torch.device]] = None
-    ):
+
+    def __init__(self,
+                 include_background=True,
+                 to_onehot_y=True,
+                 mutually_exclusive=False,
+                 add_sigmoid=False,
+                 logit_thresh=0.5,
+                 smooth=0.0,
+                 output_transform: Callable = lambda x: x,
+                 device: Optional[Union[str, torch.device]] = None):
         """
 
         Args:
             include_background (Bool): whether to include dice computation on the first channel of the predicted output.
                 Defaults to True.
             to_onehot_y (Bool): whether to convert the output prediction into the one-hot format. Defaults to True.
-            logit_thresh (Float): the threshold value to round value to 0.0 and 1.0. Defaults to None (no thresholding).
-            add_sigmoid (Bool): whether to add sigmoid function to the output prediction before computing Dice.
-                Defaults to False.
             mutually_exclusive (Bool): if True, the output prediction will be converted into a binary matrix using
                 a combination of argmax and to_onehot. Defaults to True.
+            add_sigmoid (Bool): whether to add sigmoid function to the output prediction before computing Dice.
+                Defaults to False.
+            logit_thresh (Float): the threshold value to round value to 0.0 and 1.0. Defaults to None (no thresholding).
+            smooth (Float): a small constant to avoid nan in Dice computation.
+                nan will be excluded when computing moving average.
             output_transform (Callable): transform the ignite.engine.state.output into [y_pred, y] pair.
             device (torch.device): device specification in case of distributed computation usage.
 
@@ -54,9 +56,10 @@ class MeanDice(Metric):
         super(MeanDice, self).__init__(output_transform, device=device)
         self.include_background = include_background
         self.to_onehot_y = to_onehot_y
-        self.logit_thresh = logit_thresh
-        self.add_sigmoid = add_sigmoid
         self.mutually_exclusive = mutually_exclusive
+        self.add_sigmoid = add_sigmoid
+        self.logit_thresh = logit_thresh
+        self.smooth = smooth
 
         self._sum = 0
         self._num_examples = 0
@@ -70,18 +73,20 @@ class MeanDice(Metric):
     def update(self, output: Sequence[Union[torch.Tensor, dict]]):
         assert len(output) == 2, 'MeanDice metric can only support y_pred and y.'
         y_pred, y = output
-        average = compute_meandice(y_pred, y, self.include_background, self.to_onehot_y, self.mutually_exclusive,
-                                   self.add_sigmoid, self.logit_thresh)
+        scores = compute_meandice(y_pred, y, self.include_background, self.to_onehot_y, self.mutually_exclusive,
+                                  self.add_sigmoid, self.logit_thresh, self.smooth)
 
         # add all items in current batch
-        for v in average:
-            if torch.isnan(v) == torch.tensor(False):
-                self._sum += v.item()
-                self._num_examples += 1
+        for batch in scores:
+            not_nan = ~torch.isnan(batch)
+            if not_nan.sum() == 0:
+                continue
+            class_avg = batch[not_nan].mean().item()
+            self._sum += class_avg
+            self._num_examples += 1
 
     @sync_all_reduce("_sum", "_num_examples")
     def compute(self):
         if self._num_examples == 0:
-            raise NotComputableError(
-                'MeanDice must have at least one example before it can be computed.')
+            raise NotComputableError('MeanDice must have at least one example before it can be computed.')
         return self._sum / self._num_examples

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -40,7 +40,7 @@ class MeanDice(Metric):
                 Defaults to True.
             to_onehot_y (Bool): whether to convert the output prediction into the one-hot format. Defaults to True.
             mutually_exclusive (Bool): if True, the output prediction will be converted into a binary matrix using
-                a combination of argmax and to_onehot. Defaults to True.
+                a combination of argmax and to_onehot. Defaults to False.
             add_sigmoid (Bool): whether to add sigmoid function to the output prediction before computing Dice.
                 Defaults to False.
             logit_thresh (Float): the threshold value to round value to 0.0 and 1.0. Defaults to None (no thresholding).

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -31,7 +31,6 @@ class MeanDice(Metric):
                  mutually_exclusive=False,
                  add_sigmoid=False,
                  logit_thresh=0.5,
-                 smooth=0.0,
                  output_transform: Callable = lambda x: x,
                  device: Optional[Union[str, torch.device]] = None):
         """
@@ -45,8 +44,6 @@ class MeanDice(Metric):
             add_sigmoid (Bool): whether to add sigmoid function to the output prediction before computing Dice.
                 Defaults to False.
             logit_thresh (Float): the threshold value to round value to 0.0 and 1.0. Defaults to None (no thresholding).
-            smooth (Float): a small constant to avoid nan in Dice computation.
-                nan will be excluded when computing moving average.
             output_transform (Callable): transform the ignite.engine.state.output into [y_pred, y] pair.
             device (torch.device): device specification in case of distributed computation usage.
 
@@ -59,7 +56,6 @@ class MeanDice(Metric):
         self.mutually_exclusive = mutually_exclusive
         self.add_sigmoid = add_sigmoid
         self.logit_thresh = logit_thresh
-        self.smooth = smooth
 
         self._sum = 0
         self._num_examples = 0
@@ -74,7 +70,7 @@ class MeanDice(Metric):
         assert len(output) == 2, 'MeanDice metric can only support y_pred and y.'
         y_pred, y = output
         scores = compute_meandice(y_pred, y, self.include_background, self.to_onehot_y, self.mutually_exclusive,
-                                  self.add_sigmoid, self.logit_thresh, self.smooth)
+                                  self.add_sigmoid, self.logit_thresh)
 
         # add all items in current batch
         for batch in scores:

--- a/monai/metrics/compute_meandice.py
+++ b/monai/metrics/compute_meandice.py
@@ -93,5 +93,5 @@ def compute_meandice(y_pred,
     y_pred_o = torch.sum(y_pred, reduce_axis)
     denominator = y_o + y_pred_o
 
-    f = torch.where(y_o > 0, (2.0 * intersection) / denominator, torch.tensor(float('nan')).to(y_o))
+    f = torch.where(y_o > 0, (2.0 * intersection) / denominator, torch.tensor(float('nan')).to(y_o.float()))
     return f  # returns array of Dice shape: [Batch, n_classes]

--- a/monai/metrics/compute_meandice.py
+++ b/monai/metrics/compute_meandice.py
@@ -9,55 +9,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 import torch
 
-from monai.networks.utils import one_hot, nanmean
+from monai.networks.utils import one_hot
 
 
 def compute_meandice(y_pred,
                      y,
-                     include_background=False,
+                     include_background=True,
                      to_onehot_y=True,
-                     mutually_exclusive=True,
+                     mutually_exclusive=False,
                      add_sigmoid=False,
-                     logit_thresh=None):
+                     logit_thresh=0.5,
+                     smooth=0.0):
     """Computes dice score metric from full size Tensor and collects average.
 
     Args:
         y_pred (torch.Tensor): input data to compute, typical segmentation model output.
-                               it must be One-Hot format and first dim is batch, example shape: [16, 3, 32, 32].
+            it must be One-Hot format and first dim is batch, example shape: [16, 3, 32, 32].
         y (torch.Tensor): ground truth to compute mean dice metric, the first dim is batch.
-                          example shape: [16, 3, 32, 32] for 3-class one-hot labels.
-                          alternative shape: [16, 1, 32, 32] and set `to_onehot_y=True` to convert it into [16, 3, 32, 32].
-        include_background (Bool): whether to skip dice computation on the first channel of the predicted output.
-        to_onehot_y (Bool): whether to convert `y` into the one-hot format.
+            example shape: [16, 1, 32, 32] will be converted into [16, 3, 32, 32].
+            alternative shape: [16, 3, 32, 32] and set `to_onehot_y=False` to use 3-class labels directly.
+        include_background (Bool): whether to skip Dice computation on the first channel of
+            the predicted output. Defaults to True.
+        to_onehot_y (Bool): whether to convert `y` into the one-hot format. Defaults to True.
         mutually_exclusive (Bool): if True, `y_pred` will be converted into a binary matrix using
-            a combination of argmax and to_onehot.
-        add_sigmoid (Bool): whether to add sigmoid function to y_pred before computation.
-        logit_thresh (Float): the threshold value used to convert `y_pred` into a binary matrix.
+            a combination of argmax and to_onehot.  Defaults to False.
+        add_sigmoid (Bool): whether to add sigmoid function to y_pred before computation. Defaults to False.
+        logit_thresh (Float): the threshold value used to convert (after sigmoid if `add_sigmoid=True`)
+            `y_pred` into a binary matrix. Defaults to 0.5.
+        smooth (Float): a small constant to avoid nan in Dice computation.
+
+    Returns:
+        Dice scores per batch and per class (shape: [batch_size, n_classes]).
 
     Note:
         This method provide two options to convert `y_pred` into a binary matrix:
-            (1) when `mutually_exclusive` is True, it uses a combination of argmax and to_onehot
+            (1) when `mutually_exclusive` is True, it uses a combination of argmax and to_onehot,
             (2) when `mutually_exclusive` is False, it uses a threshold `logit_thresh`
                 (optionally with a sigmoid function before thresholding).
 
     """
-    n_channels_y_pred = y_pred.shape[1]
+    n_classes = y_pred.shape[1]
 
-    if mutually_exclusive:
-        if logit_thresh is not None or add_sigmoid:
-            raise ValueError('`logit_thresh` and `add_sigmoid` are incompatible when mutually_exclusive is True.')
-        y_pred = torch.argmax(y_pred, dim=1, keepdim=True)
-        y_pred = one_hot(y_pred, n_channels_y_pred)
-    else:  # channel-wise thresholding
-        if add_sigmoid:
-            y_pred = torch.sigmoid(y_pred)
-        if logit_thresh is not None:
+    if add_sigmoid:
+        y_pred = y_pred.float().sigmoid()
+
+    if n_classes == 1:
+        if mutually_exclusive:
+            warnings.warn('y_pred has only one class, mutually_exclusive=True ignored.')
+        if to_onehot_y:
+            warnings.warn('y_pred has only one channel, to_onehot_y=True ignored.')
+        if not include_background:
+            warnings.warn('y_pred has only one channel, include_background=False ignored.')
+        # make both y and y_pred binary
+        y_pred = (y_pred >= logit_thresh).float()
+        y = (y > 0).float()
+    else:  # multi-channel y_pred
+        # make both y and y_pred binary
+        if mutually_exclusive:
+            if add_sigmoid:
+                raise ValueError('add_sigmoid=True is incompatible with mutually_exclusive=True.')
+            y_pred = torch.argmax(y_pred, dim=1, keepdim=True)
+            y_pred = one_hot(y_pred, n_classes)
+        else:
             y_pred = (y_pred >= logit_thresh).float()
-
-    if to_onehot_y:
-        y = one_hot(y, n_channels_y_pred)
+        if to_onehot_y:
+            y = one_hot(y, n_classes)
 
     if not include_background:
         y = y[:, 1:] if y.shape[1] > 1 else y
@@ -67,13 +87,12 @@ def compute_meandice(y_pred,
                                      (y.shape, y_pred.shape))
 
     # reducing only spatial dimensions (not batch nor channels)
-    reduce_axis = list(range(2, y_pred.dim()))
-    intersection = torch.sum(y * y_pred, reduce_axis)
+    batch_size, n_classes = y_pred.shape[:2]
+    y = y.view(batch_size, n_classes, -1)
+    y_pred = y_pred.view(batch_size, n_classes, -1)
 
-    y_o = torch.sum(y, reduce_axis)
-    y_pred_o = torch.sum(y_pred, reduce_axis)
-    denominator = y_o + y_pred_o
+    intersection = y * y_pred
+    sums = y + y_pred
 
-    f = torch.where(y_o > 0, (2.0 * intersection) / denominator, torch.tensor(float('nan')).to(y_o))
-    # final reduce_mean across channels, skip Nan values
-    return nanmean(v=f, inplace=True, dim=1)
+    f = 2.0 * (intersection.sum(2) + smooth) / sums.sum(2) + smooth
+    return f  # returns array of Dice shape: [Batch, n_classes]

--- a/monai/metrics/compute_meandice.py
+++ b/monai/metrics/compute_meandice.py
@@ -11,7 +11,7 @@
 
 import torch
 
-from monai.networks.utils import one_hot
+from monai.networks.utils import one_hot, nanmean
 
 
 def compute_meandice(y_pred,
@@ -74,6 +74,6 @@ def compute_meandice(y_pred,
     y_pred_o = torch.sum(y_pred, reduce_axis)
     denominator = y_o + y_pred_o
 
-    f = (2.0 * intersection) / denominator
-    # final reduce_mean across batches and channels
-    return torch.mean(f)
+    f = torch.where(y_o > 0, (2.0 * intersection) / denominator, torch.tensor(float('nan')).to(y_o))
+    # final reduce_mean across channels, skip Nan values
+    return nanmean(v=f, inplace=True, dim=1)

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -55,15 +55,3 @@ def predict_segmentation(logits):
         return (logits[:, 0] >= 0).int()  # for binary segmentation threshold on channel 0
     else:
         return logits.max(1)[1]  # take the index of the max value along dimension 1
-
-
-def nanmean(v, *args, inplace=False, **kwargs):
-    """
-    Remove Nan value and compute mean on the other data.
-    Support additional args for torch.tensor sum API.
-    """
-    if not inplace:
-        v = v.clone()
-    is_nan = torch.isnan(v)
-    v[is_nan] = 0
-    return v.sum(*args, **kwargs) / (~is_nan).float().sum(*args, **kwargs)

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -55,3 +55,15 @@ def predict_segmentation(logits):
         return (logits[:, 0] >= 0).int()  # for binary segmentation threshold on channel 0
     else:
         return logits.max(1)[1]  # take the index of the max value along dimension 1
+
+
+def nanmean(v, *args, inplace=False, **kwargs):
+    """
+    Remove Nan value and compute mean on the other data.
+    Support additional args for torch.tensor sum API.
+    """
+    if not inplace:
+        v = v.clone()
+    is_nan = torch.isnan(v)
+    v[is_nan] = 0
+    return v.sum(*args, **kwargs) / (~is_nan).float().sum(*args, **kwargs)

--- a/tests/test_compute_meandice.py
+++ b/tests/test_compute_meandice.py
@@ -49,13 +49,13 @@ TEST_CASE_2 = [  # y (2, 1, 2, 2), y_pred (2, 3, 2, 2), expected out (2, 2) (no 
     [[0.5000, 0.0000], [0.6666, 0.6666]],
 ]
 
-# remove background and not One-Hot target
-TEST_CASE_3 = [  # y (2, 1, 2, 2), y_pred (2, 3, 2, 2), expected out (2, 2) (no background)
+# should return Nan for all labels=0 case and skip for MeanDice
+TEST_CASE_3 = [
     {
         'y_pred':
         torch.zeros(2, 3, 2, 2),
         'y':
-        torch.tensor([[[[0., 0.], [0., 0.]]], [[[0., 0.], [0., 0.]]]]),
+        torch.tensor([[[[0., 0.], [0., 0.]]], [[[1., 0.], [0., 1.]]]]),
         'include_background':
         True,
         'to_onehot_y':
@@ -63,7 +63,7 @@ TEST_CASE_3 = [  # y (2, 1, 2, 2), y_pred (2, 3, 2, 2), expected out (2, 2) (no 
         'mutually_exclusive':
         True,
     },
-    [[False, True, False], [False, True, False]],
+    [[False, True, True], [False, False, True]],
 ]
 
 

--- a/tests/test_compute_meandice.py
+++ b/tests/test_compute_meandice.py
@@ -27,7 +27,7 @@ TEST_CASE_1 = [
         'logit_thresh': 0.5,
         'add_sigmoid': True,
     },
-    0.8000,
+    [0.80],
 ]
 
 # remove background and not One-Hot target
@@ -37,7 +37,7 @@ TEST_CASE_2 = [
         torch.tensor([[[[-1., 3.], [2., -4.]], [[0., -1.], [3., 2.]], [[0., 1.], [2., -1.]]],
                       [[[-2., 0.], [3., 1.]], [[0., 2.], [1., -2.]], [[-1., 2.], [4., 0.]]]]),
         'y':
-        torch.tensor([[[[1, 2], [1, 0]]], [[[1, 1], [2, 0]]]]),
+        torch.tensor([[[[1., 2.], [1., 0.]]], [[[1., 1.], [2., 0.]]]]),
         'include_background':
         False,
         'to_onehot_y':
@@ -45,7 +45,7 @@ TEST_CASE_2 = [
         'mutually_exclusive':
         True,
     },
-    0.4583,
+    [0.25, 0.67],
 ]
 
 
@@ -54,7 +54,8 @@ class TestComputeMeanDice(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     def test_value(self, input_data, expected_value):
         result = compute_meandice(**input_data)
-        self.assertAlmostEqual(result.item(), expected_value, places=4)
+        for data, target in zip(result, expected_value):
+            self.assertAlmostEqual(data.item(), target, places=2)
 
 
 if __name__ == '__main__':

--- a/tests/test_compute_meandice.py
+++ b/tests/test_compute_meandice.py
@@ -11,13 +11,14 @@
 
 import unittest
 
+import numpy as np
 import torch
 from parameterized import parameterized
 
 from monai.metrics.compute_meandice import compute_meandice
 
 # keep background
-TEST_CASE_1 = [
+TEST_CASE_1 = [  # y (1, 1, 2, 2), y_pred (1, 1, 2, 2), expected out (1, 1)
     {
         'y_pred': torch.tensor([[[[1., -1.], [-1., 1.]]]]),
         'y': torch.tensor([[[[1., 0.], [1., 1.]]]]),
@@ -27,11 +28,11 @@ TEST_CASE_1 = [
         'logit_thresh': 0.5,
         'add_sigmoid': True,
     },
-    [0.80],
+    [[0.8]],
 ]
 
 # remove background and not One-Hot target
-TEST_CASE_2 = [
+TEST_CASE_2 = [  # y (2, 1, 2, 2), y_pred (2, 3, 2, 2), expected out (2, 2) (no background)
     {
         'y_pred':
         torch.tensor([[[[-1., 3.], [2., -4.]], [[0., -1.], [3., 2.]], [[0., 1.], [2., -1.]]],
@@ -45,7 +46,24 @@ TEST_CASE_2 = [
         'mutually_exclusive':
         True,
     },
-    [0.25, 0.67],
+    [[0.5000, 0.0000], [0.6666, 0.6666]],
+]
+
+# remove background and not One-Hot target
+TEST_CASE_3 = [  # y (2, 1, 2, 2), y_pred (2, 3, 2, 2), expected out (2, 2) (no background)
+    {
+        'y_pred':
+        torch.zeros(2, 3, 2, 2),
+        'y':
+        torch.tensor([[[[0., 0.], [0., 0.]]], [[[0., 0.], [0., 0.]]]]),
+        'include_background':
+        True,
+        'to_onehot_y':
+        True,
+        'mutually_exclusive':
+        True,
+    },
+    [[False, True, False], [False, True, False]],
 ]
 
 
@@ -54,8 +72,12 @@ class TestComputeMeanDice(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     def test_value(self, input_data, expected_value):
         result = compute_meandice(**input_data)
-        for data, target in zip(result, expected_value):
-            self.assertAlmostEqual(data.item(), target, places=2)
+        self.assertTrue(np.allclose(result.cpu().numpy(), expected_value, atol=1e-4))
+
+    @parameterized.expand([TEST_CASE_3])
+    def test_nans(self, input_data, expected_value):
+        result = compute_meandice(**input_data)
+        self.assertTrue(np.allclose(np.isnan(result.cpu().numpy()), expected_value))
 
 
 if __name__ == '__main__':

--- a/tests/test_handler_mean_dice.py
+++ b/tests/test_handler_mean_dice.py
@@ -17,8 +17,7 @@ from parameterized import parameterized
 from monai.handlers.mean_dice import MeanDice
 
 TEST_CASE_1 = [{'to_onehot_y': True, 'mutually_exclusive': True}, 0.75]
-TEST_CASE_2 = [{'include_background': False, 'to_onehot_y': False, 'mutually_exclusive': False}, 0.8333333]
-
+TEST_CASE_2 = [{'include_background': False, 'to_onehot_y': True, 'mutually_exclusive': False}, 0.66666]
 TEST_CASE_3 = [{'mutually_exclusive': True, 'add_sigmoid': True}]
 
 
@@ -29,16 +28,16 @@ class TestHandlerMeanDice(unittest.TestCase):
     def test_compute(self, input_params, expected_avg):
         dice_metric = MeanDice(**input_params)
 
-        y_pred = torch.Tensor([[0, 1], [1, 0]])
-        y = torch.ones((2, 1))
+        y_pred = torch.Tensor([[[0], [1]], [[1], [0]]])
+        y = torch.ones((2, 1, 1))
         dice_metric.update([y_pred, y])
 
-        y_pred = torch.Tensor([[0, 1], [1, 0]])
-        y = torch.Tensor([[1.], [0.]])
+        y_pred = torch.Tensor([[[0], [1]], [[1], [0]]])
+        y = torch.Tensor([[[1]], [[0]]])
         dice_metric.update([y_pred, y])
 
         avg_dice = dice_metric.compute()
-        self.assertAlmostEqual(avg_dice, expected_avg)
+        self.assertAlmostEqual(avg_dice, expected_avg, places=4)
 
     @parameterized.expand([TEST_CASE_3])
     def test_misconfig(self, input_params):


### PR DESCRIPTION
Fixes #120 .
fixes https://github.com/Project-MONAI/MONAI/issues/97.

### Description
This PR is to fix the MeanDice Nan issue for all zero labels and predictions.
And it can skip the all zero labels and predictions.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
