### PR TITLE
Performances improvements of ROCAUC

### DIFF
--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -65,8 +65,8 @@ class ROCAUC(Metric):
         if y.ndimension() not in (1, 2):
             raise ValueError("targets should be of shape (batch_size, n_classes) or (batch_size, ).")
 
-        y_pred = y_pred.to(dtype=torch.float32, device="cpu").clone()
-        y = y.to(dtype=torch.long, device="cpu").clone()
+        y_pred = y_pred.to(dtype=torch.float32).clone()
+        y = y.to(dtype=torch.long).clone()
 
         self._predictions.append(y_pred)
         self._targets.append(y)

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -55,8 +55,8 @@ class ROCAUC(Metric):
         self.average = average
 
     def reset(self):
-        self._predictions = torch.tensor([], dtype=torch.float32)
-        self._targets = torch.tensor([], dtype=torch.long)
+        self._predictions = []
+        self._targets = []
 
     def update(self, output: Sequence[torch.Tensor]):
         y_pred, y = output
@@ -65,12 +65,14 @@ class ROCAUC(Metric):
         if y.ndimension() not in (1, 2):
             raise ValueError("targets should be of shape (batch_size, n_classes) or (batch_size, ).")
 
-        y_pred = y_pred.to(self._predictions)
-        y = y.to(self._targets)
+        y_pred = y_pred.detach().to(dtype=torch.float32, device="cpu").clone()
+        y = y.to(dtype=torch.long, device="cpu").clone()
 
-        self._predictions = torch.cat([self._predictions, y_pred], dim=0)
-        self._targets = torch.cat([self._targets, y], dim=0)
+        self._predictions.append(y_pred)
+        self._targets.append(y)
 
     def compute(self):
-        return compute_roc_auc(self._predictions, self._targets, self.to_onehot_y,
+        _prediction_tensor = torch.cat(self._predictions, dim=0)
+        _target_tensor = torch.cat(self._targets, dim=0)
+        return compute_roc_auc(_prediction_tensor, _target_tensor, self.to_onehot_y,
                                self.add_softmax, self.average)

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -65,7 +65,7 @@ class ROCAUC(Metric):
         if y.ndimension() not in (1, 2):
             raise ValueError("targets should be of shape (batch_size, n_classes) or (batch_size, ).")
 
-        y_pred = y_pred.detach().to(dtype=torch.float32, device="cpu").clone()
+        y_pred = y_pred.to(dtype=torch.float32, device="cpu").clone()
         y = y.to(dtype=torch.long, device="cpu").clone()
 
         self._predictions.append(y_pred)

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -65,11 +65,8 @@ class ROCAUC(Metric):
         if y.ndimension() not in (1, 2):
             raise ValueError("targets should be of shape (batch_size, n_classes) or (batch_size, ).")
 
-        y_pred = y_pred.to(dtype=torch.float32).clone()
-        y = y.to(dtype=torch.long).clone()
-
-        self._predictions.append(y_pred)
-        self._targets.append(y)
+        self._predictions.append(y_pred.clone())
+        self._targets.append(y.clone())
 
     def compute(self):
         _prediction_tensor = torch.cat(self._predictions, dim=0)


### PR DESCRIPTION
### Description
Performances improvements of ROCAUC
- detach predictions to break graph building
- clone and store predictions and targets on cpu

Related to https://github.com/pytorch/ignite/pull/967

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated
