### PR TITLE
403 consistent interp var name

### DIFF
--- a/monai/data/nifti_saver.py
+++ b/monai/data/nifti_saver.py
@@ -40,7 +40,7 @@ class NiftiSaver:
             output_postfix (str): a string appended to all output file names.
             output_ext (str): output file extension name.
             resample (bool): whether to resample before saving the data array.
-            interp_order (int): the order of the spline interpolation, default is 3.
+            interp_order (int): the order of the spline interpolation, default is InterpolationCode.SPLINE3.
                 The order has to be in the range 0 - 5.
                 https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.affine_transform.html
                 this option is used when `resample = True`.

--- a/monai/data/nifti_writer.py
+++ b/monai/data/nifti_writer.py
@@ -13,7 +13,7 @@ import nibabel as nib
 import numpy as np
 import scipy.ndimage
 
-from monai.data.utils import compute_shape_offset, to_affine_nd
+from monai.data.utils import compute_shape_offset, to_affine_nd, InterpolationCode
 
 
 def write_nifti(
@@ -23,7 +23,7 @@ def write_nifti(
     target_affine=None,
     resample=True,
     output_shape=None,
-    interp_order=3,
+    interp_order=InterpolationCode.SPLINE3,
     mode="constant",
     cval=0,
     dtype=None,
@@ -67,7 +67,7 @@ def write_nifti(
             could not be achieved by swapping/flipping data axes.
         output_shape (None or tuple of ints): output image shape.
             this option is used when resample = True.
-        interp_order (int): the order of the spline interpolation, default is 3.
+        interp_order (int): the order of the spline interpolation, default is InterpolationCode.SPLINE3.
             The order has to be in the range 0 - 5.
             https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.affine_transform.html
             this option is used when `resample = True`.

--- a/monai/data/png_saver.py
+++ b/monai/data/png_saver.py
@@ -40,7 +40,7 @@ class PNGSaver:
             output_postfix (str): a string appended to all output file names.
             output_ext (str): output file extension name.
             resample (bool): whether to resample and resize if providing spatial_shape in the metadata.
-            interp_order (int): the order of the spline interpolation, default is 3. 
+            interp_order (int): the order of the spline interpolation, default is InterpolationCode.SPLINE3.
                 This option is used when spatial_shape is specified and different from the data shape.
                 The order has to be in the range 0 - 5.
             mode (`reflect|constant|nearest|mirror|wrap`):

--- a/monai/data/png_writer.py
+++ b/monai/data/png_writer.py
@@ -25,7 +25,7 @@ def write_png(
         data (numpy.ndarray): input data to write to file.
         file_name (string): expected file name that saved on disk.
         output_shape (None or tuple of ints): output image shape.
-        interp_order (int): the order of the spline interpolation, default is 3.
+        interp_order (int): the order of the spline interpolation, default is InterpolationCode.SPLINE3.
             The order has to be in the range 0 - 5.
             this option is used when `output_shape != None`.
         mode (`reflect|constant|nearest|mirror|wrap`):

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -20,6 +20,24 @@ import numpy as np
 from monai.utils import ensure_tuple_size
 from monai.networks.layers.simplelayers import GaussianFilter
 
+import enum
+
+
+class InterpolationCode(enum.IntEnum):
+    """
+    A convenience enumeration to make code uses more expressive
+    """
+
+    SPLINE0 = 0
+    NEARESTNEIGHBOR = 0
+    SPLINE1 = 1
+    LINEAR = 1
+    SPLINE2 = 2
+    CUBIC = 2
+    SPLINE3 = 3
+    SPLINE4 = 4
+    SPLINE5 = 5
+
 
 def get_random_patch(dims, patch_size, rand_state=None):
     """

--- a/tests/test_png_rw.py
+++ b/tests/test_png_rw.py
@@ -13,7 +13,7 @@ import os
 import tempfile
 import unittest
 
-from monai.data import write_png
+from monai.data import write_png, InterpolationCode
 from skimage import io, transform
 import numpy as np
 
@@ -44,7 +44,9 @@ class TestPngWrite(unittest.TestCase):
             image_name = os.path.join(out_dir, "test.png")
             img = np.random.rand(2, 2, 3)
             write_png(img, image_name, (4, 4), scale=True)
-            img_save_val = transform.resize(img, (4, 4), order=3, mode="constant", cval=0, preserve_range=True)
+            img_save_val = transform.resize(
+                img, (4, 4), order=InterpolationCode.SPLINE3, mode="constant", cval=0, preserve_range=True
+            )
             img_save_val = (255 * img_save_val).astype(np.uint8)
             out = io.imread(image_name)
             np.testing.assert_allclose(out, img_save_val)

--- a/tests/test_rand_rotate.py
+++ b/tests/test_rand_rotate.py
@@ -33,7 +33,7 @@ class TestRandRotate(NumpyImageTestCase2D):
             prob=1.0,
             spatial_axes=spatial_axes,
             reshape=reshape,
-            order=order,
+            interp_order=order,
             mode=mode,
             cval=cval,
             prefilter=prefilter,

--- a/tests/test_rand_rotated.py
+++ b/tests/test_rand_rotated.py
@@ -34,7 +34,7 @@ class TestRandRotated(NumpyImageTestCase2D):
             prob=1.0,
             spatial_axes=spatial_axes,
             reshape=reshape,
-            order=order,
+            interp_order=order,
             mode=mode,
             cval=cval,
             prefilter=prefilter,

--- a/tests/test_rand_zoom.py
+++ b/tests/test_rand_zoom.py
@@ -30,7 +30,7 @@ class TestRandZoom(NumpyImageTestCase2D):
             prob=1.0,
             min_zoom=min_zoom,
             max_zoom=max_zoom,
-            order=order,
+            interp_order=order,
             mode=mode,
             cval=cval,
             prefilter=prefilter,
@@ -54,7 +54,7 @@ class TestRandZoom(NumpyImageTestCase2D):
                 prob=1.0,
                 min_zoom=min_zoom,
                 max_zoom=max_zoom,
-                order=order,
+                interp_order=order,
                 mode=mode,
                 cval=cval,
                 prefilter=prefilter,
@@ -81,7 +81,7 @@ class TestRandZoom(NumpyImageTestCase2D):
     @parameterized.expand([("no_min_zoom", None, 1.1, 1, TypeError), ("invalid_order", 0.9, 1.1, "s", TypeError)])
     def test_invalid_inputs(self, _, min_zoom, max_zoom, order, raises):
         with self.assertRaises(raises):
-            random_zoom = RandZoom(prob=1.0, min_zoom=min_zoom, max_zoom=max_zoom, order=order)
+            random_zoom = RandZoom(prob=1.0, min_zoom=min_zoom, max_zoom=max_zoom, interp_order=order)
             zoomed = random_zoom(self.imt[0])
 
 

--- a/tests/test_rand_zoomd.py
+++ b/tests/test_rand_zoomd.py
@@ -32,7 +32,7 @@ class TestRandZoomd(NumpyImageTestCase2D):
             prob=1.0,
             min_zoom=min_zoom,
             max_zoom=max_zoom,
-            order=order,
+            interp_order=order,
             mode=mode,
             cval=cval,
             prefilter=prefilter,
@@ -59,7 +59,7 @@ class TestRandZoomd(NumpyImageTestCase2D):
                 prob=1.0,
                 min_zoom=min_zoom,
                 max_zoom=max_zoom,
-                order=order,
+                interp_order=order,
                 mode=mode,
                 cval=cval,
                 prefilter=prefilter,
@@ -87,7 +87,7 @@ class TestRandZoomd(NumpyImageTestCase2D):
     def test_invalid_inputs(self, _, min_zoom, max_zoom, order, raises):
         key = "img"
         with self.assertRaises(raises):
-            random_zoom = RandZoomd(key, prob=1.0, min_zoom=min_zoom, max_zoom=max_zoom, order=order)
+            random_zoom = RandZoomd(key, prob=1.0, min_zoom=min_zoom, max_zoom=max_zoom, interp_order=order)
             zoomed = random_zoom({key: self.imt[0]})
 
 

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -22,7 +22,7 @@ from tests.utils import NumpyImageTestCase2D
 class TestResize(NumpyImageTestCase2D):
     def test_invalid_inputs(self):
         with self.assertRaises(TypeError):
-            resize = Resize(spatial_size=(128, 128, 3), order="order")
+            resize = Resize(spatial_size=(128, 128, 3), interp_order="order")
             resize(self.imt[0])
 
     @parameterized.expand(
@@ -35,7 +35,7 @@ class TestResize(NumpyImageTestCase2D):
     def test_correct_results(self, spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing):
         resize = Resize(
             spatial_size,
-            order=order,
+            interp_order=order,
             mode=mode,
             cval=cval,
             clip=clip,

--- a/tests/test_resized.py
+++ b/tests/test_resized.py
@@ -22,7 +22,7 @@ from tests.utils import NumpyImageTestCase2D
 class TestResized(NumpyImageTestCase2D):
     def test_invalid_inputs(self):
         with self.assertRaises(TypeError):
-            resize = Resized(keys="img", spatial_size=(128, 128, 3), order="order")
+            resize = Resized(keys="img", spatial_size=(128, 128, 3), interp_order="order")
             resize({"img": self.imt[0]})
 
     @parameterized.expand(

--- a/tests/test_rotated.py
+++ b/tests/test_rotated.py
@@ -27,15 +27,15 @@ TEST_CASES = [
 
 class TestRotated(NumpyImageTestCase2D):
     @parameterized.expand(TEST_CASES)
-    def test_correct_results(self, angle, spatial_axes, reshape, order, mode, cval, prefilter):
+    def test_correct_results(self, angle, spatial_axes, reshape, interp_order, mode, cval, prefilter):
         key = "img"
-        rotate_fn = Rotated(key, angle, spatial_axes, reshape, order, mode, cval, prefilter)
+        rotate_fn = Rotated(key, angle, spatial_axes, reshape, interp_order, mode, cval, prefilter)
         rotated = rotate_fn({key: self.imt[0]})
         expected = list()
         for channel in self.imt[0]:
             expected.append(
                 scipy.ndimage.rotate(
-                    channel, angle, spatial_axes, reshape, order=order, mode=mode, cval=cval, prefilter=prefilter
+                    channel, angle, spatial_axes, reshape, order=interp_order, mode=mode, cval=cval, prefilter=prefilter
                 )
             )
         expected = np.stack(expected).astype(np.float32)

--- a/tests/test_zoom.py
+++ b/tests/test_zoom.py
@@ -35,7 +35,13 @@ class TestZoom(NumpyImageTestCase2D):
     @parameterized.expand(VALID_CASES)
     def test_correct_results(self, zoom, order, mode, cval, prefilter, use_gpu, keep_size):
         zoom_fn = Zoom(
-            zoom=zoom, order=order, mode=mode, cval=cval, prefilter=prefilter, use_gpu=use_gpu, keep_size=keep_size
+            zoom=zoom,
+            interp_order=order,
+            mode=mode,
+            cval=cval,
+            prefilter=prefilter,
+            use_gpu=use_gpu,
+            keep_size=keep_size,
         )
         zoomed = zoom_fn(self.imt[0])
         expected = list()
@@ -48,7 +54,7 @@ class TestZoom(NumpyImageTestCase2D):
     def test_gpu_zoom(self, _, zoom, order, mode, cval, prefilter):
         if importlib.util.find_spec("cupy"):
             zoom_fn = Zoom(
-                zoom=zoom, order=order, mode=mode, cval=cval, prefilter=prefilter, use_gpu=True, keep_size=False
+                zoom=zoom, interp_order=order, mode=mode, cval=cval, prefilter=prefilter, use_gpu=True, keep_size=False
             )
             zoomed = zoom_fn(self.imt[0])
             expected = list()
@@ -69,7 +75,7 @@ class TestZoom(NumpyImageTestCase2D):
     @parameterized.expand(INVALID_CASES)
     def test_invalid_inputs(self, _, zoom, order, raises):
         with self.assertRaises(raises):
-            zoom_fn = Zoom(zoom=zoom, order=order)
+            zoom_fn = Zoom(zoom=zoom, interp_order=order)
             zoomed = zoom_fn(self.imt[0])
 
 

--- a/tests/test_zoomd.py
+++ b/tests/test_zoomd.py
@@ -36,7 +36,14 @@ class TestZoomd(NumpyImageTestCase2D):
     def test_correct_results(self, zoom, order, mode, cval, prefilter, use_gpu, keep_size):
         key = "img"
         zoom_fn = Zoomd(
-            key, zoom=zoom, order=order, mode=mode, cval=cval, prefilter=prefilter, use_gpu=use_gpu, keep_size=keep_size
+            key,
+            zoom=zoom,
+            interp_order=order,
+            mode=mode,
+            cval=cval,
+            prefilter=prefilter,
+            use_gpu=use_gpu,
+            keep_size=keep_size,
         )
         zoomed = zoom_fn({key: self.imt[0]})
         expected = list()
@@ -50,7 +57,14 @@ class TestZoomd(NumpyImageTestCase2D):
         key = "img"
         if importlib.util.find_spec("cupy"):
             zoom_fn = Zoomd(
-                key, zoom=zoom, order=order, mode=mode, cval=cval, prefilter=prefilter, use_gpu=True, keep_size=False
+                key,
+                zoom=zoom,
+                interp_order=order,
+                mode=mode,
+                cval=cval,
+                prefilter=prefilter,
+                use_gpu=True,
+                keep_size=False,
             )
             zoomed = zoom_fn({key: self.imt[0]})
             expected = list()
@@ -73,7 +87,7 @@ class TestZoomd(NumpyImageTestCase2D):
     def test_invalid_inputs(self, _, zoom, order, raises):
         key = "img"
         with self.assertRaises(raises):
-            zoom_fn = Zoomd(key, zoom=zoom, order=order)
+            zoom_fn = Zoomd(key, zoom=zoom, interp_order=order)
             zoomed = zoom_fn({key: self.imt[0]})
 
 


### PR DESCRIPTION
Fixes # 403

### Description
Use consistent naming for interpolation order

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or new feature that would cause existing functionality to change)
           variable names changed
- [X ] New tests added to cover the changes tests did not cover changed behavior
- [X] Docstrings/Documentation updated
