### PR TITLE
318 add metadata to load_png

### DIFF
--- a/docs/source/highlights.md
+++ b/docs/source/highlights.md
@@ -81,7 +81,7 @@ non-deterministic modules in the user's program.
 For example:
 ```py
 # define a transform chain for pre-processing
-train_transforms = monai.transforms.compose.Compose([
+train_transforms = monai.transforms.Compose([
     LoadNiftid(keys=['image', 'label']),
     RandRotate90d(keys=['image', 'label'], prob=0.2, spatial_axes=[0, 2]),
     ... ...

--- a/examples/notebooks/mednist_tutorial.ipynb
+++ b/examples/notebooks/mednist_tutorial.ipynb
@@ -232,7 +232,7 @@
    "outputs": [],
    "source": [
     "train_transforms = Compose([\n",
-    "    LoadPNG(),\n",
+    "    LoadPNG(image_only=True),\n",
     "    AddChannel(),\n",
     "    ScaleIntensity(),\n",
     "    RandRotate(degrees=15, prob=0.5),\n",
@@ -243,7 +243,7 @@
     "])\n",
     "\n",
     "val_transforms = Compose([\n",
-    "    LoadPNG(),\n",
+    "    LoadPNG(image_only=True),\n",
     "    AddChannel(),\n",
     "    ScaleIntensity(),\n",
     "    ToTensor()\n",

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -16,7 +16,7 @@ import torch
 from multiprocessing.pool import ThreadPool
 import threading
 
-from monai.transforms.compose import Compose, Randomizable
+from monai.transforms import Compose, Randomizable
 from monai.transforms.utils import apply_transform
 from monai.utils import process_bar
 

--- a/monai/data/nifti_reader.py
+++ b/monai/data/nifti_reader.py
@@ -15,7 +15,7 @@ from torch.utils.data import Dataset
 from torch.utils.data._utils.collate import np_str_obj_array_pattern
 
 from monai.data.utils import correct_nifti_header_if_necessary
-from monai.transforms.compose import Randomizable
+from monai.transforms import Randomizable
 
 
 def load_nifti(filename_or_obj, as_closest_canonical=False, image_only=True, dtype=None):

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -37,7 +37,7 @@ class Transform(ABC):
 
     See Also
 
-        :py:class:`monai.transforms.compose.Compose`
+        :py:class:`monai.transforms.Compose`
     """
 
     @abstractmethod
@@ -198,7 +198,7 @@ class Compose(Randomizable):
 
 class MapTransform(Transform):
     """
-    A subclass of :py:class:`monai.transforms.compose.Transform` with an assumption
+    A subclass of :py:class:`monai.transforms.Transform` with an assumption
     that the ``data`` input of ``self.__call__`` is a MutableMapping such as ``dict``.
 
     The ``keys`` parameter will be used to get and set the actual data

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -24,7 +24,7 @@ from monai.utils.misc import ensure_tuple
 
 class SpatialPadd(MapTransform):
     """
-    dictionary-based wrapper of :py:class:`monai.transforms.compose.SpatialPad`.
+    dictionary-based wrapper of :py:class:`monai.transforms.SpatialPad`.
     Performs padding to the data, symmetric for all sides or all on one side for each dimension.
     """
 
@@ -52,7 +52,7 @@ class SpatialPadd(MapTransform):
 
 class SpatialCropd(MapTransform):
     """
-    dictionary-based wrapper of :py:class:`monai.transforms.compose.SpatialCrop`.
+    dictionary-based wrapper of :py:class:`monai.transforms.SpatialCrop`.
     Either a spatial center and size must be provided, or alternatively if center and size
     are not provided, the start and end coordinates of the ROI must be provided.
     """
@@ -79,7 +79,7 @@ class SpatialCropd(MapTransform):
 
 class CenterSpatialCropd(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.CenterSpatialCrop`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.CenterSpatialCrop`.
 
     Args:
         keys (hashable items): keys of the corresponding items to be transformed.
@@ -100,7 +100,7 @@ class CenterSpatialCropd(MapTransform):
 
 class RandSpatialCropd(Randomizable, MapTransform):
     """
-    Dictionary-based version :py:class:`monai.transforms.transfroms.RandSpatialCrop`.
+    Dictionary-based version :py:class:`monai.transforms.RandSpatialCrop`.
     Crop image with random size or specific size ROI. It can crop at a random position as
     center or at the image center. And allows to set the minimum size to limit the randomly
     generated ROI. Suppose all the expected fields specified by `keys` have same shape.

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -23,7 +23,7 @@ from monai.transforms.intensity.array import NormalizeIntensity, ScaleIntensityR
 
 
 class RandGaussianNoised(Randomizable, MapTransform):
-    """Dictionary-based version :py:class:`monai.transforms.transfroms.RandGaussianNoise`.
+    """Dictionary-based version :py:class:`monai.transforms.RandGaussianNoise`.
     Add Gaussian noise to image. This transform assumes all the expected fields have same shape.
 
     Args:
@@ -210,7 +210,7 @@ class NormalizeIntensityd(MapTransform):
 
 class ThresholdIntensityd(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.ThresholdIntensity`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.ThresholdIntensity`.
 
     Args:
         keys (hashable items): keys of the corresponding items to be transformed.
@@ -233,7 +233,7 @@ class ThresholdIntensityd(MapTransform):
 
 class ScaleIntensityRanged(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.ScaleIntensityRange`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.ScaleIntensityRange`.
 
     Args:
         keys (hashable items): keys of the corresponding items to be transformed.
@@ -258,7 +258,7 @@ class ScaleIntensityRanged(MapTransform):
 
 class AdjustContrastd(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.AdjustContrast`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.AdjustContrast`.
     Changes image intensity by gamma. Each pixel/voxel intensity is updated as:
 
         `x = ((x - min) / intensity_range) ^ gamma * intensity_range + min`
@@ -280,7 +280,7 @@ class AdjustContrastd(MapTransform):
 
 class RandAdjustContrastd(Randomizable, MapTransform):
     """
-    Dictionary-based version :py:class:`monai.transforms.transfroms.RandAdjustContrast`.
+    Dictionary-based version :py:class:`monai.transforms.RandAdjustContrast`.
     Randomly changes image intensity by gamma. Each pixel/voxel intensity is updated as:
 
         `x = ((x - min) / intensity_range) ^ gamma * intensity_range + min`

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -132,7 +132,7 @@ class Orientationd(MapTransform):
 
 class Rotate90d(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.Rotate90`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.Rotate90`.
     """
 
     def __init__(self, keys, k=1, spatial_axes=(0, 1)):
@@ -153,7 +153,7 @@ class Rotate90d(MapTransform):
 
 
 class RandRotate90d(Randomizable, MapTransform):
-    """Dictionary-based version :py:class:`monai.transforms.transfroms.RandRotate90`.
+    """Dictionary-based version :py:class:`monai.transforms.RandRotate90`.
     With probability `prob`, input arrays are rotated by 90 degrees
     in the plane specified by `spatial_axes`.
     """
@@ -197,7 +197,7 @@ class RandRotate90d(Randomizable, MapTransform):
 
 class Resized(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.Resize`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.Resize`.
 
     Args:
         keys (hashable items): keys of the corresponding items to be transformed.
@@ -440,7 +440,7 @@ class Rand3DElasticd(Randomizable, MapTransform):
 
 
 class Flipd(MapTransform):
-    """Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.Flip`.
+    """Dictionary-based wrapper of :py:class:`monai.transforms.Flip`.
 
     See `numpy.flip` for additional details.
     https://docs.scipy.org/doc/numpy/reference/generated/numpy.flip.html
@@ -462,7 +462,7 @@ class Flipd(MapTransform):
 
 
 class RandFlipd(Randomizable, MapTransform):
-    """Dictionary-based version :py:class:`monai.transforms.transfroms.RandFlip`.
+    """Dictionary-based version :py:class:`monai.transforms.RandFlip`.
 
     See `numpy.flip` for additional details.
     https://docs.scipy.org/doc/numpy/reference/generated/numpy.flip.html
@@ -494,7 +494,7 @@ class RandFlipd(Randomizable, MapTransform):
 
 
 class Rotated(MapTransform):
-    """Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.Rotate`.
+    """Dictionary-based wrapper of :py:class:`monai.transforms.Rotate`.
 
     Args:
         keys (dict): Keys to pick data for transformation.
@@ -525,7 +525,7 @@ class Rotated(MapTransform):
 
 
 class RandRotated(Randomizable, MapTransform):
-    """Dictionary-based version :py:class:`monai.transforms.transfroms.RandRotate`
+    """Dictionary-based version :py:class:`monai.transforms.RandRotate`
     Randomly rotates the input arrays.
 
     Args:
@@ -580,7 +580,7 @@ class RandRotated(Randomizable, MapTransform):
 
 
 class Zoomd(MapTransform):
-    """Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.Zoom`.
+    """Dictionary-based wrapper of :py:class:`monai.transforms.Zoom`.
 
     Args:
         zoom (float or sequence): The zoom factor along the spatial axes.
@@ -608,7 +608,7 @@ class Zoomd(MapTransform):
 
 
 class RandZoomd(Randomizable, MapTransform):
-    """Dict-based version :py:class:`monai.transforms.transfroms.RandZoom`.
+    """Dict-based version :py:class:`monai.transforms.RandZoom`.
 
     Args:
         keys (dict): Keys to pick data for transformation.

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -24,7 +24,7 @@ from monai.transforms.utility.array import AddChannel, AsChannelFirst, ToTensor,
 
 class AsChannelFirstd(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.AsChannelFirst`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.AsChannelFirst`.
     """
 
     def __init__(self, keys, channel_dim=-1):
@@ -46,7 +46,7 @@ class AsChannelFirstd(MapTransform):
 
 class AsChannelLastd(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.AsChannelLast`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.AsChannelLast`.
     """
 
     def __init__(self, keys, channel_dim=0):
@@ -68,7 +68,7 @@ class AsChannelLastd(MapTransform):
 
 class AddChanneld(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.AddChannel`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.AddChannel`.
     """
 
     def __init__(self, keys):
@@ -111,7 +111,7 @@ class RepeatChanneld(MapTransform):
 
 class CastToTyped(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.CastToType`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.CastToType`.
     """
 
     def __init__(self, keys, dtype=np.float32):
@@ -133,7 +133,7 @@ class CastToTyped(MapTransform):
 
 class ToTensord(MapTransform):
     """
-    Dictionary-based wrapper of :py:class:`monai.transforms.transfroms.ToTensor`.
+    Dictionary-based wrapper of :py:class:`monai.transforms.ToTensor`.
     """
 
     def __init__(self, keys):

--- a/tests/test_integration_classification_2d.py
+++ b/tests/test_integration_classification_2d.py
@@ -49,7 +49,7 @@ def run_training_test(root_dir, train_x, train_y, val_x, val_y, device=torch.dev
     monai.config.print_config()
     # define transforms for image and classification
     train_transforms = Compose([
-        LoadPNG(),
+        LoadPNG(image_only=True),
         AddChannel(),
         ScaleIntensity(),
         RandRotate(degrees=15, prob=0.5),
@@ -59,7 +59,7 @@ def run_training_test(root_dir, train_x, train_y, val_x, val_y, device=torch.dev
         ToTensor()
     ])
     train_transforms.set_random_state(1234)
-    val_transforms = Compose([LoadPNG(), AddChannel(), ScaleIntensity(), ToTensor()])
+    val_transforms = Compose([LoadPNG(image_only=True), AddChannel(), ScaleIntensity(), ToTensor()])
 
     # create train, val data loaders
     train_ds = MedNISTDataset(train_x, train_y, train_transforms)
@@ -129,7 +129,7 @@ def run_training_test(root_dir, train_x, train_y, val_x, val_y, device=torch.dev
 
 def run_inference_test(root_dir, test_x, test_y, device=torch.device("cuda:0")):
     # define transforms for image and classification
-    val_transforms = Compose([LoadPNG(), AddChannel(), ScaleIntensity(), ToTensor()])
+    val_transforms = Compose([LoadPNG(image_only=True), AddChannel(), ScaleIntensity(), ToTensor()])
     val_ds = MedNISTDataset(test_x, test_y, val_transforms)
     val_loader = DataLoader(val_ds, batch_size=300, num_workers=10)
 

--- a/tests/test_load_png.py
+++ b/tests/test_load_png.py
@@ -20,26 +20,29 @@ from monai.transforms import LoadPNG
 TEST_CASE_1 = [
     (128, 128),
     ['test_image.png'],
+    (128, 128),
     (128, 128)
 ]
 
 TEST_CASE_2 = [
     (128, 128, 3),
     ['test_image.png'],
-    (128, 128, 3)
+    (128, 128, 3),
+    (128, 128)
 ]
 
 TEST_CASE_3 = [
     (128, 128),
     ['test_image1.png', 'test_image2.png', 'test_image3.png'],
-    (3, 128, 128)
+    (3, 128, 128),
+    (128, 128)
 ]
 
 
 class TestLoadPNG(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
-    def test_shape(self, data_shape, filenames, expected_shape):
+    def test_shape(self, data_shape, filenames, expected_shape, meta_shape):
         test_image = np.random.randint(0, 256, size=data_shape)
         tempdir = tempfile.mkdtemp()
         with tempfile.TemporaryDirectory() as tempdir:
@@ -47,9 +50,8 @@ class TestLoadPNG(unittest.TestCase):
                 filenames[i] = os.path.join(tempdir, name)
                 Image.fromarray(test_image.astype('uint8')).save(filenames[i])
             result = LoadPNG()(filenames)
-        if isinstance(result, tuple):
-            result = result[0]
-        self.assertTupleEqual(result.shape, expected_shape)
+        self.assertTupleEqual(result[1]['spatial_shape'], meta_shape)
+        self.assertTupleEqual(result[0].shape, expected_shape)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Partly fix issue 318.

### Description
This PR added meta_data(filename and spatial_shape) to load_png transform.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
