### PR TITLE
284 enable multiple runners

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 284-enable-multiple-runners
   pull_request:
 
 jobs:
@@ -77,13 +78,11 @@ jobs:
     - name: Run quick tests (GPU)
       run: |
         python -m pip list
-        pwd
-        ls -a
         nvidia-smi
-        export CUDA_DEVICE_ORDER=PCI_BUS_ID
-        export CUDA_VISIBLE_DEVICES=0,1
-        python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
-        python -c "import torch; print('{} of GPUs available'.format(torch.cuda.device_count()))"
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        echo $CUDA_VISIBLE_DEVICES
+        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+        python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
         ./runtests.sh --quick
         pip list
         coverage xml

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - 284-enable-multiple-runners
   pull_request:
 
 jobs:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - 284-enable-multiple-runners
 
 jobs:
   coverage-py3:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 284-enable-multiple-runners
 
 jobs:
   coverage-py3:
@@ -25,10 +26,10 @@ jobs:
     - name: Run unit tests report coverage
       run: |
         nvidia-smi
-        export CUDA_DEVICE_ORDER=PCI_BUS_ID
-        export CUDA_VISIBLE_DEVICES=0,1
-        python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
-        python -c "import torch; print('{} of GPUs available'.format(torch.cuda.device_count()))"
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        echo $CUDA_VISIBLE_DEVICES
+        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+        python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
         ./runtests.sh --coverage
         coverage xml
     - name: Upload coverage

--- a/tests/test_query_memory.py
+++ b/tests/test_query_memory.py
@@ -1,0 +1,26 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from tests.utils import query_memory
+
+
+class TestQueryMemory(unittest.TestCase):
+    def test_output_str(self):
+        self.assertTrue(isinstance(query_memory(2), str))
+        all_device = query_memory(-1)
+        self.assertTrue(isinstance(all_device, str))
+        self.assertEqual(query_memory("test"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,7 @@
 import os
 import tempfile
 import unittest
+from subprocess import PIPE, Popen
 
 import nibabel as nib
 import numpy as np
@@ -70,3 +71,24 @@ def expect_failure_if_no_gpu(test):
         return unittest.expectedFailure(test)
     else:
         return test
+
+
+def query_memory(n=2):
+    """
+    find best n idle device ids and return a string of ids
+    """
+    bash_string = "nvidia-smi --query-gpu=utilization.gpu,temperature.gpu,memory.used --format=csv,noheader,nounits"
+
+    try:
+        p1 = Popen(bash_string.split(), stdout=PIPE)
+        output, error = p1.communicate()
+        free_memory = [x.split(",") for x in output.decode("utf-8").split("\n")[:-1]]
+        free_memory = np.asarray(free_memory, dtype=np.float).T
+        ids = np.lexsort(free_memory)[:n]
+    except (FileNotFoundError, TypeError, IndexError):
+        ids = range(n)
+    return ",".join([f"{int(x)}" for x in ids])
+
+
+if __name__ == "__main__":
+    print(query_memory())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -75,7 +75,7 @@ def expect_failure_if_no_gpu(test):
 
 def query_memory(n=2):
     """
-    find best n idle device ids and return a string of ids
+    Find best n idle devices and return a string of device ids.
     """
     bash_string = "nvidia-smi --query-gpu=utilization.gpu,temperature.gpu,memory.used --format=csv,noheader,nounits"
 
@@ -86,7 +86,7 @@ def query_memory(n=2):
         free_memory = np.asarray(free_memory, dtype=np.float).T
         ids = np.lexsort(free_memory)[:n]
     except (FileNotFoundError, TypeError, IndexError):
-        ids = range(n)
+        ids = range(n) if isinstance(n, int) else []
     return ",".join([f"{int(x)}" for x in ids])
 
 


### PR DESCRIPTION
Fixes #284.

### Description
multiple github runners on the self-hosted machine
selecting 2 idle devices for each ci job

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)

