### PR TITLE
232-remove dependency on scikit-image and scipy, support differentiable spatial transforms

### DIFF
--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -54,6 +54,11 @@ Layers
     :members:
     :special-members: __call__
 
+`Spatial Transforms`
+~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: monai.networks.layers.AffineTransform
+    :members:
+
 `Utilities`
 ~~~~~~~~~~~
 .. automodule:: monai.networks.layers.convutils

--- a/monai/data/nifti_writer.py
+++ b/monai/data/nifti_writer.py
@@ -33,7 +33,7 @@ def write_nifti(
     into the coordinate system defined by `target_affine` when `target_affine`
     is specified.
 
-    if the coordinate transform between `affine` and `target_affine` could be
+    If the coordinate transform between `affine` and `target_affine` could be
     achieved by simply transposing and flipping `data`, no resampling will
     happen.  otherwise this function will resample `data` using the coordinate
     transform computed from `affine` and `target_affine`.  Note that the shape
@@ -45,11 +45,11 @@ def write_nifti(
     13.333x13.333 pixels. In this case `output_shape` could be specified so
     that this function writes image data to a designated shape.
 
-    when `affine` and `target_affine` are None, the data will be saved with an
+    When `affine` and `target_affine` are None, the data will be saved with an
     identity matrix as the image affine.
 
     This function assumes the NIfTI dimension notations.
-    Spatially It supports up to three dimensions, that is, H, HW, HWD for
+    Spatially it supports up to three dimensions, that is, H, HW, HWD for
     1D, 2D, 3D respectively.
     When saving multiple time steps or multiple channels `data`, time and/or
     modality axes should be appended after the first three dimensions.  For

--- a/monai/networks/layers/convutils.py
+++ b/monai/networks/layers/convutils.py
@@ -11,6 +11,8 @@
 
 import numpy as np
 
+__all__ = ["same_padding", "calculate_out_shape", "gaussian_1d"]
+
 
 def same_padding(kernel_size, dilation=1):
     """

--- a/monai/networks/layers/factories.py
+++ b/monai/networks/layers/factories.py
@@ -64,6 +64,8 @@ from typing import Callable
 
 import torch.nn as nn
 
+__all__ = ["LayerFactory", "Dropout", "Norm", "Act", "Conv", "Pool"]
+
 
 class LayerFactory:
     """

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -15,6 +15,8 @@ import torch.nn.functional as F
 
 from monai.networks.layers.convutils import gaussian_1d, same_padding
 
+__all__ = ["SkipConnection", "Flatten", "GaussianFilter"]
+
 
 class SkipConnection(nn.Module):
     """Concats the forward pass input with the result from the given submodule."""

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -9,7 +9,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .convutils import *
-from .factories import *
-from .simplelayers import *
-from .spatial_transforms import *
+import torch.nn as nn
+
+__all__ = ['SpatialTransformer']
+
+
+class SpatialTransformer(nn.Module):
+
+    def __init__(self):
+        pass
+
+    def forward(self):
+        pass

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -9,15 +9,132 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import torch
 import torch.nn as nn
 
-__all__ = ['SpatialTransformer']
+from monai.networks.utils import to_norm_affine
+
+__all__ = ["AffineTransform"]
 
 
-class SpatialTransformer(nn.Module):
+class AffineTransform(nn.Module):
+    def __init__(
+        self,
+        theta,
+        spatial_size=None,
+        normalized=False,
+        mode="bilinear",
+        padding_mode="zeros",
+        align_corners=False,
+        reverse_indexing=True,
+    ):
+        """
+        Apply affine transformations with a batch of affine matrices.
 
-    def __init__(self):
-        pass
+        `theta` must be an affine transformation matrix with shape
+        3x3 or Nx3x3 or Nx2x3 or 2x3 for spatial 2D transforms,
+        4x4 or Nx4x4 or Nx3x4 or 3x4 for spatial 3D transforms,
+        where `N` is the batch size.
 
-    def forward(self):
-        pass
+        When `normalized=False` and `reverse_indexing=True`,
+        it does the commonly used resampling in the 'pull' direction
+        following the `scipy.ndimage.affine_transform` convention.
+        See also: https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.affine_transform.html
+
+        When `normalized=True` and `reverse_indexing=False`,
+        it applies `theta` to the normalized coordinates [-1, 1] directly.
+        This is often used with `align_corners=False` to achieve resolution-agnostic resampling,
+        thus useful as a part of trainable modules such as the spatial transformer networks.
+        See also: https://pytorch.org/tutorials/intermediate/spatial_transformer_tutorial.html
+
+        Args:
+            theta (array_like): Nx3x3, Nx2x3, 3x3, 2x3 for spatial 2D inputs,
+                Nx4x4, Nx3x4, 3x4, 4x4 for spatial 3D inputs.
+            spatial_size (list or tuple of int): output spatial shape, the full output shape will be
+                `[N, C, *spatial_size]` where N and C are inferred from the `src` input of `self.forward`.
+            normalized (bool): indicating whether the provided affine matrix `theta` is defined
+                for the normalized coordinates. If `normalized=False`, `theta` will be converted
+                to operate on normalized coordinates as pytorch affine_grid works with the normalized
+                coordinates.
+            mode (`nearest|bilinear`): interpolation mode.
+                See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample.
+            padding_mode (`zeros|border|reflection`): padding mode for outside grid values.
+            align_corners (bool): see also https://pytorch.org/docs/stable/nn.functional.html#grid-sample.
+            reverse_indexing (bool): whether to reverse the spatial indexing of image and coordinates.
+                set to `False` if `theta` follows pytorch's default "D, H, W" convention.
+                set to `True` if `theta` follows `scipy.ndimage` default "i, j, k" convention.
+        """
+        super().__init__()
+
+        if spatial_size is not None:
+            if not isinstance(spatial_size, (list, tuple)):
+                raise ValueError("spatial size must be None or a list or tuple")
+        self.theta = theta.float() if torch.is_tensor(theta) else torch.tensor(theta)
+        if self.theta.ndim not in (2, 3):
+            raise ValueError("affine must be Nxdxd or dxd.")
+        if self.theta.ndim == 2:
+            self.theta = self.theta[None]  # adds a batch dim.
+        theta_shape = tuple(self.theta.shape[1:])
+        if theta_shape in ((2, 3), (3, 4)):  # needs padding to dxd
+            b = self.theta.shape[0]
+            pad_affine = torch.tensor([0, 0, 1] if theta_shape[0] == 2 else [0, 0, 0, 1]).repeat(b, 1, 1)
+            self.theta = torch.cat([self.theta, pad_affine.to(self.theta)], dim=1)
+        if tuple(self.theta.shape[1:]) not in ((3, 3), (4, 4)):
+            raise ValueError("affine must be Nx3x3 or Nx4x4, got: {}".format(self.theta.shape))
+
+        self.spatial_size = spatial_size
+        self.normalized = normalized
+        self.mode = mode
+        self.padding_mode = padding_mode
+        self.align_corners = align_corners
+        self.reverse_indexing = reverse_indexing
+
+    def forward(self, src):
+        """
+
+        Args:
+            src (array_like): image in spatial 2D (N, C, H, W) or spatial 3D (N, C, D, H, W),
+                where N is the batch dim, C is the number of channels.
+        """
+        if not torch.is_tensor(src):
+            # https://github.com/pytorch/pytorch/issues/33812
+            # src = torch.tensor(src)
+            src = torch.as_tensor(src)
+        src = src.float()  # always use float for compatibility
+        sr = src.ndim - 2  # input spatial rank
+        if sr not in (2, 3):
+            raise ValueError("src must be spatially 2D or 3D.")
+        src_size = list(src.shape)
+        if self.spatial_size is not None:
+            dst_size = list(src_size[:2]) + list(self.spatial_size)
+        else:
+            dst_size = src_size  # default to the src shape
+
+        self.theta = self.theta.to(src)
+        theta = self.theta.clone()
+        if self.reverse_indexing:
+            rev_idx = torch.as_tensor(range(sr - 1, -1, -1), device=src.device)
+            theta[:, :sr] = theta[:, rev_idx]
+            theta[:, :, :sr] = theta[:, :, rev_idx]
+        if not self.normalized:
+            theta = to_norm_affine(
+                affine=theta, src_size=src_size[2:], dst_size=dst_size[2:], align_corners=self.align_corners
+            )
+        if (theta.shape[0] == 1) and src_size[0] > 1:
+            theta = theta.repeat(src_size[0], 1, 1)  # broadcast the batch dim.
+        if theta.shape[0] != src_size[0]:
+            raise ValueError(
+                "batch dimension of affine and image does not match, got affine: {} and image: {}.".format(
+                    theta.shape[0], src_size[0]
+                )
+            )
+
+        grid = nn.functional.affine_grid(theta=theta[:, :sr], size=dst_size, align_corners=self.align_corners)
+        dst = nn.functional.grid_sample(
+            input=src.contiguous(),
+            grid=grid,
+            mode=self.mode,
+            padding_mode=self.padding_mode,
+            align_corners=self.align_corners,
+        )
+        return dst

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -21,7 +21,7 @@ import torch
 from skimage.transform import resize
 
 from monai.data.utils import zoom_affine, compute_shape_offset, to_affine_nd
-from monai.networks.layers.simplelayers import GaussianFilter
+from monai.networks.layers import AffineTransform, GaussianFilter
 from monai.transforms.compose import Transform, Randomizable
 from monai.transforms.utils import (
     create_control_grid,
@@ -39,40 +39,34 @@ class Spacing(Transform):
     Resample input image into the specified `pixdim`.
     """
 
-    def __init__(self, pixdim, diagonal=False, mode="constant", cval=0, dtype=None):
+    def __init__(self, pixdim, diagonal=False, padding_mode="border", dtype=None):
         """
         Args:
             pixdim (sequence of floats): output voxel spacing.
             diagonal (bool): whether to resample the input to have a diagonal affine matrix.
                 If True, the input data is resampled to the following affine::
-
                     np.diag((pixdim_0, pixdim_1, ..., pixdim_n, 1))
-
                 This effectively resets the volume to the world coordinate system (RAS+ in nibabel).
                 The original orientation, rotation, shearing are not preserved.
-
                 If False, this transform preserves the axes orientation, orthogonal rotation and
                 translation components from the original affine. This option will not flip/swap axes
                 of the original data.
-            mode (`reflect|constant|nearest|mirror|wrap`):
-                The mode parameter determines how the input array is extended beyond its boundaries.
-            cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
+            padding_mode (`zeros|border|reflection`): padding mode for outside grid values.
+                Defaults to `border`.
             dtype (None or np.dtype): output array data type, defaults to None to use input data's dtype.
         """
         self.pixdim = np.array(ensure_tuple(pixdim), dtype=np.float64)
         self.diagonal = diagonal
-        self.mode = mode
-        self.cval = cval
+        self.padding_mode = padding_mode
         self.dtype = dtype
 
-    def __call__(self, data_array, affine=None, interp_order=3):
+    def __call__(self, data_array, affine=None, interp_order="bilinear"):
         """
         Args:
             data_array (ndarray): in shape (num_channels, H[, W, ...]).
             affine (matrix): (N+1)x(N+1) original affine matrix for spatially ND `data_array`. Defaults to identity.
-            interp_order (int): The order of the spline interpolation, default is 3.
-                The order has to be in the range 0-5.
-                https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.zoom.html
+            interp_order (`nearest|bilinear`): interpolation mode.
+                See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample.
         Returns:
             data_array (resampled into `self.pixdim`), original pixdim, current pixdim.
         """
@@ -100,17 +94,16 @@ class Spacing(Transform):
         # resample
         dtype = data_array.dtype if self.dtype is None else self.dtype
         output_data = []
-        for data in data_array:
-            data_ = scipy.ndimage.affine_transform(
-                data.astype(dtype),
-                matrix=transform_,
-                output_shape=output_shape,
-                order=interp_order,
-                mode=self.mode,
-                cval=self.cval,
-            )
-            output_data.append(data_)
-        output_data = np.stack(output_data)
+        affine_xform = AffineTransform(
+            theta=transform_,
+            spatial_size=list(output_shape),
+            normalized=False,
+            padding_mode=self.padding_mode,
+            mode=interp_order,
+            align_corners=False,
+            reverse_indexing=True,
+        )
+        output_data = affine_xform(data_array.astype(dtype)[None])[0]  # affine layer requires a batch dim.
         new_affine = to_affine_nd(affine, new_affine)
         return output_data, affine, new_affine
 

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -37,49 +37,50 @@ from monai.utils.misc import ensure_tuple
 
 class Spacingd(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.Spacing`.
-
+    Dictionary-based wrapper of :py:class:`monai.transforms.transforms.Spacing`.
     This transform assumes the ``data`` dictionary has a key for the input
     data's affine.  The key is formed by ``meta_key_format.format(key, 'affine')``.
-
     After resampling the input array, this transform will write the new affine
      to the key formed by ``meta_key_format.format(key, 'affine')``.
-
     see also:
-        :py:class:`monai.transforms.Spacing`
+        :py:class:`monai.transforms.transforms.Spacing`
     """
 
     def __init__(
-        self, keys, pixdim, diagonal=False, mode="constant", cval=0, interp_order=3, dtype=None, meta_key_format="{}.{}"
+        self,
+        keys,
+        pixdim,
+        diagonal=False,
+        padding_mode="border",
+        interp_order="bilinear",
+        dtype=None,
+        meta_key_format="{}.{}",
     ):
         """
         Args:
             pixdim (sequence of floats): output voxel spacing.
             diagonal (bool): whether to resample the input to have a diagonal affine matrix.
                 If True, the input data is resampled to the following affine::
-
                     np.diag((pixdim_0, pixdim_1, pixdim_2, 1))
-
                 This effectively resets the volume to the world coordinate system (RAS+ in nibabel).
                 The original orientation, rotation, shearing are not preserved.
-
                 If False, the axes orientation, orthogonal rotation and
                 translations components from the original affine will be
                 preserved in the target affine. This option will not flip/swap
                 axes against the original ones.
-            mode (`reflect|constant|nearest|mirror|wrap`):
+            padding_mode (`zeros|border|reflection`): padding mode for outside grid values.
                 The mode parameter determines how the input array is extended beyond its boundaries.
-                Default is 'constant'.
-            cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
-            interp_order (int or sequence of ints): int: the same interpolation order
-                for all data indexed by `self.keys`; sequence of ints, should
-                correspond to an interpolation order for each data item indexed
+                Default is 'border'.
+            interp_order (string or sequence of strings, `nearest|bilinear`):
+                string: the same interpolation order
+                for all data indexed by `self.keys`;
+                sequence of strings: should correspond to an interpolation order for each data item indexed
                 by `self.keys` respectively.
             dtype (None or np.dtype): output array data type, defaults to None to use input data's dtype.
             meta_key_format (str): key format to read/write affine matrices to the data dictionary.
         """
         super().__init__(keys)
-        self.spacing_transform = Spacing(pixdim, diagonal=diagonal, mode=mode, cval=cval, dtype=dtype)
+        self.spacing_transform = Spacing(pixdim, diagonal=diagonal, padding_mode=padding_mode, dtype=dtype)
         interp_order = ensure_tuple(interp_order)
         self.interp_order = interp_order if len(interp_order) == len(self.keys) else interp_order * len(self.keys)
         self.meta_key_format = meta_key_format

--- a/tests/test_affine_transform.py
+++ b/tests/test_affine_transform.py
@@ -1,0 +1,353 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import torch
+from parameterized import parameterized
+
+from monai.networks.layers import AffineTransform
+from monai.networks.utils import normalize_transform, to_norm_affine
+
+TEST_NORM_CASES = [
+    [(4, 5), True, [[[0.5, 0, -1], [0, 0.666667, -1], [0, 0, 1]]]],
+    [
+        (2, 4, 5),
+        True,
+        [[[0.5, 0.0, 0.0, -1.0], [0.0, 0.6666667, 0.0, -1.0], [0.0, 0.0, 2.0, -1.0], [0.0, 0.0, 0.0, 1.0]]],
+    ],
+    [(4, 5), False, [[[0.4, 0.0, -0.8], [0.0, 0.5, -0.75], [0.0, 0.0, 1.0]]]],
+    [(2, 4, 5), False, [[[0.4, 0.0, 0.0, -0.8], [0.0, 0.5, 0.0, -0.75], [0.0, 0.0, 1.0, -0.5], [0.0, 0.0, 0.0, 1.0]]]],
+]
+
+TEST_TO_NORM_AFFINE_CASES = [
+    [
+        [[[1, 0, 0], [0, 1, 0], [0, 0, 1]]],
+        (4, 6),
+        (5, 3),
+        True,
+        [[[0.4, 0.0, -0.6], [0.0, 1.3333334, 0.33333337], [0.0, 0.0, 1.0]]],
+    ],
+    [
+        [[[1, 0, 0], [0, 1, 0], [0, 0, 1]]],
+        (4, 6),
+        (5, 3),
+        False,
+        [[[0.5, 0.0, -0.5], [0.0, 1.25, 0.25], [0.0, 0.0, 1.0]]],
+    ],
+    [
+        [[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]],
+        (2, 4, 6),
+        (3, 5, 3),
+        True,
+        [[[0.4, 0.0, 0.0, -0.6], [0.0, 1.3333334, 0.0, 0.33333337], [0.0, 0.0, 2.0, 1.0], [0.0, 0.0, 0.0, 1.0]]],
+    ],
+    [
+        [[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]],
+        (2, 4, 6),
+        (3, 5, 3),
+        False,
+        [[[0.5, 0.0, 0.0, -0.5], [0.0, 1.25, 0.0, 0.25], [0.0, 0.0, 1.5, 0.5], [0.0, 0.0, 0.0, 1.0]]],
+    ],
+]
+
+TEST_ILL_TO_NORM_AFFINE_CASES = [
+    [[[[1, 0, 0], [0, 1, 0], [0, 0, 1]]], (3, 4, 6), (3, 5, 3), False],
+    [[[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]], (4, 6), (3, 5, 3), True],
+    [[[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]], (4, 6), (3, 5, 3), True],
+]
+
+
+class TestNormTransform(unittest.TestCase):
+    @parameterized.expand(TEST_NORM_CASES)
+    def test_norm_xform(self, input_shape, align_corners, expected):
+        norm = normalize_transform(
+            input_shape, device=torch.device("cpu:0"), dtype=torch.float32, align_corners=align_corners
+        )
+        norm = norm.detach().cpu().numpy()
+        np.testing.assert_allclose(norm, expected, atol=1e-6)
+        if torch.cuda.is_available():
+            norm = normalize_transform(
+                input_shape, device=torch.device("cuda:0"), dtype=torch.float32, align_corners=align_corners
+            )
+            norm = norm.detach().cpu().numpy()
+            np.testing.assert_allclose(norm, expected, atol=1e-4)
+
+
+class TestToNormAffine(unittest.TestCase):
+    @parameterized.expand(TEST_TO_NORM_AFFINE_CASES)
+    def test_to_norm_affine(self, affine, src_size, dst_size, align_corners, expected):
+        affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+        new_affine = to_norm_affine(affine, src_size, dst_size, align_corners)
+        new_affine = new_affine.detach().cpu().numpy()
+        np.testing.assert_allclose(new_affine, expected, atol=1e-6)
+
+        if torch.cuda.is_available():
+            affine = torch.as_tensor(affine, device=torch.device("cuda:0"), dtype=torch.float32)
+            new_affine = to_norm_affine(affine, src_size, dst_size, align_corners)
+            new_affine = new_affine.detach().cpu().numpy()
+            np.testing.assert_allclose(new_affine, expected, atol=1e-4)
+
+    @parameterized.expand(TEST_ILL_TO_NORM_AFFINE_CASES)
+    def test_to_norm_affine_ill(self, affine, src_size, dst_size, align_corners):
+        with self.assertRaises(ValueError):
+            to_norm_affine(affine, src_size, dst_size, align_corners)
+        with self.assertRaises(ValueError):
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            to_norm_affine(affine, src_size, dst_size, align_corners)
+
+
+class TestAffineTransform(unittest.TestCase):
+    def test_affine_shift(self):
+        affine = [[1, 0, 0], [0, 1, -1]]
+        image = torch.as_tensor([[[[4, 1, 3, 2], [7, 6, 8, 5], [3, 5, 3, 6]]]])
+        out = AffineTransform(affine)(image)
+        out = out.detach().cpu().numpy()
+        expected = [[[[0, 4, 1, 3], [0, 7, 6, 8], [0, 3, 5, 3]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_affine_shift_1(self):
+        affine = [[1, 0, -1], [0, 1, -1]]
+        image = torch.as_tensor([[[[4, 1, 3, 2], [7, 6, 8, 5], [3, 5, 3, 6]]]])
+        out = AffineTransform(affine)(image)
+        out = out.detach().cpu().numpy()
+        expected = [[[[0, 0, 0, 0], [0, 4, 1, 3], [0, 7, 6, 8]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_affine_shift_2(self):
+        affine = [[1, 0, -1], [0, 1, 0]]
+        image = torch.as_tensor([[[[4, 1, 3, 2], [7, 6, 8, 5], [3, 5, 3, 6]]]])
+        out = AffineTransform(affine)(image)
+        out = out.detach().cpu().numpy()
+        expected = [[[[0, 0, 0, 0], [4, 1, 3, 2], [7, 6, 8, 5]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_zoom(self):
+        affine = [[1, 0, 0], [0, 2, 0]]
+        image = torch.arange(1, 13).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+        out = AffineTransform(affine, (3, 2))(image)
+        expected = [[[[1, 3], [5, 7], [9, 11]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_zoom_1(self):
+        affine = [[2, 0, 0], [0, 1, 0]]
+        image = torch.arange(1, 13).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+        out = AffineTransform(affine, (1, 4))(image)
+        expected = [[[[1, 2, 3, 4]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_zoom_2(self):
+        affine = [[2, 0, 0], [0, 2, 0]]
+        image = torch.arange(1, 13).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+        out = AffineTransform(affine, (1, 2))(image)
+        expected = [[[[1, 3]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_affine_transform_minimum(self):
+        t = np.pi / 3
+        affine = [[np.cos(t), -np.sin(t), 0], [np.sin(t), np.cos(t), 0], [0, 0, 1]]
+        affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+        image = torch.arange(24).view(1, 1, 4, 6).to(device=torch.device("cpu:0"))
+        out = AffineTransform(affine)(image)
+        out = out.detach().cpu().numpy()
+        expected = [
+            [
+                [
+                    [0.0, 0.06698727, 0.0, 0.0, 0.0, 0.0],
+                    [3.8660254, 0.86602557, 0.0, 0.0, 0.0, 0.0],
+                    [7.732051, 3.035899, 0.73205125, 0.0, 0.0, 0.0],
+                    [11.598076, 6.901923, 2.7631402, 0.0, 0.0, 0.0],
+                ]
+            ]
+        ]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_affine_transform_2d(self):
+        t = np.pi / 3
+        affine = [[np.cos(t), -np.sin(t), 0], [np.sin(t), np.cos(t), 0], [0, 0, 1]]
+        affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+        image = torch.arange(24).view(1, 1, 4, 6).to(device=torch.device("cpu:0"))
+        out = AffineTransform(affine, (3, 4), padding_mode="border", align_corners=True, mode="bilinear")(image)
+        out = out.detach().cpu().numpy()
+        expected = [
+            [
+                [
+                    [7.1525574e-07, 4.9999994e-01, 1.0000000e00, 1.4999999e00],
+                    [3.8660259e00, 1.3660253e00, 1.8660252e00, 2.3660252e00],
+                    [7.7320518e00, 3.0358994e00, 2.7320509e00, 3.2320507e00],
+                ]
+            ]
+        ]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+        if torch.cuda.is_available():
+            affine = torch.as_tensor(affine, device=torch.device("cuda:0"), dtype=torch.float32)
+            image = torch.arange(24).view(1, 1, 4, 6).to(device=torch.device("cuda:0"))
+            xform = AffineTransform(affine, (3, 4), padding_mode="border", align_corners=True, mode="bilinear")
+            out = xform(image)
+            out = out.detach().cpu().numpy()
+            expected = [
+                [
+                    [
+                        [7.1525574e-07, 4.9999994e-01, 1.0000000e00, 1.4999999e00],
+                        [3.8660259e00, 1.3660253e00, 1.8660252e00, 2.3660252e00],
+                        [7.7320518e00, 3.0358994e00, 2.7320509e00, 3.2320507e00],
+                    ]
+                ]
+            ]
+            np.testing.assert_allclose(out, expected, atol=1e-4)
+
+    def test_affine_transform_3d(self):
+        t = np.pi / 3
+        affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+        affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+        image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+        xform = AffineTransform(affine, (3, 4, 2), padding_mode="border", align_corners=False, mode="bilinear")
+        out = xform(image)
+        out = out.detach().cpu().numpy()
+        expected = [
+            [
+                [
+                    [[0.00000006, 0.5000001], [2.3660254, 1.3660254], [4.732051, 2.4019241], [5.0, 3.9019237]],
+                    [[6.0, 6.5], [8.366026, 7.3660254], [10.732051, 8.401924], [11.0, 9.901924]],
+                    [[12.0, 12.5], [14.366026, 13.366025], [16.732052, 14.401924], [17.0, 15.901923]],
+                ]
+            ],
+            [
+                [
+                    [[24.0, 24.5], [26.366024, 25.366024], [28.732052, 26.401924], [29.0, 27.901924]],
+                    [[30.0, 30.5], [32.366028, 31.366026], [34.732048, 32.401924], [35.0, 33.901924]],
+                    [[36.0, 36.5], [38.366024, 37.366024], [40.73205, 38.401924], [41.0, 39.901924]],
+                ]
+            ],
+        ]
+        np.testing.assert_allclose(out, expected, atol=1e-4)
+
+        if torch.cuda.is_available():
+            affine = torch.as_tensor(affine, device=torch.device("cuda:0"), dtype=torch.float32)
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cuda:0"))
+            xform = AffineTransform(affine, (3, 4, 2), padding_mode="border", align_corners=False, mode="bilinear")
+            out = xform(image)
+            out = out.detach().cpu().numpy()
+            expected = [
+                [
+                    [
+                        [[0.00000006, 0.5000001], [2.3660254, 1.3660254], [4.732051, 2.4019241], [5.0, 3.9019237]],
+                        [[6.0, 6.5], [8.366026, 7.3660254], [10.732051, 8.401924], [11.0, 9.901924]],
+                        [[12.0, 12.5], [14.366026, 13.366025], [16.732052, 14.401924], [17.0, 15.901923]],
+                    ]
+                ],
+                [
+                    [
+                        [[24.0, 24.5], [26.366024, 25.366024], [28.732052, 26.401924], [29.0, 27.901924]],
+                        [[30.0, 30.5], [32.366028, 31.366026], [34.732048, 32.401924], [35.0, 33.901924]],
+                        [[36.0, 36.5], [38.366024, 37.366024], [40.73205, 38.401924], [41.0, 39.901924]],
+                    ]
+                ],
+            ]
+            np.testing.assert_allclose(out, expected, atol=1e-4)
+
+    def test_ill_affine_transform(self):
+        with self.assertRaises(ValueError):  # shape not sequence
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            xform = AffineTransform(affine, range(3, 4), padding_mode="border", align_corners=False, mode="bilinear")
+
+        with self.assertRaises(ValueError):  # image too small
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            xform = AffineTransform(affine, (3, 4, 2), padding_mode="border", align_corners=False, mode="bilinear")
+            xform([1, 2, 3])
+
+        with self.assertRaises(ValueError):  # output shape too small
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+            xform = AffineTransform(affine, (3, 4), padding_mode="border", align_corners=False, mode="bilinear")
+            xform(image)
+
+        with self.assertRaises(ValueError):  # incorrect affine
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            affine = affine.unsqueeze(0).unsqueeze(0)
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+            xform = AffineTransform(affine, (2, 3, 4), padding_mode="border", align_corners=False, mode="bilinear")
+
+        with self.assertRaises(ValueError):  # batch doesn't match
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            affine = affine.unsqueeze(0)
+            affine = affine.repeat(3, 1, 1)
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+            xform = AffineTransform(affine, (2, 3, 4), padding_mode="border", align_corners=False, mode="bilinear")
+            xform(image)
+
+        with self.assertRaises(ValueError):  # wrong affine
+            affine = [[1, 0, 0, 0], [0, 0, 0, 1]]
+            xform = AffineTransform(affine, (2, 3, 4), padding_mode="border", align_corners=False, mode="bilinear")
+
+    def test_forward_2d(self):
+        x = torch.rand(2, 1, 4, 4)
+        theta = torch.Tensor([[[0, -1, 0], [1, 0, 0]]]).repeat(2, 1, 1)
+        grid = torch.nn.functional.affine_grid(theta, x.size(), align_corners=False)
+        expected = torch.nn.functional.grid_sample(x, grid, align_corners=False)
+        expected = expected.detach().cpu().numpy()
+
+        actual = AffineTransform(theta, normalized=True, reverse_indexing=False)(x)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [2, 2, 3])
+
+        theta = torch.Tensor([[0, -1, 0], [1, 0, 0]])
+        actual = AffineTransform(theta, normalized=True, reverse_indexing=False)(x)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [2, 3])
+
+        theta = torch.Tensor([[[0, -1, 0], [1, 0, 0]]])
+        actual = AffineTransform(theta, normalized=True, reverse_indexing=False)(x)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [1, 2, 3])
+
+    def test_forward_3d(self):
+        x = torch.rand(2, 1, 4, 4, 4)
+        theta = torch.Tensor([[[0, 0, -1, 0], [1, 0, 0, 0], [0, 0, 1, 0]]]).repeat(2, 1, 1)
+        grid = torch.nn.functional.affine_grid(theta, x.size(), align_corners=False)
+        expected = torch.nn.functional.grid_sample(x, grid, align_corners=False)
+        expected = expected.detach().cpu().numpy()
+
+        actual = AffineTransform(theta, normalized=True, reverse_indexing=False)(x)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [2, 3, 4])
+
+        theta = torch.Tensor([[0, 0, -1, 0], [1, 0, 0, 0], [0, 0, 1, 0]])
+        actual = AffineTransform(theta, normalized=True, reverse_indexing=False)(x)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [3, 4])
+
+        theta = torch.Tensor([[[0, 0, -1, 0], [1, 0, 0, 0], [0, 0, 1, 0]]])
+        actual = AffineTransform(theta, normalized=True, reverse_indexing=False)(x)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [1, 3, 4])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_load_spacing_orientation.py
+++ b/tests/test_load_spacing_orientation.py
@@ -31,13 +31,13 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data = {"image": filename}
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=True, mode="constant")(data_dict)
-        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=True, padding_mode="zeros")(data_dict)
         anat = nibabel.Nifti1Image(data_dict["image"][0], data_dict["image.affine"])
-        ref = resample_to_output(anat, (1, 2, 3))
+        ref = resample_to_output(anat, (1, 2, 3), order=1)
+        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(res_dict["image.affine"], ref.affine)
         np.testing.assert_allclose(res_dict["image"].shape[1:], ref.shape)
-        np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0])
+        np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0], atol=0.1)
 
     @parameterized.expand(FILES)
     def test_load_spacingd_rotate(self, filename):
@@ -48,18 +48,18 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data_dict["image.original_affine"] = data_dict["image.affine"] = (
             np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) @ affine
         )
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=True, mode="constant")(data_dict)
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=True, padding_mode="zeros")(data_dict)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         anat = nibabel.Nifti1Image(data_dict["image"][0], data_dict["image.affine"])
-        ref = resample_to_output(anat, (1, 2, 3))
+        ref = resample_to_output(anat, (1, 2, 3), order=1)
         np.testing.assert_allclose(res_dict["image.affine"], ref.affine)
         if "anatomical" not in filename:
             np.testing.assert_allclose(res_dict["image"].shape[1:], ref.shape)
-            np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0])
+            np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0], atol=0.1)
         else:
             # different from the ref implementation (shape computed by round
             # instead of ceil)
-            np.testing.assert_allclose(ref.get_fdata()[..., :-1], res_dict["image"][0])
+            np.testing.assert_allclose(ref.get_fdata()[..., :-1], res_dict["image"][0], atol=0.1)
 
     def test_load_spacingd_non_diag(self):
         data = {"image": FILES[1]}
@@ -69,7 +69,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data_dict["image.original_affine"] = data_dict["image.affine"] = (
             np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) @ affine
         )
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="constant")(data_dict)
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, padding_mode="zeros")(data_dict)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
             res_dict["image.affine"],
@@ -87,7 +87,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data = {"image": FILES[0]}
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="nearest")(data_dict)
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, padding_mode="border")(data_dict)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
             res_dict["image.affine"],
@@ -98,7 +98,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data = {"image": FILES[0]}
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="nearest")(data_dict)
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, padding_mode="border")(data_dict)
         res_dict = Orientationd(keys="image", axcodes="LPI")(res_dict)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
@@ -114,7 +114,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data_dict["image.original_affine"] = data_dict["image.affine"] = (
             np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) @ affine
         )
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="constant")(data_dict)
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, padding_mode="border")(data_dict)
         res_dict = Orientationd(keys="image", axcodes="LPI")(res_dict)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(

--- a/tests/test_nifti_rw.py
+++ b/tests/test_nifti_rw.py
@@ -82,7 +82,9 @@ class TestNiftiLoadRead(unittest.TestCase):
         np.set_printoptions(suppress=True, precision=3)
         test_image = make_nifti_image(np.arange(64).reshape(1, 8, 8), np.diag([1.5, 1.5, 1.5, 1]))
         data, header = LoadNifti(as_closest_canonical=False)(test_image)
-        data, original_affine, new_affine = Spacing([0.8, 0.8, 0.8])(data[None], header["affine"], interp_order=0)
+        data, original_affine, new_affine = Spacing([0.8, 0.8, 0.8])(
+            data[None], header["affine"], interp_order="nearest"
+        )
         data, _, new_affine = Orientation("ILP")(data, new_affine)
         if os.path.exists(test_image):
             os.remove(test_image)

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -17,27 +17,26 @@ from parameterized import parameterized
 from monai.transforms import Spacing
 
 TEST_CASES = [
-    [{"pixdim": (2.0,)}, np.ones((1, 2)), {"affine": np.eye(4)}, np.array([[1.0, 0.0]])],  # data
     [
-        {"pixdim": (1.0, 0.2, 1.5)},
+        {"pixdim": (1.0, 0.2, 1.5), "padding_mode": "zeros", "dtype": np.float},
         np.ones((1, 2, 1, 2)),  # data
         {"affine": np.eye(4)},
-        np.array([[[[1.0, 0.0]], [[1.0, 0.0]]]]),
+        np.array([[[[1.0, 0.5]], [[1.0, 0.5]]]]),
     ],
     [
-        {"pixdim": (1.0, 0.2, 1.5), "diagonal": False},
+        {"pixdim": (1.0, 0.2, 1.5), "diagonal": False, "padding_mode": "zeros"},
         np.ones((1, 2, 1, 2)),  # data
         {"affine": np.array([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2.0, 5], [0, 0, 0, 1]])},
-        np.zeros((1, 3, 1, 2)),
+        np.ones((1, 3, 1, 2)),
     ],
     [
-        {"pixdim": (3.0, 1.0)},
+        {"pixdim": (3.0, 1.0), "padding_mode": "zeros"},
         np.arange(24).reshape((2, 3, 4)),  # data
         {"affine": np.diag([-3.0, 0.2, 1.5, 1])},
         np.array([[[0, 0], [4, 0], [8, 0]], [[12, 0], [16, 0], [20, 0]]]),
     ],
     [
-        {"pixdim": (3.0, 1.0)},
+        {"pixdim": (3.0, 1.0), "padding_mode": "zeros"},
         np.arange(24).reshape((2, 3, 4)),  # data
         {},
         np.array([[[0, 1, 2, 3], [0, 0, 0, 0]], [[12, 13, 14, 15], [0, 0, 0, 0]]]),
@@ -65,7 +64,7 @@ TEST_CASES = [
         ),
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0), "mode": "nearest", "diagonal": True},
+        {"pixdim": (4.0, 5.0, 6.0), "padding_mode": "border", "diagonal": True},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
         {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
         np.array(
@@ -73,22 +72,22 @@ TEST_CASES = [
         ),
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0), "mode": "nearest", "diagonal": True},
+        {"pixdim": (4.0, 5.0, 6.0), "padding_mode": "border", "diagonal": True},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
+        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": "nearest"},
         np.array(
             [[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]], [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]]
         ),
     ],
     [
-        {"pixdim": (2.0, 5.0, 6.0), "mode": "constant", "diagonal": True},
+        {"pixdim": (2.0, 5.0, 6.0), "padding_mode": "zeros", "diagonal": True},
         np.arange(24).reshape((1, 4, 6)),  # data
-        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
+        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": "nearest"},
         np.array(
             [
                 [
                     [18, 19, 20, 21, 22, 23],
-                    [18, 19, 20, 21, 22, 23],
+                    [12, 13, 14, 15, 16, 17],
                     [12, 13, 14, 15, 16, 17],
                     [12, 13, 14, 15, 16, 17],
                     [6, 7, 8, 9, 10, 11],
@@ -99,9 +98,9 @@ TEST_CASES = [
         ),
     ],
     [
-        {"pixdim": (5.0, 3.0, 6.0), "mode": "constant", "diagonal": True, "dtype": np.float32},
+        {"pixdim": (5.0, 3.0, 6.0), "padding_mode": "border", "diagonal": True, "dtype": np.float32},
         np.arange(24).reshape((1, 4, 6)),  # data
-        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
+        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": "nearest"},
         np.array(
             [
                 [
@@ -113,17 +112,17 @@ TEST_CASES = [
         ),
     ],
     [
-        {"pixdim": (5.0, 3.0, 6.0), "mode": "constant", "diagonal": True, "dtype": np.float32},
+        {"pixdim": (5.0, 3.0, 6.0), "padding_mode": "zeros", "diagonal": True, "dtype": np.float32},
         np.arange(24).reshape((1, 4, 6)),  # data
-        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 2},
+        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": "bilinear"},
         np.array(
             [
                 [
-                    [18.0, 18.492683, 19.22439, 19.80683, 20.398048, 21.0, 21.570732, 22.243902, 22.943415],
-                    [10.392858, 10.88554, 11.617248, 12.199686, 12.790906, 13.392858, 13.963589, 14.63676, 15.336272],
-                    [2.142857, 2.63554, 3.3672473, 3.9496865, 4.540906, 5.142857, 5.7135887, 6.3867598, 7.086272],
+                    [18.0000, 18.6000, 19.2000, 19.8000, 20.4000, 21.0000, 21.6000, 22.2000, 22.8000],
+                    [10.5000, 11.1000, 11.7000, 12.3000, 12.9000, 13.5000, 14.1000, 14.7000, 15.3000],
+                    [3.0000, 3.6000, 4.2000, 4.8000, 5.4000, 6.0000, 6.6000, 7.2000, 7.8000],
                 ]
-            ],
+            ]
         ),
     ],
 ]

--- a/tests/test_spacingd.py
+++ b/tests/test_spacingd.py
@@ -33,36 +33,31 @@ class TestSpacingDCase(unittest.TestCase):
         np.testing.assert_allclose(res["image"].shape, (2, 10, 10))
         np.testing.assert_allclose(res["image.affine"], np.diag((1, 2, 1)))
 
-    def test_spacingd_1d(self):
-        data = {"image": np.arange(20).reshape((2, 10)), "image.original_affine": np.diag((3, 2, 1, 1))}
-        data["image.affine"] = data["image.original_affine"]
-        spacing = Spacingd(keys="image", pixdim=(0.2,))
-        res = spacing(data)
-        self.assertEqual(("image", "image.affine", "image.original_affine"), tuple(sorted(res)))
-        np.testing.assert_allclose(res["image"].shape, (2, 136))
-        np.testing.assert_allclose(res["image.affine"], np.diag((0.2, 2, 1, 1)))
-        np.testing.assert_allclose(res["image.original_affine"], np.diag((3, 2, 1, 1)))
-
     def test_interp_all(self):
         data = {
-            "image": np.arange(20).reshape((2, 10)),
-            "seg": np.ones((2, 10)),
+            "image": np.arange(20).reshape((2, 1, 10)),
+            "seg": np.ones((2, 1, 10)),
             "image.affine": np.eye(4),
             "seg.affine": np.eye(4),
         }
-        spacing = Spacingd(keys=("image", "seg"), interp_order=0, pixdim=(0.2,))
+        spacing = Spacingd(keys=("image", "seg"), interp_order="nearest", pixdim=(1, 0.2,))
         res = spacing(data)
         self.assertEqual(("image", "image.affine", "seg", "seg.affine"), tuple(sorted(res)))
-        np.testing.assert_allclose(res["image"].shape, (2, 46))
-        np.testing.assert_allclose(res["image.affine"], np.diag((0.2, 1, 1, 1)))
+        np.testing.assert_allclose(res["image"].shape, (2, 1, 46))
+        np.testing.assert_allclose(res["image.affine"], np.diag((1, 0.2, 1, 1)))
 
     def test_interp_sep(self):
-        data = {"image": np.ones((2, 10)), "seg": np.ones((2, 10)), "image.affine": np.eye(4), "seg.affine": np.eye(4)}
-        spacing = Spacingd(keys=("image", "seg"), interp_order=(2, 0), pixdim=(0.2,))
+        data = {
+            "image": np.ones((2, 1, 10)),
+            "seg": np.ones((2, 1, 10)),
+            "image.affine": np.eye(4),
+            "seg.affine": np.eye(4),
+        }
+        spacing = Spacingd(keys=("image", "seg"), interp_order=("bilinear", "nearest"), pixdim=(1, 0.2,))
         res = spacing(data)
         self.assertEqual(("image", "image.affine", "seg", "seg.affine"), tuple(sorted(res)))
-        np.testing.assert_allclose(res["image"].shape, (2, 46))
-        np.testing.assert_allclose(res["image.affine"], np.diag((0.2, 1, 1, 1)))
+        np.testing.assert_allclose(res["image"].shape, (2, 1, 46))
+        np.testing.assert_allclose(res["image.affine"], np.diag((1, 0.2, 1, 1)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Resolves #232 
- Partly addresses #189 for the affine cases. 
- Dense deformation field will be addressed in a separate PR.

### Description
this PR replaces the current scipy/scikit-image implementation of spatial affine transformations with a pytorch implementation. This will make the transforms differentiable.

#### sub-tasks:
- [x] implement `scipy.ndimage.affine_transform` in pytorch
- [ ] update `Spacing`, `Rotate`, `Zoom`, `Resize` to be differentiable  wrappers of the affine transform
- [ ] update `Affine` and `AffineGrid` to be differentiable wrappers of the affine transform

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
