### PR TITLE
update ci env to use torch1.5

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -39,6 +39,7 @@ jobs:
         which python
         python -m pip install --upgrade pip --no-cache-dir
         python -m pip uninstall -y torch torchvision
+        pip install torch==1.5.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
         python -m pip install -q -r requirements.txt --no-cache-dir
     - name: Run unit and integration tests
       run: |

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -18,6 +18,7 @@ jobs:
         which python
         python -m pip install --upgrade pip --no-cache-dir
         python -m pip uninstall -y torch torchvision
+        pip install torch==1.5.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
         python -m pip install --upgrade -q -r requirements.txt --no-cache-dir
         python -m pip list
     - name: Run unit tests report coverage


### PR DESCRIPTION
### Description
self hosted ci's cuda needs to be upgraded to 10.2, so that it works with pypi pytorch 1.5 (released 
 very recently). this PR is a workaround, uses `pip install torch==1.5.0+cu101` before we have cuda 10.2 test server.

full test works fine with this patch:
https://github.com/Project-MONAI/MONAI/runs/608949663

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] New tests added to cover the changes
