### PR TITLE
update changelog v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to MONAI are documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2020-04-17
+### Added
+* Public alpha source code release under the Apache 2.0 license ([highlights])
+* Various tutorials and examples
+  - Medical image classification and segmentation workflows
+  - Spacing/orientation-aware preprocessing with CPU/GPU and caching
+  - Flexible workflows with PyTorch Ignite and Lightning
+* Various GitHub Actions
+  - CI/CD pipelines via self-hosted runners
+  - Documentation publishing via readthedocs.org
+  - PyPI package publishing
+* Contributing guidelines
+* A project logo and badges
+
+[highlights]: https://github.com/Project-MONAI/MONAI/blob/master/docs/source/highlights.md
+
+[Unreleased]: https://github.com/Project-MONAI/MONAI/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/Project-MONAI/MONAI/commits/0.1.0
+


### PR DESCRIPTION
adds a release note, based on https://keepachangelog.com/en/1.0.0/
the links will be available after we tag 0.1.0

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated
