### PR TITLE
Fix typo "paris" -> "pairs"

### DIFF
--- a/examples/notebooks/unet_segmentation_3d_ignite.ipynb
+++ b/examples/notebooks/unet_segmentation_3d_ignite.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create a temporary directory and 50 random image, mask paris\n",
+    "# Create a temporary directory and 50 random image, mask pairs\n",
     "tempdir = tempfile.mkdtemp()\n",
     "\n",
     "for i in range(50):\n",


### PR DESCRIPTION
Fixes # Typo

### Description
Corrects explanation of image and mask pairs

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Docstrings/Documentation updated
