### PR TITLE
BUG: flake8-mypy module was not actually run

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -25,7 +25,7 @@ jobs:
         pip install flake8==3.7.9 flake8-mypy flake8-bugbear flake8-comprehensions flake8-executable flake8-pyi mccabe pep8-naming
         flake8 --version
         python -c 'import monai; monai.config.print_config()'
-        flake8 . --count --statistics
+        MYPYPATH=$(pwd)/monai flake8 $(pwd) --count --statistics
 
   quick-py3:
     runs-on: ${{ matrix.os }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ ignore =
     C400,C401,C402,C403,C404,C405,C407,C411,C413,C414,C415,C416,
     # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
     N812
+    # suppress flake8-mypy failures occuring when MYPYPATH=${src_dir}/monai/monai
+    T499
 per-file-ignores = __init__.py: F401
 exclude = *.pyi,.git,monai/_version.py,versioneer.py
 
@@ -44,3 +46,7 @@ versionfile_source = monai/_version.py
 versionfile_build = monai/_version.py
 tag_prefix =
 parentdir_prefix =
+
+[mypy]
+#mypy does not currently pass for monai, so disable with ignore_errors
+ignore_errors = True


### PR DESCRIPTION
Warning messages when running mypy typehint checking:

/opt/hostedtoolcache/Python/3.7.7/x64/lib/python3.7/site-packages is in the MYPYPATH. Please remove it.
See https://mypy.readthedocs.io/en/latest/running_mypy.html#how-mypy-handles-imports for more info

Were indicative of the module `flake8-mypy` not actually checking
anything.

Fixes 429

### Description
Demonstrate failure, and then disable flake8-mypy until it passes all tests reliably.


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [] New tests added to cover the changes
- [ ] Docstrings/Documentation updated
