### PR TITLE
181 use MONAI in pytorch medical segmentation program

### DIFF
--- a/monai/transforms/composables.py
+++ b/monai/transforms/composables.py
@@ -23,7 +23,8 @@ from monai.transforms.compose import Randomizable, Transform
 from monai.transforms.transforms import (LoadNifti, AsChannelFirst, Orientation,
                                          AddChannel, Spacing, Rotate90, SpatialCrop,
                                          RandAffine, Rand2DElastic, Rand3DElastic,
-                                         Rescale, Resize, Flip, Rotate, Zoom)
+                                         Rescale, Resize, Flip, Rotate, Zoom,
+                                         NormalizeIntensity, ScaleIntensityRange)
 from monai.utils.misc import ensure_tuple
 from monai.transforms.utils import generate_pos_neg_label_crop_centers, create_grid
 from monai.utils.aliases import alias
@@ -376,6 +377,42 @@ class RandRotate90d(Randomizable, MapTransform):
         d = dict(data)
         for key in self.keys:
             d[key] = rotator(d[key])
+        return d
+
+
+@export
+@alias('NormalizeIntensityD', 'NormalizeIntensityDict')
+class NormalizeIntensityd(MapTransform):
+    """
+    dictionary-based wrapper of NormalizeIntensity.
+    """
+
+    def __init__(self, keys, subtrahend=None, divisor=None):
+        MapTransform.__init__(self, keys)
+        self.normalizer = NormalizeIntensity(subtrahend, divisor)
+
+    def __call__(self, data):
+        d = dict(data)
+        for key in self.keys:
+            d[key] = self.normalizer(d[key])
+        return d
+
+
+@export
+@alias('ScaleIntensityRangeD', 'ScaleIntensityRangeDict')
+class ScaleIntensityRanged(MapTransform):
+    """
+    dictionary-based wrapper of ScaleIntensityRange.
+    """
+
+    def __init__(self, keys, a_min, a_max, b_min, b_max, do_clipping=False):
+        MapTransform.__init__(self, keys)
+        self.scaler = ScaleIntensityRange(a_min, a_max, b_min, b_max, do_clipping)
+
+    def __call__(self, data):
+        d = dict(data)
+        for key in self.keys:
+            d[key] = self.scaler(d[key])
         return d
 
 

--- a/monai/transforms/transforms.py
+++ b/monai/transforms/transforms.py
@@ -517,7 +517,7 @@ class UniformRandomPatch(Randomizable):
 
 
 @export
-class IntensityNormalizer:
+class NormalizeIntensity:
     """Normalize input based on provided args, using calculated mean and std if not provided
     (shape of subtrahend and divisor must match. if 0, entire volume uses same subtrahend and
      divisor, otherwise the shape can have dimension 1 for channels).
@@ -547,7 +547,36 @@ class IntensityNormalizer:
 
 
 @export
-class ImageEndPadder:
+class ScaleIntensityRange:
+    """Apply specific intensity scaling to the whole numpy array.
+    Scaling from [a_min, a_max] to [b_min, b_max] with clip option.
+
+    Args:
+        a_min (int or float): intensity original range min.
+        a_max (int or float): intensity original range max.
+        b_min (int or float): intensity target range min.
+        b_max (int or float): intensity target range max.
+        do_clipping (bool): whether to perform clip after scaling.
+    """
+
+    def __init__(self, a_min, a_max, b_min, b_max, do_clipping=False):
+        self.a_min = a_min
+        self.a_max = a_max
+        self.b_min = b_min
+        self.b_max = b_max
+        self.do_clipping = do_clipping
+
+    def __call__(self, img):
+        img = (img - self.a_min) / (self.a_max - self.a_min)
+        img = img * (self.b_max - self.b_min) + self.b_min
+        if self.do_clipping:
+            img = np.clip(img, self.b_min, self.b_max)
+
+        return img
+
+
+@export
+class PadImageEnd:
     """Performs padding by appending to the end of the data all on one side for each dimension.
      Uses np.pad so in practice, a mode needs to be provided. See numpy.lib.arraypad.pad
      for additional details.
@@ -558,7 +587,7 @@ class ImageEndPadder:
     """
 
     def __init__(self, out_size, mode):
-        assert out_size is not None and isinstance(out_size, (list, tuple)), 'out_size must be list or tuple.'
+        assert isinstance(out_size, (list, tuple)), 'out_size must be list or tuple.'
         self.out_size = out_size
         assert isinstance(mode, str), 'mode must be str.'
         self.mode = mode

--- a/monai/utils/sliding_window_inference.py
+++ b/monai/utils/sliding_window_inference.py
@@ -11,7 +11,7 @@
 
 import torch
 from ignite.utils import convert_tensor
-from monai.transforms.transforms import ImageEndPadder
+from monai.transforms.transforms import PadImageEnd
 from monai.data.utils import dense_patch_slices
 
 
@@ -47,7 +47,7 @@ def sliding_window_inference(inputs, roi_size, sw_batch_size, predictor, device)
     original_image_size = [image_size[i] for i in range(num_spatial_dims)]
     # in case that image size is smaller than roi size
     image_size = tuple(max(image_size[i], roi_size[i]) for i in range(num_spatial_dims))
-    inputs = ImageEndPadder(roi_size, 'constant')(inputs)  # in np array
+    inputs = PadImageEnd(roi_size, 'constant')(inputs)  # in np array
     inputs = convert_tensor(torch.from_numpy(inputs), device, False)
 
     # TODO: interval from user's specification

--- a/tests/test_normalize_intensity.py
+++ b/tests/test_normalize_intensity.py
@@ -1,0 +1,30 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+from monai.transforms import NormalizeIntensity
+from tests.utils import NumpyImageTestCase2D
+
+
+class TestNormalizeIntensity(NumpyImageTestCase2D):
+
+    def test_image_normalize_intensity(self):
+        normalizer = NormalizeIntensity()
+        normalised = normalizer(self.imt)
+        expected = (self.imt - np.mean(self.imt)) / np.std(self.imt)
+        self.assertTrue(np.allclose(normalised, expected))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_normalize_intensityd.py
+++ b/tests/test_normalize_intensityd.py
@@ -1,0 +1,31 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+from monai.transforms import NormalizeIntensityd
+from tests.utils import NumpyImageTestCase2D
+
+
+class TestNormalizeIntensityd(NumpyImageTestCase2D):
+
+    def test_image_normalize_intensityd(self):
+        key = 'img'
+        normalizer = NormalizeIntensityd(keys=[key])
+        normalised = normalizer({key: self.imt})
+        expected = (self.imt - np.mean(self.imt)) / np.std(self.imt)
+        self.assertTrue(np.allclose(normalised[key], expected))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pad_image_end.py
+++ b/tests/test_pad_image_end.py
@@ -10,20 +10,26 @@
 # limitations under the License.
 
 import unittest
-
 import numpy as np
+from parameterized import parameterized
+from monai.transforms import PadImageEnd
 
-from monai.transforms.transforms import IntensityNormalizer
-from tests.utils import NumpyImageTestCase2D
+TEST_CASE_1 = [
+    {
+        'out_size': [16, 16, 8],
+        'mode': 'constant'
+    },
+    np.zeros((1, 3, 8, 8, 4)),
+    np.zeros((1, 3, 16, 16, 8)),
+]
 
+class TestPadImageEnd(unittest.TestCase):
 
-class IntensityNormTestCase(NumpyImageTestCase2D):
-
-    def test_image_normalizer_default(self):
-        normalizer = IntensityNormalizer()
-        normalised = normalizer(self.imt)
-        expected = (self.imt - np.mean(self.imt)) / np.std(self.imt)
-        self.assertTrue(np.allclose(normalised, expected))
+    @parameterized.expand([TEST_CASE_1])
+    def test_image_end_pad_shape(self, input_param, input_data, expected_val):
+        padder = PadImageEnd(**input_param)
+        result = padder(input_data)
+        self.assertAlmostEqual(result.shape, expected_val.shape)
 
 
 if __name__ == '__main__':

--- a/tests/test_scale_intensity_range.py
+++ b/tests/test_scale_intensity_range.py
@@ -10,26 +10,21 @@
 # limitations under the License.
 
 import unittest
+
 import numpy as np
-from parameterized import parameterized
-from monai.transforms.transforms import ImageEndPadder
 
-TEST_CASE_1 = [
-    {
-        'out_size': [16, 16, 8],
-        'mode': 'constant'
-    },
-    np.zeros((1, 3, 8, 8, 4)),
-    np.zeros((1, 3, 16, 16, 8)),
-]
+from monai.transforms import ScaleIntensityRange
+from tests.utils import NumpyImageTestCase2D
 
-class TestImageEndPadder(unittest.TestCase):
 
-    @parameterized.expand([TEST_CASE_1])
-    def test_image_end_pad_shape(self, input_param, input_data, expected_val):
-        padder = ImageEndPadder(**input_param)
-        result = padder(input_data)
-        self.assertAlmostEqual(result.shape, expected_val.shape)
+class IntensityScaleIntensityRange(NumpyImageTestCase2D):
+
+    def test_image_scale_intensity_range(self):
+        scaler = ScaleIntensityRange(a_min=20, a_max=108, b_min=50, b_max=80)
+        scaled = scaler(self.imt)
+        expected = (self.imt - 20) / 88
+        expected = expected * 30 + 50
+        self.assertTrue(np.allclose(scaled, expected))
 
 
 if __name__ == '__main__':

--- a/tests/test_scale_intensity_ranged.py
+++ b/tests/test_scale_intensity_ranged.py
@@ -1,0 +1,32 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+from monai.transforms import ScaleIntensityRanged
+from tests.utils import NumpyImageTestCase2D
+
+
+class IntensityScaleIntensityRanged(NumpyImageTestCase2D):
+
+    def test_image_scale_intensity_ranged(self):
+        key = 'img'
+        scaler = ScaleIntensityRanged(keys=key, a_min=20, a_max=108, b_min=50, b_max=80)
+        scaled = scaler({key: self.imt})
+        expected = (self.imt - 20) / 88
+        expected = expected * 30 + 50
+        self.assertTrue(np.allclose(scaled[key], expected))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #181 .

### Description
This PR implemented:
1. NormalizeIntensityd transform.
2. ScaleIntensityRange, ScaleIntensityRanged transforms.
3. Segmentation training example based on MSD public dataset.

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated
