### PR TITLE
ENH: Add optional persistent on disk caching of pre-processing

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -22,6 +22,12 @@ Generic Interfaces
   :members:
   :special-members: __getitem__
 
+`PersistentDataset`
+~~~~~~~~~~~~~~~~~~~
+.. autoclass:: PersistentDataset
+  :members:
+  :special-members: __getitem__
+
 
 Patch-based dataset
 -------------------

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from .csv_saver import CSVSaver
-from .dataset import Dataset, CacheDataset
+from .dataset import Dataset, PersistentDataset, CacheDataset
 from .grid_dataset import GridPatchDataset
 from .nifti_reader import load_nifti, NiftiDataset
 from .nifti_saver import NiftiSaver

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -11,6 +11,10 @@
 
 import sys
 
+import hashlib
+import json
+from pathlib import Path
+
 import torch
 
 from multiprocessing.pool import ThreadPool
@@ -19,6 +23,7 @@ import threading
 from monai.transforms import Compose, Randomizable
 from monai.transforms.utils import apply_transform
 from monai.utils import process_bar
+from monai.utils.misc import ensure_tuple
 
 
 class Dataset(torch.utils.data.Dataset):
@@ -40,7 +45,10 @@ class Dataset(torch.utils.data.Dataset):
             transform (Callable, optional): transforms to execute operations on input data.
         """
         self.data = data
-        self.transform = transform
+        if isinstance(transform, Compose):
+            self.transform = transform
+        else:
+            self.transform = Compose(ensure_tuple(transform))
 
     def __len__(self):
         return len(self.data)
@@ -51,6 +59,135 @@ class Dataset(torch.utils.data.Dataset):
             data = self.transform(data)
 
         return data
+
+
+class PersistentDataset(Dataset):
+    """
+    Persistent storage of pre-computed values to efficiently manage larger than memory dictionary format data,
+    it can operate transforms for specific fields.  Results from the non-random transform components are computed
+    when first used, and stored in the `cache_dir` for rapid retrieval on subsequent uses.
+
+    For example, typical input data can be a list of dictionaries::
+
+        [{                            {                            {
+             'img': 'image1.nii.gz',      'img': 'image2.nii.gz',      'img': 'image3.nii.gz',
+             'seg': 'label1.nii.gz',      'seg': 'label2.nii.gz',      'seg': 'label3.nii.gz',
+             'extra': 123                 'extra': 456                 'extra': 789
+         },                           },                           }]
+
+    For a composite transform like 
+     [
+        LoadNiftid(keys=['image', 'label']),
+        Orientationd(keys=['image', 'label'], axcodes='RAS'),
+        ScaleIntensityRanged(keys=['image'], a_min=-57, a_max=164, b_min=0.0, b_max=1.0, clip=True),
+        RandCropByPosNegLabeld(keys=['image', 'label'], label_key='label', size=(96, 96, 96), pos=1,
+                           neg=1, num_samples=4, image_key='image', image_threshold=0),
+        ToTensord(keys=['image', 'label'])
+     ]
+
+     Upon first use a filename based dataset will be processed by the transform for the
+     [LoadNiftid, Orientationd, ScaleIntensityRanged] and the resulting tensor written to
+     the `cache_dir` before applying the remainging random dependant transforms
+     [RandCropByPosNegLabeld, ToTensord] elements for use in the analysis.
+
+     Subsequent uses of a dataset directly read pre-processed results from `cache_dir`
+     followed by applying the random dependant parts of transform processing.
+
+    """
+
+    def __init__(self, data, transform=None, cache_dir=None):
+        """
+        Args:
+            data (Iterable): input data to load and transform to generate dataset for model.
+            transform (Callable, optional): transforms to execute operations on input data.
+            cache_dir (Path or str or None): If specified, this is the location for persistent storage
+                of pre-computed transformed data tensors. The cache_dir is computed once, and
+                persists on disk until explicitly removed.  Different runs, programs, experiments
+                may share a common cache dir provided that the trasnsforms pre-processing is
+                consistent.
+        """
+        super().__init__(data=data, transform=transform)
+        self.cache_dir = Path(cache_dir) if cache_dir is not None else None
+
+    def _pre_first_random_transform(self, item_transformed):
+        """
+        Process the data from original state up to the first random element.
+
+        Args:
+            item_transformed: The data to be transformed
+        Returns:
+            the transformed element up to the first identified
+            random transform object
+        """
+        for _transform in self.transform.transforms:
+            # execute all the deterministic transforms before the first random transform
+            if isinstance(_transform, Randomizable):
+                break
+            item_transformed = apply_transform(_transform, item_transformed)
+        return item_transformed
+
+    def _first_random_and_beyond_transform(self, item_transformed):
+        """
+        Process the data from before the first random transform to the final state ready for evaluation.
+        Args:
+            item_transformed: The data to be transformed (already process upto the first random transform)
+        Returns:
+            the transformed element through the random transforms
+        """
+        start_post_randomize_run = False
+        for _transform in self.transform.transforms:
+            if start_post_randomize_run or isinstance(_transform, Randomizable):
+                start_post_randomize_run = True
+                item_transformed = apply_transform(_transform, item_transformed)
+        return item_transformed
+
+    def _pre_first_random_cachecheck(self, item_transformed):
+        """
+            A function to cache the expensive input data transform operations
+            so that huge data sets (larger than computer memory) can be processed
+            on the fly as needed, and intermediate results written to disk for
+            future use.
+        Args:
+            item_transformed: The current data element to be mutated into transformed representation
+
+        Returns:
+            The transformed data_element, either from cache, or explicitly computing it.
+
+        Warning:
+            The current implementation does not encode transform information as part of the
+            hashing mechanism used for generating cache names.  If the transforms applied are
+            changed in any way, the objects in the cache dir will be invalid.  The hash for the
+            cache is ONLY dependant on the input filename paths.
+        """
+        if item_transformed.get("cached", False) is False:
+            hashfile = None
+            if self.cache_dir is not None:
+                cache_dir_path: Path = Path(self.cache_dir)
+                if cache_dir_path.is_dir():
+                    # TODO: Find way to hash transforms content as part of the cache
+                    data_item_md5 = hashlib.md5(json.dumps(item_transformed, sort_keys=True).encode('utf-8')).hexdigest()
+                    hashfile: Path = Path(cache_dir_path) / f"{data_item_md5}.pt"
+
+            if hashfile is not None and hashfile.is_file():
+                item_transformed = torch.load(hashfile)
+            else:
+                item_transformed = self._pre_first_random_transform(item_transformed)
+                if hashfile is not None:
+                    # add sentinal flag to indicate that the transforms have already been computed.
+                    item_transformed["cache"] = True
+                    # NOTE: Writing to ".temp_write_cache" and then using a nearly atomic rename operation
+                    #       to make the cache more robust to manual killing of parent process
+                    #       which may leave partially written cache files in an incomplete state
+                    temp_hash_file: Path = hashfile.with_suffix(".temp_write_cache")
+                    torch.save(item_transformed, temp_hash_file)
+                    temp_hash_file.rename(hashfile)
+
+        return item_transformed
+
+    def __getitem__(self, index):
+        pre_random_item = self._pre_first_random_cachecheck(self.data[index])
+        post_random_item = self._first_random_and_beyond_transform(pre_random_item)
+        return post_random_item
 
 
 class CacheDataset(Dataset):

--- a/tests/test_persistentdataset.py
+++ b/tests/test_persistentdataset.py
@@ -11,16 +11,18 @@
 
 import unittest
 import os
+import shutil
 import numpy as np
 import tempfile
 import nibabel as nib
 from parameterized import parameterized
-from monai.data import Dataset
+from monai.data import PersistentDataset
 from monai.transforms import Compose, LoadNiftid, SimulateDelayd
 
 TEST_CASE_1 = [
     (128, 128, 128)
 ]
+
 
 class TestDataset(unittest.TestCase):
 
@@ -49,27 +51,29 @@ class TestDataset(unittest.TestCase):
         test_transform = Compose([LoadNiftid(keys=['image', 'label', 'extra']),
                                   SimulateDelayd(keys=['image', 'label', 'extra'],
                                                  delay_time=[1e-7, 1e-6, 1e-5])])
-        dataset = Dataset(data=test_data, transform=test_transform)
-        data1 = dataset[0]
-        data2 = dataset[1]
 
-        self.assertTupleEqual(data1['image'].shape, expected_shape)
-        self.assertTupleEqual(data1['label'].shape, expected_shape)
-        self.assertTupleEqual(data1['extra'].shape, expected_shape)
-        self.assertTupleEqual(data2['image'].shape, expected_shape)
-        self.assertTupleEqual(data2['label'].shape, expected_shape)
-        self.assertTupleEqual(data2['extra'].shape, expected_shape)
+        dataset_precached = PersistentDataset(data=test_data, transform=test_transform, cache_dir=tempdir)
+        data1_precached = dataset_precached[0]
+        data2_precached = dataset_precached[1]
 
-        dataset = Dataset(data=test_data, transform=LoadNiftid(keys=['image', 'label', 'extra']))
-        data1_simple = dataset[0]
-        data2_simple = dataset[1]
+        dataset_postcached = PersistentDataset(data=test_data, transform=test_transform, cache_dir=tempdir)
+        data1_postcached = dataset_postcached[0]
+        data2_postcached = dataset_postcached[1]
+        shutil.rmtree(tempdir)
 
-        self.assertTupleEqual(data1_simple['image'].shape, expected_shape)
-        self.assertTupleEqual(data1_simple['label'].shape, expected_shape)
-        self.assertTupleEqual(data1_simple['extra'].shape, expected_shape)
-        self.assertTupleEqual(data2_simple['image'].shape, expected_shape)
-        self.assertTupleEqual(data2_simple['label'].shape, expected_shape)
-        self.assertTupleEqual(data2_simple['extra'].shape, expected_shape)
+        self.assertTupleEqual(data1_precached['image'].shape, expected_shape)
+        self.assertTupleEqual(data1_precached['label'].shape, expected_shape)
+        self.assertTupleEqual(data1_precached['extra'].shape, expected_shape)
+        self.assertTupleEqual(data2_precached['image'].shape, expected_shape)
+        self.assertTupleEqual(data2_precached['label'].shape, expected_shape)
+        self.assertTupleEqual(data2_precached['extra'].shape, expected_shape)
+
+        self.assertTupleEqual(data1_postcached['image'].shape, expected_shape)
+        self.assertTupleEqual(data1_postcached['label'].shape, expected_shape)
+        self.assertTupleEqual(data1_postcached['extra'].shape, expected_shape)
+        self.assertTupleEqual(data2_postcached['image'].shape, expected_shape)
+        self.assertTupleEqual(data2_postcached['label'].shape, expected_shape)
+        self.assertTupleEqual(data2_postcached['extra'].shape, expected_shape)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allow time-consuming pre-processing steps to be pre-computed and
cached on disk for re-use in many future data experimentations runs.

This implementation allows caching to be optional and done on-the-fly
such that the persistent on-disk cache is created upon first use
of each data set.

Fixes #309

### Status
**Ready**

### Types of changes
- [X] New tests added to cover the changes
- [X] Docstrings/Documentation updated