### PR TITLE
367 add resample control to PNGSaver

### DIFF
--- a/monai/data/png_saver.py
+++ b/monai/data/png_saver.py
@@ -28,6 +28,7 @@ class PNGSaver:
         output_dir="./",
         output_postfix="seg",
         output_ext=".png",
+        resample=True,
         interp_order=3,
         mode="constant",
         cval=0,
@@ -38,6 +39,7 @@ class PNGSaver:
             output_dir (str): output image directory.
             output_postfix (str): a string appended to all output file names.
             output_ext (str): output file extension name.
+            resample (bool): whether to resample and resize if providing spatial_shape in the metadata.
             interp_order (int): the order of the spline interpolation, default is 3. 
                 This option is used when spatial_shape is specified and different from the data shape.
                 The order has to be in the range 0 - 5.
@@ -52,6 +54,7 @@ class PNGSaver:
         self.output_dir = output_dir
         self.output_postfix = output_postfix
         self.output_ext = output_ext
+        self.resample = resample
         self.interp_order = interp_order
         self.mode = mode
         self.cval = cval
@@ -80,7 +83,7 @@ class PNGSaver:
         """
         filename = meta_data["filename_or_obj"] if meta_data else str(self._data_index)
         self._data_index += 1
-        spatial_shape = meta_data.get("spatial_shape", None) if meta_data else None
+        spatial_shape = meta_data.get("spatial_shape", None) if meta_data and self.resample else None
 
         if torch.is_tensor(data):
             data = data.detach().cpu().numpy()

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -40,17 +40,19 @@ class SegmentationSaver:
             output_postfix (str): a string appended to all output file names.
             output_ext (str): output file extension name.
             resample (bool): whether to resample before saving the data array.
-                it's used for NIfTI format only.
             interp_order (int): the order of the spline interpolation, default is 0.
                 The order has to be in the range 0 - 5.
                 https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.affine_transform.html
+                this option is used when `resample = True`.
             mode (`reflect|constant|nearest|mirror|wrap`):
                 The mode parameter determines how the input array is extended beyond its boundaries.
+                this option is used when `resample = True`.
             cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
+                this option is used when `resample = True`.
             scale (bool): whether to scale data with 255 and convert to uint8 for data in range [0, 1].
                 it's used for PNG format only.
             dtype (np.dtype, optional): convert the image data to save to this data type.
-                If None, keep the original type of data.
+                If None, keep the original type of data. it's used for Nifti format only.
             batch_transform (Callable): a callable that is used to transform the
                 ignite.engine.batch into expected format to extract the meta_data dictionary.
             output_transform (Callable): a callable that is used to transform the
@@ -63,7 +65,7 @@ class SegmentationSaver:
         if output_ext in (".nii.gz", ".nii"):
             self.saver = NiftiSaver(output_dir, output_postfix, output_ext, resample, interp_order, mode, cval, dtype)
         elif output_ext == ".png":
-            self.saver = PNGSaver(output_dir, output_postfix, output_ext, interp_order, mode, cval, scale)
+            self.saver = PNGSaver(output_dir, output_postfix, output_ext, resample, interp_order, mode, cval, scale)
         self.batch_transform = batch_transform
         self.output_transform = output_transform
 


### PR DESCRIPTION
Fixes # .

### Description
This PR implemented `resample` control to PNGSaver, then users can disable resample in `SegmentationSaver` and other output saving program. Same behavior as NiftiSaver.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [x] Docstrings/Documentation updated
