### PR TITLE
WIP 229 adds release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,5 @@
+change-template: '- $TITLE (#$NUMBER)'
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -60,3 +60,10 @@ jobs:
         cd /opt/monai
         ls -al
         ngc --version
+
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: release-drafter/release-drafter@v5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #229.

### Description
adds a release drafter, automatically lists merged PRs in the release draft.
I've tested locally the draft isn't ready to publish, but is a good starting point for manual editing.

once this PR is merged the config error will go away, as the drafter requires a config being in the default branch.

![Screenshot 2020-03-31 at 13 08 08](https://user-images.githubusercontent.com/831580/78024673-ade0f300-7350-11ea-8ff4-e7d9ded36e88.png)
 

### Status
**HOLD**

I'm looking into the alternatives

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)

