### PR TITLE
328 377 flexible interp_order, padding options

### DIFF
--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -35,8 +35,7 @@ class SpatialPad(Transform):
     """
 
     def __init__(self, spatial_size, method="symmetric", mode="constant"):
-        assert isinstance(spatial_size, (list, tuple)), "spatial_out_size must be list or tuple."
-        self.spatial_size = spatial_size
+        self.spatial_size = ensure_tuple(spatial_size)
         assert method in ("symmetric", "end"), "unsupported padding type."
         self.method = method
         assert isinstance(mode, str), "mode must be str."
@@ -52,10 +51,10 @@ class SpatialPad(Transform):
         else:
             return [(0, max(self.spatial_size[i] - data_shape[i], 0)) for i in range(len(self.spatial_size))]
 
-    def __call__(self, img):
+    def __call__(self, img, mode=None):
         data_pad_width = self._determine_data_pad_width(img.shape[1:])
         all_pad_width = [(0, 0)] + data_pad_width
-        img = np.pad(img, all_pad_width, self.mode)
+        img = np.pad(img, all_pad_width, mode=mode or self.mode)
         return img
 
 

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -42,7 +42,7 @@ class SpatialPadd(MapTransform):
         """
         super().__init__(keys)
         self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.padder = SpatialPad(spatial_size, method, self.mode[0])
+        self.padder = SpatialPad(spatial_size, method)
 
     def __call__(self, data):
         d = dict(data)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -884,23 +884,23 @@ class Affine(Transform):
             as_tensor_output=True,
             device=device,
         )
-        self.resampler = Resample(padding_mode=padding_mode, as_tensor_output=as_tensor_output, device=device)
+        self.resampler = Resample(as_tensor_output=as_tensor_output, device=device)
         self.spatial_size = spatial_size
+        self.padding_mode = padding_mode
         self.mode = mode
 
-    def __call__(self, img, spatial_size=None, mode=None):
+    def __call__(self, img, spatial_size=None, padding_mode=None, mode=None):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W[, D]),
             spatial_size (list or tuple of int): output image spatial size.
                 if `img` has two spatial dimensions, `spatial_size` should have 2 elements [h, w].
                 if `img` has three spatial dimensions, `spatial_size` should have 3 elements [h, w, d].
+            padding_mode ('zeros'|'border'|'reflection'): mode of handling out of range indices. Defaults to 'zeros'.
             mode ('nearest'|'bilinear'): interpolation order. Defaults to 'bilinear'.
         """
-        spatial_size = spatial_size or self.spatial_size
-        mode = mode or self.mode
-        grid = self.affine_grid(spatial_size=spatial_size)
-        return self.resampler(img=img, grid=grid, mode=mode)
+        grid = self.affine_grid(spatial_size=spatial_size or self.spatial_size)
+        return self.resampler(img=img, grid=grid, padding_mode=padding_mode or self.padding_mode, mode=mode or self.mode)
 
 
 class RandAffine(Randomizable, Transform):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -507,11 +507,19 @@ class RandRotate(Randomizable, Transform):
         self._do_transform = self.R.random_sample() < self.prob
         self.angle = self.R.uniform(low=self.degrees[0], high=self.degrees[1])
 
-    def __call__(self, img):
+    def __call__(self, img, order=None, mode=None, cval=None, prefilter=None):
         self.randomize()
         if not self._do_transform:
             return img
-        rotator = Rotate(self.angle, self.spatial_axes, self.reshape, self.order, self.mode, self.cval, self.prefilter)
+        rotator = Rotate(
+            angle=self.angle,
+            spatial_axes=self.spatial_axes,
+            reshape=self.reshape,
+            order=self.order if order is None else order,
+            mode=self.mode if mode is None else mode,
+            cval=self.cval if cval is None else cval,
+            prefilter=self.prefilter if prefilter is None else prefilter,
+        )
         return rotator(img)
 
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -585,12 +585,13 @@ class RandZoom(Randomizable, Transform):
         self.min_zoom = min_zoom
         self.max_zoom = max_zoom
         self.prob = prob
+        self.use_gpu = use_gpu
+        self.keep_size = keep_size
+
         self.order = order
         self.mode = mode
         self.cval = cval
         self.prefilter = prefilter
-        self.use_gpu = use_gpu
-        self.keep_size = keep_size
 
         self._do_transform = False
         self._zoom = None
@@ -602,12 +603,18 @@ class RandZoom(Randomizable, Transform):
         else:
             self._zoom = self.R.uniform(self.min_zoom, self.max_zoom)
 
-    def __call__(self, img):
+    def __call__(self, img, order=None, mode=None, cval=None, prefilter=None):
         self.randomize()
         if not self._do_transform:
             return img
-        zoomer = Zoom(self._zoom, self.order, self.mode, self.cval, self.prefilter, self.use_gpu, self.keep_size)
-        return zoomer(img)
+        zoomer = Zoom(self._zoom, use_gpu=self.use_gpu, keep_size=self.keep_size)
+        return zoomer(
+            img,
+            order=self.order if order is None else order,
+            mode=self.mode if mode is None else mode,
+            cval=self.cval if cval is None else cval,
+            prefilter=self.prefilter if prefilter is None else prefilter,
+        )
 
 
 class AffineGrid(Transform):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -223,7 +223,6 @@ class Resize(Transform):
             https://scikit-image.org/docs/dev/user_guide/data_types.html.
         anti_aliasing (bool): Whether to apply a gaussian filter to image before down-scaling.
             Default is True.
-        anti_aliasing_sigma (float, tuple of floats): Standard deviation for gaussian filtering.
     """
 
     def __init__(
@@ -237,7 +236,6 @@ class Resize(Transform):
         anti_aliasing=True,
         anti_aliasing_sigma=None,
     ):
-        assert isinstance(order, int), "order must be integer."
         self.spatial_size = spatial_size
         self.order = order
         self.mode = mode
@@ -245,9 +243,10 @@ class Resize(Transform):
         self.clip = clip
         self.preserve_range = preserve_range
         self.anti_aliasing = anti_aliasing
-        self.anti_aliasing_sigma = anti_aliasing_sigma
 
-    def __call__(self, img):
+    def __call__(
+        self, img, order=None, mode=None, cval=None, clip=None, preserve_range=None, anti_aliasing=None,
+    ):
         """
         Args:
             img (ndarray): channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -256,15 +255,14 @@ class Resize(Transform):
         for channel in img:
             resized.append(
                 resize(
-                    channel,
-                    self.spatial_size,
-                    order=self.order,
-                    mode=self.mode,
-                    cval=self.cval,
-                    clip=self.clip,
-                    preserve_range=self.preserve_range,
-                    anti_aliasing=self.anti_aliasing,
-                    anti_aliasing_sigma=self.anti_aliasing_sigma,
+                    image=channel,
+                    output_shape=self.spatial_size,
+                    order=self.order if order is None else order,
+                    mode=mode or self.mode,
+                    cval=self.cval if cval is None else cval,
+                    clip=self.clip if clip is None else clip,
+                    preserve_range=self.preserve_range if preserve_range is None else preserve_range,
+                    anti_aliasing=self.anti_aliasing if anti_aliasing is None else anti_aliasing,
                 )
             )
         return np.stack(resized).astype(img.dtype)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -289,14 +289,14 @@ class Rotate(Transform):
 
     def __init__(self, angle, spatial_axes=(0, 1), reshape=True, order=1, mode="constant", cval=0, prefilter=True):
         self.angle = angle
+        self.spatial_axes = spatial_axes
         self.reshape = reshape
         self.order = order
         self.mode = mode
         self.cval = cval
         self.prefilter = prefilter
-        self.spatial_axes = spatial_axes
 
-    def __call__(self, img):
+    def __call__(self, img, order=None, mode=None, cval=None, prefilter=None):
         """
         Args:
             img (ndarray): channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -305,14 +305,14 @@ class Rotate(Transform):
         for channel in img:
             rotated.append(
                 scipy.ndimage.rotate(
-                    channel,
-                    self.angle,
-                    self.spatial_axes,
+                    input=channel,
+                    angle=self.angle,
+                    axes=self.spatial_axes,
                     reshape=self.reshape,
-                    order=self.order,
-                    mode=self.mode,
-                    cval=self.cval,
-                    prefilter=self.prefilter,
+                    order=self.order if order is None else order,
+                    mode=mode or self.mode,
+                    cval=self.cval if cval is None else cval,
+                    prefilter=self.prefilter if prefilter is None else prefilter,
                 )
             )
         return np.stack(rotated).astype(img.dtype)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -374,7 +374,7 @@ class Zoom(Transform):
                         channel,
                         zoom=self.zoom,
                         order=self.order if order is None else order,
-                        mode=self.mode if mode is None else mode,
+                        mode=mode or self.mode,
                         cval=self.cval if cval is None else cval,
                         prefilter=self.prefilter if prefilter is None else prefilter,
                     )
@@ -509,7 +509,7 @@ class RandRotate(Randomizable, Transform):
             spatial_axes=self.spatial_axes,
             reshape=self.reshape,
             order=self.order if order is None else order,
-            mode=self.mode if mode is None else mode,
+            mode=mode or self.mode,
             cval=self.cval if cval is None else cval,
             prefilter=self.prefilter if prefilter is None else prefilter,
         )
@@ -605,7 +605,7 @@ class RandZoom(Randomizable, Transform):
         return zoomer(
             img,
             order=self.order if order is None else order,
-            mode=self.mode if mode is None else mode,
+            mode=mode or self.mode,
             cval=self.cval if cval is None else cval,
             prefilter=self.prefilter if prefilter is None else prefilter,
         )

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -631,12 +631,12 @@ class RandRotated(Randomizable, MapTransform):
             This is the first two axis in spatial dimensions.
         reshape (bool): If reshape is true, the output shape is adapted so that the
             input array is contained completely in the output. Default is True.
-        order (int): Order of spline interpolation. Range 0-5. Default: 1. This is
+        order (int or sequence of int): Order of spline interpolation. Range 0-5. Default: 1. This is
             different from scipy where default interpolation is 3.
-        mode (str): Points outside boundary filled according to this mode. Options are
+        mode (str or sequence of str): Points outside boundary filled according to this mode. Options are
             'constant', 'nearest', 'reflect', 'wrap'. Default: 'constant'.
-        cval (scalar): Value to fill outside boundary. Default: 0.
-        prefilter (bool): Apply spline_filter before interpolation. Default: True.
+        cval (scalar or sequence of scalar): Value to fill outside boundary. Default: 0.
+        prefilter (bool or sequence of bool): Apply spline_filter before interpolation. Default: True.
     """
 
     def __init__(
@@ -655,11 +655,12 @@ class RandRotated(Randomizable, MapTransform):
         self.prob = prob
         self.degrees = degrees
         self.reshape = reshape
-        self.order = order
-        self.mode = mode
-        self.cval = cval
-        self.prefilter = prefilter
         self.spatial_axes = spatial_axes
+
+        self.order = ensure_tuple_rep(order, len(self.keys))
+        self.mode = ensure_tuple_rep(mode, len(self.keys))
+        self.cval = ensure_tuple_rep(cval, len(self.keys))
+        self.prefilter = ensure_tuple_rep(prefilter, len(self.keys))
 
         if not hasattr(self.degrees, "__iter__"):
             self.degrees = (-self.degrees, self.degrees)
@@ -677,9 +678,11 @@ class RandRotated(Randomizable, MapTransform):
         d = dict(data)
         if not self._do_transform:
             return d
-        rotator = Rotate(self.angle, self.spatial_axes, self.reshape, self.order, self.mode, self.cval, self.prefilter)
-        for key in self.keys:
-            d[key] = rotator(d[key])
+        rotator = Rotate(angle=self.angle, spatial_axes=self.spatial_axes, reshape=self.reshape)
+        for idx, key in enumerate(self.keys):
+            d[key] = rotator(
+                d[key], order=self.order[idx], mode=self.mode[idx], cval=self.cval[idx], prefilter=self.prefilter[idx]
+            )
         return d
 
 

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -591,32 +591,32 @@ class Rotated(MapTransform):
             This is the first two axis in spatial dimensions.
         reshape (bool): If reshape is true, the output shape is adapted so that the
             input array is contained completely in the output. Default is True.
-        order (int): Order of spline interpolation. Range 0-5. Default: 1. This is
+        order (int or sequence of int): Order of spline interpolation. Range 0-5. Default: 1. This is
             different from scipy where default interpolation is 3.
-        mode (str): Points outside boundary filled according to this mode. Options are
+        mode (str or sequence of str): Points outside boundary filled according to this mode. Options are
             'constant', 'nearest', 'reflect', 'wrap'. Default: 'constant'.
-        cval (scalar): Values to fill outside boundary. Default: 0.
-        prefilter (bool): Apply spline_filter before interpolation. Default: True.
+        cval (scalar or sequence of scalar): Values to fill outside boundary. Default: 0.
+        prefilter (bool or sequence of bool): Apply spline_filter before interpolation. Default: True.
     """
 
     def __init__(
         self, keys, angle, spatial_axes=(0, 1), reshape=True, order=1, mode="constant", cval=0, prefilter=True
     ):
         super().__init__(keys)
-        self.rotator = Rotate(
-            angle=angle,
-            spatial_axes=spatial_axes,
-            reshape=reshape,
-            order=order,
-            mode=mode,
-            cval=cval,
-            prefilter=prefilter,
-        )
+        self.rotator = Rotate(angle=angle, spatial_axes=spatial_axes, reshape=reshape)
+
+        self.order = ensure_tuple_rep(order, len(self.keys))
+        self.mode = ensure_tuple_rep(mode, len(self.keys))
+        self.cval = ensure_tuple_rep(cval, len(self.keys))
+        self.prefilter = ensure_tuple_rep(prefilter, len(self.keys))
+
 
     def __call__(self, data):
         d = dict(data)
-        for key in self.keys:
-            d[key] = self.rotator(d[key])
+        for idx, key in enumerate(self.keys):
+            d[key] = self.rotator(
+                d[key], order=self.order[idx], mode=self.mode[idx], cval=self.cval[idx], prefilter=self.prefilter[idx]
+            )
         return d
 
 

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -610,7 +610,6 @@ class Rotated(MapTransform):
         self.cval = ensure_tuple_rep(cval, len(self.keys))
         self.prefilter = ensure_tuple_rep(prefilter, len(self.keys))
 
-
     def __call__(self, data):
         d = dict(data)
         for idx, key in enumerate(self.keys):
@@ -701,14 +700,19 @@ class Zoomd(MapTransform):
 
     def __init__(self, keys, zoom, order=3, mode="constant", cval=0, prefilter=True, use_gpu=False, keep_size=False):
         super().__init__(keys)
-        self.zoomer = Zoom(
-            zoom=zoom, order=order, mode=mode, cval=cval, prefilter=prefilter, use_gpu=use_gpu, keep_size=keep_size
-        )
+        self.zoomer = Zoom(zoom=zoom, use_gpu=use_gpu, keep_size=keep_size)
+
+        self.order = ensure_tuple_rep(order, len(self.keys))
+        self.mode = ensure_tuple_rep(mode, len(self.keys))
+        self.cval = ensure_tuple_rep(cval, len(self.keys))
+        self.prefilter = ensure_tuple_rep(prefilter, len(self.keys))
 
     def __call__(self, data):
         d = dict(data)
-        for key in self.keys:
-            d[key] = self.zoomer(d[key])
+        for idx, key in enumerate(self.keys):
+            d[key] = self.zoomer(
+                d[key], order=self.order[idx], mode=self.mode[idx], cval=self.cval[idx], prefilter=self.prefilter[idx]
+            )
         return d
 
 

--- a/tests/test_rand_zoom.py
+++ b/tests/test_rand_zoom.py
@@ -78,7 +78,7 @@ class TestRandZoom(NumpyImageTestCase2D):
         zoomed = random_zoom(self.imt[0])
         self.assertTrue(np.array_equal(zoomed.shape, self.imt.shape[1:]))
 
-    @parameterized.expand([("no_min_zoom", None, 1.1, 1, TypeError), ("invalid_order", 0.9, 1.1, "s", AssertionError)])
+    @parameterized.expand([("no_min_zoom", None, 1.1, 1, TypeError), ("invalid_order", 0.9, 1.1, "s", TypeError)])
     def test_invalid_inputs(self, _, min_zoom, max_zoom, order, raises):
         with self.assertRaises(raises):
             random_zoom = RandZoom(prob=1.0, min_zoom=min_zoom, max_zoom=max_zoom, order=order)

--- a/tests/test_rand_zoomd.py
+++ b/tests/test_rand_zoomd.py
@@ -83,7 +83,7 @@ class TestRandZoomd(NumpyImageTestCase2D):
         zoomed = random_zoom({key: self.imt[0]})
         self.assertTrue(np.array_equal(zoomed[key].shape, self.imt.shape[1:]))
 
-    @parameterized.expand([("no_min_zoom", None, 1.1, 1, TypeError), ("invalid_order", 0.9, 1.1, "s", AssertionError)])
+    @parameterized.expand([("no_min_zoom", None, 1.1, 1, TypeError), ("invalid_order", 0.9, 1.1, "s", TypeError)])
     def test_invalid_inputs(self, _, min_zoom, max_zoom, order, raises):
         key = "img"
         with self.assertRaises(raises):

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -20,23 +20,28 @@ from tests.utils import NumpyImageTestCase2D
 
 
 class TestResize(NumpyImageTestCase2D):
-    @parameterized.expand([("invalid_order", "order", AssertionError)])
-    def test_invalid_inputs(self, _, order, raises):
-        with self.assertRaises(raises):
-            resize = Resize(spatial_size=(128, 128, 3), order=order)
+    def test_invalid_inputs(self):
+        with self.assertRaises(TypeError):
+            resize = Resize(spatial_size=(128, 128, 3), order="order")
             resize(self.imt[0])
 
     @parameterized.expand(
         [
-            ((64, 64), 1, "reflect", 0, True, True, True, None),
-            ((32, 32), 2, "constant", 3, False, False, False, None),
-            ((256, 256), 3, "constant", 3, False, False, False, None),
+            ((64, 64), 1, "reflect", 0, True, True, True),
+            ((32, 32), 2, "constant", 3, False, False, False),
+            ((256, 256), 3, "constant", 3, False, False, False),
         ]
     )
-    def test_correct_results(
-        self, spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing, anti_aliasing_sigma
-    ):
-        resize = Resize(spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing, anti_aliasing_sigma)
+    def test_correct_results(self, spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing):
+        resize = Resize(
+            spatial_size,
+            order=order,
+            mode=mode,
+            cval=cval,
+            clip=clip,
+            preserve_range=preserve_range,
+            anti_aliasing=anti_aliasing,
+        )
         expected = list()
         for channel in self.imt[0]:
             expected.append(
@@ -49,7 +54,6 @@ class TestResize(NumpyImageTestCase2D):
                     clip=clip,
                     preserve_range=preserve_range,
                     anti_aliasing=anti_aliasing,
-                    anti_aliasing_sigma=anti_aliasing_sigma,
                 )
             )
         expected = np.stack(expected).astype(np.float32)

--- a/tests/test_resized.py
+++ b/tests/test_resized.py
@@ -20,25 +20,20 @@ from tests.utils import NumpyImageTestCase2D
 
 
 class TestResized(NumpyImageTestCase2D):
-    @parameterized.expand([("invalid_order", "order", AssertionError)])
-    def test_invalid_inputs(self, _, order, raises):
-        with self.assertRaises(raises):
-            resize = Resized(keys="img", spatial_size=(128, 128, 3), order=order)
+    def test_invalid_inputs(self):
+        with self.assertRaises(TypeError):
+            resize = Resized(keys="img", spatial_size=(128, 128, 3), order="order")
             resize({"img": self.imt[0]})
 
     @parameterized.expand(
         [
-            ((64, 64), 1, "reflect", 0, True, True, True, None),
-            ((32, 32), 2, "constant", 3, False, False, False, None),
-            ((256, 256), 3, "constant", 3, False, False, False, None),
+            ((64, 64), 1, "reflect", 0, True, True, True),
+            ((32, 32), 2, "constant", 3, False, False, False),
+            ((256, 256), 3, "constant", 3, False, False, False),
         ]
     )
-    def test_correct_results(
-        self, spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing, anti_aliasing_sigma
-    ):
-        resize = Resized(
-            "img", spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing, anti_aliasing_sigma
-        )
+    def test_correct_results(self, spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing):
+        resize = Resized("img", spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing)
         expected = list()
         for channel in self.imt[0]:
             expected.append(
@@ -51,7 +46,6 @@ class TestResized(NumpyImageTestCase2D):
                     clip=clip,
                     preserve_range=preserve_range,
                     anti_aliasing=anti_aliasing,
-                    anti_aliasing_sigma=anti_aliasing_sigma,
                 )
             )
         expected = np.stack(expected).astype(np.float32)

--- a/tests/test_spatial_pad.py
+++ b/tests/test_spatial_pad.py
@@ -33,6 +33,8 @@ class TestSpatialPad(unittest.TestCase):
         padder = SpatialPad(**input_param)
         result = padder(input_data)
         self.assertAlmostEqual(result.shape, expected_val.shape)
+        result = padder(input_data, mode=input_param["mode"])
+        self.assertAlmostEqual(result.shape, expected_val.shape)
 
 
 if __name__ == "__main__":

--- a/tests/test_spatial_padd.py
+++ b/tests/test_spatial_padd.py
@@ -26,9 +26,15 @@ TEST_CASE_2 = [
     np.zeros((3, 15, 8, 8)),
 ]
 
+TEST_CASE_3 = [
+    {"keys": ["img"], "spatial_size": [15, 8, 8], "method": "end", "mode": {"constant", "symmetric"}},
+    {"img": np.zeros((3, 8, 8, 4))},
+    np.zeros((3, 15, 8, 8)),
+]
+
 
 class TestSpatialPadd(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_pad_shape(self, input_param, input_data, expected_val):
         padder = SpatialPadd(**input_param)
         result = padder(input_data)

--- a/tests/test_zoom.py
+++ b/tests/test_zoom.py
@@ -28,7 +28,7 @@ VALID_CASES = [
 
 GPU_CASES = [("gpu_zoom", 0.6, 1, "constant", 0, True)]
 
-INVALID_CASES = [("no_zoom", None, 1, TypeError), ("invalid_order", 0.9, "s", AssertionError)]
+INVALID_CASES = [("no_zoom", None, 1, TypeError), ("invalid_order", 0.9, "s", TypeError)]
 
 
 class TestZoom(NumpyImageTestCase2D):

--- a/tests/test_zoomd.py
+++ b/tests/test_zoomd.py
@@ -28,7 +28,7 @@ VALID_CASES = [
 
 GPU_CASES = [("gpu_zoom", 0.6, 1, "constant", 0, True)]
 
-INVALID_CASES = [("no_zoom", None, 1, TypeError), ("invalid_order", 0.9, "s", AssertionError)]
+INVALID_CASES = [("no_zoom", None, 1, TypeError), ("invalid_order", 0.9, "s", TypeError)]
 
 
 class TestZoomd(NumpyImageTestCase2D):


### PR DESCRIPTION
Fixes #328 fixes #377

### Description
- adds interpolation/padding params. to both `__init__` and  `__call__` of some of the transforms
- supports different params. for different keys in some of the dict-based transforms

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated
