### PR TITLE
Minor fix to bug in RandAffined described in #375

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -795,7 +795,7 @@ class Resample(Transform):
         """
         if not torch.is_tensor(img):
             img = torch.as_tensor(np.ascontiguousarray(img))
-        grid = torch.as_tensor(np.ascontiguousarray(grid)) if not torch.is_tensor(grid) else grid.detach().clone()
+        grid = torch.tensor(np.ascontiguousarray(grid)) if not torch.is_tensor(grid) else grid.detach().clone()
         if self.device:
             img = img.to(self.device)
             grid = grid.to(self.device)


### PR DESCRIPTION
Fixes #375  .

### Description
If Resample is called with grid which is not a torch.Tensor, this fix changes the torch.Tensor constructor so that a copy of the grid is changed, not the original data.

### Status
**Ready**

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
