### PR TITLE
130 generate batch data from transform

### DIFF
--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -11,7 +11,7 @@
 
 import math
 from itertools import starmap, product
-
+from torch.utils.data._utils.collate import default_collate
 import numpy as np
 from monai.transforms.utils import ensure_tuple_size
 
@@ -176,3 +176,16 @@ def get_valid_patch_size(dims, patch_size):
 
     # ensure patch size dimensions are not larger than image dimension, if a dimension is None or 0 use whole dimension
     return tuple(min(ms, ps or ms) for ms, ps in zip(dims, patch_size))
+
+
+def list_data_collate(batch):
+    """
+    Enhancement for PyTorch DataLoader default collate.
+    If dataset already returns a list of batch data that generated in transforms, need to merge all data to 1 list.
+    Then it's same as the default collate behavior.
+    Note:
+        Need to use this collate if apply some transforms that can generate batch data.
+    """
+    elem = batch[0]
+    data = [i for k in batch for i in k] if isinstance(elem, list) else batch
+    return default_collate(data)

--- a/monai/transforms/composables.py
+++ b/monai/transforms/composables.py
@@ -162,11 +162,10 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
         d = dict(data)
         label = d[self.label_key]
         self.randomise(label)
-        results = [dict()] * self.num_samples
+        results = [dict() for _ in range(self.num_samples)]
         for key in data.keys():
             if key in self.keys:
                 img = d[key]
-                image_samples = list()
                 for i, center in enumerate(self.centers):
                     cropper = SpatialCrop(roi_center=tuple(center), roi_size=self.size)
                     results[i][key] = cropper(img)
@@ -174,10 +173,6 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
                 for i in range(self.num_samples):
                     results[i][key] = data[key]
 
-        # also need to crop label field
-        for i, center in enumerate(self.centers):
-            cropper = SpatialCrop(roi_center=tuple(center), roi_size=self.size)
-            results[i][self.label_key] = cropper(label)
         return results
 
 

--- a/monai/transforms/composables.py
+++ b/monai/transforms/composables.py
@@ -17,8 +17,9 @@ from collections.abc import Hashable
 
 import monai
 from monai.transforms.compose import Randomizable, Transform
-from monai.transforms.transforms import Rotate90
+from monai.transforms.transforms import Rotate90, SpatialCrop
 from monai.utils.misc import ensure_tuple
+from monai.transforms.utils import generate_pos_neg_label_crop_centers
 
 export = monai.utils.export("monai.transforms")
 
@@ -118,6 +119,66 @@ class RandRotate90d(Randomizable, MapTransform):
         for key in self.keys:
             d[key] = rotator(d[key])
         return d
+
+
+@export
+class RandCropByPosNegLabeld(Randomizable, MapTransform):
+    """
+    Crop random fixed sized regions with the center being a foreground or background voxel
+    based on the Pos Neg Ratio.
+    And will return a list of dictionaries for all the cropped images.
+
+    Args:
+        keys (list): parameter will be used to get and set the actual data item to transform.
+        label_key (str): name of key for label image, this will be used for finding foreground/background.
+        size (list, tuple): the size of the crop region e.g. [224,224,128]
+        pos (int, float): used to calculate the ratio ``pos / (pos + neg)`` for the probability to pick a
+          foreground voxel as a center rather than a background voxel.
+        neg (int, float): used to calculate the ratio ``pos / (pos + neg)`` for the probability to pick a
+          foreground voxel as a center rather than a background voxel.
+        num_samples (int): number of samples (crop regions) to take in each list.
+    """
+
+    def __init__(self, keys, label_key, size, pos=1, neg=1, num_samples=1):
+        MapTransform.__init__(self, keys)
+        assert isinstance(label_key, str), 'label_key must be a string.'
+        assert isinstance(size, (list, tuple)), 'size must be list or tuple.'
+        assert all(isinstance(x, int) and x > 0 for x in size), 'all elements of size must be positive integers.'
+        assert float(pos) >= 0 and float(neg) >= 0, "pos and neg must be greater than or equal to 0."
+        assert float(pos) + float(neg) > 0, "pos and neg cannot both be 0."
+        assert isinstance(num_samples, int), \
+            "invalid samples number: {}. num_samples must be an integer.".format(num_samples)
+        assert num_samples >= 0, 'num_samples must be greater than or equal to 0.'
+        self.label_key = label_key
+        self.size = size
+        self.pos_ratio = float(pos) / (float(pos) + float(neg))
+        self.num_samples = num_samples
+        self.centers = None
+
+    def randomise(self, label):
+        self.centers = generate_pos_neg_label_crop_centers(label, self.size, self.num_samples, self.pos_ratio, self.R)
+
+    def __call__(self, data):
+        d = dict(data)
+        label = d[self.label_key]
+        self.randomise(label)
+        results = [dict()] * self.num_samples
+        for key in data.keys():
+            if key in self.keys:
+                img = d[key]
+                image_samples = list()
+                for i, center in enumerate(self.centers):
+                    cropper = SpatialCrop(roi_center=tuple(center), roi_size=self.size)
+                    results[i][key] = cropper(img)
+            else:
+                for i in range(self.num_samples):
+                    results[i][key] = data[key]
+
+        # also need to crop label field
+        for i, center in enumerate(self.centers):
+            cropper = SpatialCrop(roi_center=tuple(center), roi_size=self.size)
+            results[i][self.label_key] = cropper(label)
+        return results
 
 
 # if __name__ == "__main__":

--- a/monai/transforms/transforms.py
+++ b/monai/transforms/transforms.py
@@ -206,6 +206,60 @@ class RandRotate90(Randomizable):
         return rotator(img)
 
 
+@export
+class SpatialCrop:
+    """General purpose cropper to produce sub-volume region of interest (ROI).
+    It can support to crop 1, 2 or 3 dimensions spatial data.
+    Either a center and size must be provided, or alternatively if center and size
+    are not provided, the start and end coordinates of the ROI must be provided.
+    The sub-volume must sit the within original image.
+
+    Note: This transform will not work if the crop region is larger than the image itself.
+    """
+
+    def __init__(self, roi_center=None, roi_size=None, roi_start=None, roi_end=None):
+        """
+        Args:
+            roi_center (list or tuple): voxel coordinates for center of the crop ROI.
+            roi_size (list or tuple): size of the crop ROI.
+            roi_start (list or tuple): voxel coordinates for start of the crop ROI.
+            roi_end (list or tuple): voxel coordinates for end of the crop ROI.
+        """
+        if roi_center is not None and roi_size is not None:
+            assert isinstance(roi_center, (list, tuple)), 'roi_center must be list or tuple.'
+            assert isinstance(roi_size, (list, tuple)), 'roi_size must be list or tuple.'
+            assert all(x > 0 for x in roi_center), 'all elements of roi_center must be positive.'
+            assert all(x > 0 for x in roi_size), 'all elements of roi_size must be positive.'
+            roi_center = np.asarray(roi_center, dtype=np.uint16)
+            roi_size = np.asarray(roi_size, dtype=np.uint16)
+            self.roi_start = np.subtract(roi_center, np.floor_divide(roi_size, 2))
+            self.roi_end = np.add(self.roi_start, roi_size)
+        else:
+            assert roi_start is not None and roi_end is not None, 'roi_start and roi_end must be provided.'
+            assert isinstance(roi_start, (list, tuple)), 'roi_start must be list or tuple.'
+            assert isinstance(roi_end, (list, tuple)), 'roi_end must be list or tuple.'
+            assert all(x >= 0 for x in roi_start), 'all elements of roi_start must be greater than or equal to 0.'
+            assert all(x > 0 for x in roi_end), 'all elements of roi_end must be positive.'
+            self.roi_start = roi_start
+            self.roi_end = roi_end
+
+    def __call__(self, img):
+        max_end = img.shape[1:]
+        assert (np.subtract(max_end, self.roi_start) >= 0).all(), 'roi start out of image space.'
+        assert (np.subtract(max_end, self.roi_end) >= 0).all(), 'roi end out of image space.'
+        assert (np.subtract(self.roi_end, self.roi_start) >= 0).all(), 'invalid roi range.'
+        if len(self.roi_start) == 1:
+            data = img[:, self.roi_start[0]:self.roi_end[0]].copy()
+        elif len(self.roi_start) == 2:
+            data = img[:, self.roi_start[0]:self.roi_end[0], self.roi_start[1]:self.roi_end[1]].copy()
+        elif len(self.roi_start) == 3:
+            data = img[:, self.roi_start[0]:self.roi_end[0], self.roi_start[1]:self.roi_end[1],
+                       self.roi_start[2]:self.roi_end[2]].copy()
+        else:
+            raise ValueError('unsupported image shape.')
+        return data
+
+
 # if __name__ == "__main__":
 #     img = np.array((1, 2, 3, 4)).reshape((1, 2, 2))
 #     rotator = RandRotate90(prob=0.0, max_k=3, axes=(1, 2))

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -45,6 +45,28 @@ class TestCompose(unittest.TestCase):
         c = Compose([a, b, a, b, a])
         self.assertDictEqual(c({'a': 0, 'b': 0}), {'a': 3, 'b': 2})
 
+    def test_list_dict_compose(self):
+        def a(d):  # transform to handle dict data
+            d = dict(d)
+            d['a'] += 1
+            return d
+
+        def b(d):  # transform to generate a batch list of data
+            d = dict(d)
+            d['b'] += 1
+            d = [d] * 5
+            return d
+
+        def c(d):  # transform to handle dict data
+            d = dict(d)
+            d['c'] += 1
+            return d
+
+        transforms = Compose([a, a, b, c, c])
+        value = transforms({'a': 0, 'b': 0, 'c': 0})
+        for item in value:
+            self.assertDictEqual(item, {'a': 2, 'b': 1, 'c': 2})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generate_pos_neg_label_crop_centers.py
+++ b/tests/test_generate_pos_neg_label_crop_centers.py
@@ -1,0 +1,43 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from parameterized import parameterized
+
+from monai.transforms.utils import generate_pos_neg_label_crop_centers
+
+TEST_CASE_1 = [
+    {
+        'label': np.random.randint(0, 2, size=[3, 3, 3, 3]),
+        'size': [2, 2, 2],
+        'num_samples': 2,
+        'pos_ratio': 1.0,
+        'rand_state': np.random.RandomState()
+    },
+    list,
+    2,
+    3
+]
+
+
+class TestGeneratePosNegLabelCropCenters(unittest.TestCase):
+
+    @parameterized.expand([TEST_CASE_1])
+    def test_type_shape(self, input_data, expected_type, expected_count, expected_shape):
+        result = generate_pos_neg_label_crop_centers(**input_data)
+        self.assertIsInstance(result, expected_type)
+        self.assertEqual(len(result), expected_count)
+        self.assertEqual(len(result[0]), expected_shape)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_list_data_collate.py
+++ b/tests/test_list_data_collate.py
@@ -1,0 +1,54 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import torch
+import numpy as np
+from parameterized import parameterized
+
+from monai.data.utils import list_data_collate
+
+a = {'image': np.array([1, 2, 3]), 'label': np.array([4, 5, 6])}
+b = {'image': np.array([7, 8, 9]), 'label': np.array([10, 11, 12])}
+c = {'image': np.array([13, 14, 15]), 'label': np.array([16, 7, 18])}
+d = {'image': np.array([19, 20, 21]), 'label': np.array([22, 23, 24])}
+TEST_CASE_1 = [
+    [[a, b], [c, d]],  # dataset returns a list of dictionary data
+    dict,
+    torch.Size([4, 3])
+]
+
+e = (np.array([1, 2, 3]), np.array([4, 5, 6]))
+f = (np.array([7, 8, 9]), np.array([10, 11, 12]))
+g = (np.array([13, 14, 15]), np.array([16, 7, 18]))
+h = (np.array([19, 20, 21]), np.array([22, 23, 24]))
+TEST_CASE_2 = [
+    [[e, f], [g, h]],  # dataset returns a list of tuple data
+    list,
+    torch.Size([4, 3])
+]
+
+
+class TestListDataCollate(unittest.TestCase):
+
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
+    def test_type_shape(self, input_data, expected_type, expected_shape):
+        result = list_data_collate(input_data)
+        self.assertIsInstance(result, expected_type)
+        if isinstance(result, dict):
+            data = result['image']
+        else:
+            data = result[0]
+        self.assertEqual(data.shape, expected_shape)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_rand_crop_by_pos_neg_labeld.py
+++ b/tests/test_rand_crop_by_pos_neg_labeld.py
@@ -1,0 +1,50 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from parameterized import parameterized
+from monai.transforms.composables import RandCropByPosNegLabeld
+
+TEST_CASE_1 = [
+    {
+        'keys': ['image', 'extral'],
+        'label_key': 'label',
+        'size': [2, 2, 2],
+        'pos': 1,
+        'neg': 1,
+        'num_samples': 2
+    },
+    {
+        'image': np.random.randint(0, 2, size=[3, 3, 3, 3]),
+        'extral': np.random.randint(0, 2, size=[3, 3, 3, 3]),
+        'label': np.random.randint(0, 2, size=[3, 3, 3, 3]),
+        'affine': np.eye(3),
+        'shape': 'CHWD'
+    },
+    list,
+    (3, 2, 2, 2),
+]
+
+
+class TestRandCropByPosNegLabeld(unittest.TestCase):
+
+    @parameterized.expand([TEST_CASE_1])
+    def test_type_shape(self, input_param, input_data, expected_type, expected_shape):
+        result = RandCropByPosNegLabeld(**input_param)(input_data)
+        self.assertIsInstance(result, expected_type)
+        self.assertTupleEqual(result[0]['image'].shape, expected_shape)
+        self.assertTupleEqual(result[0]['extral'].shape, expected_shape)
+        self.assertTupleEqual(result[0]['label'].shape, expected_shape)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_rand_crop_by_pos_neg_labeld.py
+++ b/tests/test_rand_crop_by_pos_neg_labeld.py
@@ -16,7 +16,7 @@ from monai.transforms.composables import RandCropByPosNegLabeld
 
 TEST_CASE_1 = [
     {
-        'keys': ['image', 'extral'],
+        'keys': ['image', 'extral', 'label'],
         'label_key': 'label',
         'size': [2, 2, 2],
         'pos': 1,

--- a/tests/test_spatial_crop.py
+++ b/tests/test_spatial_crop.py
@@ -1,0 +1,44 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from parameterized import parameterized
+from monai.transforms.transforms import SpatialCrop
+
+TEST_CASE_1 = [
+    {
+        'roi_center': [1, 1, 1],
+        'roi_size': [2, 2, 2]
+    },
+    np.random.randint(0, 2, size=[3, 3, 3, 3]),
+    (3, 2, 2, 2),
+]
+
+TEST_CASE_2 = [
+    {
+        'roi_start': [0, 0, 0],
+        'roi_end': [2, 2, 2]
+    },
+    np.random.randint(0, 2, size=[3, 3, 3, 3]),
+    (3, 2, 2, 2),
+]
+
+class TestSpatialCrop(unittest.TestCase):
+
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
+    def test_shape(self, input_param, input_data, expected_shape):
+        result = SpatialCrop(**input_param)(input_data)
+        self.assertTupleEqual(result.shape, expected_shape)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #130 .

### Description
This PR mainly contains 4 features:
1. **Generate 1 batch** data from crop transform, for example:
    input 3 images, crop out 4 smaller images on every original images, then generate batch=12.
    All the following transforms can still apply to every item in the batch list(_Compose function_).
2. **General crop** transform at the vanilla level.
    It's a general crop transform, can support "center + size" or "start point + end point" modes.
3. Randomly crop out batch data based on a **positive/negative label ratio**.
    According to the label values, randomly select "crop centers" at positive or negative label positions.
4. Enhancement to default **collate_fn** for **list** data type.

Usage example:
1. Define transforms for dict data:
```py
transforms = [
    LoadNiftid(keys=['image', 'extral', 'label']),
    NormalizeIntensityd(keys=['image'], divdior=1.0),
    RandCropByPosNegLabeld(
        keys=['image', 'extral'],
        label_key='label',
        size=[128, 128, 128],
        pos=1, neg=1, num_samples=2
    ),
    RandRotate90d(keys=['image', 'label'])
    ... ...
]
```
2. Define Dataset, DataLoader and use "list_data_collate":
```py
dataset = NiftiDataset(transforms=transforms)
dataloader = DataLoader(dataset=dataset, batch_size=4, collate_fn=list_data_collate)
```

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
