### PR TITLE
340-adds a code formatter workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,25 @@
+name: chatops
+
+# currently dispatches /black command to project-monai/monai-code-formatter
+on:
+  issue_comment:
+    types: [created, edited]
+jobs:
+  dispatch_command:
+    runs-on: ubuntu-latest
+    steps:
+      - name: dispatch
+        uses: peter-evans/slash-command-dispatch@v1.1.3
+        with:
+          token: ${{ secrets.PR_MAINTAIN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          reactions: false
+          config: >
+            [
+              {
+                "command": "black",
+                "permission": "none",
+                "issue_type": "pull-request",
+                "repository": "project-monai/monai-code-formatter"
+              }
+            ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,20 @@ License information: all source code files should start with this paragraph:
 
 ```
 
+### Automatic code formatting
+MONAI provides support of automatic Python code formatting via [a customised GitHub action](https://github.com/Project-MONAI/monai-code-formatter).
+This makes the project's Python coding style consistent and reduces maintenance burdens.
+Commenting a pull request with `/black` triggers the formatting action based on [`psf/Black`](https://github.com/psf/black) (this is implemented with [`slach command dispatch`](https://github.com/marketplace/actions/slash-command-dispatch)).
+
+
+Steps for the formatting process:
+- After submitting a pull request or push to an existing pull request,
+make a comment to the pull request to trigger the formatting action.
+The first line of the comment must be `/black` so that it will be interpreted by [the comment parser](https://github.com/marketplace/actions/slash-command-dispatch#how-are-comments-parsed-for-slash-commands).
+- [Auto] The GitHub action tries to format all Python files (using [`psf/Black`](https://github.com/psf/black)) in the branch and makes a commit under the name "MONAI bot" if there's code change (The actual formatting action is deployed at [project-monai/monai-code-formatter](https://github.com/Project-MONAI/monai-code-formatter).
+- [Auto] After the formatting commit, the GitHub action adds an emoji to the comment that triggered the process.
+- Repeat the above steps if necessary.
+
 ### Utility functions
 MONAI provides a set of generic utility functions and frequently used routines.
 These are located in [``monai/utils``](./monai/utils/) and in the module folders such as [``networks/utils.py``](./monai/networks/).


### PR DESCRIPTION
implement an automatic workflow for #340.

### Description
~adds an auto code formatting workflow ([new documentation here](https://github.com/Project-MONAI/MONAI/blob/38f4a50614bc855227f6b8874ff9c31e728ed27d/CONTRIBUTING.md#automatic-code-formatting)) using a [customised github action](https://github.com/Project-MONAI/monai-code-formatter)~

This is implemented with [slash command dispatch](https://github.com/marketplace/actions/slash-command-dispatch). It supports formatting the PRs from forks (given that the contributor uses the default setting: 'Allow edits and access to secrets by maintainers').

The formatter is triggered by commenting a pull request with `/black` (see demo https://github.com/wyli/testworkflow/pulls).
this will be available after merging the config into the master branch.



### Status
**READY**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated
