### PR TITLE
STYLE: Prefer fstrings for python 3.6+

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,8 +56,8 @@ def generate_apidocs(*args):
     if hasattr(sys, "real_prefix"):  # called from a virtualenv
         apidoc_command_path = os.path.join(sys.prefix, "bin", "sphinx-apidoc")
         apidoc_command_path = os.path.abspath(apidoc_command_path)
-    print("output_path {}".format(output_path))
-    print("module_path {}".format(module_path))
+    print(f"output_path {output_path}")
+    print(f"module_path {module_path}")
     subprocess.check_call(
         [apidoc_command_path, "-f", "-e"]
         + ["-o", output_path]

--- a/examples/classification_3d/densenet_training_array.py
+++ b/examples/classification_3d/densenet_training_array.py
@@ -84,7 +84,7 @@ def main():
     writer = SummaryWriter()
     for epoch in range(5):
         print("-" * 10)
-        print("epoch {}/{}".format(epoch + 1, 5))
+        print(f"epoch {epoch + 1}/{5}")
         model.train()
         epoch_loss = 0
         step = 0
@@ -98,11 +98,11 @@ def main():
             optimizer.step()
             epoch_loss += loss.item()
             epoch_len = len(train_ds) // train_loader.batch_size
-            print("{}/{}, train_loss: {:.4f}".format(step, epoch_len, loss.item()))
+            print(f"{step}/{epoch_len}, train_loss: {loss.item():.4f}")
             writer.add_scalar("train_loss", loss.item(), epoch_len * epoch + step)
         epoch_loss /= step
         epoch_loss_values.append(epoch_loss)
-        print("epoch {} average loss: {:.4f}".format(epoch + 1, epoch_loss))
+        print(f"epoch {epoch + 1} average loss: {epoch_loss:.4f}")
 
         if (epoch + 1) % val_interval == 0:
             model.eval()
@@ -128,7 +128,7 @@ def main():
                     )
                 )
                 writer.add_scalar("val_accuracy", metric, epoch + 1)
-    print("train completed, best_metric: {:.4f} at epoch: {}".format(best_metric, best_metric_epoch))
+    print(f"train completed, best_metric: {best_metric:.4f} at epoch: {best_metric_epoch}")
     writer.close()
 
 

--- a/examples/classification_3d/densenet_training_dict.py
+++ b/examples/classification_3d/densenet_training_dict.py
@@ -101,7 +101,7 @@ def main():
     writer = SummaryWriter()
     for epoch in range(5):
         print("-" * 10)
-        print("epoch {}/{}".format(epoch + 1, 5))
+        print(f"epoch {epoch + 1}/{5}")
         model.train()
         epoch_loss = 0
         step = 0
@@ -115,10 +115,10 @@ def main():
             optimizer.step()
             epoch_loss += loss.item()
             epoch_len = len(train_ds) // train_loader.batch_size
-            print("{}/{}, train_loss: {:.4f}".format(step, epoch_len, loss.item()))
+            print(f"{step}/{epoch_len}, train_loss: {loss.item():.4f}")
             writer.add_scalar("train_loss", loss.item(), epoch_len * epoch + step)
         epoch_loss /= step
-        print("epoch {} average loss: {:.4f}".format(epoch + 1, epoch_loss))
+        print(f"epoch {epoch + 1} average loss: {epoch_loss:.4f}")
 
         if (epoch + 1) % val_interval == 0:
             model.eval()
@@ -144,7 +144,7 @@ def main():
                     )
                 )
                 writer.add_scalar("val_accuracy", acc_metric, epoch + 1)
-    print("train completed, best_metric: {:.4f} at epoch: {}".format(best_metric, best_metric_epoch))
+    print(f"train completed, best_metric: {best_metric:.4f} at epoch: {best_metric_epoch}")
     writer.close()
 
 

--- a/examples/segmentation_3d/unet_evaluation_array.py
+++ b/examples/segmentation_3d/unet_evaluation_array.py
@@ -32,15 +32,15 @@ def main():
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     tempdir = tempfile.mkdtemp()
-    print("generating synthetic data to {} (this may take a while)".format(tempdir))
+    print(f"generating synthetic data to {tempdir} (this may take a while)")
     for i in range(5):
         im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1)
 
         n = nib.Nifti1Image(im, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "im%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"im{i:d}.nii.gz"))
 
         n = nib.Nifti1Image(seg, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "seg%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"seg{i:d}.nii.gz"))
 
     images = sorted(glob(os.path.join(tempdir, "im*.nii.gz")))
     segs = sorted(glob(os.path.join(tempdir, "seg*.nii.gz")))

--- a/examples/segmentation_3d/unet_evaluation_dict.py
+++ b/examples/segmentation_3d/unet_evaluation_dict.py
@@ -32,15 +32,15 @@ def main():
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     tempdir = tempfile.mkdtemp()
-    print("generating synthetic data to {} (this may take a while)".format(tempdir))
+    print(f"generating synthetic data to {tempdir} (this may take a while)")
     for i in range(5):
         im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1, channel_dim=-1)
 
         n = nib.Nifti1Image(im, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "im%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"im{i:d}.nii.gz"))
 
         n = nib.Nifti1Image(seg, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "seg%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"seg{i:d}.nii.gz"))
 
     images = sorted(glob(os.path.join(tempdir, "im*.nii.gz")))
     segs = sorted(glob(os.path.join(tempdir, "seg*.nii.gz")))

--- a/examples/segmentation_3d/unet_training_array.py
+++ b/examples/segmentation_3d/unet_training_array.py
@@ -34,15 +34,15 @@ def main():
 
     # create a temporary directory and 40 random image, mask paris
     tempdir = tempfile.mkdtemp()
-    print("generating synthetic data to {} (this may take a while)".format(tempdir))
+    print(f"generating synthetic data to {tempdir} (this may take a while)")
     for i in range(40):
         im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1)
 
         n = nib.Nifti1Image(im, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "im%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"im{i:d}.nii.gz"))
 
         n = nib.Nifti1Image(seg, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "seg%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"seg{i:d}.nii.gz"))
 
     images = sorted(glob(os.path.join(tempdir, "im*.nii.gz")))
     segs = sorted(glob(os.path.join(tempdir, "seg*.nii.gz")))
@@ -103,7 +103,7 @@ def main():
     writer = SummaryWriter()
     for epoch in range(5):
         print("-" * 10)
-        print("epoch {}/{}".format(epoch + 1, 5))
+        print(f"epoch {epoch + 1}/{5}")
         model.train()
         epoch_loss = 0
         step = 0
@@ -117,11 +117,11 @@ def main():
             optimizer.step()
             epoch_loss += loss.item()
             epoch_len = len(train_ds) // train_loader.batch_size
-            print("{}/{}, train_loss: {:.4f}".format(step, epoch_len, loss.item()))
+            print(f"{step}/{epoch_len}, train_loss: {loss.item():.4f}")
             writer.add_scalar("train_loss", loss.item(), epoch_len * epoch + step)
         epoch_loss /= step
         epoch_loss_values.append(epoch_loss)
-        print("epoch {} average loss: {:.4f}".format(epoch + 1, epoch_loss))
+        print(f"epoch {epoch + 1} average loss: {epoch_loss:.4f}")
 
         if (epoch + 1) % val_interval == 0:
             model.eval()
@@ -159,7 +159,7 @@ def main():
                 plot_2d_or_3d_image(val_labels, epoch + 1, writer, index=0, tag="label")
                 plot_2d_or_3d_image(val_outputs, epoch + 1, writer, index=0, tag="output")
     shutil.rmtree(tempdir)
-    print("train completed, best_metric: {:.4f} at epoch: {}".format(best_metric, best_metric_epoch))
+    print(f"train completed, best_metric: {best_metric:.4f} at epoch: {best_metric_epoch}")
     writer.close()
 
 

--- a/examples/segmentation_3d/unet_training_dict.py
+++ b/examples/segmentation_3d/unet_training_dict.py
@@ -42,15 +42,15 @@ def main():
 
     # create a temporary directory and 40 random image, mask paris
     tempdir = tempfile.mkdtemp()
-    print("generating synthetic data to {} (this may take a while)".format(tempdir))
+    print(f"generating synthetic data to {tempdir} (this may take a while)")
     for i in range(40):
         im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1, channel_dim=-1)
 
         n = nib.Nifti1Image(im, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "img%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"img{i:d}.nii.gz"))
 
         n = nib.Nifti1Image(seg, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "seg%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"seg{i:d}.nii.gz"))
 
     images = sorted(glob(os.path.join(tempdir, "img*.nii.gz")))
     segs = sorted(glob(os.path.join(tempdir, "seg*.nii.gz")))
@@ -127,7 +127,7 @@ def main():
     writer = SummaryWriter()
     for epoch in range(5):
         print("-" * 10)
-        print("epoch {}/{}".format(epoch + 1, 5))
+        print(f"epoch {epoch + 1}/{5}")
         model.train()
         epoch_loss = 0
         step = 0
@@ -141,11 +141,11 @@ def main():
             optimizer.step()
             epoch_loss += loss.item()
             epoch_len = len(train_ds) // train_loader.batch_size
-            print("{}/{}, train_loss: {:.4f}".format(step, epoch_len, loss.item()))
+            print(f"{step}/{epoch_len}, train_loss: {loss.item():.4f}")
             writer.add_scalar("train_loss", loss.item(), epoch_len * epoch + step)
         epoch_loss /= step
         epoch_loss_values.append(epoch_loss)
-        print("epoch {} average loss: {:.4f}".format(epoch + 1, epoch_loss))
+        print(f"epoch {epoch + 1} average loss: {epoch_loss:.4f}")
 
         if (epoch + 1) % val_interval == 0:
             model.eval()
@@ -183,7 +183,7 @@ def main():
                 plot_2d_or_3d_image(val_labels, epoch + 1, writer, index=0, tag="label")
                 plot_2d_or_3d_image(val_outputs, epoch + 1, writer, index=0, tag="output")
     shutil.rmtree(tempdir)
-    print("train completed, best_metric: {:.4f} at epoch: {}".format(best_metric, best_metric_epoch))
+    print(f"train completed, best_metric: {best_metric:.4f} at epoch: {best_metric_epoch}")
     writer.close()
 
 

--- a/examples/segmentation_3d_ignite/unet_evaluation_array.py
+++ b/examples/segmentation_3d_ignite/unet_evaluation_array.py
@@ -34,15 +34,15 @@ def main():
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     tempdir = tempfile.mkdtemp()
-    print("generating synthetic data to {} (this may take a while)".format(tempdir))
+    print(f"generating synthetic data to {tempdir} (this may take a while)")
     for i in range(5):
         im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1)
 
         n = nib.Nifti1Image(im, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "im%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"im{i:d}.nii.gz"))
 
         n = nib.Nifti1Image(seg, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "seg%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"seg{i:d}.nii.gz"))
 
     images = sorted(glob(os.path.join(tempdir, "im*.nii.gz")))
     segs = sorted(glob(os.path.join(tempdir, "seg*.nii.gz")))

--- a/examples/segmentation_3d_ignite/unet_evaluation_dict.py
+++ b/examples/segmentation_3d_ignite/unet_evaluation_dict.py
@@ -34,15 +34,15 @@ def main():
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     tempdir = tempfile.mkdtemp()
-    print("generating synthetic data to {} (this may take a while)".format(tempdir))
+    print(f"generating synthetic data to {tempdir} (this may take a while)")
     for i in range(5):
         im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1, channel_dim=-1)
 
         n = nib.Nifti1Image(im, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "im%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"im{i:d}.nii.gz"))
 
         n = nib.Nifti1Image(seg, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "seg%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"seg{i:d}.nii.gz"))
 
     images = sorted(glob(os.path.join(tempdir, "im*.nii.gz")))
     segs = sorted(glob(os.path.join(tempdir, "seg*.nii.gz")))

--- a/examples/segmentation_3d_ignite/unet_training_array.py
+++ b/examples/segmentation_3d_ignite/unet_training_array.py
@@ -41,15 +41,15 @@ def main():
 
     # create a temporary directory and 40 random image, mask paris
     tempdir = tempfile.mkdtemp()
-    print("generating synthetic data to {} (this may take a while)".format(tempdir))
+    print(f"generating synthetic data to {tempdir} (this may take a while)")
     for i in range(40):
         im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1)
 
         n = nib.Nifti1Image(im, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "im%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"im{i:d}.nii.gz"))
 
         n = nib.Nifti1Image(seg, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "seg%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"seg{i:d}.nii.gz"))
 
     images = sorted(glob(os.path.join(tempdir, "im*.nii.gz")))
     segs = sorted(glob(os.path.join(tempdir, "seg*.nii.gz")))

--- a/examples/segmentation_3d_ignite/unet_training_dict.py
+++ b/examples/segmentation_3d_ignite/unet_training_dict.py
@@ -49,15 +49,15 @@ def main():
 
     # create a temporary directory and 40 random image, mask paris
     tempdir = tempfile.mkdtemp()
-    print("generating synthetic data to {} (this may take a while)".format(tempdir))
+    print(f"generating synthetic data to {tempdir} (this may take a while)")
     for i in range(40):
         im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1, channel_dim=-1)
 
         n = nib.Nifti1Image(im, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "img%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"img{i:d}.nii.gz"))
 
         n = nib.Nifti1Image(seg, np.eye(4))
-        nib.save(n, os.path.join(tempdir, "seg%i.nii.gz" % i))
+        nib.save(n, os.path.join(tempdir, f"seg{i:d}.nii.gz"))
 
     images = sorted(glob(os.path.join(tempdir, "img*.nii.gz")))
     segs = sorted(glob(os.path.join(tempdir, "seg*.nii.gz")))

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -46,8 +46,8 @@ def print_config(file=sys.stdout):
     Print the package versions to `file`.
     Defaults to `sys.stdout`.
     """
-    for kv in get_config_values().items():
-        print("%s: %s" % kv, file=file, flush=True)
+    for k, v in get_config_values().items():
+        print(f"{k}: {v}", file=file, flush=True)
 
 
 def set_visible_devices(*dev_inds):

--- a/monai/data/nifti_saver.py
+++ b/monai/data/nifti_saver.py
@@ -92,7 +92,7 @@ class NiftiSaver:
         if torch.is_tensor(data):
             data = data.detach().cpu().numpy()
         filename = create_file_basename(self.output_postfix, filename, self.output_dir)
-        filename = "{}{}".format(filename, self.output_ext)
+        filename = f"{filename}{self.output_ext}"
         # change data to "channel last" format and write to nifti format file
         data = np.moveaxis(data, 0, -1)
         write_nifti(

--- a/monai/data/png_saver.py
+++ b/monai/data/png_saver.py
@@ -86,7 +86,7 @@ class PNGSaver:
             data = data.detach().cpu().numpy()
 
         filename = create_file_basename(self.output_postfix, filename, self.output_dir)
-        filename = "{}{}".format(filename, self.output_ext)
+        filename = f"{filename}{self.output_ext}"
 
         if data.shape[0] == 1:
             data = data.squeeze(0)

--- a/monai/data/sliding_window_inference.py
+++ b/monai/data/sliding_window_inference.py
@@ -31,7 +31,7 @@ def sliding_window_inference(inputs, roi_size, sw_batch_size, predictor):
         execute on 1 image/per inference, run a batch of window slices of 1 input image.
     """
     num_spatial_dims = len(inputs.shape) - 2
-    assert len(roi_size) == num_spatial_dims, "roi_size {} does not match input dims.".format(roi_size)
+    assert len(roi_size) == num_spatial_dims, f"roi_size {roi_size} does not match input dims."
 
     # determine image spatial size and batch size
     # Note: all input images must have the same image size and batch size

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -248,7 +248,7 @@ def rectify_header_sform_qform(img_nii):
             return img_nii
 
     norm = np.sqrt(np.sum(np.square(img_nii.affine[:d, :d]), 0))
-    warnings.warn("Modifying image pixdim from {} to {}".format(pixdim, norm))
+    warnings.warn(f"Modifying image pixdim from {pixdim} to {norm}")
 
     img_nii.header.set_zooms(norm)
     return img_nii

--- a/monai/engine/multi_gpu_supervised_trainer.py
+++ b/monai/engine/multi_gpu_supervised_trainer.py
@@ -28,7 +28,7 @@ def get_devices_spec(devices=None):
         list of torch.device: list of devices.
     """
     if devices is None:
-        devices = [torch.device("cuda:%i" % d) for d in range(torch.cuda.device_count())]
+        devices = [torch.device(f"cuda:{d:d}") for d in range(torch.cuda.device_count())]
 
         if len(devices) == 0:
             raise ValueError("No GPU devices available")

--- a/monai/handlers/checkpoint_loader.py
+++ b/monai/handlers/checkpoint_loader.py
@@ -40,4 +40,4 @@ class CheckpointLoader:
     def __call__(self, engine):
         checkpoint = torch.load(self.load_path)
         Checkpoint.load_objects(to_load=self.load_dict, checkpoint=checkpoint)
-        print("Restored all variables from {}".format(self.load_path))
+        print(f"Restored all variables from {self.load_path}")

--- a/monai/handlers/stats_handler.py
+++ b/monai/handlers/stats_handler.py
@@ -121,7 +121,7 @@ class StatsHandler(object):
             e (Exception): the exception caught in Ignite during engine.run().
 
         """
-        self.logger.exception("Exception: {}".format(e))
+        self.logger.exception(f"Exception: {e}")
         # import traceback
         # traceback.print_exc()
 
@@ -138,7 +138,7 @@ class StatsHandler(object):
             return
         current_epoch = self.global_epoch_transform(engine.state.epoch)
 
-        out_str = "Epoch[{}] Metrics -- ".format(current_epoch)
+        out_str = f"Epoch[{current_epoch}] Metrics -- "
         for name in sorted(prints_dict):
             value = prints_dict[name]
             out_str += self.key_var_format.format(name, value)
@@ -190,6 +190,6 @@ class StatsHandler(object):
         current_epoch = engine.state.epoch
         num_epochs = engine.state.max_epochs
 
-        base_str = "Epoch: {}/{}, Iter: {}/{} --".format(current_epoch, num_epochs, current_iteration, num_iterations)
+        base_str = f"Epoch: {current_epoch}/{num_epochs}, Iter: {current_iteration}/{num_iterations} --"
 
         self.logger.info(" ".join([base_str, out_str]))

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -144,7 +144,7 @@ class GeneralizedDiceLoss(_Loss):
         elif w_type == "square":
             self.w_func = lambda x: torch.reciprocal(x * x)
         else:
-            raise ValueError("unknown option for `w_type`: {}".format(w_type))
+            raise ValueError(f"unknown option for `w_type`: {w_type}")
 
     def forward(self, pred, ground, smooth=1e-5):
         """

--- a/monai/networks/blocks/convolutions.py
+++ b/monai/networks/blocks/convolutions.py
@@ -122,7 +122,7 @@ class ResidualUnit(nn.Module):
                 conv_only,
             )
 
-            self.conv.add_module("unit%i" % su, unit)
+            self.conv.add_module(f"unit{su:d}", unit)
 
             # after first loop set channels and strides to what they should be for subsequent units
             schannels = out_channels

--- a/monai/networks/nets/highresnet.py
+++ b/monai/networks/nets/highresnet.py
@@ -84,7 +84,7 @@ class HighResBlock(nn.Module):
         self.project, self.pad = None, None
         if in_channels != out_channels:
             if channel_matching not in ("pad", "project"):
-                raise ValueError("channel matching must be pad or project, got {}.".format(channel_matching))
+                raise ValueError(f"channel matching must be pad or project, got {channel_matching}.")
             if channel_matching == "project":
                 self.project = conv_type(in_channels, out_channels, kernel_size=1)
             if channel_matching == "pad":

--- a/monai/transforms/adaptors.py
+++ b/monai/transforms/adaptors.py
@@ -104,11 +104,11 @@ def adaptor(function, outputs, inputs=None):
     def must_be_types_or_none(variable_name, variable, types):
         if variable is not None:
             if not isinstance(variable, types):
-                raise ValueError("'{}' must be None or {} but is {}".format(variable_name, types, type(variable)))
+                raise ValueError(f"'{variable_name}' must be None or {types} but is {type(variable)}")
 
     def must_be_types(variable_name, variable, types):
         if not isinstance(variable, types):
-            raise ValueError("'{}' must be one of {} but is {}".format(variable_name, types, type(variable)))
+            raise ValueError(f"'{variable_name}' must be one of {types} but is {type(variable)}")
 
     def map_names(ditems, input_map):
         return {input_map(k, k): v for k, v in ditems.items()}

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -84,7 +84,7 @@ class Randomizable(ABC):
 
         if state is not None:
             if not isinstance(state, np.random.RandomState):
-                raise ValueError("`state` must be a `np.random.RandomState`, got {}".format(type(state)))
+                raise ValueError(f"`state` must be a `np.random.RandomState`, got {type(state)}")
             self.R = state
             return self
 
@@ -183,9 +183,9 @@ class Compose(Randomizable):
             try:
                 _transform.randomize()
             except TypeError as type_error:
+                tfm_name: str = type(_transform).__name__
                 warnings.warn(
-                    'Transform "{0}" in Compose not randomized\n{0}.{1}.'.format(type(_transform).__name__, type_error),
-                    RuntimeWarning,
+                    f'Transform "{tfm_name}" in Compose not randomized\n{tfm_name}.{type_error}.', RuntimeWarning,
                 )
 
     def __call__(self, input_):
@@ -221,7 +221,7 @@ class MapTransform(Transform):
             raise ValueError("keys unspecified")
         for key in self.keys:
             if not isinstance(key, Hashable):
-                raise ValueError("keys should be a hashable or a sequence of hashables, got {}".format(type(key)))
+                raise ValueError(f"keys should be a hashable or a sequence of hashables, got {type(key)}")
 
     @abstractmethod
     def __call__(self, data):

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -60,7 +60,7 @@ class LoadNiftid(MapTransform):
             for k in sorted(data[1]):
                 key_to_add = self.meta_key_format.format(key, k)
                 if key_to_add in d and not self.overwriting_keys:
-                    raise KeyError("meta data key {} already exists.".format(key_to_add))
+                    raise KeyError(f"meta data key {key_to_add} already exists.")
                 d[key_to_add] = data[1][k]
         return d
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -89,7 +89,7 @@ class Spacing(Transform):
         if out_d.size < sr:
             out_d = np.append(out_d, [1.0] * (out_d.size - sr))
         if np.any(out_d <= 0):
-            raise ValueError("pixdim must be positive, got {}".format(out_d))
+            raise ValueError(f"pixdim must be positive, got {out_d}")
         # compute output affine, shape and offset
         new_affine = zoom_affine(affine_, out_d, diagonal=self.diagonal)
         output_shape, offset = compute_shape_offset(data_array.shape[1:], affine_, new_affine)
@@ -168,8 +168,8 @@ class Orientation(Transform):
             dst = nib.orientations.axcodes2ornt(self.axcodes[:sr], labels=self.labels)
             if len(dst) < sr:
                 raise ValueError(
-                    "`self.axcodes` should have at least {0} elements"
-                    ' given the data array is in spatial {0}D, got "{1}"'.format(sr, self.axcodes)
+                    f"`self.axcodes` should have at least {sr} elements"
+                    f' given the data array is in spatial {sr}D, got "{self.axcodes}"'
                 )
             spatial_ornt = nib.orientations.ornt_transform(src, dst)
         ornt = spatial_ornt.copy()

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -311,7 +311,7 @@ def create_rotate(spatial_dims, radians):
             )
         return affine
 
-    raise ValueError("create_rotate got spatial_dims={}, radians={}.".format(spatial_dims, radians))
+    raise ValueError(f"create_rotate got spatial_dims={spatial_dims}, radians={radians}.")
 
 
 def create_shear(spatial_dims, coefs):
@@ -388,7 +388,7 @@ def generate_spatial_bounding_box(img, select_fn=lambda x: x > 0, channel_indexe
     box_start = list()
     box_end = list()
     for i in range(data.ndim):
-        assert len(nonzero_idx[i]) > 0, "did not find nonzero index at spatial dim {}".format(i)
+        assert len(nonzero_idx[i]) > 0, f"did not find nonzero index at spatial dim {i}"
         box_start.append(max(0, np.min(nonzero_idx[i]) - margin))
         box_end.append(min(data.shape[i], np.max(nonzero_idx[i]) + margin + 1))
     return box_start, box_end

--- a/monai/utils/aliases.py
+++ b/monai/utils/aliases.py
@@ -62,10 +62,10 @@ def resolve_name(name):
             mod = importlib.import_module(modname)
             obj = getattr(mod, declname, None)
         except ModuleNotFoundError:
-            raise ValueError("Module %r not found" % modname)
+            raise ValueError(f"Module {modname!r} not found")
 
         if obj is None:
-            raise ValueError("Module %r does not have member %r" % (modname, declname))
+            raise ValueError(f"Module {modname!r} does not have member {declname!r}")
 
     # attempt to resolve a simple name
     if obj is None:
@@ -92,6 +92,6 @@ def resolve_name(name):
             obj = getattr(mods[0], name)
 
         if obj is None:
-            raise ValueError("No module with member %r found" % name)
+            raise ValueError(f"No module with member {name!r} found")
 
     return obj

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -75,6 +75,6 @@ def process_bar(index, count, bar_len=30, newline=False):
     end = "\r" if newline is False else "\r\n"
     filled_len = int(bar_len * index // count)
     bar = "[" + "=" * filled_len + " " * (bar_len - filled_len) + "]"
-    print("{}/{} {:s}  ".format(index, count, bar), end=end)
+    print(f"{index}/{count} {bar:s}  ", end=end)
     if index == count:
         print("")

--- a/monai/visualize/img2tensorboard.py
+++ b/monai/visualize/img2tensorboard.py
@@ -150,23 +150,23 @@ def plot_2d_or_3d_image(data, step, writer, index=0, max_channels=1, max_frames=
     if d.ndim == 2:
         d = rescale_array(d, 0, 1)
         dataformats = "HW"
-        writer.add_image("{}_{}".format(tag, dataformats), d, step, dataformats=dataformats)
+        writer.add_image(f"{tag}_{dataformats}", d, step, dataformats=dataformats)
         return
 
     if d.ndim == 3:
         if d.shape[0] == 3 and max_channels == 3:  # RGB
             dataformats = "CHW"
-            writer.add_image("{}_{}".format(tag, dataformats), d, step, dataformats=dataformats)
+            writer.add_image(f"{tag}_{dataformats}", d, step, dataformats=dataformats)
             return
         for j, d2 in enumerate(d[:max_channels]):
             d2 = rescale_array(d2, 0, 1)
             dataformats = "HW"
-            writer.add_image("{}_{}_{}".format(tag, dataformats, j), d2, step, dataformats=dataformats)
+            writer.add_image(f"{tag}_{dataformats}_{j}", d2, step, dataformats=dataformats)
             return
 
     if d.ndim >= 4:
         spatial = d.shape[-3:]
         for j, d3 in enumerate(d.reshape([-1] + list(spatial))[:max_channels]):
             d3 = rescale_array(d3, 0, 255)
-            add_animated_gif(writer, "{}_HWD_{}".format(tag, j), d3[None], max_frames, 1.0, step)
+            add_animated_gif(writer, f"{tag}_HWD_{j}", d3[None], max_frames, 1.0, step)
         return

--- a/tests/test_handler_stats.py
+++ b/tests/test_handler_stats.py
@@ -47,8 +47,8 @@ class TestHandlerStats(unittest.TestCase):
 
         # check logging output
         output_str = log_stream.getvalue()
-        grep = re.compile(".*{}.*".format(key_to_handler))
-        has_key_word = re.compile(".*{}.*".format(key_to_print))
+        grep = re.compile(f".*{key_to_handler}.*")
+        has_key_word = re.compile(f".*{key_to_print}.*")
         for idx, line in enumerate(output_str.split("\n")):
             if grep.match(line):
                 if idx in [5, 10]:
@@ -74,8 +74,8 @@ class TestHandlerStats(unittest.TestCase):
 
         # check logging output
         output_str = log_stream.getvalue()
-        grep = re.compile(".*{}.*".format(key_to_handler))
-        has_key_word = re.compile(".*{}.*".format(key_to_print))
+        grep = re.compile(f".*{key_to_handler}.*")
+        has_key_word = re.compile(f".*{key_to_print}.*")
         for idx, line in enumerate(output_str.split("\n")):
             if grep.match(line):
                 if idx in [1, 2, 3, 6, 7, 8]:
@@ -101,8 +101,8 @@ class TestHandlerStats(unittest.TestCase):
 
         # check logging output
         output_str = log_stream.getvalue()
-        grep = re.compile(".*{}.*".format(key_to_handler))
-        has_key_word = re.compile(".*{}.*".format(key_to_print))
+        grep = re.compile(f".*{key_to_handler}.*")
+        has_key_word = re.compile(f".*{key_to_print}.*")
         for idx, line in enumerate(output_str.split("\n")):
             if grep.match(line):
                 if idx in [1, 2, 3, 6, 7, 8]:

--- a/tests/test_integration_classification_2d.py
+++ b/tests/test_integration_classification_2d.py
@@ -92,7 +92,7 @@ def run_training_test(root_dir, train_x, train_y, val_x, val_y, device=torch.dev
     model_filename = os.path.join(root_dir, "best_metric_model.pth")
     for epoch in range(epoch_num):
         print("-" * 10)
-        print("Epoch {}/{}".format(epoch + 1, epoch_num))
+        print(f"Epoch {epoch + 1}/{epoch_num}")
         model.train()
         epoch_loss = 0
         step = 0
@@ -107,7 +107,7 @@ def run_training_test(root_dir, train_x, train_y, val_x, val_y, device=torch.dev
             epoch_loss += loss.item()
         epoch_loss /= step
         epoch_loss_values.append(epoch_loss)
-        print("epoch %d average loss:%0.4f" % (epoch + 1, epoch_loss))
+        print(f"epoch {epoch + 1} average loss:{epoch_loss:0.4f}")
 
         if (epoch + 1) % val_interval == 0:
             model.eval()
@@ -128,10 +128,10 @@ def run_training_test(root_dir, train_x, train_y, val_x, val_y, device=torch.dev
                     torch.save(model.state_dict(), model_filename)
                     print("saved new best metric model")
                 print(
-                    "current epoch %d current AUC: %0.4f current accuracy: %0.4f best AUC: %0.4f at epoch %d"
-                    % (epoch + 1, auc_metric, acc_metric, best_metric, best_metric_epoch)
+                    f"current epoch {epoch +1} current AUC: {auc_metric:0.4f} "
+                    f"current accuracy: {acc_metric:0.4f} best AUC: {best_metric:0.4f} at epoch {best_metric_epoch}"
                 )
-    print("train completed, best_metric: %0.4f  at epoch: %d" % (best_metric, best_metric_epoch))
+    print(f"train completed, best_metric: {best_metric:0.4f}  at epoch: {best_metric_epoch}")
     return epoch_loss_values, best_metric, best_metric_epoch
 
 

--- a/tests/test_integration_determinism.py
+++ b/tests/test_integration_determinism.py
@@ -76,7 +76,7 @@ class TestDeterminism(unittest.TestCase):
 
     def test_training(self):
         loss, step = run_test(device=self.device)
-        print("Deterministic loss {} at training step {}".format(loss, step))
+        print(f"Deterministic loss {loss} at training step {step}")
         np.testing.assert_allclose(step, 4)
         np.testing.assert_allclose(loss, 0.5346279, rtol=1e-6)
 

--- a/tests/test_integration_segmentation_3d.py
+++ b/tests/test_integration_segmentation_3d.py
@@ -110,7 +110,7 @@ def run_training_test(root_dir, device=torch.device("cuda:0"), cachedataset=Fals
     model_filename = os.path.join(root_dir, "best_metric_model.pth")
     for epoch in range(6):
         print("-" * 10)
-        print("Epoch {}/{}".format(epoch + 1, 6))
+        print(f"Epoch {epoch + 1}/{6}")
         model.train()
         epoch_loss = 0
         step = 0
@@ -124,11 +124,11 @@ def run_training_test(root_dir, device=torch.device("cuda:0"), cachedataset=Fals
             optimizer.step()
             epoch_loss += loss.item()
             epoch_len = len(train_ds) // train_loader.batch_size
-            print("%d/%d, train_loss:%0.4f" % (step, epoch_len, loss.item()))
+            print(f"{step}/{epoch_len}, train_loss:{loss.item():0.4f}")
             writer.add_scalar("train_loss", loss.item(), epoch_len * epoch + step)
         epoch_loss /= step
         epoch_loss_values.append(epoch_loss)
-        print("epoch %d average loss:%0.4f" % (epoch + 1, epoch_loss))
+        print(f"epoch {epoch +1} average loss:{epoch_loss:0.4f}")
 
         if (epoch + 1) % val_interval == 0:
             model.eval()
@@ -155,15 +155,15 @@ def run_training_test(root_dir, device=torch.device("cuda:0"), cachedataset=Fals
                     torch.save(model.state_dict(), model_filename)
                     print("saved new best metric model")
                 print(
-                    "current epoch %d current mean dice: %0.4f best mean dice: %0.4f at epoch %d"
-                    % (epoch + 1, metric, best_metric, best_metric_epoch)
+                    f"current epoch {epoch +1} current mean dice: {metric:0.4f} "
+                    f"best mean dice: {best_metric:0.4f} at epoch {best_metric_epoch}"
                 )
                 writer.add_scalar("val_mean_dice", metric, epoch + 1)
                 # plot the last model output as GIF image in TensorBoard with the corresponding image and label
                 plot_2d_or_3d_image(val_images, epoch + 1, writer, index=0, tag="image")
                 plot_2d_or_3d_image(val_labels, epoch + 1, writer, index=0, tag="label")
                 plot_2d_or_3d_image(val_outputs, epoch + 1, writer, index=0, tag="output")
-    print("train completed, best_metric: %0.4f  at epoch: %d" % (best_metric, best_metric_epoch))
+    print(f"train completed, best_metric: {best_metric:0.4f}  at epoch: {best_metric_epoch}")
     writer.close()
     return epoch_loss_values, best_metric, best_metric_epoch
 
@@ -233,9 +233,9 @@ class IntegrationSegmentation3D(unittest.TestCase):
         for i in range(40):
             im, seg = create_test_image_3d(128, 128, 128, num_seg_classes=1, channel_dim=-1)
             n = nib.Nifti1Image(im, np.eye(4))
-            nib.save(n, os.path.join(self.data_dir, "img%i.nii.gz" % i))
+            nib.save(n, os.path.join(self.data_dir, f"img{i:d}.nii.gz"))
             n = nib.Nifti1Image(seg, np.eye(4))
-            nib.save(n, os.path.join(self.data_dir, "seg%i.nii.gz" % i))
+            nib.save(n, os.path.join(self.data_dir, f"seg{i:d}.nii.gz"))
 
         np.random.seed(seed=None)
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu:0")

--- a/tests/test_integration_sliding_window.py
+++ b/tests/test_integration_sliding_window.py
@@ -53,7 +53,7 @@ def run_test(batch_size, img_name, seg_name, output_dir, device=torch.device("cu
     infer_engine.run(loader)
 
     basename = os.path.basename(img_name)[: -len(".nii.gz")]
-    saved_name = os.path.join(output_dir, basename, "{}_seg.nii.gz".format(basename))
+    saved_name = os.path.join(output_dir, basename, f"{basename}_seg.nii.gz")
     return saved_name
 
 


### PR DESCRIPTION
Fixes #358

### Description

The primary benefit is readability:

Comparing percent and .format call formatting vs f-string:
 - with f-string, you don’t have to order multiple inputs
   in your head to see what output will look like
 - Extra parenthesis, and binary operation or function call
   can become last drop to make a complicated piece just too
   much to parse. Not that f-string did any magic, but it
   lacks an extra set of parenthesis.
 - It also uses 6 chars less than percent formatting and
   10 chars less than the format call.

```bash
pip install flynt
flint

Running flynt v.0.46.1
Execution time:                            1.270s
Files modified:                            36
Character count reduction:                 775 (0.08%)

Per expression type:
Old style (`%`) expressions attempted:     94/102 (92.2%)
`.format(...)` calls attempted:            69/70 (98.6%)
No `.format(...)` calls attempted.
F-string expressions created:              146
Out of all attempted transforms, 9 resulted in errors.
To find out specific error messages, use --verbose flag.
```
### Status
**Ready**

### Types of changes
- [X] Style