### PR TITLE
Resolve tests.test_convolutions failure due to relative path resolution

### DIFF
--- a/tests/test_convolutions.py
+++ b/tests/test_convolutions.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .utils import TorchImageTestCase2D
+from tests.utils import TorchImageTestCase2D
 
 from monai.networks.blocks import Convolution, ResidualUnit
 


### PR DESCRIPTION
from .utils import TorchImageTestCase2D
ImportError: attempted relative import with no known parent package

### Description
Running test failed due to relative import resolution

### Status
Ready

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
