### PR TITLE
WIP:  Test more consistent modern type hinting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ venv.bak/
 # mkdocs documentation
 /site
 
+# pytype cache
+.pytype/
+
 # mypy
 .mypy_cache/
 examples/scd_lvsegs.npz

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,3 +17,4 @@ sphinxcontrib-htmlhelp==1.0.2
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3
+sphinx-autodoc-typehints>=1.10.3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,6 +90,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
 ]

--- a/examples/notebooks/3d_image_transforms.ipynb
+++ b/examples/notebooks/3d_image_transforms.ipynb
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loader = LoadNifti(dtype=np.float32)"
+    "loader = LoadNifti(dtype: np.dtype = np.float32)"
    ]
   },
   {

--- a/monai/_version.py
+++ b/monai/_version.py
@@ -57,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -75,10 +76,9 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=(subprocess.PIPE if hide_stderr else None)
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -115,16 +115,19 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print("Tried directories %s but none started with prefix %s" % (str(rootdirs), parentdir_prefix))
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -180,7 +183,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -189,7 +192,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -197,19 +200,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -224,8 +234,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -233,10 +242,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS, ["describe", "--tags", "--dirty", "--always", "--long", "--match", "%s*" % tag_prefix], cwd=root
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -259,17 +267,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -278,10 +285,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (full_tag, tag_prefix)
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -292,13 +298,11 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[0].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -329,8 +333,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -444,11 +447,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -468,9 +473,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -484,8 +493,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -494,13 +502,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):  # lgtm[py/unused-loop-variable]
+        for i in cfg.versionfile_source.split("/"):  # lgtm[py/unused-loop-variable]
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -514,6 +525,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/monai/data/csv_saver.py
+++ b/monai/data/csv_saver.py
@@ -24,7 +24,7 @@ class CSVSaver:
     the cached data into CSV file. If no meta data provided, use index from 0 to save data.
     """
 
-    def __init__(self, output_dir="./", filename="predictions.csv", overwrite=True):
+    def __init__(self, output_dir: str = "./", filename: str = "predictions.csv", overwrite: bool = True):
         """
         Args:
             output_dir (str): output CSV file directory.
@@ -34,7 +34,7 @@ class CSVSaver:
 
         """
         self.output_dir = output_dir
-        self._cache_dict = OrderedDict()
+        self._cache_dict: OrderedDict = OrderedDict()
         assert isinstance(filename, str) and filename[-4:] == ".csv", "filename must be a string with CSV format."
         self._filepath = os.path.join(output_dir, filename)
         self.overwrite = overwrite

--- a/monai/data/csv_saver.py
+++ b/monai/data/csv_saver.py
@@ -9,11 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import OrderedDict
+from typing import Union
+
 import os
 import csv
 import numpy as np
 import torch
-from collections import OrderedDict
 
 
 class CSVSaver:
@@ -60,7 +62,7 @@ class CSVSaver:
                     f.write("," + str(result))
                 f.write("\n")
 
-    def save(self, data, meta_data=None):
+    def save(self, data: np.ndarray, meta_data=None):
         """Save data into the cache dictionary. The metadata should have the following key:
             - ``'filename_or_obj'`` -- save the data corresponding to file name or object.
         If meta_data is None, use the default index from 0 to save data instead.
@@ -76,7 +78,7 @@ class CSVSaver:
             data = data.detach().cpu().numpy()
         self._cache_dict[save_key] = data.astype(np.float32)
 
-    def save_batch(self, batch_data, meta_data=None):
+    def save_batch(self, batch_data: Union[torch.Tensor, np.ndarray], meta_data=None):
         """Save a batch of data into the cache dictionary.
 
         args:

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -53,7 +53,7 @@ class Dataset(_TorchDataset):
     def __len__(self):
         return len(self.data)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int):
         data = self.data[index]
         if self.transform is not None:
             data = self.transform(data)
@@ -228,7 +228,7 @@ class CacheDataset(Dataset):
     and the outcome not cached.
     """
 
-    def __init__(self, data, transform, cache_num=sys.maxsize, cache_rate=1.0, num_workers=0):
+    def __init__(self, data, transform, cache_num: int = sys.maxsize, cache_rate: float = 1.0, num_workers: int = 0):
         """
         Args:
             data (Iterable): input data to load and transform to generate dataset for model.
@@ -275,7 +275,7 @@ class CacheDataset(Dataset):
             self._item_processed += 1
             process_bar(self._item_processed, self.cache_num)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int):
         if index < self.cache_num:
             # load data from cache and execute from the first random transform
             start_run = False
@@ -325,7 +325,7 @@ class ZipDataset(_TorchDataset):
     def __len__(self):
         return self.len
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int):
         def to_list(x):
             return list(x) if isinstance(x, (tuple, list)) else [x]
 
@@ -398,7 +398,7 @@ class ArrayDataset(ZipDataset, Randomizable):
     def randomize(self):
         self.seed = self.R.randint(np.iinfo(np.int32).max)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int):
         self.randomize()
         for dataset in self.datasets:
             if isinstance(dataset.transform, Randomizable):

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -27,6 +27,7 @@ from monai.utils import process_bar, get_seed
 
 from torch.utils.data import Dataset as _TorchDataset
 
+
 class Dataset(_TorchDataset):
     """
     A generic dataset with a length property and an optional callable data transform

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -9,8 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional, Callable
 import sys
-
 import hashlib
 import json
 from pathlib import Path
@@ -41,7 +41,7 @@ class Dataset(_TorchDataset):
          },                           },                           }]
     """
 
-    def __init__(self, data, transform=None):
+    def __init__(self, data, transform: Optional[Callable] = None):
         """
         Args:
             data (Iterable): input data to load and transform to generate dataset for model.
@@ -95,7 +95,7 @@ class PersistentDataset(Dataset):
     followed by applying the random dependant parts of transform processing.
     """
 
-    def __init__(self, data, transform=None, cache_dir=None):
+    def __init__(self, data, transform: Optional[Callable] = None, cache_dir=None):
         """
         Args:
             data (Iterable): input data to load and transform to generate dataset for model.
@@ -228,7 +228,9 @@ class CacheDataset(Dataset):
     and the outcome not cached.
     """
 
-    def __init__(self, data, transform, cache_num: int = sys.maxsize, cache_rate: float = 1.0, num_workers: int = 0):
+    def __init__(
+        self, data, transform: Callable, cache_num: int = sys.maxsize, cache_rate: float = 1.0, num_workers: int = 0
+    ):
         """
         Args:
             data (Iterable): input data to load and transform to generate dataset for model.
@@ -275,7 +277,7 @@ class CacheDataset(Dataset):
             self._item_processed += 1
             process_bar(self._item_processed, self.cache_num)
 
-    def __getitem__(self, index: int):
+    def __getitem__(self, index):
         if index < self.cache_num:
             # load data from cache and execute from the first random transform
             start_run = False
@@ -377,7 +379,13 @@ class ArrayDataset(ZipDataset, Randomizable):
     """
 
     def __init__(
-        self, img_files, img_transform=None, seg_files=None, seg_transform=None, labels=None, label_transform=None
+        self,
+        img_files,
+        img_transform: Optional[Callable] = None,
+        seg_files=None,
+        seg_transform: Optional[Callable] = None,
+        labels=None,
+        label_transform: Optional[Callable] = None,
     ):
         """
         Initializes the dataset with the filename lists. The transform `img_transform` is applied

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -25,8 +25,9 @@ from monai.transforms import Compose, Randomizable
 from monai.transforms.utils import apply_transform
 from monai.utils import process_bar, get_seed
 
+from torch.utils.data import Dataset as _TorchDataset
 
-class Dataset(torch.utils.data.Dataset):
+class Dataset(_TorchDataset):
     """
     A generic dataset with a length property and an optional callable data transform
     when fetching a data sample.
@@ -290,7 +291,7 @@ class CacheDataset(Dataset):
         return data
 
 
-class ZipDataset(torch.utils.data.Dataset):
+class ZipDataset(_TorchDataset):
     """
     Zip several PyTorch datasets and output data(with the same index) together in a tuple.
     If the output of single dataset is already a tuple, flatten it and extend to the result.

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -121,7 +121,7 @@ class PersistentDataset(Dataset):
             the transformed element up to the first identified
             random transform object
         """
-        for _transform in self.transform.transforms:
+        for _transform in self.transform.transforms:  # pytype: disable=attribute-error
             # execute all the deterministic transforms before the first random transform
             if isinstance(_transform, Randomizable):
                 break
@@ -137,7 +137,7 @@ class PersistentDataset(Dataset):
             the transformed element through the random transforms
         """
         start_post_randomize_run = False
-        for _transform in self.transform.transforms:
+        for _transform in self.transform.transforms:  # pytype: disable=attribute-error
             if start_post_randomize_run or isinstance(_transform, Randomizable):
                 start_post_randomize_run = True
                 item_transformed = apply_transform(_transform, item_transformed)
@@ -282,7 +282,7 @@ class CacheDataset(Dataset):
             # load data from cache and execute from the first random transform
             start_run = False
             data = self._cache[index]
-            for _transform in self.transform.transforms:
+            for _transform in self.transform.transforms:  # pytype: disable=attribute-error
                 if not start_run and not isinstance(_transform, Randomizable):
                     continue
                 else:

--- a/monai/data/grid_dataset.py
+++ b/monai/data/grid_dataset.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import math
+from typing import Optional, Tuple, Iterable
 
 import torch
 from torch.utils.data import IterableDataset
@@ -22,7 +23,14 @@ class GridPatchDataset(IterableDataset):
     Yields patches from arrays read from an input dataset. The patches are chosen in a contiguous grid sampling scheme.
     """
 
-    def __init__(self, dataset, patch_size, start_pos=(), pad_mode: str = "wrap", **pad_opts):
+    def __init__(
+        self,
+        dataset,
+        patch_size: Optional[Iterable[int]],
+        start_pos: Iterable[int] = (),
+        pad_mode: Optional[str] = "wrap",
+        **pad_opts: Optional[dict],
+    ):
         """
         Initializes this dataset in terms of the input dataset and patch size. The `patch_size` is the size of the 
         patch to sample from the input arrays. Tt is assumed the arrays first dimension is the channel dimension which
@@ -32,17 +40,17 @@ class GridPatchDataset(IterableDataset):
 
         Args:
             dataset (Dataset): the dataset to read array data from
-            patch_size (tuple of int or None): size of patches to generate slices for, 0/None selects whole dimension
-            start_pos (tuple of it, optional): starting position in the array, default is 0 for each dimension
-            pad_mode (str, optional): padding mode, see numpy.pad
-            pad_opts (dict, optional): padding options, see numpy.pad
+            patch_size: size of patches to generate slices for, 0/None selects whole dimension
+            start_pos: starting position in the array, default is 0 for each dimension
+            pad_mode: padding mode, see numpy.pad
+            pad_opts: padding options, see numpy.pad
         """
 
         self.dataset = dataset
-        self.patch_size = (None,) + tuple(patch_size)
-        self.start_pos = start_pos
-        self.pad_mode = pad_mode
-        self.pad_opts = pad_opts
+        self.patch_size: Tuple[None, ...] = (None,) + tuple(patch_size) if patch_size else (None,)
+        self.start_pos: Iterable[int] = start_pos
+        self.pad_mode: Optional[str] = pad_mode
+        self.pad_opts: Optional[dict] = pad_opts
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()

--- a/monai/data/grid_dataset.py
+++ b/monai/data/grid_dataset.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import math
-from typing import Optional
 
 import torch
 from torch.utils.data import IterableDataset
@@ -23,7 +22,7 @@ class GridPatchDataset(IterableDataset):
     Yields patches from arrays read from an input dataset. The patches are chosen in a contiguous grid sampling scheme.
     """
 
-    def __init__(self, dataset, patch_size, start_pos=(), pad_mode: Optional[str] = "wrap", **pad_opts):
+    def __init__(self, dataset, patch_size, start_pos=(), pad_mode: str = "wrap", **pad_opts):
         """
         Initializes this dataset in terms of the input dataset and patch size. The `patch_size` is the size of the 
         patch to sample from the input arrays. Tt is assumed the arrays first dimension is the channel dimension which

--- a/monai/data/grid_dataset.py
+++ b/monai/data/grid_dataset.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import math
+from typing import Optional
 
 import torch
 from torch.utils.data import IterableDataset
@@ -22,7 +23,7 @@ class GridPatchDataset(IterableDataset):
     Yields patches from arrays read from an input dataset. The patches are chosen in a contiguous grid sampling scheme.
     """
 
-    def __init__(self, dataset, patch_size, start_pos=(), pad_mode="wrap", **pad_opts):
+    def __init__(self, dataset, patch_size, start_pos=(), pad_mode: Optional[str] = "wrap", **pad_opts):
         """
         Initializes this dataset in terms of the input dataset and patch size. The `patch_size` is the size of the 
         patch to sample from the input arrays. Tt is assumed the arrays first dimension is the channel dimension which

--- a/monai/data/nifti_reader.py
+++ b/monai/data/nifti_reader.py
@@ -31,7 +31,7 @@ class NiftiDataset(Dataset, Randomizable):
         transform=None,
         seg_transform=None,
         image_only: bool = True,
-        dtype=np.float32,
+        dtype: np.dtype = np.float32,
     ):
         """
         Initializes the dataset with the image and segmentation filename lists. The transform `transform` is applied

--- a/monai/data/nifti_reader.py
+++ b/monai/data/nifti_reader.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional, Callable
+
 import numpy as np
 from torch.utils.data import Dataset
 from monai.transforms import LoadNifti
@@ -28,10 +30,10 @@ class NiftiDataset(Dataset, Randomizable):
         seg_files=None,
         labels=None,
         as_closest_canonical: bool = False,
-        transform=None,
-        seg_transform=None,
+        transform: Optional[Callable] = None,
+        seg_transform: Optional[Callable] = None,
         image_only: bool = True,
-        dtype: np.dtype = np.float32,
+        dtype: Optional[np.dtype] = np.float32,
     ):
         """
         Initializes the dataset with the image and segmentation filename lists. The transform `transform` is applied

--- a/monai/data/nifti_reader.py
+++ b/monai/data/nifti_reader.py
@@ -27,10 +27,10 @@ class NiftiDataset(Dataset, Randomizable):
         image_files,
         seg_files=None,
         labels=None,
-        as_closest_canonical=False,
+        as_closest_canonical: bool = False,
         transform=None,
         seg_transform=None,
-        image_only=True,
+        image_only: bool = True,
         dtype=np.float32,
     ):
         """
@@ -67,7 +67,7 @@ class NiftiDataset(Dataset, Randomizable):
     def randomize(self):
         self.seed = self.R.randint(np.iinfo(np.int32).max)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int):
         self.randomize()
         meta_data = None
         img_loader = LoadNifti(

--- a/monai/data/nifti_reader.py
+++ b/monai/data/nifti_reader.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Callable
+from typing import List, Callable, Optional, Union
 
 import numpy as np
 from torch.utils.data import Dataset
@@ -26,9 +26,9 @@ class NiftiDataset(Dataset, Randomizable):
 
     def __init__(
         self,
-        image_files,
-        seg_files=None,
-        labels=None,
+        image_files: List[str],
+        seg_files: Optional[List[str]] = None,
+        labels: Optional[Union[List, np.ndarray]] = None,
         as_closest_canonical: bool = False,
         transform: Optional[Callable] = None,
         seg_transform: Optional[Callable] = None,
@@ -40,27 +40,27 @@ class NiftiDataset(Dataset, Randomizable):
         to the images and `seg_transform` to the segmentations.
 
         Args:
-            image_files (list of str): list of image filenames
-            seg_files (list of str): if in segmentation task, list of segmentation filenames
-            labels (list or array): if in classification task, list of classification labels
-            as_closest_canonical (bool): if True, load the image as closest to canonical orientation
-            transform (Callable, optional): transform to apply to image arrays
-            seg_transform (Callable, optional): transform to apply to segmentation arrays
-            image_only (bool): if True return only the image volume, other return image volume and header dict
-            dtype (np.dtype, optional): if not None convert the loaded image to this data type
+            image_files: list of image filenames
+            seg_files: if in segmentation task, list of segmentation filenames
+            labels: if in classification task, list of classification labels
+            as_closest_canonical: if True, load the image as closest to canonical orientation
+            transform: transform to apply to image arrays
+            seg_transform: transform to apply to segmentation arrays
+            image_only: if True return only the image volume, other return image volume and header dict
+            dtype: if not None convert the loaded image to this data type
         """
 
         if seg_files is not None and len(image_files) != len(seg_files):
             raise ValueError("Must have same number of image and segmentation files")
 
-        self.image_files = image_files
-        self.seg_files = seg_files
-        self.labels = labels
-        self.as_closest_canonical = as_closest_canonical
-        self.transform = transform
-        self.seg_transform = seg_transform
-        self.image_only = image_only
-        self.dtype = dtype
+        self.image_files: List[str] = image_files
+        self.seg_files: Optional[List[str]] = seg_files
+        self.labels: Optional[Union[List, np.array]] = labels
+        self.as_closest_canonical: bool = as_closest_canonical
+        self.transform: Optional[Callable] = transform
+        self.seg_transform: Optional[Callable] = seg_transform
+        self.image_only: bool = image_only
+        self.dtype: Optional[np.dtype] = dtype
         self.set_random_state(seed=get_seed())
 
     def __len__(self):

--- a/monai/data/nifti_saver.py
+++ b/monai/data/nifti_saver.py
@@ -38,34 +38,34 @@ class NiftiSaver:
     ):
         """
         Args:
-            output_dir (str): output image directory.
-            output_postfix (str): a string appended to all output file names.
-            output_ext (str): output file extension name.
-            resample (bool): whether to resample before saving the data array.
-            interp_order (int): the order of the spline interpolation, default is InterpolationCode.SPLINE3.
+            output_dir: output image directory.
+            output_postfix: a string appended to all output file names.
+            output_ext: output file extension name.
+            resample: whether to resample before saving the data array.
+            interp_order: the order of the spline interpolation, default is InterpolationCode.SPLINE3.
                 The order has to be in the range 0 - 5.
                 https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.affine_transform.html
                 this option is used when `resample = True`.
             mode (`reflect|constant|nearest|mirror|wrap`):
                 The mode parameter determines how the input array is extended beyond its boundaries.
                 this option is used when `resample = True`.
-            cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
+            cval: Value to fill past edges of input if mode is "constant". Default is 0.0.
                 this option is used when `resample = True`.
-            dtype (np.dtype, optional): convert the image data to save to this data type.
+            dtype: convert the image data to save to this data type.
                 If None, keep the original type of data.
 
         """
-        self.output_dir = output_dir
-        self.output_postfix = output_postfix
-        self.output_ext = output_ext
-        self.resample = resample
-        self.interp_order = interp_order
-        self.mode = mode
-        self.cval = cval
-        self.dtype = dtype
-        self._data_index = 0
+        self.output_dir: str = output_dir
+        self.output_postfix: str = output_postfix
+        self.output_ext: str = output_ext
+        self.resample: bool = resample
+        self.interp_order: int = interp_order
+        self.mode: str = mode
+        self.cval: float = cval
+        self.dtype: Optional[np.dtype] = dtype
+        self._data_index: int = 0
 
-    def save(self, data: Union[torch.Tensor, np.ndarray], meta_data=None):
+    def save(self, data: Union[torch.Tensor, np.ndarray], meta_data: Optional[dict] = None):
         """
         Save data into a Nifti file.
         The metadata could optionally have the following keys:
@@ -78,14 +78,14 @@ class NiftiSaver:
         If meta_data is None, use the default index from 0 to save data instead.
 
         args:
-            data (Tensor or ndarray): target data content that to be saved as a NIfTI format file.
+            data: target data content that to be saved as a NIfTI format file.
                 Assuming the data shape starts with a channel dimension and followed by spatial dimensions.
-            meta_data (dict): the meta data information corresponding to the data.
+            meta_data: the meta data information corresponding to the data.
 
         See Also
             :py:meth:`monai.data.nifti_writer.write_nifti`
         """
-        filename = meta_data["filename_or_obj"] if meta_data else str(self._data_index)
+        filename: str = meta_data["filename_or_obj"] if meta_data else str(self._data_index)
         self._data_index += 1
         original_affine = meta_data.get("original_affine", None) if meta_data else None
         affine = meta_data.get("affine", None) if meta_data else None
@@ -110,12 +110,12 @@ class NiftiSaver:
             dtype=self.dtype or data.dtype,
         )
 
-    def save_batch(self, batch_data: Union[torch.Tensor, np.ndarray], meta_data=None):
+    def save_batch(self, batch_data: Union[torch.Tensor, np.ndarray], meta_data: Optional[dict] = None):
         """Save a batch of data into Nifti format files.
 
         args:
-            batch_data (Tensor or ndarray): target batch data content that save into NIfTI format.
-            meta_data (dict): every key-value in the meta_data is corresponding to a batch of data.
+            batch_data: target batch data content that save into NIfTI format.
+            meta_data: every key-value in the meta_data is corresponding to a batch of data.
         """
         for i, data in enumerate(batch_data):  # save a batch of files
             self.save(data, {k: meta_data[k][i] for k in meta_data} if meta_data else None)

--- a/monai/data/nifti_saver.py
+++ b/monai/data/nifti_saver.py
@@ -25,12 +25,12 @@ class NiftiSaver:
 
     def __init__(
         self,
-        output_dir="./",
-        output_postfix="seg",
-        output_ext=".nii.gz",
-        resample=True,
-        interp_order=3,
-        mode="constant",
+        output_dir: str = "./",
+        output_postfix: str = "seg",
+        output_ext: str = ".nii.gz",
+        resample: bool = True,
+        interp_order: int = 3,
+        mode: str = "constant",
         cval=0,
         dtype=None,
     ):

--- a/monai/data/nifti_saver.py
+++ b/monai/data/nifti_saver.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union, Optional
+
 import numpy as np
 import torch
 from monai.data.nifti_writer import write_nifti
@@ -31,8 +33,8 @@ class NiftiSaver:
         resample: bool = True,
         interp_order: int = 3,
         mode: str = "constant",
-        cval=0,
-        dtype=None,
+        cval: Union[int, float] = 0,
+        dtype: Optional[np.dtype] = None,
     ):
         """
         Args:
@@ -63,7 +65,7 @@ class NiftiSaver:
         self.dtype = dtype
         self._data_index = 0
 
-    def save(self, data, meta_data=None):
+    def save(self, data: Union[torch.Tensor, np.ndarray], meta_data=None):
         """
         Save data into a Nifti file.
         The metadata could optionally have the following keys:
@@ -108,7 +110,7 @@ class NiftiSaver:
             dtype=self.dtype or data.dtype,
         )
 
-    def save_batch(self, batch_data, meta_data=None):
+    def save_batch(self, batch_data: Union[torch.Tensor, np.ndarray], meta_data=None):
         """Save a batch of data into Nifti format files.
 
         args:

--- a/monai/data/nifti_writer.py
+++ b/monai/data/nifti_writer.py
@@ -9,24 +9,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional, Tuple, List
+
 import nibabel as nib
 import numpy as np
 import scipy.ndimage
 
-from monai.data.utils import compute_shape_offset, to_affine_nd, InterpolationCode
+from monai.data.utils import compute_shape_offset, to_affine_nd, InterpolationCode, InterpolationCodeType
 
 
 def write_nifti(
-    data,
-    file_name,
-    affine=None,
-    target_affine=None,
-    resample=True,
-    output_shape=None,
-    interp_order=InterpolationCode.SPLINE3,
-    mode="constant",
-    cval=0,
-    dtype=None,
+    data: np.ndarray,
+    file_name: str,
+    affine: Optional[np.ndarray] = None,
+    target_affine: Optional[np.ndarray] = None,
+    resample: bool = True,
+    output_shape: Optional[Tuple[int]] = None,
+    interp_order: InterpolationCodeType = InterpolationCode.SPLINE3,
+    mode: str = "constant",
+    cval: float = 0,
+    dtype: Optional[np.dtype] = None,
 ):
     """
     Write numpy data into NIfTI files to disk.  This function converts data
@@ -57,17 +59,17 @@ def write_nifti(
     could be `(64, 64, 1, 8)`,
 
     Args:
-        data (numpy.ndarray): input data to write to file.
-        file_name (string): expected file name that saved on disk.
-        affine (numpy.ndarray): the current affine of `data`. Defaults to `np.eye(4)`
-        target_affine (numpy.ndarray, optional): before saving
+        data: input data to write to file.
+        file_name: expected file name that saved on disk.
+        affine: the current affine of `data`. Defaults to `np.eye(4)`
+        target_affine: before saving
             the (`data`, `affine`) as a Nifti1Image,
             transform the data into the coordinates defined by `target_affine`.
-        resample (bool): whether to run resampling when the target affine
+        resample: whether to run resampling when the target affine
             could not be achieved by swapping/flipping data axes.
-        output_shape (None or tuple of ints): output image shape.
+        output_shape: output image shape.
             this option is used when resample = True.
-        interp_order (int): the order of the spline interpolation, default is InterpolationCode.SPLINE3.
+        interp_order: the order of the spline interpolation, default is InterpolationCode.SPLINE3.
             The order has to be in the range 0 - 5.
             https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.affine_transform.html
             this option is used when `resample = True`.
@@ -76,10 +78,10 @@ def write_nifti(
             this option is used when `resample = True`.
         cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
             this option is used when `resample = True`.
-        dtype (np.dtype, optional): convert the image to save to this data type.
+        dtype: convert the image to save to this data type.
     """
     assert isinstance(data, np.ndarray), "input data must be numpy array."
-    sr = min(data.ndim, 3)
+    sr: int = min(data.ndim, 3)
     if affine is None:
         affine = np.eye(4, dtype=np.float64)
     affine = to_affine_nd(sr, affine)
@@ -114,7 +116,7 @@ def write_nifti(
     if data.ndim > 3:  # multi channel, resampling each channel
         spatial_shape, channel_shape = data.shape[:3], data.shape[3:]
         data_ = data.astype(dtype).reshape(list(spatial_shape) + [-1])
-        data_chns = []
+        data_chns: List[np.ndarray] = []
         for chn in range(data_.shape[-1]):
             data_chns.append(
                 scipy.ndimage.affine_transform(
@@ -126,8 +128,8 @@ def write_nifti(
                     cval=cval,
                 )
             )
-        data_chns = np.stack(data_chns, axis=-1)
-        data_ = data_chns.reshape(list(data_chns.shape[:3]) + list(channel_shape))
+        data_chns_np: np.ndarray = np.stack(data_chns, axis=-1)
+        data_ = data_chns_np.reshape(list(data_chns_np.shape[:3]) + list(channel_shape))
     else:
         data_ = data.astype(dtype)
         data_ = scipy.ndimage.affine_transform(

--- a/monai/data/png_saver.py
+++ b/monai/data/png_saver.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union
+
 import torch
 import numpy as np
 from monai.data.png_writer import write_png
@@ -31,7 +33,7 @@ class PNGSaver:
         resample: bool = True,
         interp_order: int = 3,
         mode: str = "constant",
-        cval=0,
+        cval: Union[int, float] = 0,
         scale: bool = False,
     ):
         """
@@ -61,7 +63,7 @@ class PNGSaver:
         self.scale = scale
         self._data_index = 0
 
-    def save(self, data, meta_data=None):
+    def save(self, data: Union[torch.Tensor, np.ndarray], meta_data=None):
         """
         Save data into a png file.
         The metadata could optionally have the following keys:
@@ -108,7 +110,7 @@ class PNGSaver:
             scale=self.scale,
         )
 
-    def save_batch(self, batch_data, meta_data=None):
+    def save_batch(self, batch_data: Union[torch.Tensor, np.ndarray], meta_data=None):
         """Save a batch of data into png format files.
 
         args:

--- a/monai/data/png_saver.py
+++ b/monai/data/png_saver.py
@@ -25,14 +25,14 @@ class PNGSaver:
 
     def __init__(
         self,
-        output_dir="./",
-        output_postfix="seg",
-        output_ext=".png",
-        resample=True,
-        interp_order=3,
-        mode="constant",
+        output_dir: str = "./",
+        output_postfix: str = "seg",
+        output_ext: str = ".png",
+        resample: bool = True,
+        interp_order: int = 3,
+        mode: str = "constant",
         cval=0,
-        scale=False,
+        scale: bool = False,
     ):
         """
         Args:

--- a/monai/data/png_writer.py
+++ b/monai/data/png_writer.py
@@ -14,7 +14,15 @@ from skimage import io, transform
 
 
 def write_png(
-    data, file_name, output_shape=None, interp_order=3, mode="constant", cval=0, scale=False, plugin=None, **plugin_args
+    data,
+    file_name,
+    output_shape=None,
+    interp_order=3,
+    mode="constant",
+    cval=0,
+    scale=False,
+    plugin=None,
+    **plugin_args,
 ):
     """
     Write numpy data into png files to disk.  

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import os
 import warnings
 import math
@@ -39,7 +41,7 @@ class InterpolationCode(enum.IntEnum):
     SPLINE5 = 5
 
 
-def get_random_patch(dims, patch_size, rand_state=None):
+def get_random_patch(dims, patch_size, rand_state: Optional[np.random.RandomState] = None):
     """
     Returns a tuple of slices to define a random patch in an array of shape `dims` with size `patch_size` or the as
     close to it as possible within the given dimension. It is expected that `patch_size` is a valid patch for a source
@@ -143,7 +145,9 @@ def dense_patch_slices(image_size, patch_size, scan_interval):
     return slices
 
 
-def iter_patch(arr, patch_size, start_pos=(), copy_back=True, pad_mode="wrap", **pad_opts):
+def iter_patch(
+    arr: np.ndarray, patch_size, start_pos=(), copy_back: bool = True, pad_mode: Optional[str] = "wrap", **pad_opts
+):
     """
     Yield successive patches from `arr` of size `patch_size`. The iteration can start from position `start_pos` in `arr`
     but drawing from a padded array extended by the `patch_size` in each dimension (so these coordinates can be negative
@@ -274,7 +278,7 @@ def rectify_header_sform_qform(img_nii):
     return img_nii
 
 
-def zoom_affine(affine, scale, diagonal=True):
+def zoom_affine(affine, scale, diagonal: bool = True):
     """
     To make column norm of `affine` the same as `scale`.  if diagonal is False,
     returns an affine that combines orthogonal rotation and the new scale.
@@ -384,7 +388,7 @@ def to_affine_nd(r, affine):
     return new_affine
 
 
-def create_file_basename(postfix, input_file_name, folder_path, data_root_dir=""):
+def create_file_basename(postfix: str, input_file_name: str, folder_path: str, data_root_dir: str = ""):
     """
     Utility function to create the path to the output file based on the input
     filename (extension is added by lib level writer before writing the file)

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -23,6 +23,7 @@ from monai.utils import ensure_tuple_size
 from monai.networks.layers.simplelayers import GaussianFilter
 
 import enum
+from typing import Union
 
 
 class InterpolationCode(enum.IntEnum):
@@ -39,6 +40,9 @@ class InterpolationCode(enum.IntEnum):
     SPLINE3 = 3
     SPLINE4 = 4
     SPLINE5 = 5
+
+
+InterpolationCodeType = Union[int, InterpolationCode]
 
 
 def get_random_patch(dims, patch_size, rand_state: Optional[np.random.RandomState] = None):

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -9,10 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Callable
 
 import torch
 from monai.inferers.inferer import SimpleInferer
+from ignite.metrics import Metric
+from ignite.engine import Engine
 from .workflow import Workflow
 from .utils import default_prepare_batch
 from .utils import CommonKeys as Keys
@@ -39,13 +41,13 @@ class Evaluator(Workflow):
 
     def __init__(
         self,
-        device,
+        device: torch.device,
         val_data_loader,
-        prepare_batch=default_prepare_batch,
-        iteration_update=None,
-        key_val_metric=None,
+        prepare_batch: Callable = default_prepare_batch,
+        iteration_update: Optional[Callable] = None,
+        key_val_metric: Optional[Metric] = None,
         additional_metrics=None,
-        val_handlers: Optional[list] = None,
+        val_handlers=None,
     ):
         super().__init__(
             device=device,
@@ -103,11 +105,11 @@ class SupervisedEvaluator(Evaluator):
 
     def __init__(
         self,
-        device,
+        device: torch.device,
         val_data_loader,
         network,
-        prepare_batch=default_prepare_batch,
-        iteration_update=None,
+        prepare_batch: Callable = default_prepare_batch,
+        iteration_update: Optional[Callable] = None,
         inferer=SimpleInferer(),
         key_val_metric=None,
         additional_metrics=None,
@@ -120,7 +122,7 @@ class SupervisedEvaluator(Evaluator):
         self.network = network
         self.inferer = inferer
 
-    def _iteration(self, engine, batchdata):
+    def _iteration(self, engine: Engine, batchdata):
         """
         callback function for the Supervised Evaluation processing logic of 1 iteration in Ignite Engine.
 

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import torch
 from monai.inferers.inferer import SimpleInferer
 from .workflow import Workflow
@@ -43,7 +45,7 @@ class Evaluator(Workflow):
         iteration_update=None,
         key_val_metric=None,
         additional_metrics=None,
-        val_handlers=None,
+        val_handlers: Optional[list] = None,
     ):
         super().__init__(
             device=device,
@@ -57,7 +59,7 @@ class Evaluator(Workflow):
             handlers=val_handlers,
         )
 
-    def run(self, global_epoch=1):
+    def run(self, global_epoch: int = 1):
         """
         Execute validation/evaluation based on Ignite Engine.
 

--- a/monai/engines/multi_gpu_supervised_trainer.py
+++ b/monai/engines/multi_gpu_supervised_trainer.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable
+
 import torch
 from ignite.engine import create_supervised_trainer, create_supervised_evaluator, _prepare_batch
 from .utils import get_devices_spec
@@ -23,13 +25,13 @@ def _default_eval_transform(x, y, y_pred):
 
 
 def create_multigpu_supervised_trainer(
-    net,
+    net: torch.nn.Module,
     optimizer,
     loss_fn,
     devices=None,
-    non_blocking=False,
-    prepare_batch=_prepare_batch,
-    output_transform=_default_transform,
+    non_blocking: bool = False,
+    prepare_batch: Callable = _prepare_batch,
+    output_transform: Callable = _default_transform,
 ):
     """
     Derived from `create_supervised_trainer` in Ignite.
@@ -66,12 +68,12 @@ def create_multigpu_supervised_trainer(
 
 
 def create_multigpu_supervised_evaluator(
-    net,
+    net: torch.nn.Module,
     metrics=None,
     devices=None,
-    non_blocking=False,
-    prepare_batch=_prepare_batch,
-    output_transform=_default_eval_transform,
+    non_blocking: bool = False,
+    prepare_batch: Callable = _prepare_batch,
+    output_transform: Callable = _default_eval_transform,
 ):
     """
     Derived from `create_supervised_evaluator` in Ignite.

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -9,6 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, Optional
+
+import torch
+from ignite.metrics import Metric
+from ignite.engine import Engine
 from monai.inferers.inferer import SimpleInferer
 from .workflow import Workflow
 from .utils import default_prepare_batch
@@ -63,18 +68,18 @@ class SupervisedTrainer(Trainer):
 
     def __init__(
         self,
-        device,
+        device: torch.device,
         max_epochs: int,
         train_data_loader,
         network,
         optimizer,
         loss_function,
-        prepare_batch=default_prepare_batch,
-        iteration_update=None,
+        prepare_batch: Callable = default_prepare_batch,
+        iteration_update: Optional[Callable] = None,
         lr_scheduler=None,
         inferer=SimpleInferer(),
         amp: bool = True,
-        key_train_metric=None,
+        key_train_metric: Optional[Metric] = None,
         additional_metrics=None,
         train_handlers=None,
     ):
@@ -96,7 +101,7 @@ class SupervisedTrainer(Trainer):
         self.loss_function = loss_function
         self.inferer = inferer
 
-    def _iteration(self, engine, batchdata):
+    def _iteration(self, engine: Engine, batchdata):
         """
         Callback function for the Supervised Training processing logic of 1 iteration in Ignite Engine.
 

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -64,7 +64,7 @@ class SupervisedTrainer(Trainer):
     def __init__(
         self,
         device,
-        max_epochs,
+        max_epochs: int,
         train_data_loader,
         network,
         optimizer,
@@ -73,7 +73,7 @@ class SupervisedTrainer(Trainer):
         iteration_update=None,
         lr_scheduler=None,
         inferer=SimpleInferer(),
-        amp=True,
+        amp: bool = True,
         key_train_metric=None,
         additional_metrics=None,
         train_handlers=None,

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -9,8 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 import torch
 
 
@@ -32,7 +30,7 @@ class CommonKeys:
     INFO = "info"
 
 
-def get_devices_spec(devices: Optional[list] = None):
+def get_devices_spec(devices=None):
     """
     Get a valid specification for one or more devices. If `devices` is None get devices for all CUDA devices available.
     If `devices` is and zero-length structure a single CPU compute device is returned. In any other cases `devices` is

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import torch
 
 
@@ -30,7 +32,7 @@ class CommonKeys:
     INFO = "info"
 
 
-def get_devices_spec(devices=None):
+def get_devices_spec(devices: Optional[list] = None):
     """
     Get a valid specification for one or more devices. If `devices` is None get devices for all CUDA devices available.
     If `devices` is and zero-length structure a single CPU compute device is returned. In any other cases `devices` is

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -122,7 +122,7 @@ class Workflow(ABC, Engine):
         super().run(data=self.data_loader, epoch_length=len(self.data_loader))
 
     @abstractmethod
-    def _iteration(self, engine, batchdata):
+    def _iteration(self, engine: Engine, batchdata):
         """
         Abstract callback function for the processing logic of 1 iteration in Ignite Engine.
         Need subclass to implement different logics, like SupervisedTrainer/Evaluator, GANTrainer, etc.

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -54,7 +54,11 @@ class Workflow(ABC, Engine):
         additional_metrics=None,
         handlers=None,
     ):
+        # pytype: disable=invalid-directive
+        # pytype: disable=wrong-arg-count
         super().__init__(iteration_update if iteration_update is not None else self._iteration)
+        # pytype: enable=invalid-directive
+        # pytype: enable=wrong-arg-count
         # FIXME:
         if amp:
             self.logger.info("Will add AMP support when PyTorch v1.6 released.")

--- a/monai/handlers/checkpoint_loader.py
+++ b/monai/handlers/checkpoint_loader.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 import logging
 import torch
-from ignite.engine import Events
+from ignite.engine import Events, Engine
 from ignite.handlers import Checkpoint
 
 
@@ -45,7 +45,7 @@ class CheckpointLoader:
                 load_dict[k] = v.module
         self.load_dict = load_dict
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         if self.logger is None:
             self.logger = engine.logger
         return engine.add_event_handler(Events.STARTED, self)

--- a/monai/handlers/checkpoint_loader.py
+++ b/monai/handlers/checkpoint_loader.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import logging
 import torch
 from ignite.engine import Events
@@ -33,7 +35,7 @@ class CheckpointLoader:
 
     """
 
-    def __init__(self, load_path, load_dict, name=None):
+    def __init__(self, load_path: str, load_dict, name: Optional[str] = None):
         assert load_path is not None, "must provide clear path to load checkpoint."
         self.load_path = load_path
         assert load_dict is not None and len(load_dict) > 0, "must provide target objects to load."

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -12,7 +12,7 @@
 from typing import Optional
 
 import logging
-from ignite.engine import Events
+from ignite.engine import Events, Engine
 from ignite.handlers import ModelCheckpoint
 
 
@@ -126,7 +126,7 @@ class CheckpointSaver:
                 require_empty=False,
             )
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         if self.logger is None:
             self.logger = engine.logger
         if self._final_checkpoint is not None:

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import logging
 from ignite.engine import Events
 from ignite.handlers import ModelCheckpoint
@@ -55,17 +57,17 @@ class CheckpointSaver:
 
     def __init__(
         self,
-        save_dir,
+        save_dir: str,
         save_dict,
-        name=None,
-        file_prefix="",
-        save_final=False,
-        save_key_metric=False,
-        key_metric_name=None,
-        key_metric_n_saved=1,
-        epoch_level=True,
-        save_interval=0,
-        n_saved=None,
+        name: Optional[str] = None,
+        file_prefix: str = "",
+        save_final: bool = False,
+        save_key_metric: bool = False,
+        key_metric_name: Optional[str] = None,
+        key_metric_n_saved: int = 1,
+        epoch_level: bool = True,
+        save_interval: int = 0,
+        n_saved: Optional[int] = None,
     ):
         assert save_dir is not None, "must provide directory to save the checkpoints."
         self.save_dir = save_dir

--- a/monai/handlers/classification_saver.py
+++ b/monai/handlers/classification_saver.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from ignite.engine import Events
 import logging
 from monai.data import CSVSaver
@@ -21,12 +23,12 @@ class ClassificationSaver:
 
     def __init__(
         self,
-        output_dir="./",
-        filename="predictions.csv",
-        overwrite=True,
+        output_dir: str = "./",
+        filename: str = "predictions.csv",
+        overwrite: bool = True,
         batch_transform=lambda x: x,
         output_transform=lambda x: x,
-        name=None,
+        name: Optional[str] = None,
     ):
         """
         Args:

--- a/monai/handlers/classification_saver.py
+++ b/monai/handlers/classification_saver.py
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Callable
 
-from ignite.engine import Events
+from ignite.engine import Events, Engine
 import logging
 from monai.data import CSVSaver
 
@@ -26,8 +26,8 @@ class ClassificationSaver:
         output_dir: str = "./",
         filename: str = "predictions.csv",
         overwrite: bool = True,
-        batch_transform=lambda x: x,
-        output_transform=lambda x: x,
+        batch_transform: Callable = lambda x: x,
+        output_transform: Callable = lambda x: x,
         name: Optional[str] = None,
     ):
         """
@@ -51,7 +51,7 @@ class ClassificationSaver:
 
         self.logger = None if name is None else logging.getLogger(name)
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         if self.logger is None:
             self.logger = engine.logger
         if not engine.has_event_handler(self, Events.ITERATION_COMPLETED):
@@ -59,7 +59,7 @@ class ClassificationSaver:
         if not engine.has_event_handler(self.saver.finalize, Events.COMPLETED):
             engine.add_event_handler(Events.COMPLETED, lambda engine: self.saver.finalize())
 
-    def __call__(self, engine):
+    def __call__(self, engine: Engine):
         """
         This method assumes self.batch_transform will extract metadata from the input batch.
 

--- a/monai/handlers/lr_schedule_handler.py
+++ b/monai/handlers/lr_schedule_handler.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import logging
 from ignite.engine import Events
 from monai.utils import ensure_tuple
@@ -19,7 +21,14 @@ class LrScheduleHandler:
     Ignite handler to update the Learning Rate based on PyTorch LR scheduler.
     """
 
-    def __init__(self, lr_scheduler, print_lr=True, name=None, epoch_level=True, step_transform=lambda engine: ()):
+    def __init__(
+        self,
+        lr_scheduler,
+        print_lr: bool = True,
+        name: Optional[str] = None,
+        epoch_level: bool = True,
+        step_transform=lambda engine: (),
+    ):
         """
         Args:
             lr_scheduler (torch.optim.lr_scheduler): typically, lr_scheduler should be PyTorch

--- a/monai/handlers/lr_schedule_handler.py
+++ b/monai/handlers/lr_schedule_handler.py
@@ -9,10 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Callable
 
 import logging
-from ignite.engine import Events
+from ignite.engine import Events, Engine
 from monai.utils import ensure_tuple
 
 
@@ -27,7 +27,7 @@ class LrScheduleHandler:
         print_lr: bool = True,
         name: Optional[str] = None,
         epoch_level: bool = True,
-        step_transform=lambda engine: (),
+        step_transform: Callable = lambda engine: (),
     ):
         """
         Args:
@@ -49,7 +49,7 @@ class LrScheduleHandler:
             raise ValueError("argument `step_transform` must be a callable.")
         self.step_transform = step_transform
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         if self.logger is None:
             self.logger = engine.logger
         if self.epoch_level:

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -31,7 +31,7 @@ class MeanDice(Metric):
         add_sigmoid: bool = False,
         logit_thresh: float = 0.5,
         output_transform: Callable = lambda x: x,
-        device: Optional[Union[str, torch.device]] = None,
+        device: Optional[torch.device] = None,
     ):
         """
 

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -25,11 +25,11 @@ class MeanDice(Metric):
 
     def __init__(
         self,
-        include_background=True,
-        to_onehot_y=False,
-        mutually_exclusive=False,
-        add_sigmoid=False,
-        logit_thresh=0.5,
+        include_background: bool = True,
+        to_onehot_y: bool = False,
+        mutually_exclusive: bool = False,
+        add_sigmoid: bool = False,
+        logit_thresh: float = 0.5,
         output_transform: Callable = lambda x: x,
         device: Optional[Union[str, torch.device]] = None,
     ):

--- a/monai/handlers/metric_logger.py
+++ b/monai/handlers/metric_logger.py
@@ -10,21 +10,22 @@
 # limitations under the License.
 
 from collections import defaultdict
+from typing import Callable
 
-from ignite.engine import Events
+from ignite.engine import Events, Engine
 
 
 class MetricLogger:
-    def __init__(self, loss_transform=lambda x: x, metric_transform=lambda x: x):
+    def __init__(self, loss_transform: Callable = lambda x: x, metric_transform: Callable = lambda x: x):
         self.loss_transform = loss_transform
         self.metric_transform = metric_transform
-        self.loss = []
-        self.metrics = defaultdict(list)
+        self.loss: list = []
+        self.metrics: defaultdict = defaultdict(list)
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         return engine.add_event_handler(Events.ITERATION_COMPLETED, self)
 
-    def __call__(self, engine):
+    def __call__(self, engine: Engine):
         self.loss.append(self.loss_transform(engine.state.output))
 
         for m, v in engine.state.metrics.items():

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Union, Callable
 
 import torch
 from ignite.metrics import Metric
@@ -51,7 +51,7 @@ class ROCAUC(Metric):
         to_onehot_y: bool = False,
         add_softmax: bool = False,
         average: str = "macro",
-        output_transform=lambda x: x,
+        output_transform: Callable = lambda x: x,
         device: Optional[Union[str, torch.device]] = None,
     ):
         super().__init__(output_transform, device=device)

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -22,8 +22,8 @@ class ROCAUC(Metric):
     accumulating predictions and the ground-truth during an epoch and applying `compute_roc_auc`.
 
     Args:
-        to_onehot_y (bool): whether to convert `y` into the one-hot format. Defaults to False.
-        add_softmax (bool): whether to add softmax function to `y_pred` before computation. Defaults to False.
+        to_onehot_y: whether to convert `y` into the one-hot format. Defaults to False.
+        add_softmax: whether to add softmax function to `y_pred` before computation. Defaults to False.
         average (`macro|weighted|micro|None`): type of averaging performed if not binary classification.
             Default is 'macro'.
 
@@ -39,7 +39,7 @@ class ROCAUC(Metric):
             :class:`~ignite.engine.Engine` `process_function` output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
-        device (torch.device): device specification in case of distributed computation usage.
+        device: device specification in case of distributed computation usage.
 
     Note:
         ROCAUC expects y to be comprised of 0's and 1's.  y_pred must either be probability estimates or confidence values.
@@ -48,9 +48,9 @@ class ROCAUC(Metric):
 
     def __init__(
         self,
-        to_onehot_y=False,
-        add_softmax=False,
-        average="macro",
+        to_onehot_y: bool = False,
+        add_softmax: bool = False,
+        average: str = "macro",
         output_transform=lambda x: x,
         device: Optional[Union[str, torch.device]] = None,
     ):

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -9,9 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Union, Callable
 
-from ignite.engine import Events
+import numpy as np
+from ignite.engine import Events, Engine
 import logging
 from monai.data import NiftiSaver, PNGSaver
 
@@ -29,11 +30,11 @@ class SegmentationSaver:
         resample: bool = True,
         interp_order: int = 0,
         mode: str = "constant",
-        cval=0,
+        cval: Union[int, float] = 0,
         scale: bool = False,
-        dtype=None,
-        batch_transform=lambda x: x,
-        output_transform=lambda x: x,
+        dtype: Optional[np.dtype] = None,
+        batch_transform: Callable = lambda x: x,
+        output_transform: Callable = lambda x: x,
         name: Optional[str] = None,
     ):
         """
@@ -73,7 +74,7 @@ class SegmentationSaver:
 
         self.logger = None if name is None else logging.getLogger(name)
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         if self.logger is None:
             self.logger = engine.logger
         if not engine.has_event_handler(self, Events.ITERATION_COMPLETED):

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from ignite.engine import Events
 import logging
 from monai.data import NiftiSaver, PNGSaver
@@ -21,18 +23,18 @@ class SegmentationSaver:
 
     def __init__(
         self,
-        output_dir="./",
-        output_postfix="seg",
-        output_ext=".nii.gz",
-        resample=True,
-        interp_order=0,
-        mode="constant",
+        output_dir: str = "./",
+        output_postfix: str = "seg",
+        output_ext: str = ".nii.gz",
+        resample: bool = True,
+        interp_order: int = 0,
+        mode: str = "constant",
         cval=0,
-        scale=False,
+        scale: bool = False,
         dtype=None,
         batch_transform=lambda x: x,
         output_transform=lambda x: x,
-        name=None,
+        name: Optional[str] = None,
     ):
         """
         Args:

--- a/monai/handlers/stats_handler.py
+++ b/monai/handlers/stats_handler.py
@@ -73,7 +73,7 @@ class StatsHandler(object):
         self.tag_name = tag_name
         self.key_var_format = key_var_format
         if logger_handler is not None:
-            self.logger.addHandler(logger_handler)
+            self.logger.addHandler(logger_handler)  # pytype: disable=attribute-error
 
     def attach(self, engine: Engine):
         """Register a set of Ignite Event-Handlers to a specified Ignite engine.

--- a/monai/handlers/stats_handler.py
+++ b/monai/handlers/stats_handler.py
@@ -117,7 +117,7 @@ class StatsHandler(object):
         else:
             self._default_iteration_print(engine)
 
-    def exception_raised(self, engine: Engine, e):
+    def exception_raised(self, engine, e):
         """handler for train or validation/evaluation exception raised Event.
         Print the exception information and traceback.
 
@@ -130,7 +130,7 @@ class StatsHandler(object):
         # import traceback
         # traceback.print_exc()
 
-    def _default_epoch_print(self, engine: Engine):
+    def _default_epoch_print(self, engine):
         """Execute epoch level log operation based on Ignite engine.state data.
         print the values from Ignite state.metrics dict.
 

--- a/monai/handlers/stats_handler.py
+++ b/monai/handlers/stats_handler.py
@@ -117,7 +117,7 @@ class StatsHandler(object):
         else:
             self._default_iteration_print(engine)
 
-    def exception_raised(self, engine, e):
+    def exception_raised(self, engine: Engine, e):
         """handler for train or validation/evaluation exception raised Event.
         Print the exception information and traceback.
 
@@ -130,7 +130,7 @@ class StatsHandler(object):
         # import traceback
         # traceback.print_exc()
 
-    def _default_epoch_print(self, engine):
+    def _default_epoch_print(self, engine: Engine):
         """Execute epoch level log operation based on Ignite engine.state data.
         print the values from Ignite state.metrics dict.
 

--- a/monai/handlers/tensorboard_handlers.py
+++ b/monai/handlers/tensorboard_handlers.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Callable
 
 import numpy as np
 import warnings
@@ -39,10 +39,10 @@ class TensorBoardStatsHandler(object):
         self,
         summary_writer: Optional[SummaryWriter] = None,
         log_dir: str = "./runs",
-        epoch_event_writer=None,
-        iteration_event_writer=None,
-        output_transform=lambda x: x,
-        global_epoch_transform=lambda x: x,
+        epoch_event_writer: Optional[Callable] = None,
+        iteration_event_writer: Optional[Callable] = None,
+        output_transform: Callable = lambda x: x,
+        global_epoch_transform: Callable = lambda x: x,
         tag_name: str = DEFAULT_TAG,
     ):
         """
@@ -186,9 +186,9 @@ class TensorBoardImageHandler(object):
         log_dir: str = "./runs",
         interval=1,
         epoch_level=True,
-        batch_transform=lambda x: x,
-        output_transform=lambda x: x,
-        global_iter_transform=lambda x: x,
+        batch_transform: Callable = lambda x: x,
+        output_transform: Callable = lambda x: x,
+        global_iter_transform: Callable = lambda x: x,
         index: int = 0,
         max_channels: int = 1,
         max_frames: int = 64,
@@ -227,9 +227,8 @@ class TensorBoardImageHandler(object):
         else:
             engine.add_event_handler(Events.ITERATION_COMPLETED(every=self.interval), self)
 
-    def __call__(self, engine):
+    def __call__(self, engine: Engine):
         step = self.global_iter_transform(engine.state.epoch if self.epoch_level else engine.state.iteration)
-
         show_images = self.batch_transform(engine.state.batch)[0]
         if torch.is_tensor(show_images):
             show_images = show_images.detach().cpu().numpy()

--- a/monai/handlers/tensorboard_handlers.py
+++ b/monai/handlers/tensorboard_handlers.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import numpy as np
 import warnings
 import torch
@@ -35,13 +37,13 @@ class TensorBoardStatsHandler(object):
 
     def __init__(
         self,
-        summary_writer=None,
-        log_dir="./runs",
+        summary_writer: Optional[SummaryWriter] = None,
+        log_dir: str = "./runs",
         epoch_event_writer=None,
         iteration_event_writer=None,
         output_transform=lambda x: x,
         global_epoch_transform=lambda x: x,
-        tag_name=DEFAULT_TAG,
+        tag_name: str = DEFAULT_TAG,
     ):
         """
         Args:
@@ -180,16 +182,16 @@ class TensorBoardImageHandler(object):
 
     def __init__(
         self,
-        summary_writer=None,
-        log_dir="./runs",
+        summary_writer: Optional[SummaryWriter] = None,
+        log_dir: str = "./runs",
         interval=1,
         epoch_level=True,
         batch_transform=lambda x: x,
         output_transform=lambda x: x,
         global_iter_transform=lambda x: x,
-        index=0,
-        max_channels=1,
-        max_frames=64,
+        index: int = 0,
+        max_channels: int = 1,
+        max_frames: int = 64,
     ):
         """
         Args:

--- a/monai/handlers/validation_handler.py
+++ b/monai/handlers/validation_handler.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ignite.engine import Events
+from ignite.engine import Events, Engine
 from monai.engines import Evaluator
 
 
@@ -20,7 +20,7 @@ class ValidationHandler:
 
     """
 
-    def __init__(self, validator, interval: int, epoch_level: bool = True):
+    def __init__(self, validator: Evaluator, interval: int, epoch_level: bool = True):
         """
         Args:
             validator (Evaluator): run the validator when trigger validation, suppose to be Evaluator.
@@ -35,11 +35,11 @@ class ValidationHandler:
         self.interval = interval
         self.epoch_level = epoch_level
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         if self.epoch_level:
             engine.add_event_handler(Events.EPOCH_COMPLETED(every=self.interval), self)
         else:
             engine.add_event_handler(Events.ITERATION_COMPLETED(every=self.interval), self)
 
-    def __call__(self, engine):
+    def __call__(self, engine: Engine):
         self.validator.run(engine.state.epoch)

--- a/monai/handlers/validation_handler.py
+++ b/monai/handlers/validation_handler.py
@@ -20,7 +20,7 @@ class ValidationHandler:
 
     """
 
-    def __init__(self, validator, interval, epoch_level=True):
+    def __init__(self, validator, interval: int, epoch_level: bool = True):
         """
         Args:
             validator (Evaluator): run the validator when trigger validation, suppose to be Evaluator.

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -69,7 +69,7 @@ class SlidingWindowInferer(Inferer):
 
     """
 
-    def __init__(self, roi_size, sw_batch_size=1, overlap=0.25, blend_mode="constant"):
+    def __init__(self, roi_size, sw_batch_size: int = 1, overlap: float = 0.25, blend_mode: str = "constant"):
         Inferer.__init__(self)
         if not isinstance(roi_size, (list, tuple)):
             raise ValueError("must specify the roi size in a list or tuple for SlidingWindow.")

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -11,6 +11,7 @@
 
 from abc import ABC, abstractmethod
 from .utils import sliding_window_inference
+import torch
 
 
 class Inferer(ABC):
@@ -20,7 +21,7 @@ class Inferer(ABC):
     """
 
     @abstractmethod
-    def __call__(self, inputs, network):
+    def __call__(self, inputs: torch.Tensor, network):
         """
         Run inference on `inputs` with the `network` model.
 
@@ -40,7 +41,7 @@ class SimpleInferer(Inferer):
     def __init__(self):
         Inferer.__init__(self)
 
-    def __call__(self, inputs, network):
+    def __call__(self, inputs: torch.Tensor, network):
         """Unified callable function API of Inferers.
 
         Args:
@@ -78,7 +79,7 @@ class SlidingWindowInferer(Inferer):
         self.overlap = overlap
         self.blend_mode = blend_mode
 
-    def __call__(self, inputs, network):
+    def __call__(self, inputs: torch.Tensor, network):
         """
         Unified callable function API of Inferers.
 

--- a/monai/inferers/utils.py
+++ b/monai/inferers/utils.py
@@ -14,7 +14,9 @@ import torch.nn.functional as F
 from monai.data.utils import dense_patch_slices, compute_importance_map
 
 
-def sliding_window_inference(inputs, roi_size, sw_batch_size, predictor, overlap=0.25, blend_mode="constant"):
+def sliding_window_inference(
+    inputs, roi_size, sw_batch_size, predictor, overlap=0.25, blend_mode="constant",
+):
     """Use SlidingWindow method to execute inference.
 
     Args:
@@ -111,7 +113,7 @@ def sliding_window_inference(inputs, roi_size, sw_batch_size, predictor, overlap
     return output_image[..., : original_image_size[0], : original_image_size[1]]  # 2D
 
 
-def _get_scan_interval(image_size, roi_size, num_spatial_dims, overlap: float):
+def _get_scan_interval(image_size, roi_size, num_spatial_dims: int, overlap: float):
     assert len(image_size) == num_spatial_dims, "image coord different from spatial dims."
     assert len(roi_size) == num_spatial_dims, "roi coord different from spatial dims."
 

--- a/monai/inferers/utils.py
+++ b/monai/inferers/utils.py
@@ -62,12 +62,11 @@ def sliding_window_inference(inputs, roi_size, sw_batch_size, predictor, overlap
         slice_index_range = range(slice_index, min(slice_index + sw_batch_size, len(slices)))
         input_slices = []
         for curr_index in slice_index_range:
-            if num_spatial_dims == 3:
-                slice_i, slice_j, slice_k = slices[curr_index]
-                input_slices.append(inputs[0, :, slice_i, slice_j, slice_k])
+            curr_slice = slices[curr_index]
+            if len(curr_slice) == 3:
+                input_slices.append(inputs[0, :, curr_slice[0], curr_slice[1], curr_slice[2]])
             else:
-                slice_i, slice_j = slices[curr_index]
-                input_slices.append(inputs[0, :, slice_i, slice_j])
+                input_slices.append(inputs[0, :, curr_slice[0], curr_slice[1]])
         slice_batches.append(torch.stack(input_slices))
 
     # Perform predictions
@@ -92,18 +91,17 @@ def sliding_window_inference(inputs, roi_size, sw_batch_size, predictor, overlap
 
         # store the result in the proper location of the full output. Apply weights from importance map.
         for curr_index in slice_index_range:
-            if num_spatial_dims == 3:
-                slice_i, slice_j, slice_k = slices[curr_index]
-                output_image[0, :, slice_i, slice_j, slice_k] += (
+            curr_slice = slices[curr_index]
+            if len(curr_slice) == 3:
+                output_image[0, :, curr_slice[0], curr_slice[1], curr_slice[2]] += (
                     importance_map * output_rois[window_id][curr_index - slice_index, :]
                 )
-                count_map[0, :, slice_i, slice_j, slice_k] += importance_map
+                count_map[0, :, curr_slice[0], curr_slice[1], curr_slice[2]] += importance_map
             else:
-                slice_i, slice_j = slices[curr_index]
-                output_image[0, :, slice_i, slice_j] += (
+                output_image[0, :, curr_slice[0], curr_slice[1]] += (
                     importance_map * output_rois[window_id][curr_index - slice_index, :]
                 )
-                count_map[0, :, slice_i, slice_j] += importance_map
+                count_map[0, :, curr_slice[0], curr_slice[1]] += importance_map
 
     # account for any overlapping sections
     output_image /= count_map

--- a/monai/inferers/utils.py
+++ b/monai/inferers/utils.py
@@ -111,7 +111,7 @@ def sliding_window_inference(inputs, roi_size, sw_batch_size, predictor, overlap
     return output_image[..., : original_image_size[0], : original_image_size[1]]  # 2D
 
 
-def _get_scan_interval(image_size, roi_size, num_spatial_dims, overlap):
+def _get_scan_interval(image_size, roi_size, num_spatial_dims, overlap: float):
     assert len(image_size) == num_spatial_dims, "image coord different from spatial dims."
     assert len(roi_size) == num_spatial_dims, "roi coord different from spatial dims."
 

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -32,13 +32,13 @@ class DiceLoss(_Loss):
 
     def __init__(
         self,
-        include_background=True,
-        to_onehot_y=False,
-        do_sigmoid=False,
-        do_softmax=False,
-        squared_pred=False,
-        jaccard=False,
-        reduction="mean",
+        include_background: bool = True,
+        to_onehot_y: bool = False,
+        do_sigmoid: bool = False,
+        do_softmax: bool = False,
+        squared_pred: bool = False,
+        jaccard: bool = False,
+        reduction: str = "mean",
     ):
         """
         Args:
@@ -64,7 +64,7 @@ class DiceLoss(_Loss):
         self.squared_pred = squared_pred
         self.jaccard = jaccard
 
-    def forward(self, input, target, smooth=1e-5):
+    def forward(self, input, target, smooth: float = 1e-5):
         """
         Args:
             input (tensor): the shape should be BNH[WD].
@@ -167,7 +167,7 @@ class GeneralizedDiceLoss(_Loss):
         elif w_type == "square":
             self.w_func = lambda x: torch.reciprocal(x * x)
 
-    def forward(self, input, target, smooth=1e-5):
+    def forward(self, input, target, smooth: float = 1e-5):
         """
         Args:
             input (tensor): the shape should be BNH[WD].

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import warnings
+from typing import Callable
 
 import torch
 from torch.nn.modules.loss import _Loss
@@ -64,7 +65,7 @@ class DiceLoss(_Loss):
         self.squared_pred = squared_pred
         self.jaccard = jaccard
 
-    def forward(self, input, target, smooth: float = 1e-5):
+    def forward(self, input: torch.Tensor, target: torch.Tensor, smooth: float = 1e-5):
         """
         Args:
             input (tensor): the shape should be BNH[WD].
@@ -133,12 +134,12 @@ class GeneralizedDiceLoss(_Loss):
 
     def __init__(
         self,
-        include_background=True,
-        to_onehot_y=False,
-        do_sigmoid=False,
-        do_softmax=False,
-        w_type="square",
-        reduction="mean",
+        include_background: bool = True,
+        to_onehot_y: bool = False,
+        do_sigmoid: bool = False,
+        do_softmax: bool = False,
+        w_type: str = "square",
+        reduction: str = "mean",
     ):
         """
         Args:
@@ -161,13 +162,13 @@ class GeneralizedDiceLoss(_Loss):
             raise ValueError("do_sigmoid=True and do_softmax=True are not compatible.")
         self.do_sigmoid = do_sigmoid
         self.do_softmax = do_softmax
-        self.w_func = torch.ones_like
+        self.w_func: Callable = torch.ones_like
         if w_type == "simple":
             self.w_func = torch.reciprocal
         elif w_type == "square":
             self.w_func = lambda x: torch.reciprocal(x * x)
 
-    def forward(self, input, target, smooth: float = 1e-5):
+    def forward(self, input: torch.Tensor, target: torch.Tensor, smooth: float = 1e-5):
         """
         Args:
             input (tensor): the shape should be BNH[WD].

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import torch
 import torch.nn.functional as F
 from torch.nn.modules.loss import _WeightedLoss
@@ -20,7 +22,7 @@ class FocalLoss(_WeightedLoss):
     [1] "Focal Loss for Dense Object Detection", T. Lin et al., ICCV 2017
     """
 
-    def __init__(self, gamma: float = 2.0, weight=None, reduction: str = "mean"):
+    def __init__(self, gamma: float = 2.0, weight: Optional[torch.Tensor] = None, reduction: str = "mean"):
         """
         Args:
             gamma (float): value of the exponent gamma in the definition of the Focal loss.

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -20,7 +20,7 @@ class FocalLoss(_WeightedLoss):
     [1] "Focal Loss for Dense Object Detection", T. Lin et al., ICCV 2017
     """
 
-    def __init__(self, gamma=2.0, weight=None, reduction="mean"):
+    def __init__(self, gamma: float = 2.0, weight=None, reduction: str = "mean"):
         """
         Args:
             gamma (float): value of the exponent gamma in the definition of the Focal loss.

--- a/monai/losses/tversky.py
+++ b/monai/losses/tversky.py
@@ -32,13 +32,13 @@ class TverskyLoss(_Loss):
 
     def __init__(
         self,
-        include_background=True,
-        to_onehot_y=False,
-        do_sigmoid=False,
-        do_softmax=False,
-        alpha=0.5,
-        beta=0.5,
-        reduction="mean",
+        include_background: bool = True,
+        to_onehot_y: bool = False,
+        do_sigmoid: bool = False,
+        do_softmax: bool = False,
+        alpha: float = 0.5,
+        beta: float = 0.5,
+        reduction: str = "mean",
     ):
 
         """
@@ -68,7 +68,7 @@ class TverskyLoss(_Loss):
         self.alpha = alpha
         self.beta = beta
 
-    def forward(self, input, target, smooth=1e-5):
+    def forward(self, input, target, smooth: float = 1e-5):
         """
         Args:
             input (tensor): the shape should be BNH[WD].

--- a/monai/losses/tversky.py
+++ b/monai/losses/tversky.py
@@ -68,7 +68,7 @@ class TverskyLoss(_Loss):
         self.alpha = alpha
         self.beta = beta
 
-    def forward(self, input, target, smooth: float = 1e-5):
+    def forward(self, input: torch.Tensor, target: torch.Tensor, smooth: float = 1e-5):
         """
         Args:
             input (tensor): the shape should be BNH[WD].

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -17,7 +17,13 @@ from monai.networks.utils import one_hot
 
 
 def compute_meandice(
-    y_pred, y, include_background=True, to_onehot_y=False, mutually_exclusive=False, add_sigmoid=False, logit_thresh=0.5
+    y_pred,
+    y,
+    include_background: bool = True,
+    to_onehot_y: bool = False,
+    mutually_exclusive: bool = False,
+    add_sigmoid: bool = False,
+    logit_thresh: float = 0.5,
 ):
     """Computes Dice score metric from full size Tensor and collects average.
 

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -17,8 +17,8 @@ from monai.networks.utils import one_hot
 
 
 def compute_meandice(
-    y_pred,
-    y,
+    y_pred: torch.Tensor,
+    y: torch.Tensor,
     include_background: bool = True,
     to_onehot_y: bool = False,
     mutually_exclusive: bool = False,

--- a/monai/metrics/rocauc.py
+++ b/monai/metrics/rocauc.py
@@ -50,7 +50,13 @@ def _calculate(y, y_pred):
     return auc / (nneg * (n - nneg))
 
 
-def compute_roc_auc(y_pred, y, to_onehot_y: bool = False, add_softmax: bool = False, average: Optional[str] = "macro"):
+def compute_roc_auc(
+    y_pred: torch.Tensor,
+    y: torch.Tensor,
+    to_onehot_y: bool = False,
+    add_softmax: bool = False,
+    average: Optional[str] = "macro",
+):
     """Computes Area Under the Receiver Operating Characteristic Curve (ROC AUC). Referring to:
     `sklearn.metrics.roc_auc_score <https://scikit-learn.org/stable/modules/generated/
     sklearn.metrics.roc_auc_score.html#sklearn.metrics.roc_auc_score>`_.

--- a/monai/metrics/rocauc.py
+++ b/monai/metrics/rocauc.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import torch
 import warnings
 import numpy as np
@@ -48,7 +50,7 @@ def _calculate(y, y_pred):
     return auc / (nneg * (n - nneg))
 
 
-def compute_roc_auc(y_pred, y, to_onehot_y=False, add_softmax=False, average="macro"):
+def compute_roc_auc(y_pred, y, to_onehot_y: bool = False, add_softmax: bool = False, average: Optional[str] = "macro"):
     """Computes Area Under the Receiver Operating Characteristic Curve (ROC AUC). Referring to:
     `sklearn.metrics.roc_auc_score <https://scikit-learn.org/stable/modules/generated/
     sklearn.metrics.roc_auc_score.html#sklearn.metrics.roc_auc_score>`_.

--- a/monai/networks/layers/factories.py
+++ b/monai/networks/layers/factories.py
@@ -60,7 +60,7 @@ can be parameterized with the factory name and the arguments to pass to the crea
     layer = use_factory( (fact.TEST, kwargs) )
 """
 
-from typing import Callable
+from typing import Callable, Any
 
 import torch.nn as nn
 
@@ -100,7 +100,7 @@ class LayerFactory:
 
         return _add
 
-    def get_constructor(self, factory_name, *args):
+    def get_constructor(self, factory_name, *args) -> Any:
         """
         Get the constructor for the given factory name and arguments.
         """
@@ -111,7 +111,7 @@ class LayerFactory:
         fact = self.factories[factory_name.upper()]
         return fact(*args)
 
-    def __getitem__(self, args):
+    def __getitem__(self, args) -> Any:
         """
         Get the given name or name/arguments pair. If `args` is a callable it is assumed to be the constructor
         itself and is returned, otherwise it should be the factory name or a pair containing the name and arguments.

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -37,7 +37,7 @@ class Flatten(nn.Module):
 
 
 class GaussianFilter(nn.Module):
-    def __init__(self, spatial_dims, sigma, truncated=4.0):
+    def __init__(self, spatial_dims, sigma, truncated: float = 4.0):
         """
         Args:
             spatial_dims (int): number of spatial dimensions of the input image.

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -56,7 +56,7 @@ class GaussianFilter(nn.Module):
         for idx, param in enumerate(self.kernel):
             self.register_parameter(f"kernel_{idx}", param)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor):
         """
         Args:
             x (tensor): in shape [Batch, chns, H, W, D].

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -15,6 +15,7 @@ import torch
 import torch.nn as nn
 
 from monai.networks.layers.factories import Conv, Dropout, Pool, Norm
+from typing import Callable
 
 
 def densenet121(**kwargs):
@@ -42,9 +43,9 @@ class _DenseLayer(nn.Sequential):
         super(_DenseLayer, self).__init__()
 
         out_channels = bn_size * growth_rate
-        conv_type = Conv[Conv.CONV, spatial_dims]
-        norm_type = Norm[Norm.BATCH, spatial_dims]
-        dropout_type = Dropout[Dropout.DROPOUT, spatial_dims]
+        conv_type: Callable = Conv[Conv.CONV, spatial_dims]
+        norm_type: Callable = Norm[Norm.BATCH, spatial_dims]
+        dropout_type: Callable = Dropout[Dropout.DROPOUT, spatial_dims]
 
         self.add_module("norm1", norm_type(in_channels))
         self.add_module("relu1", nn.ReLU(inplace=True))
@@ -75,9 +76,9 @@ class _Transition(nn.Sequential):
     def __init__(self, spatial_dims, in_channels, out_channels):
         super(_Transition, self).__init__()
 
-        conv_type = Conv[Conv.CONV, spatial_dims]
-        norm_type = Norm[Norm.BATCH, spatial_dims]
-        pool_type = Pool[Pool.AVG, spatial_dims]
+        conv_type: Callable = Conv[Conv.CONV, spatial_dims]
+        norm_type: Callable = Norm[Norm.BATCH, spatial_dims]
+        pool_type: Callable = Pool[Pool.AVG, spatial_dims]
 
         self.add_module("norm", norm_type(in_channels))
         self.add_module("relu", nn.ReLU(inplace=True))
@@ -117,10 +118,10 @@ class DenseNet(nn.Module):
 
         super(DenseNet, self).__init__()
 
-        conv_type = Conv[Conv.CONV, spatial_dims]
-        norm_type = Norm[Norm.BATCH, spatial_dims]
-        pool_type = Pool[Pool.MAX, spatial_dims]
-        avg_pool_type = Pool[Pool.ADAPTIVEAVG, spatial_dims]
+        conv_type: Callable = Conv[Conv.CONV, spatial_dims]
+        norm_type: Callable = Norm[Norm.BATCH, spatial_dims]
+        pool_type: Callable = Pool[Pool.MAX, spatial_dims]
+        avg_pool_type: Callable = Pool[Pool.ADAPTIVEAVG, spatial_dims]
 
         self.features = nn.Sequential(
             OrderedDict(
@@ -165,6 +166,8 @@ class DenseNet(nn.Module):
             )
         )
 
+        # Avoid Built-in function isinstance was called with the wrong arguments warning
+        # pytype: disable=wrong-arg-types
         for m in self.modules():
             if isinstance(m, conv_type):
                 nn.init.kaiming_normal_(m.weight)
@@ -173,6 +176,7 @@ class DenseNet(nn.Module):
                 nn.init.constant_(m.bias, 0)
             elif isinstance(m, nn.Linear):
                 nn.init.constant_(m.bias, 0)
+        # pytype: enable=wrong-arg-types
 
     def forward(self, x):
         x = self.features(x)

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -10,12 +10,12 @@
 # limitations under the License.
 
 from collections import OrderedDict
+from typing import Callable
 
 import torch
 import torch.nn as nn
 
 from monai.networks.layers.factories import Conv, Dropout, Pool, Norm
-from typing import Callable
 
 
 def densenet121(**kwargs):

--- a/monai/networks/nets/highresnet.py
+++ b/monai/networks/nets/highresnet.py
@@ -37,7 +37,14 @@ DEFAULT_LAYER_PARAMS_3D = (
 
 class ConvNormActi(nn.Module):
     def __init__(
-        self, spatial_dims, in_channels, out_channels, kernel_size, norm_type=None, acti_type=None, dropout_prob=None
+        self,
+        spatial_dims: int,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        norm_type: Optional[str] = None,
+        acti_type: Optional[str] = None,
+        dropout_prob: Optional[float] = None,
     ):
 
         super(ConvNormActi, self).__init__()
@@ -65,14 +72,14 @@ class ConvNormActi(nn.Module):
 class HighResBlock(nn.Module):
     def __init__(
         self,
-        spatial_dims,
-        in_channels,
-        out_channels,
+        spatial_dims: int,
+        in_channels: int,
+        out_channels: int,
         kernels=(3, 3),
         dilation=1,
-        norm_type="instance",
-        acti_type="relu",
-        channel_matching="pad",
+        norm_type: str = "instance",
+        acti_type: str = "relu",
+        channel_matching: str = "pad",
     ):
         """
         Args:

--- a/monai/networks/nets/highresnet.py
+++ b/monai/networks/nets/highresnet.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -140,12 +142,12 @@ class HighResNet(nn.Module):
 
     def __init__(
         self,
-        spatial_dims=3,
-        in_channels=1,
-        out_channels=1,
-        norm_type="batch",
-        acti_type="relu",
-        dropout_prob=None,
+        spatial_dims: int = 3,
+        in_channels: int = 1,
+        out_channels: int = 1,
+        norm_type: str = "batch",
+        acti_type: str = "relu",
+        dropout_prob: Optional[float] = None,
         layer_params=DEFAULT_LAYER_PARAMS_3D,
     ):
 

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -46,7 +46,7 @@ def slice_channels(tensor, *slicevals):
     return tensor[slices]
 
 
-def predict_segmentation(logits, mutually_exclusive=False, threshold=0):
+def predict_segmentation(logits, mutually_exclusive: bool = False, threshold: float = 0):
     """
     Given the logits from a network, computing the segmentation by thresholding all values above 0
     if multi-labels task, computing the `argmax` along the channel axis if multi-classes task,

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn.functional as f
 
 
-def one_hot(labels, num_classes):
+def one_hot(labels: torch.Tensor, num_classes):
     """
     For a tensor `labels` of dimensions B1[spatial_dims], return a tensor of dimensions `BN[spatial_dims]`
     for `num_classes` N number of classes.
@@ -39,14 +39,14 @@ def one_hot(labels, num_classes):
     return labels
 
 
-def slice_channels(tensor, *slicevals):
+def slice_channels(tensor: torch.Tensor, *slicevals):
     slices = [slice(None)] * len(tensor.shape)
     slices[1] = slice(*slicevals)
 
     return tensor[slices]
 
 
-def predict_segmentation(logits, mutually_exclusive: bool = False, threshold: float = 0):
+def predict_segmentation(logits: torch.Tensor, mutually_exclusive: bool = False, threshold: float = 0):
     """
     Given the logits from a network, computing the segmentation by thresholding all values above 0
     if multi-labels task, computing the `argmax` along the channel axis if multi-classes task,

--- a/monai/transforms/adaptors.py
+++ b/monai/transforms/adaptors.py
@@ -96,7 +96,6 @@ Outputs:
 
 """
 
-import monai
 from monai.utils import export as _monai_export
 
 

--- a/monai/transforms/adaptors.py
+++ b/monai/transforms/adaptors.py
@@ -99,6 +99,7 @@ Outputs:
 import monai
 from monai.utils import export as _monai_export
 
+
 @_monai_export("monai.transforms")
 def adaptor(function, outputs, inputs=None):
     def must_be_types_or_none(variable_name, variable, types):

--- a/monai/transforms/adaptors.py
+++ b/monai/transforms/adaptors.py
@@ -97,9 +97,9 @@ Outputs:
 """
 
 import monai
+from monai.utils import export as _monai_export
 
-
-@monai.utils.export("monai.transforms")
+@_monai_export("monai.transforms")
 def adaptor(function, outputs, inputs=None):
     def must_be_types_or_none(variable_name, variable, types):
         if variable is not None:
@@ -184,7 +184,7 @@ def adaptor(function, outputs, inputs=None):
     return _inner
 
 
-@monai.utils.export("monai.transforms")
+@_monai_export("monai.transforms")
 def apply_alias(fn, name_map):
     def _inner(data):
 
@@ -205,7 +205,7 @@ def apply_alias(fn, name_map):
     return _inner
 
 
-@monai.utils.export("monai.transforms")
+@_monai_export("monai.transforms")
 def to_kwargs(fn):
     def _inner(data):
         return fn(**data)

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -13,12 +13,15 @@ A collection of generic interfaces for MONAI transforms.
 """
 
 import warnings
-from typing import Hashable, Optional
+from typing import Hashable, Union, Optional
 from abc import ABC, abstractmethod
 import numpy as np
 
 from monai.utils.misc import ensure_tuple, get_seed
 from .utils import apply_transform
+from torch import Tensor
+
+TransformDataType = Union[np.ndarray, Tensor]
 
 
 class Transform(ABC):
@@ -41,7 +44,7 @@ class Transform(ABC):
     """
 
     @abstractmethod
-    def __call__(self, data, *args, **kwargs):
+    def __call__(self, data: TransformDataType, *args, **kwargs) -> TransformDataType:
         """
         ``data`` is an element which often comes from an iteration over an
         iterable, such as :py:class:`torch.utils.data.Dataset`. This method should

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -219,7 +219,7 @@ class MapTransform(Transform):
 
     """
 
-    def __init__(self, keys):
+    def __init__(self, keys: Hashable):
         self.keys = ensure_tuple(keys)
         if not self.keys:
             raise ValueError("keys unspecified")

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -13,7 +13,7 @@ A collection of generic interfaces for MONAI transforms.
 """
 
 import warnings
-from typing import Hashable
+from typing import Hashable, Optional
 from abc import ABC, abstractmethod
 import numpy as np
 
@@ -64,7 +64,7 @@ class Randomizable(ABC):
 
     R = np.random.RandomState()
 
-    def set_random_state(self, seed=None, state=None):
+    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         """
         Set the random state locally, to control the randomness, the derived
         classes should use :py:attr:`self.R` instead of `np.random` to introduce random
@@ -174,7 +174,7 @@ class Compose(Randomizable):
         self.transforms = transforms
         self.set_random_state(seed=get_seed())
 
-    def set_random_state(self, seed=None, state=None):
+    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         for _transform in self.transforms:
             if not isinstance(_transform, Randomizable):
                 continue

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -13,6 +13,8 @@ A collection of "vanilla" transforms for crop and pad operations
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
+from typing import Optional, Callable
+
 import numpy as np
 
 from monai.data.utils import get_random_patch, get_valid_patch_size
@@ -34,7 +36,7 @@ class SpatialPad(Transform):
             for more details, please check: https://docs.scipy.org/doc/numpy/reference/generated/numpy.pad.html
     """
 
-    def __init__(self, spatial_size, method="symmetric", mode="constant"):
+    def __init__(self, spatial_size, method: str = "symmetric", mode: str = "constant"):
         self.spatial_size = ensure_tuple(spatial_size)
         assert method in ("symmetric", "end"), "unsupported padding type."
         self.method = method
@@ -51,7 +53,7 @@ class SpatialPad(Transform):
         else:
             return [(0, max(self.spatial_size[i] - data_shape[i], 0)) for i in range(len(self.spatial_size))]
 
-    def __call__(self, img, mode=None):
+    def __call__(self, img, mode: Optional[str] = None):
         data_pad_width = self._determine_data_pad_width(img.shape[1:])
         all_pad_width = [(0, 0)] + data_pad_width
         img = np.pad(img, all_pad_width, mode=mode or self.mode)
@@ -130,7 +132,7 @@ class RandSpatialCrop(Randomizable, Transform):
             The actual size is sampled from `randint(roi_size, img_size)`.
     """
 
-    def __init__(self, roi_size, random_center=True, random_size=True):
+    def __init__(self, roi_size, random_center: bool = True, random_size: bool = True):
         self.roi_size = roi_size
         self.random_center = random_center
         self.random_size = random_size
@@ -177,7 +179,7 @@ class CropForeground(Transform):
 
     """
 
-    def __init__(self, select_fn=lambda x: x > 0, channel_indexes=None, margin=0):
+    def __init__(self, select_fn: Callable = lambda x: x > 0, channel_indexes=None, margin: int = 0):
         """
         Args:
             select_fn (Callable): function to select expected foreground, default is to select values > 0.

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -15,6 +15,8 @@ defined in :py:class:`monai.transforms.croppad.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
+from typing import Union, Hashable, Optional, Callable
+
 from monai.data.utils import get_random_patch, get_valid_patch_size
 from monai.transforms.compose import MapTransform, Randomizable
 from monai.transforms.croppad.array import SpatialCrop, CenterSpatialCrop, SpatialPad
@@ -28,7 +30,7 @@ class SpatialPadd(MapTransform):
     Performs padding to the data, symmetric for all sides or all on one side for each dimension.
     """
 
-    def __init__(self, keys, spatial_size, method="symmetric", mode="constant"):
+    def __init__(self, keys: Hashable, spatial_size, method: str = "symmetric", mode="constant"):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -58,7 +60,7 @@ class SpatialCropd(MapTransform):
     are not provided, the start and end coordinates of the ROI must be provided.
     """
 
-    def __init__(self, keys, roi_center=None, roi_size=None, roi_start=None, roi_end=None):
+    def __init__(self, keys: Hashable, roi_center=None, roi_size=None, roi_start=None, roi_end=None):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -88,7 +90,7 @@ class CenterSpatialCropd(MapTransform):
         roi_size (list, tuple): the size of the crop region e.g. [224,224,128]
     """
 
-    def __init__(self, keys, roi_size):
+    def __init__(self, keys: Hashable, roi_size):
         super().__init__(keys)
         self.cropper = CenterSpatialCrop(roi_size)
 
@@ -116,7 +118,7 @@ class RandSpatialCropd(Randomizable, MapTransform):
             The actual size is sampled from `randint(roi_size, img_size)`.
     """
 
-    def __init__(self, keys, roi_size, random_center=True, random_size=True):
+    def __init__(self, keys: Hashable, roi_size, random_center: bool = True, random_size: bool = True):
         super().__init__(keys)
         self.roi_size = roi_size
         self.random_center = random_center
@@ -155,7 +157,14 @@ class CropForegroundd(MapTransform):
     channels. And it can also add margin to every dim of the bounding box of foreground object.
     """
 
-    def __init__(self, keys, source_key, select_fn=lambda x: x > 0, channel_indexes=None, margin=0):
+    def __init__(
+        self,
+        keys: Hashable,
+        source_key: str,
+        select_fn: Callable = lambda x: x > 0,
+        channel_indexes: Callable = None,
+        margin=0,
+    ):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -204,7 +213,17 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
             the valid image content area.
     """
 
-    def __init__(self, keys, label_key, size, pos=1, neg=1, num_samples=1, image_key=None, image_threshold=0):
+    def __init__(
+        self,
+        keys: Hashable,
+        label_key: str,
+        size,
+        pos: Union[int, float] = 1,
+        neg: Union[int, float] = 1,
+        num_samples: int = 1,
+        image_key: Optional[str] = None,
+        image_threshold: Union[int, float] = 0,
+    ):
         super().__init__(keys)
         assert isinstance(label_key, str), "label_key must be a string."
         assert isinstance(size, (list, tuple)), "size must be list or tuple."

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -13,28 +13,28 @@ A collection of "vanilla" transforms for intensity adjustment
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Union, Optional
 
 import numpy as np
 
 from monai.transforms.compose import Transform, Randomizable
 from monai.transforms.utils import rescale_array
+from typing import Union, List, Tuple, Optional
 
 
 class RandGaussianNoise(Randomizable, Transform):
     """Add Gaussian noise to image.
 
     Args:
-        prob (float): Probability to add Gaussian noise.
-        mean (float or array of floats): Mean or “centre” of the distribution.
-        std (float): Standard deviation (spread) of distribution.
+        prob: Probability to add Gaussian noise.
+        mean: Mean or “centre” of the distribution.
+        std: Standard deviation (spread) of distribution.
     """
 
-    def __init__(self, prob: float = 0.1, mean: float = 0.0, std: float = 0.1):
-        self.prob = prob
-        self.mean = mean
-        self.std = std
-        self._do_transform = False
+    def __init__(self, prob: float = 0.1, mean: Union[float, List[float]] = 0.0, std: float = 0.1):
+        self.prob: float = prob
+        self.mean: Union[float, List[float]] = mean
+        self.std: float = std
+        self._do_transform: bool = False
         self._noise = None
 
     def randomize(self, im_shape):
@@ -64,17 +64,19 @@ class RandShiftIntensity(Randomizable, Transform):
     """Randomly shift intensity with randomly picked offset.
     """
 
-    def __init__(self, offsets, prob: float = 0.1):
+    def __init__(self, offsets: Union[int, float, Tuple, List], prob: float = 0.1):
         """
         Args:
-            offsets(int, float, tuple or list): offset range to randomly shift.
+            offsets: offset range to randomly shift.
                 if single number, offset value is picked from (-offsets, offsets).
-            prob (float): probability of shift.
+            prob: probability of shift.
         """
-        self.offsets = (-offsets, offsets) if not isinstance(offsets, (list, tuple)) else offsets
+        self.offsets: Union[int, float, Tuple, List] = (-offsets, offsets) if not isinstance(
+            offsets, (list, tuple)
+        ) else offsets
         assert len(self.offsets) == 2, "offsets should be a number or pair of numbers."
-        self.prob = prob
-        self._do_transform = False
+        self.prob: float = prob
+        self._do_transform: bool = False
 
     def randomize(self):
         self._offset = self.R.uniform(low=self.offsets[0], high=self.offsets[1])

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -94,7 +94,12 @@ class ScaleIntensity(Transform):
     If `minv` and `maxv` not provided, use `factor` to scale image by ``v = v * (1 + factor)``.
     """
 
-    def __init__(self, minv: Union[int, float] = 0.0, maxv: Union[int, float] = 1.0, factor: Optional[float] = None):
+    def __init__(
+        self,
+        minv: Optional[Union[int, float]] = 0.0,
+        maxv: Optional[Union[int, float]] = 1.0,
+        factor: Optional[float] = None,
+    ):
         """
         Args:
             minv (int or float): minimum value of output data.

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -13,6 +13,8 @@ A collection of "vanilla" transforms for intensity adjustment
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
+from typing import Union, Optional
+
 import numpy as np
 
 from monai.transforms.compose import Transform, Randomizable
@@ -28,7 +30,7 @@ class RandGaussianNoise(Randomizable, Transform):
         std (float): Standard deviation (spread) of distribution.
     """
 
-    def __init__(self, prob=0.1, mean=0.0, std=0.1):
+    def __init__(self, prob: float = 0.1, mean: float = 0.0, std: float = 0.1):
         self.prob = prob
         self.mean = mean
         self.std = std
@@ -51,7 +53,7 @@ class ShiftIntensity(Transform):
         offset (int or float): offset value to shift the intensity of image.
     """
 
-    def __init__(self, offset):
+    def __init__(self, offset: Union[int, float]):
         self.offset = offset
 
     def __call__(self, img):
@@ -62,7 +64,7 @@ class RandShiftIntensity(Randomizable, Transform):
     """Randomly shift intensity with randomly picked offset.
     """
 
-    def __init__(self, offsets, prob=0.1):
+    def __init__(self, offsets, prob: float = 0.1):
         """
         Args:
             offsets(int, float, tuple or list): offset range to randomly shift.
@@ -92,7 +94,7 @@ class ScaleIntensity(Transform):
     If `minv` and `maxv` not provided, use `factor` to scale image by ``v = v * (1 + factor)``.
     """
 
-    def __init__(self, minv=0.0, maxv=1.0, factor=None):
+    def __init__(self, minv: Union[int, float] = 0.0, maxv: Union[int, float] = 1.0, factor: Optional[float] = None):
         """
         Args:
             minv (int or float): minimum value of output data.
@@ -116,7 +118,7 @@ class RandScaleIntensity(Randomizable, Transform):
     is randomly picked from (factors[0], factors[0]).
     """
 
-    def __init__(self, factors, prob=0.1):
+    def __init__(self, factors, prob: float = 0.1):
         """
         Args:
             factors(float, tuple or list): factor range to randomly scale by ``v = v * (1 + factor)``.
@@ -156,7 +158,13 @@ class NormalizeIntensity(Transform):
             or calculate on the entire image directly.
     """
 
-    def __init__(self, subtrahend=None, divisor=None, nonzero=False, channel_wise=False):
+    def __init__(
+        self,
+        subtrahend: Optional[np.ndarray] = None,
+        divisor: Optional[np.ndarray] = None,
+        nonzero: bool = False,
+        channel_wise: bool = False,
+    ):
         if subtrahend is not None or divisor is not None:
             assert isinstance(subtrahend, np.ndarray) and isinstance(
                 divisor, np.ndarray
@@ -195,7 +203,7 @@ class ThresholdIntensity(Transform):
         cval (float or int): value to fill the remaining parts of the image, default is 0.
     """
 
-    def __init__(self, threshold, above=True, cval=0):
+    def __init__(self, threshold: Union[int, float], above: bool = True, cval: Union[int, float] = 0):
         assert isinstance(threshold, (float, int)), "must set the threshold to filter intensity."
         self.threshold = threshold
         self.above = above
@@ -217,7 +225,14 @@ class ScaleIntensityRange(Transform):
         clip (bool): whether to perform clip after scaling.
     """
 
-    def __init__(self, a_min, a_max, b_min, b_max, clip=False):
+    def __init__(
+        self,
+        a_min: Union[int, float],
+        a_max: Union[int, float],
+        b_min: Union[int, float],
+        b_max: Union[int, float],
+        clip: bool = False,
+    ):
         self.a_min = a_min
         self.a_max = a_max
         self.b_min = b_min
@@ -241,7 +256,7 @@ class AdjustContrast(Transform):
         gamma (float): gamma value to adjust the contrast as function.
     """
 
-    def __init__(self, gamma):
+    def __init__(self, gamma: Union[int, float]):
         assert isinstance(gamma, (float, int)), "gamma must be a float or int number."
         self.gamma = gamma
 

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -15,6 +15,9 @@ defined in :py:class:`monai.transforms.intensity.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
+from typing import Hashable, Union, Optional
+
+import numpy as np
 from monai.transforms.compose import MapTransform, Randomizable
 from monai.transforms.intensity.array import (
     NormalizeIntensity,
@@ -38,7 +41,7 @@ class RandGaussianNoised(Randomizable, MapTransform):
         std (float): Standard deviation (spread) of distribution.
     """
 
-    def __init__(self, keys, prob=0.1, mean=0.0, std=0.1):
+    def __init__(self, keys: Hashable, prob: float = 0.1, mean=0.0, std: float = 0.1):
         super().__init__(keys)
         self.prob = prob
         self.mean = mean
@@ -67,7 +70,7 @@ class ShiftIntensityd(MapTransform):
     dictionary-based wrapper of :py:class:`monai.transforms.ShiftIntensity`.
     """
 
-    def __init__(self, keys, offset):
+    def __init__(self, keys: Hashable, offset: Union[int, float]):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -89,7 +92,7 @@ class RandShiftIntensityd(Randomizable, MapTransform):
     dictionary-based version :py:class:`monai.transforms.RandShiftIntensity`.
     """
 
-    def __init__(self, keys, offsets, prob=0.1):
+    def __init__(self, keys: Hashable, offsets, prob: float = 0.1):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -127,7 +130,13 @@ class ScaleIntensityd(MapTransform):
     If `minv` and `maxv` not provided, use `factor` to scale image by ``v = v * (1 + factor)``.
     """
 
-    def __init__(self, keys, minv=0.0, maxv=1.0, factor=None):
+    def __init__(
+        self,
+        keys: Hashable,
+        minv: Union[int, float] = 0.0,
+        maxv: Union[int, float] = 1.0,
+        factor: Optional[float] = None,
+    ):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -152,7 +161,7 @@ class RandScaleIntensityd(Randomizable, MapTransform):
     dictionary-based version :py:class:`monai.transforms.RandScaleIntensity`.
     """
 
-    def __init__(self, keys, factors, prob=0.1):
+    def __init__(self, keys: Hashable, factors, prob: float = 0.1):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -200,7 +209,14 @@ class NormalizeIntensityd(MapTransform):
             or calculate on the entire image directly.
     """
 
-    def __init__(self, keys, subtrahend=None, divisor=None, nonzero=False, channel_wise=False):
+    def __init__(
+        self,
+        keys: Hashable,
+        subtrahend: Optional[np.ndarray] = None,
+        divisor: Optional[np.ndarray] = None,
+        nonzero: bool = False,
+        channel_wise: bool = False,
+    ):
         super().__init__(keys)
         self.normalizer = NormalizeIntensity(subtrahend, divisor, nonzero, channel_wise)
 
@@ -223,7 +239,7 @@ class ThresholdIntensityd(MapTransform):
         cval (float or int): value to fill the remaining parts of the image, default is 0.
     """
 
-    def __init__(self, keys, threshold, above=True, cval=0):
+    def __init__(self, keys: Hashable, threshold: Union[int, float], above: bool = True, cval: Union[int, float] = 0):
         super().__init__(keys)
         self.filter = ThresholdIntensity(threshold, above, cval)
 
@@ -248,7 +264,15 @@ class ScaleIntensityRanged(MapTransform):
         clip (bool): whether to perform clip after scaling.
     """
 
-    def __init__(self, keys, a_min, a_max, b_min, b_max, clip=False):
+    def __init__(
+        self,
+        keys: Hashable,
+        a_min: Union[int, float],
+        a_max: Union[int, float],
+        b_min: Union[int, float],
+        b_max: Union[int, float],
+        clip: bool = False,
+    ):
         super().__init__(keys)
         self.scaler = ScaleIntensityRange(a_min, a_max, b_min, b_max, clip)
 
@@ -270,7 +294,7 @@ class AdjustContrastd(MapTransform):
         gamma (float): gamma value to adjust the contrast as function.
     """
 
-    def __init__(self, keys, gamma):
+    def __init__(self, keys: Hashable, gamma: Union[int, float]):
         super().__init__(keys)
         self.adjuster = AdjustContrast(gamma)
 

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -88,11 +88,13 @@ class LoadNifti(Transform):
             if not compatible_meta:
                 for meta_key in header:
                     meta_datum = header[meta_key]
+                    # pytype: disable=attribute-error
                     if (
                         type(meta_datum).__name__ == "ndarray"
                         and np_str_obj_array_pattern.search(meta_datum.dtype.str) is not None
                     ):
                         continue
+                    # pytype: enable=attribute-error
                     compatible_meta[meta_key] = meta_datum
             else:
                 assert np.allclose(

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -13,6 +13,8 @@ A collection of "vanilla" transforms for IO functions
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
+from typing import Optional
+
 import numpy as np
 import nibabel as nib
 from PIL import Image
@@ -31,7 +33,9 @@ class LoadNifti(Transform):
     that the affine transform of all the images should be same if ``image_only=False``.
     """
 
-    def __init__(self, as_closest_canonical=False, image_only=False, dtype: np.dtype = np.float32):
+    def __init__(
+        self, as_closest_canonical: bool = False, image_only: bool = False, dtype: Optional[np.dtype] = np.float32
+    ):
         """
         Args:
             as_closest_canonical (bool): if True, load the image as closest to canonical axis format.
@@ -108,7 +112,7 @@ class LoadPNG(Transform):
     https://pillow.readthedocs.io/en/stable/reference/Image.html
     """
 
-    def __init__(self, image_only=False, dtype: np.dtype = np.float32):
+    def __init__(self, image_only: bool = False, dtype: Optional[np.dtype] = np.float32):
         """Args:
             image_only (bool): if True return only the image volume, otherwise return image data array and metadata.
             dtype (np.dtype, optional): if not None convert the loaded image to this data type.

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -31,7 +31,7 @@ class LoadNifti(Transform):
     that the affine transform of all the images should be same if ``image_only=False``.
     """
 
-    def __init__(self, as_closest_canonical=False, image_only=False, dtype=np.float32):
+    def __init__(self, as_closest_canonical=False, image_only=False, dtype: np.dtype = np.float32):
         """
         Args:
             as_closest_canonical (bool): if True, load the image as closest to canonical axis format.
@@ -108,7 +108,7 @@ class LoadPNG(Transform):
     https://pillow.readthedocs.io/en/stable/reference/Image.html
     """
 
-    def __init__(self, image_only=False, dtype=np.float32):
+    def __init__(self, image_only=False, dtype: np.dtype = np.float32):
         """Args:
             image_only (bool): if True return only the image volume, otherwise return image data array and metadata.
             dtype (np.dtype, optional): if not None convert the loaded image to this data type.

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -32,7 +32,12 @@ class LoadNiftid(MapTransform):
     """
 
     def __init__(
-        self, keys, as_closest_canonical=False, dtype=np.float32, meta_key_format="{}.{}", overwriting_keys=False
+        self,
+        keys,
+        as_closest_canonical=False,
+        dtype: np.dtype = np.float32,
+        meta_key_format="{}.{}",
+        overwriting_keys=False,
     ):
         """
         Args:
@@ -70,7 +75,7 @@ class LoadPNGd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.LoadPNG`.
     """
 
-    def __init__(self, keys, dtype=np.float32, meta_key_format="{}.{}"):
+    def __init__(self, keys, dtype: np.dtype = np.float32, meta_key_format="{}.{}"):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -15,6 +15,8 @@ defined in :py:class:`monai.transforms.io.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
+from typing import Hashable, Optional
+
 import numpy as np
 
 from monai.transforms.compose import MapTransform
@@ -33,11 +35,11 @@ class LoadNiftid(MapTransform):
 
     def __init__(
         self,
-        keys,
-        as_closest_canonical=False,
-        dtype: np.dtype = np.float32,
-        meta_key_format="{}.{}",
-        overwriting_keys=False,
+        keys: Hashable,
+        as_closest_canonical: bool = False,
+        dtype: Optional[np.dtype] = np.float32,
+        meta_key_format: str = "{}.{}",
+        overwriting_keys: bool = False,
     ):
         """
         Args:
@@ -75,7 +77,7 @@ class LoadPNGd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.LoadPNG`.
     """
 
-    def __init__(self, keys, dtype: np.dtype = np.float32, meta_key_format="{}.{}"):
+    def __init__(self, keys: Hashable, dtype: Optional[np.dtype] = np.float32, meta_key_format: str = "{}.{}"):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -13,7 +13,7 @@ A collection of "vanilla" transforms for the model output tensors
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Optional
+from typing import Optional, Callable
 
 import torch
 from monai.transforms.compose import Transform
@@ -64,12 +64,14 @@ class Activations(Transform):
 
     """
 
-    def __init__(self, sigmoid: bool = False, softmax: bool = False, other=None):
+    def __init__(self, sigmoid: bool = False, softmax: bool = False, other: Optional[Callable] = None):
         self.sigmoid = sigmoid
         self.softmax = softmax
         self.other = other
 
-    def __call__(self, img, sigmoid: Optional[bool] = None, softmax: Optional[bool] = None, other=None):
+    def __call__(
+        self, img, sigmoid: Optional[bool] = None, softmax: Optional[bool] = None, other: Optional[Callable] = None
+    ):
         if sigmoid is True and softmax is True:
             raise ValueError("sigmoid=True and softmax=True are not compatible.")
         if sigmoid or self.sigmoid:
@@ -178,7 +180,9 @@ class KeepLargestConnectedComponent(Transform):
 
     """
 
-    def __init__(self, applied_values, independent=True, background=0, connectivity=None):
+    def __init__(
+        self, applied_values, independent: bool = True, background: int = 0, connectivity: Optional[int] = None
+    ):
         """
         Args:
             applied_values (list or tuple of int): number list for applying the connected component on.

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -13,6 +13,8 @@ A collection of "vanilla" transforms for the model output tensors
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
+from typing import Optional
+
 import torch
 from monai.transforms.compose import Transform
 from monai.networks.utils import one_hot
@@ -32,11 +34,11 @@ class SplitChannel(Transform):
 
     """
 
-    def __init__(self, to_onehot=False, num_classes=None):
+    def __init__(self, to_onehot: bool = False, num_classes: Optional[int] = None):
         self.to_onehot = to_onehot
         self.num_classes = num_classes
 
-    def __call__(self, img, to_onehot=None, num_classes=None):
+    def __call__(self, img, to_onehot: Optional[bool] = None, num_classes: Optional[int] = None):
         if to_onehot or self.to_onehot:
             if num_classes is None:
                 num_classes = self.num_classes
@@ -62,12 +64,12 @@ class Activations(Transform):
 
     """
 
-    def __init__(self, sigmoid=False, softmax=False, other=None):
+    def __init__(self, sigmoid: bool = False, softmax: bool = False, other=None):
         self.sigmoid = sigmoid
         self.softmax = softmax
         self.other = other
 
-    def __call__(self, img, sigmoid=None, softmax=None, other=None):
+    def __call__(self, img, sigmoid: Optional[bool] = None, softmax: Optional[bool] = None, other=None):
         if sigmoid is True and softmax is True:
             raise ValueError("sigmoid=True and softmax=True are not compatible.")
         if sigmoid or self.sigmoid:
@@ -100,14 +102,29 @@ class AsDiscrete(Transform):
 
     """
 
-    def __init__(self, argmax=False, to_onehot=False, n_classes=None, threshold_values=False, logit_thresh=0.5):
+    def __init__(
+        self,
+        argmax: bool = False,
+        to_onehot: bool = False,
+        n_classes: Optional[int] = None,
+        threshold_values: bool = False,
+        logit_thresh: float = 0.5,
+    ):
         self.argmax = argmax
         self.to_onehot = to_onehot
         self.n_classes = n_classes
         self.threshold_values = threshold_values
         self.logit_thresh = logit_thresh
 
-    def __call__(self, img, argmax=None, to_onehot=None, n_classes=None, threshold_values=None, logit_thresh=None):
+    def __call__(
+        self,
+        img,
+        argmax: Optional[bool] = None,
+        to_onehot: Optional[bool] = None,
+        n_classes: Optional[int] = None,
+        threshold_values: Optional[bool] = None,
+        logit_thresh: Optional[float] = None,
+    ):
         if argmax or self.argmax:
             img = torch.argmax(img, dim=1, keepdim=True)
 

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -15,7 +15,7 @@ defined in :py:class:`monai.transforms.utility.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
-from typing import Optional
+from typing import Optional, Hashable
 
 from monai.utils.misc import ensure_tuple_rep
 from monai.transforms.compose import MapTransform
@@ -29,7 +29,7 @@ class SplitChanneld(MapTransform):
 
     """
 
-    def __init__(self, keys, output_postfixes, to_onehot=False, num_classes=None):
+    def __init__(self, keys: Hashable, output_postfixes, to_onehot=False, num_classes=None):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -65,7 +65,7 @@ class Activationsd(MapTransform):
     Add activation layers to the input data specified by `keys`.
     """
 
-    def __init__(self, keys, output_postfix: str = "act", sigmoid=False, softmax=False, other=None):
+    def __init__(self, keys: Hashable, output_postfix: str = "act", sigmoid=False, softmax=False, other=None):
         """
         Args:
             keys (hashable items): keys of the corresponding items to model output and label.
@@ -106,7 +106,7 @@ class AsDiscreted(MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         output_postfix: str = "discreted",
         argmax=False,
         to_onehot=False,
@@ -161,7 +161,7 @@ class KeepLargestConnectedComponentd(MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         applied_values,
         independent: bool = True,
         background: int = 0,

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -15,6 +15,8 @@ defined in :py:class:`monai.transforms.utility.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
+from typing import Optional
+
 from monai.utils.misc import ensure_tuple_rep
 from monai.transforms.compose import MapTransform
 from monai.transforms.post.array import SplitChannel, Activations, AsDiscrete, KeepLargestConnectedComponent
@@ -63,7 +65,7 @@ class Activationsd(MapTransform):
     Add activation layers to the input data specified by `keys`.
     """
 
-    def __init__(self, keys, output_postfix="act", sigmoid=False, softmax=False, other=None):
+    def __init__(self, keys, output_postfix: str = "act", sigmoid=False, softmax=False, other=None):
         """
         Args:
             keys (hashable items): keys of the corresponding items to model output and label.
@@ -105,7 +107,7 @@ class AsDiscreted(MapTransform):
     def __init__(
         self,
         keys,
-        output_postfix="discreted",
+        output_postfix: str = "discreted",
         argmax=False,
         to_onehot=False,
         n_classes=None,
@@ -158,7 +160,13 @@ class KeepLargestConnectedComponentd(MapTransform):
     """
 
     def __init__(
-        self, keys, applied_values, independent=True, background=0, connectivity=None, output_postfix="largestcc",
+        self,
+        keys,
+        applied_values,
+        independent: bool = True,
+        background: int = 0,
+        connectivity: Optional[int] = None,
+        output_postfix: str = "largestcc",
     ):
         """
         Args:

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -13,7 +13,7 @@ A collection of "vanilla" transforms for spatial operations
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Optional
+from typing import Optional, Union
 
 import warnings
 import numpy as np
@@ -42,7 +42,13 @@ class Spacing(Transform):
     """
 
     def __init__(
-        self, pixdim, diagonal: bool = False, interp_order=3, mode: str = "nearest", cval: float = 0, dtype=None
+        self,
+        pixdim,
+        diagonal: bool = False,
+        interp_order=3,
+        mode: str = "nearest",
+        cval: Union[int, float] = 0,
+        dtype: Optional[np.dtype] = None,
     ):
         """
         Args:
@@ -73,7 +79,15 @@ class Spacing(Transform):
         self.cval = cval
         self.dtype = dtype
 
-    def __call__(self, data_array, affine=None, interp_order=None, mode=None, cval=None, dtype=None):
+    def __call__(
+        self,
+        data_array: np.ndarray,
+        affine=None,
+        interp_order=None,
+        mode: Optional[str] = None,
+        cval: Union[int, float] = None,
+        dtype: Optional[np.dtype] = None,
+    ):
         """
         Args:
             data_array (ndarray): in shape (num_channels, H[, W, ...]).
@@ -148,7 +162,7 @@ class Orientation(Transform):
         self.as_closest_canonical = as_closest_canonical
         self.labels = labels
 
-    def __call__(self, data_array, affine=None):
+    def __call__(self, data_array: np.ndarray, affine=None):
         """
         original orientation of `data_array` is defined by `affine`.
 
@@ -234,7 +248,7 @@ class Resize(Transform):
         spatial_size,
         interp_order=InterpolationCode.LINEAR,
         mode: str = "reflect",
-        cval: float = 0,
+        cval: Union[int, float] = 0,
         clip: bool = True,
         preserve_range: bool = True,
         anti_aliasing: bool = True,
@@ -252,7 +266,7 @@ class Resize(Transform):
         img,
         order=None,
         mode: Optional[str] = None,
-        cval: Optional[float] = None,
+        cval: Optional[Union[int, float]] = None,
         clip: Optional[bool] = None,
         preserve_range: Optional[bool] = None,
         anti_aliasing: Optional[bool] = None,
@@ -304,7 +318,7 @@ class Rotate(Transform):
         reshape: bool = True,
         interp_order=1,
         mode: str = "constant",
-        cval: float = 0,
+        cval: Union[int, float] = 0,
         prefilter: bool = True,
     ):
         self.angle = angle
@@ -320,7 +334,7 @@ class Rotate(Transform):
         img,
         order=None,
         mode: Optional[str] = None,
-        cval: Optional[float] = None,
+        cval: Optional[Union[int, float]] = None,
         prefilter: Optional[bool] = None,
     ):
         """
@@ -366,7 +380,7 @@ class Zoom(Transform):
         zoom,
         interp_order=InterpolationCode.SPLINE3,
         mode: str = "constant",
-        cval: float = 0,
+        cval: Union[int, float] = 0,
         prefilter: bool = True,
         use_gpu: bool = False,
         keep_size: bool = True,
@@ -457,7 +471,7 @@ class Rotate90(Transform):
         self.k = k
         self.spatial_axes = spatial_axes
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray):
         """
         Args:
             img (ndarray): channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -530,7 +544,7 @@ class RandRotate(Randomizable, Transform):
         reshape: bool = True,
         interp_order=InterpolationCode.LINEAR,
         mode: str = "constant",
-        cval: float = 0,
+        cval: Union[int, float] = 0,
         prefilter: bool = True,
     ):
         self.degrees = degrees
@@ -558,7 +572,7 @@ class RandRotate(Randomizable, Transform):
         img,
         order=None,
         mode: Optional[str] = None,
-        cval: Optional[float] = None,
+        cval: Optional[Union[int, float]] = None,
         prefilter: Optional[bool] = None,
     ):
         self.randomize()
@@ -628,11 +642,11 @@ class RandZoom(Randomizable, Transform):
         min_zoom=0.9,
         max_zoom=1.1,
         interp_order=InterpolationCode.SPLINE3,
-        mode="constant",
-        cval=0,
-        prefilter=True,
-        use_gpu=False,
-        keep_size=True,
+        mode: str = "constant",
+        cval: Union[int, float] = 0,
+        prefilter: bool = True,
+        use_gpu: bool = False,
+        keep_size: bool = True,
     ):
         if hasattr(min_zoom, "__iter__") and hasattr(max_zoom, "__iter__"):
             assert len(min_zoom) == len(max_zoom), "min_zoom and max_zoom must have same length."
@@ -657,7 +671,14 @@ class RandZoom(Randomizable, Transform):
         else:
             self._zoom = self.R.uniform(self.min_zoom, self.max_zoom)
 
-    def __call__(self, img, order=None, mode=None, cval=None, prefilter=None):
+    def __call__(
+        self,
+        img,
+        order=None,
+        mode: Optional[str] = None,
+        cval: Union[int, float] = None,
+        prefilter: Optional[bool] = None,
+    ):
         self.randomize()
         if not self._do_transform:
             return img
@@ -682,8 +703,8 @@ class AffineGrid(Transform):
         shear_params=None,
         translate_params=None,
         scale_params=None,
-        as_tensor_output=True,
-        device=None,
+        as_tensor_output: bool = True,
+        device: Optional[torch.device] = None,
     ):
         self.rotate_params = rotate_params
         self.shear_params = shear_params
@@ -737,8 +758,8 @@ class RandAffineGrid(Randomizable, Transform):
         shear_range=None,
         translate_range=None,
         scale_range=None,
-        as_tensor_output=True,
-        device=None,
+        as_tensor_output: bool = True,
+        device: Optional[torch.device] = None,
     ):
         """
         Args:
@@ -809,7 +830,7 @@ class RandDeformGrid(Randomizable, Transform):
     generate random deformation grid
     """
 
-    def __init__(self, spacing, magnitude_range, as_tensor_output: bool = True, device=None):
+    def __init__(self, spacing, magnitude_range, as_tensor_output: bool = True, device: Optional[torch.device] = None):
         """
         Args:
             spacing (2 or 3 ints): spacing of the grid in 2D or 3D.
@@ -845,7 +866,11 @@ class RandDeformGrid(Randomizable, Transform):
 
 class Resample(Transform):
     def __init__(
-        self, padding_mode: str = "zeros", mode: str = "bilinear", as_tensor_output: bool = False, device=None
+        self,
+        padding_mode: str = "zeros",
+        mode: str = "bilinear",
+        as_tensor_output: bool = False,
+        device: Optional[torch.device] = None,
     ):
         """
         computes output image using values from `img`, locations from `grid` using pytorch.
@@ -862,7 +887,13 @@ class Resample(Transform):
         self.as_tensor_output = as_tensor_output
         self.device = device
 
-    def __call__(self, img, grid, padding_mode=None, mode: Optional[str] = None):
+    def __call__(
+        self,
+        img: Union[np.ndarray, torch.Tensor],
+        grid: Union[np.ndarray, torch.Tensor],
+        padding_mode: Optional[str] = None,
+        mode: Optional[str] = None,
+    ):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W[, D]).
@@ -908,7 +939,7 @@ class Affine(Transform):
         mode: str = "bilinear",
         padding_mode: str = "zeros",
         as_tensor_output: bool = False,
-        device=None,
+        device: Optional[torch.device] = None,
     ):
         """
         The affine transformations are applied in rotate, shear, translate, scale order.
@@ -945,7 +976,13 @@ class Affine(Transform):
         self.padding_mode = padding_mode
         self.mode = mode
 
-    def __call__(self, img, spatial_size=None, padding_mode: Optional[str] = None, mode: Optional[str] = None):
+    def __call__(
+        self,
+        img: Union[np.ndarray, torch.Tensor],
+        spatial_size=None,
+        padding_mode: Optional[str] = None,
+        mode: Optional[str] = None,
+    ):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W[, D]),
@@ -977,7 +1014,7 @@ class RandAffine(Randomizable, Transform):
         mode: str = "bilinear",
         padding_mode: str = "zeros",
         as_tensor_output: bool = True,
-        device=None,
+        device: Optional[torch.device] = None,
     ):
         """
         Args:
@@ -1023,7 +1060,13 @@ class RandAffine(Randomizable, Transform):
         self.do_transform = self.R.rand() < self.prob
         self.rand_affine_grid.randomize()
 
-    def __call__(self, img, spatial_size=None, padding_mode: Optional[str] = None, mode: Optional[str] = None):
+    def __call__(
+        self,
+        img: Union[np.ndarray, torch.Tensor],
+        spatial_size=None,
+        padding_mode: Optional[str] = None,
+        mode: Optional[str] = None,
+    ):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W[, D]),
@@ -1062,7 +1105,7 @@ class Rand2DElastic(Randomizable, Transform):
         mode: str = "bilinear",
         padding_mode: str = "zeros",
         as_tensor_output: bool = False,
-        device=None,
+        device: Optional[torch.device] = None,
     ):
         """
         Args:
@@ -1114,7 +1157,13 @@ class Rand2DElastic(Randomizable, Transform):
         self.deform_grid.randomize(spatial_size)
         self.rand_affine_grid.randomize()
 
-    def __call__(self, img, spatial_size=None, padding_mode: Optional[str] = None, mode: Optional[str] = None):
+    def __call__(
+        self,
+        img: Union[np.ndarray, torch.Tensor],
+        spatial_size=None,
+        padding_mode: Optional[str] = None,
+        mode: Optional[str] = None,
+    ):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W),
@@ -1152,7 +1201,7 @@ class Rand3DElastic(Randomizable, Transform):
         mode: str = "bilinear",
         padding_mode: str = "zeros",
         as_tensor_output: bool = False,
-        device=None,
+        device: Optional[torch.device] = None,
     ):
         """
         Args:
@@ -1204,7 +1253,9 @@ class Rand3DElastic(Randomizable, Transform):
         self.sigma = self.R.uniform(self.sigma_range[0], self.sigma_range[1])
         self.rand_affine_grid.randomize()
 
-    def __call__(self, img, spatial_size=None, padding_mode=None, mode=None):
+    def __call__(
+        self, img, spatial_size=None, padding_mode=None, mode=None,
+    ):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W, D),

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -13,6 +13,8 @@ A collection of "vanilla" transforms for spatial operations
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
+from typing import Optional
+
 import warnings
 import numpy as np
 import scipy.ndimage
@@ -39,7 +41,9 @@ class Spacing(Transform):
     Resample input image into the specified `pixdim`.
     """
 
-    def __init__(self, pixdim, diagonal=False, interp_order=3, mode="nearest", cval=0, dtype=None):
+    def __init__(
+        self, pixdim, diagonal: bool = False, interp_order=3, mode: str = "nearest", cval: float = 0, dtype=None
+    ):
         """
         Args:
             pixdim (sequence of floats): output voxel spacing.
@@ -121,7 +125,7 @@ class Orientation(Transform):
     Change the input image's orientation into the specified based on `axcodes`.
     """
 
-    def __init__(self, axcodes=None, as_closest_canonical=False, labels=tuple(zip("LPI", "RAS"))):
+    def __init__(self, axcodes=None, as_closest_canonical: bool = False, labels=tuple(zip("LPI", "RAS"))):
         """
         Args:
             axcodes (N elements sequence): for spatial ND input's orientation.
@@ -229,11 +233,11 @@ class Resize(Transform):
         self,
         spatial_size,
         interp_order=InterpolationCode.LINEAR,
-        mode="reflect",
-        cval=0,
-        clip=True,
-        preserve_range=True,
-        anti_aliasing=True,
+        mode: str = "reflect",
+        cval: float = 0,
+        clip: bool = True,
+        preserve_range: bool = True,
+        anti_aliasing: bool = True,
     ):
         self.spatial_size = spatial_size
         self.interp_order = interp_order
@@ -244,7 +248,14 @@ class Resize(Transform):
         self.anti_aliasing = anti_aliasing
 
     def __call__(
-        self, img, order=None, mode=None, cval=None, clip=None, preserve_range=None, anti_aliasing=None,
+        self,
+        img,
+        order=None,
+        mode: Optional[str] = None,
+        cval: Optional[float] = None,
+        clip: Optional[bool] = None,
+        preserve_range: Optional[bool] = None,
+        anti_aliasing: Optional[bool] = None,
     ):
         """
         Args:
@@ -287,7 +298,14 @@ class Rotate(Transform):
     """
 
     def __init__(
-        self, angle, spatial_axes=(0, 1), reshape=True, interp_order=1, mode="constant", cval=0, prefilter=True
+        self,
+        angle,
+        spatial_axes=(0, 1),
+        reshape: bool = True,
+        interp_order=1,
+        mode: str = "constant",
+        cval: float = 0,
+        prefilter: bool = True,
     ):
         self.angle = angle
         self.spatial_axes = spatial_axes
@@ -297,7 +315,14 @@ class Rotate(Transform):
         self.cval = cval
         self.prefilter = prefilter
 
-    def __call__(self, img, order=None, mode=None, cval=None, prefilter=None):
+    def __call__(
+        self,
+        img,
+        order=None,
+        mode: Optional[str] = None,
+        cval: Optional[float] = None,
+        prefilter: Optional[bool] = None,
+    ):
         """
         Args:
             img (ndarray): channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -340,11 +365,11 @@ class Zoom(Transform):
         self,
         zoom,
         interp_order=InterpolationCode.SPLINE3,
-        mode="constant",
-        cval=0,
-        prefilter=True,
-        use_gpu=False,
-        keep_size=True,
+        mode: str = "constant",
+        cval: float = 0,
+        prefilter: bool = True,
+        use_gpu: bool = False,
+        keep_size: bool = True,
     ):
         self.zoom = zoom
         self.interp_order = interp_order
@@ -366,7 +391,9 @@ class Zoom(Transform):
         else:
             self._zoom = scipy.ndimage.zoom
 
-    def __call__(self, img, order=None, mode=None, cval=None, prefilter=None):
+    def __call__(
+        self, img, order=None, mode=None, cval=None, prefilter=None,
+    ):
         """
         Args:
             img (ndarray): channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -420,7 +447,7 @@ class Rotate90(Transform):
     Rotate an array by 90 degrees in the plane specified by `axes`.
     """
 
-    def __init__(self, k=1, spatial_axes=(0, 1)):
+    def __init__(self, k: int = 1, spatial_axes=(0, 1)):
         """
         Args:
             k (int): number of times to rotate by 90 degrees.
@@ -447,7 +474,7 @@ class RandRotate90(Randomizable, Transform):
     in the plane specified by `spatial_axes`.
     """
 
-    def __init__(self, prob=0.1, max_k=3, spatial_axes=(0, 1)):
+    def __init__(self, prob: float = 0.1, max_k: int = 3, spatial_axes=(0, 1)):
         """
         Args:
             prob (float): probability of rotating.
@@ -498,13 +525,13 @@ class RandRotate(Randomizable, Transform):
     def __init__(
         self,
         degrees,
-        prob=0.1,
+        prob: float = 0.1,
         spatial_axes=(0, 1),
-        reshape=True,
+        reshape: bool = True,
         interp_order=InterpolationCode.LINEAR,
-        mode="constant",
-        cval=0,
-        prefilter=True,
+        mode: str = "constant",
+        cval: float = 0,
+        prefilter: bool = True,
     ):
         self.degrees = degrees
         self.prob = prob
@@ -526,7 +553,14 @@ class RandRotate(Randomizable, Transform):
         self._do_transform = self.R.random_sample() < self.prob
         self.angle = self.R.uniform(low=self.degrees[0], high=self.degrees[1])
 
-    def __call__(self, img, order=None, mode=None, cval=None, prefilter=None):
+    def __call__(
+        self,
+        img,
+        order=None,
+        mode: Optional[str] = None,
+        cval: Optional[float] = None,
+        prefilter: Optional[bool] = None,
+    ):
         self.randomize()
         if not self._do_transform:
             return img
@@ -552,7 +586,7 @@ class RandFlip(Randomizable, Transform):
         spatial_axis (None, int or tuple of ints): Spatial axes along which to flip over. Default is None.
     """
 
-    def __init__(self, prob=0.1, spatial_axis=None):
+    def __init__(self, prob: float = 0.1, spatial_axis=None):
         self.prob = prob
         self.flipper = Flip(spatial_axis=spatial_axis)
         self._do_transform = False
@@ -590,7 +624,7 @@ class RandZoom(Randomizable, Transform):
 
     def __init__(
         self,
-        prob=0.1,
+        prob: float = 0.1,
         min_zoom=0.9,
         max_zoom=1.1,
         interp_order=InterpolationCode.SPLINE3,
@@ -775,7 +809,7 @@ class RandDeformGrid(Randomizable, Transform):
     generate random deformation grid
     """
 
-    def __init__(self, spacing, magnitude_range, as_tensor_output=True, device=None):
+    def __init__(self, spacing, magnitude_range, as_tensor_output: bool = True, device=None):
         """
         Args:
             spacing (2 or 3 ints): spacing of the grid in 2D or 3D.
@@ -810,7 +844,9 @@ class RandDeformGrid(Randomizable, Transform):
 
 
 class Resample(Transform):
-    def __init__(self, padding_mode="zeros", mode="bilinear", as_tensor_output=False, device=None):
+    def __init__(
+        self, padding_mode: str = "zeros", mode: str = "bilinear", as_tensor_output: bool = False, device=None
+    ):
         """
         computes output image using values from `img`, locations from `grid` using pytorch.
         supports spatially 2D or 3D (num_channels, H, W[, D]).
@@ -826,7 +862,7 @@ class Resample(Transform):
         self.as_tensor_output = as_tensor_output
         self.device = device
 
-    def __call__(self, img, grid, padding_mode=None, mode=None):
+    def __call__(self, img, grid, padding_mode=None, mode: Optional[str] = None):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W[, D]).
@@ -869,9 +905,9 @@ class Affine(Transform):
         translate_params=None,
         scale_params=None,
         spatial_size=None,
-        mode="bilinear",
-        padding_mode="zeros",
-        as_tensor_output=False,
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
+        as_tensor_output: bool = False,
         device=None,
     ):
         """
@@ -909,7 +945,7 @@ class Affine(Transform):
         self.padding_mode = padding_mode
         self.mode = mode
 
-    def __call__(self, img, spatial_size=None, padding_mode=None, mode=None):
+    def __call__(self, img, spatial_size=None, padding_mode: Optional[str] = None, mode: Optional[str] = None):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W[, D]),
@@ -932,15 +968,15 @@ class RandAffine(Randomizable, Transform):
 
     def __init__(
         self,
-        prob=0.1,
+        prob: float = 0.1,
         rotate_range=None,
         shear_range=None,
         translate_range=None,
         scale_range=None,
         spatial_size=None,
-        mode="bilinear",
-        padding_mode="zeros",
-        as_tensor_output=True,
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
+        as_tensor_output: bool = True,
         device=None,
     ):
         """
@@ -978,7 +1014,7 @@ class RandAffine(Randomizable, Transform):
         self.do_transform = False
         self.prob = prob
 
-    def set_random_state(self, seed=None, state=None):
+    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         self.rand_affine_grid.set_random_state(seed, state)
         super().set_random_state(seed, state)
         return self
@@ -987,7 +1023,7 @@ class RandAffine(Randomizable, Transform):
         self.do_transform = self.R.rand() < self.prob
         self.rand_affine_grid.randomize()
 
-    def __call__(self, img, spatial_size=None, padding_mode=None, mode=None):
+    def __call__(self, img, spatial_size=None, padding_mode: Optional[str] = None, mode: Optional[str] = None):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W[, D]),
@@ -1017,15 +1053,15 @@ class Rand2DElastic(Randomizable, Transform):
         self,
         spacing,
         magnitude_range,
-        prob=0.1,
+        prob: float = 0.1,
         rotate_range=None,
         shear_range=None,
         translate_range=None,
         scale_range=None,
         spatial_size=None,
-        mode="bilinear",
-        padding_mode="zeros",
-        as_tensor_output=False,
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
+        as_tensor_output: bool = False,
         device=None,
     ):
         """
@@ -1067,7 +1103,7 @@ class Rand2DElastic(Randomizable, Transform):
         self.prob = prob
         self.do_transform = False
 
-    def set_random_state(self, seed=None, state=None):
+    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         self.deform_grid.set_random_state(seed, state)
         self.rand_affine_grid.set_random_state(seed, state)
         super().set_random_state(seed, state)
@@ -1078,7 +1114,7 @@ class Rand2DElastic(Randomizable, Transform):
         self.deform_grid.randomize(spatial_size)
         self.rand_affine_grid.randomize()
 
-    def __call__(self, img, spatial_size=None, padding_mode=None, mode=None):
+    def __call__(self, img, spatial_size=None, padding_mode: Optional[str] = None, mode: Optional[str] = None):
         """
         Args:
             img (ndarray or tensor): shape must be (num_channels, H, W),
@@ -1107,15 +1143,15 @@ class Rand3DElastic(Randomizable, Transform):
         self,
         sigma_range,
         magnitude_range,
-        prob=0.1,
+        prob: float = 0.1,
         rotate_range=None,
         shear_range=None,
         translate_range=None,
         scale_range=None,
         spatial_size=None,
-        mode="bilinear",
-        padding_mode="zeros",
-        as_tensor_output=False,
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
+        as_tensor_output: bool = False,
         device=None,
     ):
         """
@@ -1155,7 +1191,7 @@ class Rand3DElastic(Randomizable, Transform):
         self.magnitude = 1.0
         self.sigma = 1.0
 
-    def set_random_state(self, seed=None, state=None):
+    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         self.rand_affine_grid.set_random_state(seed, state)
         super().set_random_state(seed, state)
         return self

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -13,7 +13,7 @@ A collection of "vanilla" transforms for spatial operations
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Optional, Union
+from typing import Optional, Union, List
 
 import warnings
 import numpy as np
@@ -910,7 +910,8 @@ class Resample(Transform):
         for i, dim in enumerate(img.shape[1:]):
             grid[i] = 2.0 * grid[i] / (dim - 1.0)
         grid = grid[:-1] / grid[-1:]
-        grid = grid[range(img.ndim - 2, -1, -1)]
+        index_ordering: List[int] = [x for x in range(img.ndim - 2, -1, -1)]
+        grid = grid[index_ordering]
         grid = grid.permute(list(range(grid.ndim))[1:] + [0])
         out = torch.nn.functional.grid_sample(
             img[None].float(),

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -51,7 +51,15 @@ class Spacingd(MapTransform):
     """
 
     def __init__(
-        self, keys, pixdim, diagonal=False, interp_order=3, mode="nearest", cval=0, dtype=None, meta_key_format="{}.{}"
+        self,
+        keys,
+        pixdim,
+        diagonal: bool = False,
+        interp_order=3,
+        mode="nearest",
+        cval=0,
+        dtype=None,
+        meta_key_format: str = "{}.{}",
     ):
         """
         Args:
@@ -119,7 +127,12 @@ class Orientationd(MapTransform):
     """
 
     def __init__(
-        self, keys, axcodes=None, as_closest_canonical=False, labels=tuple(zip("LPI", "RAS")), meta_key_format="{}.{}"
+        self,
+        keys,
+        axcodes=None,
+        as_closest_canonical: bool = False,
+        labels=tuple(zip("LPI", "RAS")),
+        meta_key_format: str = "{}.{}",
     ):
         """
         Args:
@@ -155,7 +168,7 @@ class Rotate90d(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.Rotate90`.
     """
 
-    def __init__(self, keys, k=1, spatial_axes=(0, 1)):
+    def __init__(self, keys, k: int = 1, spatial_axes=(0, 1)):
         """
         Args:
             k (int): number of times to rotate by 90 degrees.
@@ -178,7 +191,7 @@ class RandRotate90d(Randomizable, MapTransform):
     in the plane specified by `spatial_axes`.
     """
 
-    def __init__(self, keys, prob=0.1, max_k=3, spatial_axes=(0, 1)):
+    def __init__(self, keys, prob: float = 0.1, max_k: int = 3, spatial_axes=(0, 1)):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -280,14 +293,14 @@ class RandAffined(Randomizable, MapTransform):
         self,
         keys,
         spatial_size,
-        prob=0.1,
+        prob: float = 0.1,
         rotate_range=None,
         shear_range=None,
         translate_range=None,
         scale_range=None,
         mode="bilinear",
         padding_mode="zeros",
-        as_tensor_output=True,
+        as_tensor_output: bool = True,
         device=None,
     ):
         """
@@ -360,14 +373,14 @@ class Rand2DElasticd(Randomizable, MapTransform):
         spatial_size,
         spacing,
         magnitude_range,
-        prob=0.1,
+        prob: float = 0.1,
         rotate_range=None,
         shear_range=None,
         translate_range=None,
         scale_range=None,
         mode="bilinear",
         padding_mode="zeros",
-        as_tensor_output=False,
+        as_tensor_output: bool = False,
         device=None,
     ):
         """
@@ -447,14 +460,14 @@ class Rand3DElasticd(Randomizable, MapTransform):
         spatial_size,
         sigma_range,
         magnitude_range,
-        prob=0.1,
+        prob: float = 0.1,
         rotate_range=None,
         shear_range=None,
         translate_range=None,
         scale_range=None,
         mode="bilinear",
         padding_mode="zeros",
-        as_tensor_output=False,
+        as_tensor_output: bool = False,
         device=None,
     ):
         """
@@ -600,9 +613,9 @@ class Rotated(MapTransform):
     def __init__(
         self,
         keys,
-        angle,
+        angle: float,
         spatial_axes=(0, 1),
-        reshape=True,
+        reshape: bool = True,
         interp_order=InterpolationCode.LINEAR,
         mode="constant",
         cval=0,
@@ -654,9 +667,9 @@ class RandRotated(Randomizable, MapTransform):
         self,
         keys,
         degrees,
-        prob=0.1,
+        prob: float = 0.1,
         spatial_axes=(0, 1),
-        reshape=True,
+        reshape: bool = True,
         interp_order=InterpolationCode.LINEAR,
         mode="constant",
         cval=0,
@@ -725,7 +738,7 @@ class Zoomd(MapTransform):
         mode="constant",
         cval=0,
         prefilter=True,
-        use_gpu=False,
+        use_gpu: bool = False,
         keep_size=True,
     ):
         super().__init__(keys)
@@ -774,15 +787,15 @@ class RandZoomd(Randomizable, MapTransform):
     def __init__(
         self,
         keys,
-        prob=0.1,
+        prob: float = 0.1,
         min_zoom=0.9,
         max_zoom=1.1,
         interp_order=InterpolationCode.SPLINE3,
         mode="constant",
         cval=0,
         prefilter=True,
-        use_gpu=False,
-        keep_size=True,
+        use_gpu: bool = False,
+        keep_size: bool = True,
     ):
         super().__init__(keys)
         if hasattr(min_zoom, "__iter__") and hasattr(max_zoom, "__iter__"):

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -15,6 +15,9 @@ defined in :py:class:`monai.transforms.spatial.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
+from typing import Hashable, Optional
+
+import numpy as np
 import torch
 from monai.data.utils import InterpolationCode
 
@@ -52,13 +55,13 @@ class Spacingd(MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         pixdim,
         diagonal: bool = False,
         interp_order=3,
         mode="nearest",
         cval=0,
-        dtype=None,
+        dtype: Optional[np.dtype] = None,
         meta_key_format: str = "{}.{}",
     ):
         """
@@ -128,7 +131,7 @@ class Orientationd(MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         axcodes=None,
         as_closest_canonical: bool = False,
         labels=tuple(zip("LPI", "RAS")),
@@ -168,7 +171,7 @@ class Rotate90d(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.Rotate90`.
     """
 
-    def __init__(self, keys, k: int = 1, spatial_axes=(0, 1)):
+    def __init__(self, keys: Hashable, k: int = 1, spatial_axes=(0, 1)):
         """
         Args:
             k (int): number of times to rotate by 90 degrees.
@@ -191,7 +194,7 @@ class RandRotate90d(Randomizable, MapTransform):
     in the plane specified by `spatial_axes`.
     """
 
-    def __init__(self, keys, prob: float = 0.1, max_k: int = 3, spatial_axes=(0, 1)):
+    def __init__(self, keys: Hashable, prob: float = 0.1, max_k: int = 3, spatial_axes=(0, 1)):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -250,7 +253,7 @@ class Resized(MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         spatial_size,
         interp_order=1,
         mode="reflect",
@@ -291,7 +294,7 @@ class RandAffined(Randomizable, MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         spatial_size,
         prob: float = 0.1,
         rotate_range=None,
@@ -301,7 +304,7 @@ class RandAffined(Randomizable, MapTransform):
         mode="bilinear",
         padding_mode="zeros",
         as_tensor_output: bool = True,
-        device=None,
+        device: Optional[torch.device] = None,
     ):
         """
         Args:
@@ -369,7 +372,7 @@ class Rand2DElasticd(Randomizable, MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         spatial_size,
         spacing,
         magnitude_range,
@@ -381,7 +384,7 @@ class Rand2DElasticd(Randomizable, MapTransform):
         mode="bilinear",
         padding_mode="zeros",
         as_tensor_output: bool = False,
-        device=None,
+        device: Optional[torch.device] = None,
     ):
         """
         Args:
@@ -422,7 +425,7 @@ class Rand2DElasticd(Randomizable, MapTransform):
         self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
         self.mode = ensure_tuple_rep(mode, len(self.keys))
 
-    def set_random_state(self, seed=None, state=None):
+    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         self.rand_2d_elastic.set_random_state(seed, state)
         super().set_random_state(seed, state)
         return self
@@ -456,7 +459,7 @@ class Rand3DElasticd(Randomizable, MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         spatial_size,
         sigma_range,
         magnitude_range,
@@ -468,7 +471,7 @@ class Rand3DElasticd(Randomizable, MapTransform):
         mode="bilinear",
         padding_mode="zeros",
         as_tensor_output: bool = False,
-        device=None,
+        device: Optional[torch.device] = None,
     ):
         """
         Args:
@@ -510,7 +513,7 @@ class Rand3DElasticd(Randomizable, MapTransform):
         self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
         self.mode = ensure_tuple_rep(mode, len(self.keys))
 
-    def set_random_state(self, seed=None, state=None):
+    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         self.rand_3d_elastic.set_random_state(seed, state)
         super().set_random_state(seed, state)
         return self
@@ -548,7 +551,7 @@ class Flipd(MapTransform):
         spatial_axis (None, int or tuple of ints): Spatial axes along which to flip over. Default is None.
     """
 
-    def __init__(self, keys, spatial_axis=None):
+    def __init__(self, keys: Hashable, spatial_axis=None):
         super().__init__(keys)
         self.flipper = Flip(spatial_axis=spatial_axis)
 
@@ -570,7 +573,7 @@ class RandFlipd(Randomizable, MapTransform):
         spatial_axis (None, int or tuple of ints): Spatial axes along which to flip over. Default is None.
     """
 
-    def __init__(self, keys, prob=0.1, spatial_axis=None):
+    def __init__(self, keys: Hashable, prob: float = 0.1, spatial_axis=None):
         super().__init__(keys)
         self.spatial_axis = spatial_axis
         self.prob = prob
@@ -612,7 +615,7 @@ class Rotated(MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         angle: float,
         spatial_axes=(0, 1),
         reshape: bool = True,
@@ -665,7 +668,7 @@ class RandRotated(Randomizable, MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         degrees,
         prob: float = 0.1,
         spatial_axes=(0, 1),
@@ -732,7 +735,7 @@ class Zoomd(MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         zoom,
         interp_order=InterpolationCode.SPLINE3,
         mode="constant",
@@ -786,7 +789,7 @@ class RandZoomd(Randomizable, MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         prob: float = 0.1,
         min_zoom=0.9,
         max_zoom=1.1,

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -15,7 +15,7 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 
 import time
 
-from typing import Callable
+from typing import Callable, Optional
 import logging
 import numpy as np
 import torch
@@ -39,7 +39,7 @@ class AsChannelFirst(Transform):
         channel_dim (int): which dimension of input image is the channel, default is the last dimension.
     """
 
-    def __init__(self, channel_dim=-1):
+    def __init__(self, channel_dim: int = -1):
         assert isinstance(channel_dim, int) and channel_dim >= -1, "invalid channel dimension."
         self.channel_dim = channel_dim
 
@@ -62,7 +62,7 @@ class AsChannelLast(Transform):
         channel_dim (int): which dimension of input image is the channel, default is the first dimension.
     """
 
-    def __init__(self, channel_dim=0):
+    def __init__(self, channel_dim: int = 0):
         assert isinstance(channel_dim, int) and channel_dim >= -1, "invalid channel dimension."
         self.channel_dim = channel_dim
 
@@ -98,7 +98,7 @@ class RepeatChannel(Transform):
         repeats (int): the number of repetitions for each element.
     """
 
-    def __init__(self, repeats):
+    def __init__(self, repeats: int):
         assert repeats > 0, "repeats count must be greater than 0."
         self.repeats = repeats
 
@@ -151,7 +151,7 @@ class SqueezeDim(Transform):
     Squeeze undesired unitary dimensions
     """
 
-    def __init__(self, dim=None):
+    def __init__(self, dim: Optional[int] = None):
         """
         Args:
             dim (int): dimension to be squeezed.
@@ -177,11 +177,11 @@ class DataStats(Transform):
 
     def __init__(
         self,
-        prefix="Data",
-        data_shape=True,
-        intensity_range=True,
-        data_value=False,
-        additional_info: Callable = None,
+        prefix: str = "Data",
+        data_shape: bool = True,
+        intensity_range: bool = True,
+        data_value: bool = False,
+        additional_info: Optional[Callable] = None,
         logger_handler=None,
     ):
         """
@@ -240,7 +240,7 @@ class SimulateDelay(Transform):
     to sub-optimal design choices.
     """
 
-    def __init__(self, delay_time=0.0):
+    def __init__(self, delay_time: float = 0.0):
         """
         Args:
             delay_time(float): The minimum amount of time, in fractions of seconds,

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -111,7 +111,7 @@ class CastToType(Transform):
     Cast the image data to specified numpy data type.
     """
 
-    def __init__(self, dtype=np.float32):
+    def __init__(self, dtype: np.dtype = np.float32):
         """
         Args:
             dtype (np.dtype): convert image to this data type, default is `np.float32`.

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -118,7 +118,7 @@ class CastToType(Transform):
         """
         self.dtype = dtype
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray):
         assert isinstance(img, np.ndarray), "image must be numpy array."
         return img.astype(self.dtype)
 
@@ -161,7 +161,7 @@ class SqueezeDim(Transform):
             assert isinstance(dim, int) and dim >= -1, "invalid channel dimension."
         self.dim = dim
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray):
         """
         Args:
             img (ndarray): numpy arrays with required dimension `dim` removed
@@ -182,7 +182,7 @@ class DataStats(Transform):
         intensity_range: bool = True,
         data_value: bool = False,
         additional_info: Optional[Callable] = None,
-        logger_handler=None,
+        logger_handler: Optional[logging.Handler] = None,
     ):
         """
         Args:
@@ -203,13 +203,21 @@ class DataStats(Transform):
         if additional_info is not None and not callable(additional_info):
             raise ValueError("argument `additional_info` must be a callable.")
         self.additional_info = additional_info
-        self.output = None
+        self.output: Optional[str] = None
         logging.basicConfig(level=logging.NOTSET)
         self._logger = logging.getLogger("DataStats")
         if logger_handler is not None:
             self._logger.addHandler(logger_handler)
 
-    def __call__(self, img, prefix=None, data_shape=None, intensity_range=None, data_value=None, additional_info=None):
+    def __call__(
+        self,
+        img,
+        prefix: Optional[str] = None,
+        data_shape: Optional[bool] = None,
+        intensity_range: Optional[bool] = None,
+        data_value: Optional[bool] = None,
+        additional_info=None,
+    ):
         lines = [f"{prefix or self.prefix} statistics:"]
 
         if self.data_shape if data_shape is None else data_shape:

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -15,6 +15,8 @@ defined in :py:class:`monai.transforms.utility.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
+from typing import Optional
+
 import numpy as np
 
 from monai.transforms.compose import MapTransform
@@ -37,7 +39,7 @@ class AsChannelFirstd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.AsChannelFirst`.
     """
 
-    def __init__(self, keys, channel_dim=-1):
+    def __init__(self, keys, channel_dim: int = -1):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -59,7 +61,7 @@ class AsChannelLastd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.AsChannelLast`.
     """
 
-    def __init__(self, keys, channel_dim=0):
+    def __init__(self, keys, channel_dim: int = 0):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -102,7 +104,7 @@ class RepeatChanneld(MapTransform):
     dictionary-based wrapper of :py:class:`monai.transforms.RepeatChannel`.
     """
 
-    def __init__(self, keys, repeats):
+    def __init__(self, keys, repeats: int):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -185,7 +187,7 @@ class SqueezeDimd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.SqueezeDim`.
     """
 
-    def __init__(self, keys, dim=None):
+    def __init__(self, keys, dim: Optional[int] = None):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -126,7 +126,7 @@ class CastToTyped(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.CastToType`.
     """
 
-    def __init__(self, keys, dtype=np.float32):
+    def __init__(self, keys, dtype: np.dtype = np.float32):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -15,7 +15,8 @@ defined in :py:class:`monai.transforms.utility.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
-from typing import Optional
+from logging import Handler
+from typing import Optional, Hashable
 
 import numpy as np
 
@@ -39,7 +40,7 @@ class AsChannelFirstd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.AsChannelFirst`.
     """
 
-    def __init__(self, keys, channel_dim: int = -1):
+    def __init__(self, keys: Hashable, channel_dim: int = -1):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -61,7 +62,7 @@ class AsChannelLastd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.AsChannelLast`.
     """
 
-    def __init__(self, keys, channel_dim: int = 0):
+    def __init__(self, keys: Hashable, channel_dim: int = 0):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -83,7 +84,7 @@ class AddChanneld(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.AddChannel`.
     """
 
-    def __init__(self, keys):
+    def __init__(self, keys: Hashable):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -104,7 +105,7 @@ class RepeatChanneld(MapTransform):
     dictionary-based wrapper of :py:class:`monai.transforms.RepeatChannel`.
     """
 
-    def __init__(self, keys, repeats: int):
+    def __init__(self, keys: Hashable, repeats: int):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -126,7 +127,7 @@ class CastToTyped(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.CastToType`.
     """
 
-    def __init__(self, keys, dtype: np.dtype = np.float32):
+    def __init__(self, keys: Hashable, dtype: np.dtype = np.float32):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -148,7 +149,7 @@ class ToTensord(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.ToTensor`.
     """
 
-    def __init__(self, keys):
+    def __init__(self, keys: Hashable):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -170,7 +171,7 @@ class DeleteKeysd(MapTransform):
     It will remove the key-values and copy the others to construct a new dictionary.
     """
 
-    def __init__(self, keys):
+    def __init__(self, keys: Hashable):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -187,7 +188,7 @@ class SqueezeDimd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.SqueezeDim`.
     """
 
-    def __init__(self, keys, dim: Optional[int] = None):
+    def __init__(self, keys: Hashable, dim: Optional[int] = None):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
@@ -212,13 +213,13 @@ class DataStatsd(MapTransform):
 
     def __init__(
         self,
-        keys,
+        keys: Hashable,
         prefix="Data",
         data_shape=True,
         intensity_range=True,
         data_value=False,
         additional_info=None,
-        logger_handler=None,
+        logger_handler: Optional[Handler] = None,
     ):
         """
         Args:
@@ -262,7 +263,7 @@ class SimulateDelayd(MapTransform):
     dictionary-based wrapper of :py:class:monai.transforms.utility.array.SimulateDelay.
     """
 
-    def __init__(self, keys, delay_time=0.0):
+    def __init__(self, keys: Hashable, delay_time=0.0):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -11,6 +11,7 @@
 
 import random
 import warnings
+from typing import Optional, Union
 
 import torch
 import numpy as np
@@ -162,7 +163,13 @@ def one_hot(labels, num_classes):
 
 
 def generate_pos_neg_label_crop_centers(
-    label, size, num_samples, pos_ratio, image=None, image_threshold=0, rand_state=np.random
+    label: np.ndarray,
+    size,
+    num_samples: int,
+    pos_ratio: float,
+    image: Optional[np.ndarray] = None,
+    image_threshold: Union[int, float] = 0,
+    rand_state: np.random.RandomState = np.random,
 ):
     """Generate valid sample locations based on image with option for specifying foreground ratio
     Valid: samples sitting entirely within image, expected input shape: [C, H, W, D] or [C, H, W]
@@ -249,7 +256,7 @@ def apply_transform(transform, data):
         raise Exception(f"applying transform {transform}.").with_traceback(e.__traceback__)
 
 
-def create_grid(spatial_size, spacing=None, homogeneous=True, dtype=float):
+def create_grid(spatial_size, spacing=None, homogeneous: bool = True, dtype: type = float):
     """
     compute a `spatial_size` mesh.
 
@@ -267,7 +274,7 @@ def create_grid(spatial_size, spacing=None, homogeneous=True, dtype=float):
     return np.concatenate([coords, np.ones_like(coords[:1])])
 
 
-def create_control_grid(spatial_shape, spacing, homogeneous=True, dtype=float):
+def create_control_grid(spatial_shape, spacing, homogeneous: bool = True, dtype: type = float):
     """
     control grid with two additional point in each direction
     """
@@ -319,7 +326,7 @@ def create_rotate(spatial_dims, radians):
     raise ValueError(f"create_rotate got spatial_dims={spatial_dims}, radians={radians}.")
 
 
-def create_shear(spatial_dims, coefs):
+def create_shear(spatial_dims: int, coefs):
     """
     create a shearing matrix
     Args:
@@ -345,7 +352,7 @@ def create_shear(spatial_dims, coefs):
     raise NotImplementedError
 
 
-def create_scale(spatial_dims, scaling_factor):
+def create_scale(spatial_dims: int, scaling_factor):
     """
     create a scaling matrix
     Args:
@@ -358,7 +365,7 @@ def create_scale(spatial_dims, scaling_factor):
     return np.diag(scaling_factor[:spatial_dims] + [1.0])
 
 
-def create_translate(spatial_dims, shift):
+def create_translate(spatial_dims: int, shift):
     """
     create a translation matrix
     Args:
@@ -372,7 +379,7 @@ def create_translate(spatial_dims, shift):
     return affine
 
 
-def generate_spatial_bounding_box(img, select_fn=lambda x: x > 0, channel_indexes=None, margin=0):
+def generate_spatial_bounding_box(img, select_fn=lambda x: x > 0, channel_indexes=None, margin: int = 0):
     """
     generate the spatial bounding box of foreground in the image with start-end positions.
     Users can define arbitrary function to select expected foreground from the whole image or specified channels.
@@ -399,7 +406,7 @@ def generate_spatial_bounding_box(img, select_fn=lambda x: x > 0, channel_indexe
     return box_start, box_end
 
 
-def get_largest_connected_component_mask(img, connectivity=None):
+def get_largest_connected_component_mask(img, connectivity: Optional[int] = None):
     """
     Gets the largest connected component mask of an image.
 

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -11,7 +11,7 @@
 
 import random
 import warnings
-from typing import Optional, Union
+from typing import Optional, Union, Callable
 
 import torch
 import numpy as np
@@ -53,7 +53,7 @@ def zero_margins(img, margin):
     return True
 
 
-def rescale_array(arr, minv=0.0, maxv=1.0, dtype=np.float32):
+def rescale_array(arr, minv=0.0, maxv=1.0, dtype: Optional[np.dtype] = np.float32):
     """Rescale the values of numpy array `arr` to be from `minv` to `maxv`."""
     if dtype is not None:
         arr = arr.astype(dtype)
@@ -237,7 +237,7 @@ def generate_pos_neg_label_crop_centers(
     return centers
 
 
-def apply_transform(transform, data):
+def apply_transform(transform: Callable, data):
     """
     Transform `data` with `transform`.
     If `data` is a list or tuple, each item of `data` will be transformed
@@ -256,7 +256,7 @@ def apply_transform(transform, data):
         raise Exception(f"applying transform {transform}.").with_traceback(e.__traceback__)
 
 
-def create_grid(spatial_size, spacing=None, homogeneous: bool = True, dtype: type = float):
+def create_grid(spatial_size, spacing=None, homogeneous: bool = True, dtype: np.dtype = float):
     """
     compute a `spatial_size` mesh.
 
@@ -274,7 +274,7 @@ def create_grid(spatial_size, spacing=None, homogeneous: bool = True, dtype: typ
     return np.concatenate([coords, np.ones_like(coords[:1])])
 
 
-def create_control_grid(spatial_shape, spacing, homogeneous: bool = True, dtype: type = float):
+def create_control_grid(spatial_shape, spacing, homogeneous: bool = True, dtype: Optional[np.dtype] = float):
     """
     control grid with two additional point in each direction
     """
@@ -288,7 +288,7 @@ def create_control_grid(spatial_shape, spacing, homogeneous: bool = True, dtype:
     return create_grid(grid_shape, spacing, homogeneous, dtype)
 
 
-def create_rotate(spatial_dims, radians):
+def create_rotate(spatial_dims: int, radians):
     """
     create a 2D or 3D rotation matrix
 
@@ -379,7 +379,9 @@ def create_translate(spatial_dims: int, shift):
     return affine
 
 
-def generate_spatial_bounding_box(img, select_fn=lambda x: x > 0, channel_indexes=None, margin: int = 0):
+def generate_spatial_bounding_box(
+    img: np.ndarray, select_fn: Callable = lambda x: x > 0, channel_indexes=None, margin: int = 0
+):
     """
     generate the spatial bounding box of foreground in the image with start-end positions.
     Users can define arbitrary function to select expected foreground from the whole image or specified channels.

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -68,18 +68,18 @@ def rescale_array(arr, minv=0.0, maxv=1.0, dtype=np.float32):
     return (norm * (maxv - minv)) + minv  # rescale by minv and maxv, which is the normalized array by default
 
 
-def rescale_instance_array(arr, minv=0.0, maxv=1.0, dtype=np.float32):
+def rescale_instance_array(arr: np.ndarray, minv: float = 0.0, maxv: float = 1.0, dtype: np.dtype = np.float32):
     """Rescale each array slice along the first dimension of `arr` independently."""
-    out = np.zeros(arr.shape, dtype)
+    out: np.ndarray = np.zeros(arr.shape, dtype)
     for i in range(arr.shape[0]):
         out[i] = rescale_array(arr[i], minv, maxv, dtype)
 
     return out
 
 
-def rescale_array_int_max(arr, dtype=np.uint16):
+def rescale_array_int_max(arr: np.ndarray, dtype: np.dtype = np.uint16):
     """Rescale the array `arr` to be between the minimum and maximum values of the type `dtype`."""
-    info = np.iinfo(dtype)
+    info: np.iinfo = np.iinfo(dtype)
     return rescale_array(arr, info.min, info.max).astype(dtype)
 
 

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -87,7 +87,7 @@ def is_scalar(val):
     return np.isscalar(val)
 
 
-def process_bar(index, count, bar_len=30, newline=False):
+def process_bar(index: int, count: int, bar_len: int = 30, newline: bool = False):
     """print a process bar to track some time consuming task.
 
     Args:

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -36,7 +36,7 @@ def export(modname):
     return _inner
 
 
-def load_submodules(basemod, load_all=True, exclude_pattern="(.*[tT]est.*)|(_.*)"):
+def load_submodules(basemod, load_all: bool = True, exclude_pattern: str = "(.*[tT]est.*)|(_.*)"):
     """
     Traverse the source of the module structure starting with module `basemod`, loading all packages plus all files if
     `loadAll` is True, excluding anything whose name matches `excludePattern`.

--- a/monai/visualize/img2tensorboard.py
+++ b/monai/visualize/img2tensorboard.py
@@ -20,12 +20,12 @@ from monai.transforms.utils import rescale_array
 from typing import Sequence, Union
 
 
-def _image3_animated_gif(tag: str, image: Union[np.array, torch.Tensor], scale_factor: float = 1):
+def _image3_animated_gif(tag: str, image: Union[np.ndarray, torch.Tensor], scale_factor: float = 1):
     """Function to actually create the animated gif.
     Args:
-        tag (str): Data identifier
-        image (np.array or Tensor): 3D image tensors expected to be in `HWD` format
-        scale_factor (float): amount to multiply values by. if the image data is between 0 and 1, using 255 for this value will
+        tag: Data identifier
+        image: 3D image tensors expected to be in `HWD` format
+        scale_factor: amount to multiply values by. if the image data is between 0 and 1, using 255 for this value will
         scale it to displayable range
     """
     assert len(image.shape) == 3, "3D image tensors expected to be in `HWD` format, len(image.shape) != 3"
@@ -47,7 +47,7 @@ def _image3_animated_gif(tag: str, image: Union[np.array, torch.Tensor], scale_f
 
 def make_animated_gif_summary(
     tag: str,
-    image: Union[np.array, torch.Tensor],
+    image: Union[np.ndarray, torch.Tensor],
     max_out: int = 3,
     animation_axes: Sequence[int] = (3,),
     image_axes: Sequence[int] = (1, 2),
@@ -57,13 +57,13 @@ def make_animated_gif_summary(
     """Creates an animated gif out of an image tensor in 'CHWD' format and returns Summary.
 
     Args:
-        tag (str): Data identifier
-        image (np.array or Tensor): The image, expected to be in CHWD format
-        max_out (int): maximum number of slices to animate through
-        animation_axes (Sequence[int]): axis to animate on (not currently used)
-        image_axes (Sequence[int]): axes of image (not currently used)
-        other_indices (dict): (not currently used)
-        scale_factor (float): amount to multiply values by.
+        tag: Data identifier
+        image: The image, expected to be in CHWD format
+        max_out: maximum number of slices to animate through
+        animation_axes: axis to animate on (not currently used)
+        image_axes: axes of image (not currently used)
+        other_indices: (not currently used)
+        scale_factor: amount to multiply values by.
             if the image data is between 0 and 1, using 255 for this value will scale it to displayable range
     """
 
@@ -85,7 +85,7 @@ def make_animated_gif_summary(
     image = image[tuple(slicing)]
 
     for it_i in range(min(max_out, list(image.shape)[0])):
-        one_channel_img: Union[torch.Tensor, np.array] = image[it_i, :, :, :].squeeze(dim=0) if torch.is_tensor(
+        one_channel_img: Union[torch.Tensor, np.ndarray] = image[it_i, :, :, :].squeeze(dim=0) if torch.is_tensor(
             image
         ) else image[it_i, :, :, :]
         summary_op = _image3_animated_gif(tag + suffix.format(it_i), one_channel_img, scale_factor)
@@ -95,7 +95,7 @@ def make_animated_gif_summary(
 def add_animated_gif(
     writer: SummaryWriter,
     tag: str,
-    image_tensor: Union[np.array, torch.Tensor],
+    image_tensor: Union[np.ndarray, torch.Tensor],
     max_out: int,
     scale_factor: float,
     global_step: int = None,
@@ -103,13 +103,13 @@ def add_animated_gif(
     """Creates an animated gif out of an image tensor in 'CHWD' format and writes it with SummaryWriter.
 
     Args:
-        writer (SummaryWriter): Tensorboard SummaryWriter to write to
-        tag (str): Data identifier
-        image_tensor (np.array or Tensor): tensor for the image to add, expected to be in CHWD format
-        max_out (int): maximum number of slices to animate through
-        scale_factor (float): amount to multiply values by. If the image data is between 0 and 1, using 255 for this value will
+        writer: Tensorboard SummaryWriter to write to
+        tag: Data identifier
+        image_tensor: tensor for the image to add, expected to be in CHWD format
+        max_out: maximum number of slices to animate through
+        scale_factor: amount to multiply values by. If the image data is between 0 and 1, using 255 for this value will
             scale it to displayable range
-        global_step (int): Global step value to record
+        global_step: Global step value to record
     """
     writer._get_file_writer().add_summary(
         make_animated_gif_summary(
@@ -122,7 +122,7 @@ def add_animated_gif(
 def add_animated_gif_no_channels(
     writer: SummaryWriter,
     tag: str,
-    image_tensor: Union[np.array, torch.Tensor],
+    image_tensor: Union[np.ndarray, torch.Tensor],
     max_out: int,
     scale_factor: float,
     global_step: int = None,
@@ -132,13 +132,13 @@ def add_animated_gif_no_channels(
     after inserting a channel dimension of 1.
 
     Args:
-        writer (SummaryWriter): Tensorboard SummaryWriter to write to
-        tag (str): Data identifier
-        image_tensor (np.array or Tensor): tensor for the image to add, expected to be in CHWD format
-        max_out (int): maximum number of slices to animate through
-        scale_factor (float): amount to multiply values by. If the image data is between 0 and 1,
+        writer: Tensorboard SummaryWriter to write to
+        tag: Data identifier
+        image_tensor: tensor for the image to add, expected to be in CHWD format
+        max_out: maximum number of slices to animate through
+        scale_factor: amount to multiply values by. If the image data is between 0 and 1,
                               using 255 for this value will scale it to displayable range
-        global_step (int): Global step value to record
+        global_step: Global step value to record
     """
     writer._get_file_writer().add_summary(
         make_animated_gif_summary(

--- a/monai/visualize/img2tensorboard.py
+++ b/monai/visualize/img2tensorboard.py
@@ -17,7 +17,7 @@ from torch.utils.tensorboard import SummaryWriter
 from tensorboard.compat.proto import summary_pb2
 from monai.transforms.utils import rescale_array
 
-from typing import Sequence, Union
+from typing import Sequence, Union, Optional
 
 
 def _image3_animated_gif(tag: str, image: Union[np.ndarray, torch.Tensor], scale_factor: float = 1):
@@ -51,7 +51,7 @@ def make_animated_gif_summary(
     max_out: int = 3,
     animation_axes: Sequence[int] = (3,),
     image_axes: Sequence[int] = (1, 2),
-    other_indices: dict = None,
+    other_indices=None,
     scale_factor: float = 1,
 ):
     """Creates an animated gif out of an image tensor in 'CHWD' format and returns Summary.
@@ -98,7 +98,7 @@ def add_animated_gif(
     image_tensor: Union[np.ndarray, torch.Tensor],
     max_out: int,
     scale_factor: float,
-    global_step: int = None,
+    global_step: Optional[int] = None,
 ):
     """Creates an animated gif out of an image tensor in 'CHWD' format and writes it with SummaryWriter.
 
@@ -125,7 +125,7 @@ def add_animated_gif_no_channels(
     image_tensor: Union[np.ndarray, torch.Tensor],
     max_out: int,
     scale_factor: float,
-    global_step: int = None,
+    global_step: Optional[int] = None,
 ):
     """Creates an animated gif out of an image tensor in 'HWD' format that does not have
     a channel dimension and writes it with SummaryWriter. This is similar to the "add_animated_gif"
@@ -148,7 +148,15 @@ def add_animated_gif_no_channels(
     )
 
 
-def plot_2d_or_3d_image(data, step, writer, index=0, max_channels=1, max_frames=64, tag="output"):
+def plot_2d_or_3d_image(
+    data: Union[torch.Tensor, np.ndarray],
+    step: int,
+    writer: SummaryWriter,
+    index: int = 0,
+    max_channels: int = 1,
+    max_frames: int = 64,
+    tag: str = "output",
+):
     """Plot 2D or 3D image on the TensorBoard, 3D image will be converted to GIF image.
 
     Note:

--- a/monai/visualize/img2tensorboard.py.orig
+++ b/monai/visualize/img2tensorboard.py.orig
@@ -51,7 +51,11 @@ def make_animated_gif_summary(
     max_out: int = 3,
     animation_axes: Sequence[int] = (3,),
     image_axes: Sequence[int] = (1, 2),
+<<<<<<< HEAD
+    other_indices=None,
+=======
     other_indices: Optional[dict] = None,
+>>>>>>> WIP: Test function parameter type-hints sphinx representation
     scale_factor: float = 1,
 ):
     """Creates an animated gif out of an image tensor in 'CHWD' format and returns Summary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ exclude = '''
     | \.mypy_cache
     | \.tox
     | \.venv
+    | \.mypy_cache
+    | \.pytype
     | _build
     | buck-out
     | build

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,3 +64,32 @@ warn_no_return=True
 # than the full run.
 warn_redundant_casts=True
 warn_unused_ignores=True
+# NOTE: All relative paths are relative to the location of this file.
+
+[pytype]
+# Space-separated list of files or directories to exclude.
+exclude = **/*_test.py **/test_*.py
+# Space-separated list of files or directories to process.
+inputs = monai 
+# Keep going past errors to analyze as many files as possible.
+keep_going = False
+# Run N jobs in parallel.
+jobs = 8
+# All pytype output goes here.
+output = .pytype
+# Paths to source code directories, separated by ':'.
+pythonpath = .
+# Python version (major.minor) of the target code.
+python_version = 3.6
+# Experimental: Check variable values against their annotations.
+check_variable_types = False
+# Comma or space separated list of error names to ignore.
+disable = pyi-error
+# Don't report errors.
+report_errors = True
+# Experimental: Infer precise return types even for invalid function calls.
+precise_return = False
+# Experimental: solve unknown types to label with structural types.
+protocols = False
+# Experimental: Only load submodules that are explicitly imported.
+strict_import = False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,6 +31,7 @@ def _enter_pr_4800(self):
 
 # workaround for https://bugs.python.org/issue29620
 try:
-    unittest.case._AssertWarnsContext.__enter__ = _enter_pr_4800
+    # Avoid mypy warning "tests/__init__.py:34: error: Cannot assign to a method"
+    unittest.case._AssertWarnsContext.__enter__ = _enter_pr_4800  # type: ignore
 except AttributeError:
     pass


### PR DESCRIPTION
### Description
Initial testing for more exhaustive use of type hints.  

I have two developers who could work through MONAI documentation using the now preferred type hints for the modern python programming style in python 3.6+.  As many tools use this information, IDE's and static analyzers seem to perform more consistently with PEP 484 type hints than alternative documentation inserted types.

The current type hinting is great for backward compatibility prior to 3.6, but as 3.6 is now the minimum version, we can/should use modern supported PEP 484.

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [X] Docstrings/Documentation updated
