### PR TITLE
348 drop Python 3.5 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ platforms = OS Independent
 license = Apache License 2.0
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.6
 install_requires =
     torch >=1.4
     pytorch-ignite ==0.3.0


### PR DESCRIPTION
Fixes #348 .

### Description
This PR drops python 3.5 support from document and CI tests.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated
