### PR TITLE
286 change spacing default mode

### DIFF
--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -173,7 +173,7 @@ class CropForegroundd(MapTransform):
     def __call__(self, data):
         d = dict(data)
         box_start, box_end = generate_spatial_bounding_box(
-            data[self.source_key], self.select_fn, self.channel_indexes, self.margin
+            d[self.source_key], self.select_fn, self.channel_indexes, self.margin
         )
         cropper = SpatialCrop(roi_start=box_start, roi_end=box_end)
         for key in self.keys:

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -39,7 +39,7 @@ class Spacing(Transform):
     Resample input image into the specified `pixdim`.
     """
 
-    def __init__(self, pixdim, diagonal=False, mode="constant", cval=0, dtype=None):
+    def __init__(self, pixdim, diagonal=False, mode="nearest", cval=0, dtype=None):
         """
         Args:
             pixdim (sequence of floats): output voxel spacing.

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -50,7 +50,7 @@ class Spacingd(MapTransform):
     """
 
     def __init__(
-        self, keys, pixdim, diagonal=False, mode="constant", cval=0, interp_order=3, dtype=None, meta_key_format="{}.{}"
+        self, keys, pixdim, diagonal=False, mode="nearest", cval=0, interp_order=3, dtype=None, meta_key_format="{}.{}"
     ):
         """
         Args:
@@ -69,7 +69,7 @@ class Spacingd(MapTransform):
                 axes against the original ones.
             mode (`reflect|constant|nearest|mirror|wrap`):
                 The mode parameter determines how the input array is extended beyond its boundaries.
-                Default is 'constant'.
+                Default is 'nearest'.
             cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
             interp_order (int or sequence of ints): int: the same interpolation order
                 for all data indexed by `self.keys`; sequence of ints, should

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -17,108 +17,129 @@ from parameterized import parameterized
 from monai.transforms import Spacing
 
 TEST_CASES = [
+    [{"pixdim": (2.0,), "mode": "constant"}, np.ones((1, 2)), {"affine": np.eye(4)}, np.array([[1.0, 0.0]])],  # data
     [
-        {'pixdim': (2.0,), 'mode': 'constant'},
-        np.ones((1, 2)),  # data
-        {'affine': np.eye(4)},
-        np.array([[1., 0.]])
-    ],
-    [
-        {'pixdim': (1.0, 0.2, 1.5), 'mode': 'constant'},
+        {"pixdim": (1.0, 0.2, 1.5), "mode": "constant"},
         np.ones((1, 2, 1, 2)),  # data
-        {'affine': np.eye(4)},
-        np.array([[[[1., 0.]], [[1., 0.]]]])
+        {"affine": np.eye(4)},
+        np.array([[[[1.0, 0.0]], [[1.0, 0.0]]]]),
     ],
     [
-        {'pixdim': (1.0, 0.2, 1.5), 'diagonal': False, 'mode': 'constant'},
+        {"pixdim": (1.0, 0.2, 1.5), "diagonal": False, "mode": "constant"},
         np.ones((1, 2, 1, 2)),  # data
-        {
-            'affine': np.array([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2., 5], [0, 0, 0, 1]],),
-        },
-        np.zeros((1, 3, 1, 2))
+        {"affine": np.array([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2.0, 5], [0, 0, 0, 1]],),},
+        np.zeros((1, 3, 1, 2)),
     ],
     [
-        {'pixdim': (3.0, 1.0), 'mode': 'constant'},
+        {"pixdim": (3.0, 1.0), "mode": "constant"},
         np.arange(24).reshape((2, 3, 4)),  # data
-        {'affine': np.diag([-3.0, 0.2, 1.5, 1])},
-        np.array([[[0, 0], [4, 0], [8, 0]], [[12, 0], [16, 0], [20, 0]]])
+        {"affine": np.diag([-3.0, 0.2, 1.5, 1])},
+        np.array([[[0, 0], [4, 0], [8, 0]], [[12, 0], [16, 0], [20, 0]]]),
     ],
     [
-        {'pixdim': (3.0, 1.0), 'mode': 'constant'},
+        {"pixdim": (3.0, 1.0), "mode": "constant"},
         np.arange(24).reshape((2, 3, 4)),  # data
         {},
-        np.array([[[0, 1, 2, 3], [0, 0, 0, 0]], [[12, 13, 14, 15], [0, 0, 0, 0]]])
+        np.array([[[0, 1, 2, 3], [0, 0, 0, 0]], [[12, 13, 14, 15], [0, 0, 0, 0]]]),
     ],
     [
-        {'pixdim': (1.0, 1.0), 'mode': 'constant'},
+        {"pixdim": (1.0, 1.0), "mode": "constant"},
         np.arange(24).reshape((2, 3, 4)),  # data
         {},
-        np.array([[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]])
-    ],
-    [
-        {'pixdim': (4.0, 5.0, 6.0), 'mode': 'constant'},
-        np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {'affine': np.array([[-4, 0, 0, 4], [0, 5, 0, -5], [0, 0, 6, -6], [0, 0, 0, 1]])},
-        np.arange(24).reshape((1, 2, 3, 4)),  # data
-    ],
-    [
-        {'pixdim': (4.0, 5.0, 6.0), 'diagonal': True, 'mode': 'constant'},
-        np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {'affine': np.array([[-4, 0, 0, 4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
-        np.array([[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]],
-                   [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]])
-    ],
-    [
-        {'pixdim': (4.0, 5.0, 6.0), 'mode': 'nearest', 'diagonal': True},
-        np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {'affine': np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
-        np.array([[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]],
-                   [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]])
-    ],
-    [
-        {'pixdim': (4.0, 5.0, 6.0), 'mode': 'nearest', 'diagonal': True},
-        np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {'affine': np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), 'interp_order': 0},
-        np.array([[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]],
-                   [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]])
-    ],
-    [
-        {'pixdim': (2.0, 5.0, 6.0), 'mode': 'constant', 'diagonal': True},
-        np.arange(24).reshape((1, 4, 6)),  # data
-        {'affine': np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), 'interp_order': 0},
-        np.array([[[18, 19, 20, 21, 22, 23], [18, 19, 20, 21, 22, 23], [12, 13, 14, 15, 16, 17],
-                   [12, 13, 14, 15, 16, 17], [6, 7, 8, 9, 10, 11], [6, 7, 8, 9, 10, 11], [0, 1, 2, 3, 4, 5]]])
-    ],
-    [
-        {'pixdim': (5., 3., 6.), 'mode': 'constant', 'diagonal': True, 'dtype': np.float32},
-        np.arange(24).reshape((1, 4, 6)),  # data
-        {'affine': np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), 'interp_order': 0},
-        np.array([[[18., 19., 19., 20., 20., 21., 22., 22., 23], [12., 13., 13., 14., 14., 15., 16., 16., 17.],
-                   [6., 7., 7., 8., 8., 9., 10., 10., 11.]]],)
-    ],
-    [
-        {'pixdim': (5., 3., 6.), 'mode': 'constant', 'diagonal': True, 'dtype': np.float32},
-        np.arange(24).reshape((1, 4, 6)),  # data
-        {'affine': np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), 'interp_order': 2},
         np.array(
-            [[[18., 18.492683, 19.22439, 19.80683, 20.398048, 21., 21.570732, 22.243902, 22.943415],
-              [10.392858, 10.88554, 11.617248, 12.199686, 12.790906, 13.392858, 13.963589, 14.63676, 15.336272],
-              [2.142857, 2.63554, 3.3672473, 3.9496865, 4.540906, 5.142857, 5.7135887, 6.3867598, 7.086272]]],)
+            [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]
+        ),
+    ],
+    [
+        {"pixdim": (4.0, 5.0, 6.0), "mode": "constant"},
+        np.arange(24).reshape((1, 2, 3, 4)),  # data
+        {"affine": np.array([[-4, 0, 0, 4], [0, 5, 0, -5], [0, 0, 6, -6], [0, 0, 0, 1]])},
+        np.arange(24).reshape((1, 2, 3, 4)),  # data
+    ],
+    [
+        {"pixdim": (4.0, 5.0, 6.0), "diagonal": True, "mode": "constant"},
+        np.arange(24).reshape((1, 2, 3, 4)),  # data
+        {"affine": np.array([[-4, 0, 0, 4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
+        np.array(
+            [[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]], [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]]
+        ),
+    ],
+    [
+        {"pixdim": (4.0, 5.0, 6.0), "mode": "nearest", "diagonal": True},
+        np.arange(24).reshape((1, 2, 3, 4)),  # data
+        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
+        np.array(
+            [[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]], [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]]
+        ),
+    ],
+    [
+        {"pixdim": (4.0, 5.0, 6.0), "mode": "nearest", "diagonal": True},
+        np.arange(24).reshape((1, 2, 3, 4)),  # data
+        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
+        np.array(
+            [[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]], [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]]
+        ),
+    ],
+    [
+        {"pixdim": (2.0, 5.0, 6.0), "mode": "constant", "diagonal": True},
+        np.arange(24).reshape((1, 4, 6)),  # data
+        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
+        np.array(
+            [
+                [
+                    [18, 19, 20, 21, 22, 23],
+                    [18, 19, 20, 21, 22, 23],
+                    [12, 13, 14, 15, 16, 17],
+                    [12, 13, 14, 15, 16, 17],
+                    [6, 7, 8, 9, 10, 11],
+                    [6, 7, 8, 9, 10, 11],
+                    [0, 1, 2, 3, 4, 5],
+                ]
+            ]
+        ),
+    ],
+    [
+        {"pixdim": (5.0, 3.0, 6.0), "mode": "constant", "diagonal": True, "dtype": np.float32},
+        np.arange(24).reshape((1, 4, 6)),  # data
+        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
+        np.array(
+            [
+                [
+                    [18.0, 19.0, 19.0, 20.0, 20.0, 21.0, 22.0, 22.0, 23],
+                    [12.0, 13.0, 13.0, 14.0, 14.0, 15.0, 16.0, 16.0, 17.0],
+                    [6.0, 7.0, 7.0, 8.0, 8.0, 9.0, 10.0, 10.0, 11.0],
+                ]
+            ],
+        ),
+    ],
+    [
+        {"pixdim": (5.0, 3.0, 6.0), "mode": "constant", "diagonal": True, "dtype": np.float32},
+        np.arange(24).reshape((1, 4, 6)),  # data
+        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 2},
+        np.array(
+            [
+                [
+                    [18.0, 18.492683, 19.22439, 19.80683, 20.398048, 21.0, 21.570732, 22.243902, 22.943415],
+                    [10.392858, 10.88554, 11.617248, 12.199686, 12.790906, 13.392858, 13.963589, 14.63676, 15.336272],
+                    [2.142857, 2.63554, 3.3672473, 3.9496865, 4.540906, 5.142857, 5.7135887, 6.3867598, 7.086272],
+                ]
+            ],
+        ),
     ],
 ]
 
 
 class TestSpacingCase(unittest.TestCase):
-
     @parameterized.expand(TEST_CASES)
     def test_spacing(self, init_param, img, data_param, expected_output):
         res = Spacing(**init_param)(img, **data_param)
         np.testing.assert_allclose(res[0], expected_output, atol=1e-6)
-        if 'original_affine' in data_param:
-            np.testing.assert_allclose(res[1], data_param['original_affine'])
-        np.testing.assert_allclose(init_param['pixdim'],
-                                   np.sqrt(np.sum(np.square(res[2]), axis=0))[:len(init_param['pixdim'])])
+        if "original_affine" in data_param:
+            np.testing.assert_allclose(res[1], data_param["original_affine"])
+        np.testing.assert_allclose(
+            init_param["pixdim"], np.sqrt(np.sum(np.square(res[2]), axis=0))[: len(init_param["pixdim"])]
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -27,7 +27,7 @@ TEST_CASES = [
     [
         {"pixdim": (1.0, 0.2, 1.5), "diagonal": False, "mode": "constant"},
         np.ones((1, 2, 1, 2)),  # data
-        {"affine": np.array([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2.0, 5], [0, 0, 0, 1]],),},
+        {"affine": np.array([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2.0, 5], [0, 0, 0, 1]])},
         np.zeros((1, 3, 1, 2)),
     ],
     [

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -17,129 +17,108 @@ from parameterized import parameterized
 from monai.transforms import Spacing
 
 TEST_CASES = [
-    [{"pixdim": (2.0,)}, np.ones((1, 2)), {"affine": np.eye(4)}, np.array([[1.0, 0.0]])],  # data
     [
-        {"pixdim": (1.0, 0.2, 1.5)},
-        np.ones((1, 2, 1, 2)),  # data
-        {"affine": np.eye(4)},
-        np.array([[[[1.0, 0.0]], [[1.0, 0.0]]]]),
+        {'pixdim': (2.0,), 'mode': 'constant'},
+        np.ones((1, 2)),  # data
+        {'affine': np.eye(4)},
+        np.array([[1., 0.]])
     ],
     [
-        {"pixdim": (1.0, 0.2, 1.5), "diagonal": False},
+        {'pixdim': (1.0, 0.2, 1.5), 'mode': 'constant'},
         np.ones((1, 2, 1, 2)),  # data
-        {"affine": np.array([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2.0, 5], [0, 0, 0, 1]])},
-        np.zeros((1, 3, 1, 2)),
+        {'affine': np.eye(4)},
+        np.array([[[[1., 0.]], [[1., 0.]]]])
     ],
     [
-        {"pixdim": (3.0, 1.0)},
+        {'pixdim': (1.0, 0.2, 1.5), 'diagonal': False, 'mode': 'constant'},
+        np.ones((1, 2, 1, 2)),  # data
+        {
+            'affine': np.array([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2., 5], [0, 0, 0, 1]],),
+        },
+        np.zeros((1, 3, 1, 2))
+    ],
+    [
+        {'pixdim': (3.0, 1.0), 'mode': 'constant'},
         np.arange(24).reshape((2, 3, 4)),  # data
-        {"affine": np.diag([-3.0, 0.2, 1.5, 1])},
-        np.array([[[0, 0], [4, 0], [8, 0]], [[12, 0], [16, 0], [20, 0]]]),
+        {'affine': np.diag([-3.0, 0.2, 1.5, 1])},
+        np.array([[[0, 0], [4, 0], [8, 0]], [[12, 0], [16, 0], [20, 0]]])
     ],
     [
-        {"pixdim": (3.0, 1.0)},
+        {'pixdim': (3.0, 1.0), 'mode': 'constant'},
         np.arange(24).reshape((2, 3, 4)),  # data
         {},
-        np.array([[[0, 1, 2, 3], [0, 0, 0, 0]], [[12, 13, 14, 15], [0, 0, 0, 0]]]),
+        np.array([[[0, 1, 2, 3], [0, 0, 0, 0]], [[12, 13, 14, 15], [0, 0, 0, 0]]])
     ],
     [
-        {"pixdim": (1.0, 1.0)},
+        {'pixdim': (1.0, 1.0), 'mode': 'constant'},
         np.arange(24).reshape((2, 3, 4)),  # data
         {},
-        np.array(
-            [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]
-        ),
+        np.array([[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]])
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0)},
+        {'pixdim': (4.0, 5.0, 6.0), 'mode': 'constant'},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {"affine": np.array([[-4, 0, 0, 4], [0, 5, 0, -5], [0, 0, 6, -6], [0, 0, 0, 1]])},
+        {'affine': np.array([[-4, 0, 0, 4], [0, 5, 0, -5], [0, 0, 6, -6], [0, 0, 0, 1]])},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0), "diagonal": True},
+        {'pixdim': (4.0, 5.0, 6.0), 'diagonal': True, 'mode': 'constant'},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {"affine": np.array([[-4, 0, 0, 4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
-        np.array(
-            [[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]], [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]]
-        ),
+        {'affine': np.array([[-4, 0, 0, 4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
+        np.array([[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]],
+                   [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]])
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0), "mode": "nearest", "diagonal": True},
+        {'pixdim': (4.0, 5.0, 6.0), 'mode': 'nearest', 'diagonal': True},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
-        np.array(
-            [[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]], [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]]
-        ),
+        {'affine': np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
+        np.array([[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]],
+                   [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]])
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0), "mode": "nearest", "diagonal": True},
+        {'pixdim': (4.0, 5.0, 6.0), 'mode': 'nearest', 'diagonal': True},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
-        np.array(
-            [[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]], [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]]
-        ),
+        {'affine': np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), 'interp_order': 0},
+        np.array([[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]],
+                   [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]])
     ],
     [
-        {"pixdim": (2.0, 5.0, 6.0), "mode": "constant", "diagonal": True},
+        {'pixdim': (2.0, 5.0, 6.0), 'mode': 'constant', 'diagonal': True},
         np.arange(24).reshape((1, 4, 6)),  # data
-        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
-        np.array(
-            [
-                [
-                    [18, 19, 20, 21, 22, 23],
-                    [18, 19, 20, 21, 22, 23],
-                    [12, 13, 14, 15, 16, 17],
-                    [12, 13, 14, 15, 16, 17],
-                    [6, 7, 8, 9, 10, 11],
-                    [6, 7, 8, 9, 10, 11],
-                    [0, 1, 2, 3, 4, 5],
-                ]
-            ]
-        ),
+        {'affine': np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), 'interp_order': 0},
+        np.array([[[18, 19, 20, 21, 22, 23], [18, 19, 20, 21, 22, 23], [12, 13, 14, 15, 16, 17],
+                   [12, 13, 14, 15, 16, 17], [6, 7, 8, 9, 10, 11], [6, 7, 8, 9, 10, 11], [0, 1, 2, 3, 4, 5]]])
     ],
     [
-        {"pixdim": (5.0, 3.0, 6.0), "mode": "constant", "diagonal": True, "dtype": np.float32},
+        {'pixdim': (5., 3., 6.), 'mode': 'constant', 'diagonal': True, 'dtype': np.float32},
         np.arange(24).reshape((1, 4, 6)),  # data
-        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
-        np.array(
-            [
-                [
-                    [18.0, 19.0, 19.0, 20.0, 20.0, 21.0, 22.0, 22.0, 23],
-                    [12.0, 13.0, 13.0, 14.0, 14.0, 15.0, 16.0, 16.0, 17.0],
-                    [6.0, 7.0, 7.0, 8.0, 8.0, 9.0, 10.0, 10.0, 11.0],
-                ]
-            ],
-        ),
+        {'affine': np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), 'interp_order': 0},
+        np.array([[[18., 19., 19., 20., 20., 21., 22., 22., 23], [12., 13., 13., 14., 14., 15., 16., 16., 17.],
+                   [6., 7., 7., 8., 8., 9., 10., 10., 11.]]],)
     ],
     [
-        {"pixdim": (5.0, 3.0, 6.0), "mode": "constant", "diagonal": True, "dtype": np.float32},
+        {'pixdim': (5., 3., 6.), 'mode': 'constant', 'diagonal': True, 'dtype': np.float32},
         np.arange(24).reshape((1, 4, 6)),  # data
-        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 2},
+        {'affine': np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), 'interp_order': 2},
         np.array(
-            [
-                [
-                    [18.0, 18.492683, 19.22439, 19.80683, 20.398048, 21.0, 21.570732, 22.243902, 22.943415],
-                    [10.392858, 10.88554, 11.617248, 12.199686, 12.790906, 13.392858, 13.963589, 14.63676, 15.336272],
-                    [2.142857, 2.63554, 3.3672473, 3.9496865, 4.540906, 5.142857, 5.7135887, 6.3867598, 7.086272],
-                ]
-            ],
-        ),
+            [[[18., 18.492683, 19.22439, 19.80683, 20.398048, 21., 21.570732, 22.243902, 22.943415],
+              [10.392858, 10.88554, 11.617248, 12.199686, 12.790906, 13.392858, 13.963589, 14.63676, 15.336272],
+              [2.142857, 2.63554, 3.3672473, 3.9496865, 4.540906, 5.142857, 5.7135887, 6.3867598, 7.086272]]],)
     ],
 ]
 
 
 class TestSpacingCase(unittest.TestCase):
+
     @parameterized.expand(TEST_CASES)
     def test_spacing(self, init_param, img, data_param, expected_output):
         res = Spacing(**init_param)(img, **data_param)
         np.testing.assert_allclose(res[0], expected_output, atol=1e-6)
-        if "original_affine" in data_param:
-            np.testing.assert_allclose(res[1], data_param["original_affine"])
-        np.testing.assert_allclose(
-            init_param["pixdim"], np.sqrt(np.sum(np.square(res[2]), axis=0))[: len(init_param["pixdim"])]
-        )
+        if 'original_affine' in data_param:
+            np.testing.assert_allclose(res[1], data_param['original_affine'])
+        np.testing.assert_allclose(init_param['pixdim'],
+                                   np.sqrt(np.sum(np.square(res[2]), axis=0))[:len(init_param['pixdim'])])
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #286 .

### Description
This PR changes the default mode of spacing transform as "nearest" is more suitable.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [x] Docstrings/Documentation updated
