### PR TITLE
update randspatialcrop docstring

### DIFF
--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -18,7 +18,7 @@ import numpy as np
 from monai.data.utils import get_random_patch, get_valid_patch_size
 from monai.transforms.compose import Transform, Randomizable
 from monai.transforms.utils import generate_spatial_bounding_box
-from monai.utils.misc import ensure_tuple
+from monai.utils.misc import ensure_tuple, ensure_tuple_rep
 
 
 class SpatialPad(Transform):
@@ -127,6 +127,7 @@ class RandSpatialCrop(Randomizable, Transform):
             if `random_size` is False, specify the expected ROI size to crop. e.g. [224, 224, 128]
         random_center (bool): crop at random position as center or the image center.
         random_size (bool): crop with random size or specific size ROI.
+            The actual size is sampled from `randint(roi_size, img_size)`.
     """
 
     def __init__(self, roi_size, random_center=True, random_size=True):
@@ -135,7 +136,7 @@ class RandSpatialCrop(Randomizable, Transform):
         self.random_size = random_size
 
     def randomize(self, img_size):
-        self._size = [self.roi_size] * len(img_size) if not isinstance(self.roi_size, (list, tuple)) else self.roi_size
+        self._size = ensure_tuple_rep(self.roi_size, len(img_size))
         if self.random_size:
             self._size = [self.R.randint(low=self._size[i], high=img_size[i] + 1) for i in range(len(img_size))]
         if self.random_center:

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -113,6 +113,7 @@ class RandSpatialCropd(Randomizable, MapTransform):
             if `random_size` is False, specify the expected ROI size to crop. e.g. [224, 224, 128]
         random_center (bool): crop at random position as center or the image center.
         random_size (bool): crop with random size or specific size ROI.
+            The actual size is sampled from `randint(roi_size, img_size)`.
     """
 
     def __init__(self, keys, roi_size, random_center=True, random_size=True):
@@ -122,7 +123,7 @@ class RandSpatialCropd(Randomizable, MapTransform):
         self.random_size = random_size
 
     def randomize(self, img_size):
-        self._size = [self.roi_size] * len(img_size) if not isinstance(self.roi_size, (list, tuple)) else self.roi_size
+        self._size = ensure_tuple_rep(self.roi_size, len(img_size))
         if self.random_size:
             self._size = [self.R.randint(low=self._size[i], high=img_size[i] + 1) for i in range(len(img_size))]
         if self.random_center:


### PR DESCRIPTION
Fixes docstring in RandSpatialCrop.
make use of `ensure_tuple_rep`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated
