### PR TITLE
Fix call to non existent function

### DIFF
--- a/monai/networks/layers/factories.py
+++ b/monai/networks/layers/factories.py
@@ -138,7 +138,7 @@ class LayerFactory:
         if key in self.factories:
             return key
 
-        return super().__getattr__(key)
+        return super().__getattribute__(key)
 
 
 def split_args(args):


### PR DESCRIPTION

### Description

Calling ` return super().__getattr__(key)` on a class without an explicit superclass is an error because `__getattr__` is undefined in the implicit superclass.


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated
