### PR TITLE
update python_requires, testpypi filenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         set -e
 
         # build tar.gz and wheel
-        python setup.py sdist bdist_wheel
+        python setup.py sdist bdist_wheel --build-number $(date +'%Y%m%d%H%M')
         tmp_dir=$(mktemp -d)
         cp dist/monai* "$tmp_dir"
         cd "$tmp_dir"
@@ -57,15 +57,23 @@ jobs:
         rm -r "$tmp_dir"
 
     - if: matrix.python-version == '3.8' && startsWith(github.ref, 'refs/tags/')
+      name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist
+        path: dist/
+
+    - if: matrix.python-version == '3.8' && startsWith(github.ref, 'refs/tags/')
+      name: Check artifacts
+      run: |
+        ls -al dist/
+        rm dist/monai*.tar.gz
+        ls -al dist/
+
+    - if: matrix.python-version == '3.8' && startsWith(github.ref, 'refs/tags/')
       name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.TEST_PYPI }}
         repository_url: https://test.pypi.org/legacy/
 
-    - if: matrix.python-version == '3.8' && startsWith(github.ref, 'refs/tags/')
-      name: Upload artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: dist
-        path: dist/

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ platforms = OS Independent
 license = Apache License 2.0
 
 [options]
-python_requires = >= 3
+python_requires = >= 3.5
 install_requires =
     torch >=1.4
     pytorch-ignite ==0.3.0


### PR DESCRIPTION
- changed to require python  >=3.5 (to be consistent with the testing envs)
- adds testpypi build number to avoid duplicated files

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)

