### PR TITLE
228 automatic pip packaging and uploading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,10 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI }}
         repository_url: https://test.pypi.org/legacy/
+
+    - if: matrix.python-version == '3.8'
+      name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist-packages
+        path: dist/monai*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,4 +68,4 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: dist-packages
-        path: dist/monai*
+        path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: release
+
+on:
+  push:
+    branches:
+      - 'releases/*'
+    tags:
+      - '*'
+
+jobs:
+  packaging:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install setuptools
+      run: |
+        python -m pip install --user --upgrade setuptools wheel
+    - name: Build and test source archive and wheel file
+      run: |
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        root_dir=$PWD
+        echo "$root_dir"
+        set -e
+
+        # build tar.gz and wheel
+        python setup.py sdist bdist_wheel
+        tmp_dir=$(mktemp -d)
+        cp dist/monai* "$tmp_dir"
+        cd "$tmp_dir"
+        ls -al
+
+        # install from wheel
+        python -m pip install monai*.whl
+        python -c 'import monai; monai.config.print_config()' 2>&1 | grep -iv "unknown"
+        python -c 'import monai; print(monai.__file__)'
+        python -m pip uninstall -y monai
+        rm monai*.whl
+
+        # install from tar.gz
+        python -m pip install monai*.tar.gz
+        python -c 'import monai; monai.config.print_config()' 2>&1 | grep -iv "unknown"
+        python -c 'import monai; print(monai.__file__)'
+        python -m pip uninstall -y monai
+        rm monai*.tar.gz
+
+        # clean up
+        cd "$root_dir"
+        rm -r "$tmp_dir"
+
+    - if: matrix.python-version == '3.8'
+      name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,16 +56,16 @@ jobs:
         cd "$root_dir"
         rm -r "$tmp_dir"
 
-    - if: matrix.python-version == '3.8'
+    - if: matrix.python-version == '3.8' && startsWith(github.ref, 'refs/tags/')
       name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.TEST_PYPI }}
         repository_url: https://test.pypi.org/legacy/
 
-    - if: matrix.python-version == '3.8'
+    - if: matrix.python-version == '3.8' && startsWith(github.ref, 'refs/tags/')
       name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
-        name: dist-packages
+        name: dist
         path: dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ All code review comments should be specific, constructive, and actionable.
 
 ### Release a new version
 - Prepare [a release note](https://github.com/Project-MONAI/MONAI/releases).
-- Checkout a new branch `releases/[version numbere]`.
+- Checkout a new branch `releases/[version numbere]` from the master branch.
 - Create a tag, for example `git tag -a 0.1a -m "version 0.1a"`.
 - Push the tag to the codebase, for example `git push origin 0.1a`.
   This step will trigger package building and testing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,11 +117,12 @@ All code review comments should be specific, constructive, and actionable.
 
 ### Release a new version
 - Prepare [a release note](https://github.com/Project-MONAI/MONAI/releases)
-- Checkout a new branch `releasing-version-N`
+- Checkout a new branch `releases/[version numbere]`
 - Create a tag, for example `git tag -a 0.1a -m "version 0.1a"`
 - [Generate distribution archives](https://packaging.python.org/tutorials/packaging-projects/) `python3 setup.py sdist bdist_wheel`
 - Test the package locally `pip install monai`
 - Upload the package to [PyPI](https://pypi.org/project/monai/)
 - Publish the release note
 
-Note that the release should be tagged with a [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant [semantic versioning](https://semver.org/spec/v2.0.0.html) number.
+Note that the release should be tagged with a [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant 
+[semantic versioning](https://semver.org/spec/v2.0.0.html) number.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,16 +116,18 @@ All code review comments should be specific, constructive, and actionable.
 ## Admin tasks
 
 ### Release a new version
-- Prepare [a release note](https://github.com/Project-MONAI/MONAI/releases)
-- Checkout a new branch `releases/[version numbere]`
-- Create a tag, for example `git tag -a 0.1a -m "version 0.1a"`
-- Push the tag to the codebase `git push origin 0.1a`
-  This step will trigger package building and testing. The resultant packages are automatically uploaded to
+- Prepare [a release note](https://github.com/Project-MONAI/MONAI/releases).
+- Checkout a new branch `releases/[version numbere]`.
+- Create a tag, for example `git tag -a 0.1a -m "version 0.1a"`.
+- Push the tag to the codebase, for example `git push origin 0.1a`.
+  This step will trigger package building and testing.
+  The resultant packages are automatically uploaded to
   [TestPyPI](https://test.pypi.org/project/monai/).  The packages are also available for downloading as
-  repository's artifacts.
-- Upload the package to [PyPI](https://pypi.org/project/monai/)
-  This could be done manually by ``twine upload dist/*``, given the artifacts are in the folder ``dist/``.
-- Publish the release note
+  repository's artifacts (e.g. the file at https://github.com/Project-MONAI/MONAI/actions/runs/66570977).
+- Check the release test at [TestPyPI](https://test.pypi.org/project/monai/), download the artifacts when the CI finishes
+- Upload the packages to [PyPI](https://pypi.org/project/monai/).
+  This could be done manually by ``twine upload dist/*``, given the artifacts are unzipped to the folder ``dist/``.
+- Publish the release note.
 
 Note that the release should be tagged with a [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant
 [semantic versioning](https://semver.org/spec/v2.0.0.html) number.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,17 +117,30 @@ All code review comments should be specific, constructive, and actionable.
 
 ### Release a new version
 - Prepare [a release note](https://github.com/Project-MONAI/MONAI/releases).
-- Checkout a new branch `releases/[version numbere]` from the master branch.
+- Checkout a new branch `releases/[version number]` from the master branch.
 - Create a tag, for example `git tag -a 0.1a -m "version 0.1a"`.
 - Push the tag to the codebase, for example `git push origin 0.1a`.
   This step will trigger package building and testing.
   The resultant packages are automatically uploaded to
   [TestPyPI](https://test.pypi.org/project/monai/).  The packages are also available for downloading as
   repository's artifacts (e.g. the file at https://github.com/Project-MONAI/MONAI/actions/runs/66570977).
-- Check the release test at [TestPyPI](https://test.pypi.org/project/monai/), download the artifacts when the CI finishes
+- Check the release test at [TestPyPI](https://test.pypi.org/project/monai/), download the artifacts when the CI finishes.
 - Upload the packages to [PyPI](https://pypi.org/project/monai/).
   This could be done manually by ``twine upload dist/*``, given the artifacts are unzipped to the folder ``dist/``.
 - Publish the release note.
 
 Note that the release should be tagged with a [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant
 [semantic versioning](https://semver.org/spec/v2.0.0.html) number.
+
+If any error occurs during the release process, first checkout a new branch from the master, make PRs to the master
+to fix the bugs via the regular contribution procedure.
+Then rollback the release branch and tag:
+ - remove any artifacts (website UI) and tag (`git tag -d` and `git push origin -d`).
+ - reset the `releases/[version number]` branch to the latest master:
+ ```bash
+git checkout master
+git pull origin master
+git checkout releases/[version number]
+git reset --hard master
+```
+Finally, repeat the tagging and TestPyPI uploading process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,10 +121,10 @@ All code review comments should be specific, constructive, and actionable.
 - Create a tag, for example `git tag -a 0.1a -m "version 0.1a"`
 - Push the tag to the codebase `git push origin 0.1a`
   This step will trigger package building and testing. The resultant packages are automatically uploaded to
-  [TestPyPI](https://test.pypi.org/project/monai/).
-- [Generate distribution archives](https://packaging.python.org/tutorials/packaging-projects/) `python3 setup.py sdist bdist_wheel`
-- Test the package locally `pip install monai`
+  [TestPyPI](https://test.pypi.org/project/monai/).  The packages are also available for downloading as
+  repository's artifacts.
 - Upload the package to [PyPI](https://pypi.org/project/monai/)
+  This could be done manually by ``twine upload dist/*``, given the artifacts are in the folder ``dist/``.
 - Publish the release note
 
 Note that the release should be tagged with a [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,10 +119,13 @@ All code review comments should be specific, constructive, and actionable.
 - Prepare [a release note](https://github.com/Project-MONAI/MONAI/releases)
 - Checkout a new branch `releases/[version numbere]`
 - Create a tag, for example `git tag -a 0.1a -m "version 0.1a"`
+- Push the tag to the codebase `git push origin 0.1a`
+  This step will trigger package building and testing. The resultant packages are automatically uploaded to
+  [TestPyPI](https://test.pypi.org/project/monai/).
 - [Generate distribution archives](https://packaging.python.org/tutorials/packaging-projects/) `python3 setup.py sdist bdist_wheel`
 - Test the package locally `pip install monai`
 - Upload the package to [PyPI](https://pypi.org/project/monai/)
 - Publish the release note
 
-Note that the release should be tagged with a [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant 
+Note that the release should be tagged with a [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant
 [semantic versioning](https://semver.org/spec/v2.0.0.html) number.


### PR DESCRIPTION
Fixes #228

### Description
added an automated workflow for releasing. pushing to a release branch (name matches `releases/*`) will trigger:
- builds and tests with python 3.5/3.6/3.7/3.8

additionally, if it's a tagging push:
- upload the packages to [github artefacts](https://github.com/Project-MONAI/MONAI/actions/runs/66617687)
- upload the packages to testpypi https://test.pypi.org/project/monai/#history

these steps are described in [the contributing.md](https://github.com/Project-MONAI/MONAI/blob/releases/0.1a1.dev6/CONTRIBUTING.md#admin-tasks) as well 


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated
