### PR TITLE
232 adds an affine transform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
   * [Utility functions](#utility-functions)
   * [Building the documentation](#building-the-documentation)
 - [Unit testing](#unit-testing)
+- [Linting and code style testing](#linting-and-code-style-testing)
 - [The code reviewing process (for the maintainers)](#the-code-reviewing-process)
   * [Reviewing pull requests](#reviewing-pull-requests)
 - [Admin tasks](#admin-tasks)
@@ -116,7 +117,7 @@ When new classes or methods are added, it is recommended to:
 MONAI tests are located under `tests/`.
 
 - The unit test's file name follows `test_[module_name].py`.
-- The integration test's file name follows `integration_[workflow_name].py`.
+- The integration test's file name follows `test_integration_[workflow_name].py`.
 
 A bash script (`runtests.sh`) is provided to run all tests locally
 Please run ``./runtests.sh -h`` to see all options.

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -54,16 +54,15 @@ Nifti format handling
 
 Reading
 ~~~~~~~
-.. automodule:: monai.data.NiftiDataset
+.. autoclass:: monai.data.NiftiDataset
   :members:
 
 Writing Nifti
 ~~~~~~~~~~~~~
-.. automodule:: monai.data.NiftiSaver
+.. autoclass:: monai.data.NiftiSaver
   :members:
 
-.. automodule:: monai.data.write_nifti
-  :members:
+.. autofunction:: monai.data.write_nifti
 
 
 PNG format handling
@@ -71,11 +70,10 @@ PNG format handling
 
 Writing PNG
 ~~~~~~~~~~~
-.. automodule:: monai.data.PNGSaver
+.. autoclass:: monai.data.PNGSaver
   :members:
 
-.. automodule:: monai.data.write_png
-  :members:
+.. autofunction:: monai.data.write_png
 
 
 Synthetic

--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -48,8 +48,8 @@ Layers
 .. autoclass:: GaussianFilter
     :members:
 
-`Spatial Transforms`
-~~~~~~~~~~~~~~~~~~~~
+`Affine Transform`
+~~~~~~~~~~~~~~~~~~
 .. autoclass:: monai.networks.layers.AffineTransform
     :members:
 

--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -48,6 +48,11 @@ Layers
 .. autoclass:: GaussianFilter
     :members:
 
+`Spatial Transforms`
+~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: monai.networks.layers.AffineTransform
+    :members:
+
 `Utilities`
 ~~~~~~~~~~~
 .. automodule:: monai.networks.layers.convutils

--- a/monai/data/nifti_writer.py
+++ b/monai/data/nifti_writer.py
@@ -33,7 +33,7 @@ def write_nifti(
     into the coordinate system defined by `target_affine` when `target_affine`
     is specified.
 
-    if the coordinate transform between `affine` and `target_affine` could be
+    If the coordinate transform between `affine` and `target_affine` could be
     achieved by simply transposing and flipping `data`, no resampling will
     happen.  otherwise this function will resample `data` using the coordinate
     transform computed from `affine` and `target_affine`.  Note that the shape
@@ -45,11 +45,11 @@ def write_nifti(
     13.333x13.333 pixels. In this case `output_shape` could be specified so
     that this function writes image data to a designated shape.
 
-    when `affine` and `target_affine` are None, the data will be saved with an
+    When `affine` and `target_affine` are None, the data will be saved with an
     identity matrix as the image affine.
 
     This function assumes the NIfTI dimension notations.
-    Spatially It supports up to three dimensions, that is, H, HW, HWD for
+    Spatially it supports up to three dimensions, that is, H, HW, HWD for
     1D, 2D, 3D respectively.
     When saving multiple time steps or multiple channels `data`, time and/or
     modality axes should be appended after the first three dimensions.  For

--- a/monai/data/synthetic.py
+++ b/monai/data/synthetic.py
@@ -14,7 +14,9 @@ import numpy as np
 from monai.transforms.utils import rescale_array
 
 
-def create_test_image_2d(width, height, num_objs=12, rad_max=30, noise_max=0.0, num_seg_classes=5, channel_dim=None):
+def create_test_image_2d(
+    width, height, num_objs=12, rad_max=30, noise_max=0.0, num_seg_classes=5, channel_dim=None, random_state=None
+):
     """
     Return a noisy 2D image with `num_obj` circles and a 2D mask image. The maximum radius of the circles is given as
     `rad_max`. The mask will have `num_seg_classes` number of classes for segmentations labeled sequentially from 1, plus a
@@ -23,22 +25,23 @@ def create_test_image_2d(width, height, num_objs=12, rad_max=30, noise_max=0.0, 
     dimension, otherwise create an image with channel dimension as first dim or last dim.
     """
     image = np.zeros((width, height))
+    rs = np.random if random_state is None else random_state
 
     for i in range(num_objs):
-        x = np.random.randint(rad_max, width - rad_max)
-        y = np.random.randint(rad_max, height - rad_max)
-        rad = np.random.randint(5, rad_max)
+        x = rs.randint(rad_max, width - rad_max)
+        y = rs.randint(rad_max, height - rad_max)
+        rad = rs.randint(5, rad_max)
         spy, spx = np.ogrid[-x : width - x, -y : height - y]
         circle = (spx * spx + spy * spy) <= rad * rad
 
         if num_seg_classes > 1:
-            image[circle] = np.ceil(np.random.random() * num_seg_classes)
+            image[circle] = np.ceil(rs.random() * num_seg_classes)
         else:
-            image[circle] = np.random.random() * 0.5 + 0.5
+            image[circle] = rs.random() * 0.5 + 0.5
 
     labels = np.ceil(image).astype(np.int32)
 
-    norm = np.random.uniform(0, num_seg_classes * noise_max, size=image.shape)
+    norm = rs.uniform(0, num_seg_classes * noise_max, size=image.shape)
     noisyimage = rescale_array(np.maximum(image, norm))
 
     if channel_dim is not None:
@@ -52,7 +55,7 @@ def create_test_image_2d(width, height, num_objs=12, rad_max=30, noise_max=0.0, 
 
 
 def create_test_image_3d(
-    height, width, depth, num_objs=12, rad_max=30, noise_max=0.0, num_seg_classes=5, channel_dim=None
+    height, width, depth, num_objs=12, rad_max=30, noise_max=0.0, num_seg_classes=5, channel_dim=None, random_state=None
 ):
     """
     Return a noisy 3D image and segmentation.
@@ -61,23 +64,24 @@ def create_test_image_3d(
         :py:meth:`~create_test_image_2d`
     """
     image = np.zeros((width, height, depth))
+    rs = np.random if random_state is None else random_state
 
     for i in range(num_objs):
-        x = np.random.randint(rad_max, width - rad_max)
-        y = np.random.randint(rad_max, height - rad_max)
-        z = np.random.randint(rad_max, depth - rad_max)
-        rad = np.random.randint(5, rad_max)
+        x = rs.randint(rad_max, width - rad_max)
+        y = rs.randint(rad_max, height - rad_max)
+        z = rs.randint(rad_max, depth - rad_max)
+        rad = rs.randint(5, rad_max)
         spy, spx, spz = np.ogrid[-x : width - x, -y : height - y, -z : depth - z]
         circle = (spx * spx + spy * spy + spz * spz) <= rad * rad
 
         if num_seg_classes > 1:
-            image[circle] = np.ceil(np.random.random() * num_seg_classes)
+            image[circle] = np.ceil(rs.random() * num_seg_classes)
         else:
-            image[circle] = np.random.random() * 0.5 + 0.5
+            image[circle] = rs.random() * 0.5 + 0.5
 
     labels = np.ceil(image).astype(np.int32)
 
-    norm = np.random.uniform(0, num_seg_classes * noise_max, size=image.shape)
+    norm = rs.uniform(0, num_seg_classes * noise_max, size=image.shape)
     noisyimage = rescale_array(np.maximum(image, norm))
 
     if channel_dim is not None:

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -428,7 +428,7 @@ def compute_importance_map(patch_size, mode="constant", sigma_scale=0.125, devic
         patch_size (tuple): Size of the required importance map. This should be either H, W [,D].
         mode (str): Importance map type. Options are 'constant' (Each weight has value 1.0)
             or 'gaussian' (Importance becomes lower away from center).
-        sigma_scale (float): Sigma_scale to calculate sigma for each dimension 
+        sigma_scale (float): Sigma_scale to calculate sigma for each dimension
             (sigma = sigma_scale * dim_size). Used for gaussian mode only.
         device (str of pytorch device): Device to put importance map on.
 
@@ -444,7 +444,7 @@ def compute_importance_map(patch_size, mode="constant", sigma_scale=0.125, devic
 
         importance_map = torch.zeros(patch_size, device=device)
         importance_map[tuple(center_coords)] = 1
-        pt_gaussian = GaussianFilter(len(patch_size), sigmas).to(device)
+        pt_gaussian = GaussianFilter(len(patch_size), sigmas).to(device=device, dtype=torch.float)
         importance_map = pt_gaussian(importance_map.unsqueeze(0).unsqueeze(0))
         importance_map = importance_map.squeeze(0).squeeze(0)
         importance_map = importance_map / torch.max(importance_map)

--- a/monai/networks/layers/__init__.py
+++ b/monai/networks/layers/__init__.py
@@ -12,3 +12,4 @@
 from .convutils import *
 from .factories import *
 from .simplelayers import *
+from .spatial_transforms import *

--- a/monai/networks/layers/convutils.py
+++ b/monai/networks/layers/convutils.py
@@ -11,6 +11,8 @@
 
 import numpy as np
 
+__all__ = ["same_padding", "calculate_out_shape", "gaussian_1d"]
+
 
 def same_padding(kernel_size, dilation=1):
     """

--- a/monai/networks/layers/factories.py
+++ b/monai/networks/layers/factories.py
@@ -64,6 +64,8 @@ from typing import Callable
 
 import torch.nn as nn
 
+__all__ = ["LayerFactory", "Dropout", "Norm", "Act", "Conv", "Pool"]
+
 
 class LayerFactory:
     """

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -51,7 +51,7 @@ class GaussianFilter(nn.Module):
         self.spatial_dims = int(spatial_dims)
         _sigma = ensure_tuple_rep(sigma, self.spatial_dims)
         self.kernel = [
-            torch.nn.Parameter(torch.as_tensor(gaussian_1d(s, truncated), dtype=torch.float32), False) for s in _sigma
+            torch.nn.Parameter(torch.as_tensor(gaussian_1d(s, truncated), dtype=torch.float), False) for s in _sigma
         ]
         self.padding = [same_padding(k.size()[0]) for k in self.kernel]
         self.conv_n = [F.conv1d, F.conv2d, F.conv3d][spatial_dims - 1]
@@ -67,8 +67,7 @@ class GaussianFilter(nn.Module):
             raise TypeError(f"x must be a Tensor, got {type(x).__name__}.")
         chns = x.shape[1]
         sp_dim = self.spatial_dims
-        # no inplace change of x
-        x = x.clone().to(self.kernel[0]).contiguous()  # assign to the first kernel's device and dtype
+        x = x.clone()  # no inplace change of x
 
         def _conv(input_, d):
             if d < 0:

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -63,9 +63,12 @@ class GaussianFilter(nn.Module):
         Args:
             x (tensor): in shape [Batch, chns, H, W, D].
         """
+        if not torch.is_tensor(x):
+            raise TypeError(f"x must be a Tensor, got {type(x).__name__}.")
         chns = x.shape[1]
         sp_dim = self.spatial_dims
-        x = torch.as_tensor(x).to(self.kernel[0]).contiguous()  # assign to the first kernel's device and dtype
+        # no inplace change of x
+        x = x.clone().to(self.kernel[0]).contiguous()  # assign to the first kernel's device and dtype
 
         def _conv(input_, d):
             if d < 0:

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -16,6 +16,8 @@ import torch.nn.functional as F
 from monai.networks.layers.convutils import gaussian_1d, same_padding
 from monai.utils.misc import ensure_tuple_rep
 
+__all__ = ["SkipConnection", "Flatten", "GaussianFilter"]
+
 
 class SkipConnection(nn.Module):
     """Concats the forward pass input with the result from the given submodule."""

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -1,0 +1,147 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+
+from monai.networks.utils import to_norm_affine
+from monai.utils import ensure_tuple
+
+__all__ = ["AffineTransform"]
+
+
+class AffineTransform(nn.Module):
+    def __init__(
+        self,
+        spatial_size=None,
+        normalized=False,
+        mode="bilinear",
+        padding_mode="zeros",
+        align_corners=False,
+        reverse_indexing=True,
+    ):
+        """
+        Apply affine transformations with a batch of affine matrices.
+
+        When `normalized=False` and `reverse_indexing=True`,
+        it does the commonly used resampling in the 'pull' direction
+        following the ``scipy.ndimage.affine_transform`` convention.
+        In this case `theta` is equivalent to (ndim+1, ndim+1) input ``matrix`` of ``scipy.ndimage.affine_transform``,
+        operates on homogeneous coordinates.
+        See also: https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.affine_transform.html
+
+        When `normalized=True` and `reverse_indexing=False`,
+        it applies `theta` to the normalized coordinates (coords. in the range of [-1, 1]) directly.
+        This is often used with `align_corners=False` to achieve resolution-agnostic resampling,
+        thus useful as a part of trainable modules such as the spatial transformer networks.
+        See also: https://pytorch.org/tutorials/intermediate/spatial_transformer_tutorial.html
+
+        Args:
+            spatial_size (list or tuple of int): output spatial shape, the full output shape will be
+                `[N, C, *spatial_size]` where N and C are inferred from the `src` input of `self.forward`.
+            normalized (bool): indicating whether the provided affine matrix `theta` is defined
+                for the normalized coordinates. If `normalized=False`, `theta` will be converted
+                to operate on normalized coordinates as pytorch affine_grid works with the normalized
+                coordinates.
+            mode (`nearest|bilinear`): interpolation mode.
+                See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample.
+            padding_mode (`zeros|border|reflection`): padding mode for outside grid values.
+            align_corners (bool): see also https://pytorch.org/docs/stable/nn.functional.html#grid-sample.
+            reverse_indexing (bool): whether to reverse the spatial indexing of image and coordinates.
+                set to `False` if `theta` follows pytorch's default "D, H, W" convention.
+                set to `True` if `theta` follows `scipy.ndimage` default "i, j, k" convention.
+        """
+        super().__init__()
+        self.spatial_size = ensure_tuple(spatial_size) if spatial_size is not None else None
+        self.normalized = normalized
+        self.mode = mode
+        self.padding_mode = padding_mode
+        self.align_corners = align_corners
+        self.reverse_indexing = reverse_indexing
+
+    def forward(self, src, theta, spatial_size=None):
+        """
+        ``theta`` must be an affine transformation matrix with shape
+        3x3 or Nx3x3 or Nx2x3 or 2x3 for spatial 2D transforms,
+        4x4 or Nx4x4 or Nx3x4 or 3x4 for spatial 3D transforms,
+        where `N` is the batch size. `theta` will be converted into float Tensor for the computation.
+
+        Args:
+            src (array_like): image in spatial 2D (N, C, H, W) or spatial 3D (N, C, D, H, W),
+                where N is the batch dim, C is the number of channels.
+            theta (array_like): Nx3x3, Nx2x3, 3x3, 2x3 for spatial 2D inputs,
+                Nx4x4, Nx3x4, 3x4, 4x4 for spatial 3D inputs. When the batch dimension is omitted,
+                `theta` will be repeated N times, N is the batch dim of `src`.
+            spatial_size (list or tuple of int): output spatial shape, the full output shape will be
+                `[N, C, *spatial_size]` where N and C are inferred from the `src`.
+        """
+        # validate `theta`
+        if not torch.is_tensor(theta) or not torch.is_tensor(src):
+            raise TypeError(
+                f"both src and theta must be torch Tensor, got {type(src).__name__}, {type(theta).__name__}."
+            )
+        if theta.ndim not in (2, 3):
+            raise ValueError("affine must be Nxdxd or dxd.")
+        if theta.ndim == 2:
+            theta = theta[None]  # adds a batch dim.
+        theta = theta.float()
+        theta_shape = tuple(theta.shape[1:])
+        if theta_shape in ((2, 3), (3, 4)):  # needs padding to dxd
+            pad_affine = torch.tensor([0, 0, 1] if theta_shape[0] == 2 else [0, 0, 0, 1])
+            pad_affine = pad_affine.repeat(theta.shape[0], 1, 1).to(theta)
+            pad_affine.requires_grad = False
+            theta = torch.cat([theta, pad_affine], dim=1)
+        if tuple(theta.shape[1:]) not in ((3, 3), (4, 4)):
+            raise ValueError(f"affine must be Nx3x3 or Nx4x4, got: {theta.shape}.")
+
+        # validate `src`
+        src = src.float()  # always use float for compatibility
+        sr = src.ndim - 2  # input spatial rank
+        if sr not in (2, 3):
+            raise ValueError("src must be spatially 2D or 3D.")
+
+        # set output shape
+        src_size = tuple(src.shape)
+        dst_size = src_size  # default to the src shape
+        if self.spatial_size is not None:
+            dst_size = src_size[:2] + self.spatial_size
+        if spatial_size is not None:
+            dst_size = src_size[:2] + ensure_tuple(spatial_size)
+
+        # reverse and normalise theta if needed
+        theta = theta.to(src)
+        if self.reverse_indexing:
+            rev_idx = torch.as_tensor(range(sr - 1, -1, -1), device=src.device)
+            theta[:, :sr] = theta[:, rev_idx]
+            theta[:, :, :sr] = theta[:, :, rev_idx]
+        if not self.normalized:
+            theta = to_norm_affine(
+                affine=theta, src_size=src_size[2:], dst_size=dst_size[2:], align_corners=self.align_corners
+            )
+        if (theta.shape[0] == 1) and src_size[0] > 1:
+            # adds a batch dim to `theta` in order to match `src`
+            theta = theta.repeat(src_size[0], 1, 1)
+        if theta.shape[0] != src_size[0]:
+            raise ValueError(
+                "batch dimension of affine and image does not match, got affine: {} and image: {}.".format(
+                    theta.shape[0], src_size[0]
+                )
+            )
+
+        grid = nn.functional.affine_grid(theta=theta[:, :sr], size=dst_size, align_corners=self.align_corners)
+        dst = nn.functional.grid_sample(
+            input=src.contiguous(),
+            grid=grid,
+            mode=self.mode,
+            padding_mode=self.padding_mode,
+            align_corners=self.align_corners,
+        )
+        return dst

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -92,7 +92,7 @@ class AffineTransform(nn.Module):
             raise ValueError("affine must be Nxdxd or dxd.")
         if theta.ndim == 2:
             theta = theta[None]  # adds a batch dim.
-        theta = theta.float()
+        theta = theta.clone().float()  # no in-place change of theta
         theta_shape = tuple(theta.shape[1:])
         if theta_shape in ((2, 3), (3, 4)):  # needs padding to dxd
             pad_affine = torch.tensor([0, 0, 1] if theta_shape[0] == 2 else [0, 0, 0, 1])

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -75,7 +75,7 @@ class AffineTransform(nn.Module):
         where `N` is the batch size. `theta` will be converted into float Tensor for the computation.
 
         Args:
-            src (array_like): image in spatial 2D (N, C, H, W) or spatial 3D (N, C, D, H, W),
+            src (array_like): image in spatial 2D or 3D (N, C, spatial_dims),
                 where N is the batch dim, C is the number of channels.
             theta (array_like): Nx3x3, Nx2x3, 3x3, 2x3 for spatial 2D inputs,
                 Nx4x4, Nx3x4, 3x4, 4x4 for spatial 3D inputs. When the batch dimension is omitted,

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -13,6 +13,7 @@ Utilities and types for defining networks, these depend on PyTorch.
 """
 
 import warnings
+
 import torch
 import torch.nn.functional as f
 
@@ -65,3 +66,62 @@ def predict_segmentation(logits, mutually_exclusive=False, threshold=0):
             warnings.warn("single channel prediction, `mutually_exclusive=True` ignored, use threshold instead.")
             return (logits >= threshold).int()
         return logits.argmax(1, keepdim=True)
+
+
+def normalize_transform(shape, device=None, dtype=None, align_corners=False):
+    """
+    Compute an affine matrix according to the input shape.
+    The transform normalizes the homogeneous image coordinates to the
+    range of `[-1, 1]`.
+
+    Args:
+        shape (sequence of int): input spatial shape
+        device (torch device): device on which the returned affine will be allocated.
+        dtype (torch dtype): data type of the returned affine
+        align_corners (bool): if True, consider -1 and 1 to refer to the centers of the
+            corner pixels rather than the image corners.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.grid_sample
+    """
+    shape_ = list(shape)[::-1]
+    if align_corners:
+        norm = torch.as_tensor(shape_ + [1.0], dtype=dtype, device=device)
+        norm[:-1] = 2.0 / (norm[:-1] - 1.0)
+        norm = torch.diag(norm)
+        norm[:-1, -1] = -1.0
+    else:
+        norm = torch.as_tensor(shape_ + [1.0], dtype=dtype, device=device)
+        norm[:-1] = 2.0 / norm[:-1]
+        norm = torch.diag(norm)
+        norm[:-1, -1] = 1.0 / torch.as_tensor(shape_, dtype=dtype, device=device) - 1.0
+    norm = norm.unsqueeze(0)  # adds a batch dim.
+    norm.requires_grad = False
+    return norm
+
+
+def to_norm_affine(affine, src_size, dst_size, align_corners=False):
+    """
+    Given ``affine`` defined for coordinates in the pixel space, compute the corresponding affine
+    for the normalized coordinates.
+
+    Args:
+        affine (torch Tensor): Nxdxd batched square matrix
+        src_size (sequence of int): source image spatial shape
+        dst_size (sequence of int): target image spatial shape
+        align_corners (bool): if True, consider -1 and 1 to refer to the centers of the
+            corner pixels rather than the image corners.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.grid_sample
+    """
+    if not torch.is_tensor(affine):
+        raise ValueError("affine must be a tensor")
+    if affine.ndim != 3 or affine.shape[1] != affine.shape[2]:
+        raise ValueError(f"affine must be Nxdxd, got {tuple(affine.shape)}")
+    sr = affine.shape[1] - 1
+    if sr != len(src_size) or sr != len(dst_size):
+        raise ValueError(
+            f"affine suggests a {sr}-D transform, but the sizes are src_size={src_size}, dst_size={dst_size}"
+        )
+
+    src_xform = normalize_transform(src_size, affine.device, affine.dtype, align_corners)
+    dst_xform = normalize_transform(dst_size, affine.device, affine.dtype, align_corners)
+    new_affine = src_xform @ affine @ torch.inverse(dst_xform)
+    return new_affine

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -797,7 +797,7 @@ class RandDeformGrid(Randomizable, Transform):
         self.device = device
 
     def randomize(self, grid_size):
-        self.random_offset = self.R.normal(size=([len(grid_size)] + list(grid_size)))
+        self.random_offset = self.R.normal(size=([len(grid_size)] + list(grid_size))).astype(np.float32)
         self.rand_mag = self.R.uniform(self.magnitude[0], self.magnitude[1])
 
     def __call__(self, spatial_size):
@@ -1163,7 +1163,7 @@ class Rand3DElastic(Randomizable, Transform):
     def randomize(self, grid_size):
         self.do_transform = self.R.rand() < self.prob
         if self.do_transform:
-            self.rand_offset = self.R.uniform(-1.0, 1.0, [3] + list(grid_size))
+            self.rand_offset = self.R.uniform(-1.0, 1.0, [3] + list(grid_size)).astype(np.float32)
         self.magnitude = self.R.uniform(self.magnitude_range[0], self.magnitude_range[1])
         self.sigma = self.R.uniform(self.sigma_range[0], self.sigma_range[1])
         self.rand_affine_grid.randomize()
@@ -1183,6 +1183,7 @@ class Rand3DElastic(Randomizable, Transform):
         if self.do_transform:
             grid = torch.as_tensor(np.ascontiguousarray(grid), device=self.device)
             gaussian = GaussianFilter(3, self.sigma, 3.0).to(device=self.device)
-            grid[:3] += gaussian(torch.as_tensor(self.rand_offset[None]))[0] * self.magnitude
+            offset = torch.as_tensor(self.rand_offset[None], device=self.device)
+            grid[:3] += gaussian(offset)[0] * self.magnitude
             grid = self.rand_affine_grid(grid=grid)
         return self.resampler(img, grid, padding_mode=self.padding_mode, mode=mode or self.mode)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -1183,6 +1183,6 @@ class Rand3DElastic(Randomizable, Transform):
         if self.do_transform:
             grid = torch.as_tensor(np.ascontiguousarray(grid), device=self.device)
             gaussian = GaussianFilter(3, self.sigma, 3.0).to(device=self.device)
-            grid[:3] += gaussian(self.rand_offset[None])[0] * self.magnitude
+            grid[:3] += gaussian(torch.as_tensor(self.rand_offset[None]))[0] * self.magnitude
             grid = self.rand_affine_grid(grid=grid)
         return self.resampler(img, grid, padding_mode=self.padding_mode, mode=mode or self.mode)

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -514,7 +514,9 @@ class Rand3DElasticd(Randomizable, MapTransform):
             device = self.rand_3d_elastic.device
             grid = torch.tensor(grid).to(device)
             gaussian = GaussianFilter(spatial_dims=3, sigma=self.rand_3d_elastic.sigma, truncated=3.0).to(device)
-            grid[:3] += gaussian(self.rand_3d_elastic.rand_offset[None])[0] * self.rand_3d_elastic.magnitude
+            grid[:3] += (
+                gaussian(torch.tensor(self.rand_3d_elastic.rand_offset[None]))[0] * self.rand_3d_elastic.magnitude
+            )
             grid = self.rand_3d_elastic.rand_affine_grid(grid=grid)
 
         for idx, key in enumerate(self.keys):

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -514,9 +514,8 @@ class Rand3DElasticd(Randomizable, MapTransform):
             device = self.rand_3d_elastic.device
             grid = torch.tensor(grid).to(device)
             gaussian = GaussianFilter(spatial_dims=3, sigma=self.rand_3d_elastic.sigma, truncated=3.0).to(device)
-            grid[:3] += (
-                gaussian(torch.tensor(self.rand_3d_elastic.rand_offset[None]))[0] * self.rand_3d_elastic.magnitude
-            )
+            offset = torch.tensor(self.rand_3d_elastic.rand_offset[None], device=device)
+            grid[:3] += gaussian(offset)[0] * self.rand_3d_elastic.magnitude
             grid = self.rand_3d_elastic.rand_affine_grid(grid=grid)
 
         for idx, key in enumerate(self.keys):

--- a/tests/test_affine_transform.py
+++ b/tests/test_affine_transform.py
@@ -1,0 +1,351 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import torch
+from parameterized import parameterized
+
+from monai.networks.layers import AffineTransform
+from monai.networks.utils import normalize_transform, to_norm_affine
+
+TEST_NORM_CASES = [
+    [(4, 5), True, [[[0.5, 0, -1], [0, 0.666667, -1], [0, 0, 1]]]],
+    [
+        (2, 4, 5),
+        True,
+        [[[0.5, 0.0, 0.0, -1.0], [0.0, 0.6666667, 0.0, -1.0], [0.0, 0.0, 2.0, -1.0], [0.0, 0.0, 0.0, 1.0]]],
+    ],
+    [(4, 5), False, [[[0.4, 0.0, -0.8], [0.0, 0.5, -0.75], [0.0, 0.0, 1.0]]]],
+    [(2, 4, 5), False, [[[0.4, 0.0, 0.0, -0.8], [0.0, 0.5, 0.0, -0.75], [0.0, 0.0, 1.0, -0.5], [0.0, 0.0, 0.0, 1.0]]]],
+]
+
+TEST_TO_NORM_AFFINE_CASES = [
+    [
+        [[[1, 0, 0], [0, 1, 0], [0, 0, 1]]],
+        (4, 6),
+        (5, 3),
+        True,
+        [[[0.4, 0.0, -0.6], [0.0, 1.3333334, 0.33333337], [0.0, 0.0, 1.0]]],
+    ],
+    [
+        [[[1, 0, 0], [0, 1, 0], [0, 0, 1]]],
+        (4, 6),
+        (5, 3),
+        False,
+        [[[0.5, 0.0, -0.5], [0.0, 1.25, 0.25], [0.0, 0.0, 1.0]]],
+    ],
+    [
+        [[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]],
+        (2, 4, 6),
+        (3, 5, 3),
+        True,
+        [[[0.4, 0.0, 0.0, -0.6], [0.0, 1.3333334, 0.0, 0.33333337], [0.0, 0.0, 2.0, 1.0], [0.0, 0.0, 0.0, 1.0]]],
+    ],
+    [
+        [[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]],
+        (2, 4, 6),
+        (3, 5, 3),
+        False,
+        [[[0.5, 0.0, 0.0, -0.5], [0.0, 1.25, 0.0, 0.25], [0.0, 0.0, 1.5, 0.5], [0.0, 0.0, 0.0, 1.0]]],
+    ],
+]
+
+TEST_ILL_TO_NORM_AFFINE_CASES = [
+    [[[[1, 0, 0], [0, 1, 0], [0, 0, 1]]], (3, 4, 6), (3, 5, 3), False],
+    [[[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]], (4, 6), (3, 5, 3), True],
+    [[[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]]], (4, 6), (3, 5, 3), True],
+]
+
+
+class TestNormTransform(unittest.TestCase):
+    @parameterized.expand(TEST_NORM_CASES)
+    def test_norm_xform(self, input_shape, align_corners, expected):
+        norm = normalize_transform(
+            input_shape, device=torch.device("cpu:0"), dtype=torch.float32, align_corners=align_corners
+        )
+        norm = norm.detach().cpu().numpy()
+        np.testing.assert_allclose(norm, expected, atol=1e-6)
+        if torch.cuda.is_available():
+            norm = normalize_transform(
+                input_shape, device=torch.device("cuda:0"), dtype=torch.float32, align_corners=align_corners
+            )
+            norm = norm.detach().cpu().numpy()
+            np.testing.assert_allclose(norm, expected, atol=1e-4)
+
+
+class TestToNormAffine(unittest.TestCase):
+    @parameterized.expand(TEST_TO_NORM_AFFINE_CASES)
+    def test_to_norm_affine(self, affine, src_size, dst_size, align_corners, expected):
+        affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+        new_affine = to_norm_affine(affine, src_size, dst_size, align_corners)
+        new_affine = new_affine.detach().cpu().numpy()
+        np.testing.assert_allclose(new_affine, expected, atol=1e-6)
+
+        if torch.cuda.is_available():
+            affine = torch.as_tensor(affine, device=torch.device("cuda:0"), dtype=torch.float32)
+            new_affine = to_norm_affine(affine, src_size, dst_size, align_corners)
+            new_affine = new_affine.detach().cpu().numpy()
+            np.testing.assert_allclose(new_affine, expected, atol=1e-4)
+
+    @parameterized.expand(TEST_ILL_TO_NORM_AFFINE_CASES)
+    def test_to_norm_affine_ill(self, affine, src_size, dst_size, align_corners):
+        with self.assertRaises(ValueError):
+            to_norm_affine(affine, src_size, dst_size, align_corners)
+        with self.assertRaises(ValueError):
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            to_norm_affine(affine, src_size, dst_size, align_corners)
+
+
+class TestAffineTransform(unittest.TestCase):
+    def test_affine_shift(self):
+        affine = torch.as_tensor([[1, 0, 0], [0, 1, -1]])
+        image = torch.as_tensor([[[[4, 1, 3, 2], [7, 6, 8, 5], [3, 5, 3, 6]]]])
+        out = AffineTransform()(image, affine)
+        out = out.detach().cpu().numpy()
+        expected = [[[[0, 4, 1, 3], [0, 7, 6, 8], [0, 3, 5, 3]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_affine_shift_1(self):
+        affine = torch.as_tensor([[1, 0, -1], [0, 1, -1]])
+        image = torch.as_tensor([[[[4, 1, 3, 2], [7, 6, 8, 5], [3, 5, 3, 6]]]])
+        out = AffineTransform()(image, affine)
+        out = out.detach().cpu().numpy()
+        expected = [[[[0, 0, 0, 0], [0, 4, 1, 3], [0, 7, 6, 8]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_affine_shift_2(self):
+        affine = torch.as_tensor([[1, 0, -1], [0, 1, 0]])
+        image = torch.as_tensor([[[[4, 1, 3, 2], [7, 6, 8, 5], [3, 5, 3, 6]]]])
+        out = AffineTransform()(image, affine)
+        out = out.detach().cpu().numpy()
+        expected = [[[[0, 0, 0, 0], [4, 1, 3, 2], [7, 6, 8, 5]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_zoom(self):
+        affine = torch.as_tensor([[1, 0, 0], [0, 2, 0]])
+        image = torch.arange(1, 13).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+        out = AffineTransform((3, 2))(image, affine)
+        expected = [[[[1, 3], [5, 7], [9, 11]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_zoom_1(self):
+        affine = torch.as_tensor([[2, 0, 0], [0, 1, 0]])
+        image = torch.arange(1, 13).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+        out = AffineTransform()(image, affine, (1, 4))
+        expected = [[[[1, 2, 3, 4]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_zoom_2(self):
+        affine = torch.as_tensor([[2, 0, 0], [0, 2, 0]])
+        image = torch.arange(1, 13).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+        out = AffineTransform((1, 2))(image, affine)
+        expected = [[[[1, 3]]]]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_affine_transform_minimum(self):
+        t = np.pi / 3
+        affine = [[np.cos(t), -np.sin(t), 0], [np.sin(t), np.cos(t), 0], [0, 0, 1]]
+        affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+        image = torch.arange(24).view(1, 1, 4, 6).to(device=torch.device("cpu:0"))
+        out = AffineTransform()(image, affine)
+        out = out.detach().cpu().numpy()
+        expected = [
+            [
+                [
+                    [0.0, 0.06698727, 0.0, 0.0, 0.0, 0.0],
+                    [3.8660254, 0.86602557, 0.0, 0.0, 0.0, 0.0],
+                    [7.732051, 3.035899, 0.73205125, 0.0, 0.0, 0.0],
+                    [11.598076, 6.901923, 2.7631402, 0.0, 0.0, 0.0],
+                ]
+            ]
+        ]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+    def test_affine_transform_2d(self):
+        t = np.pi / 3
+        affine = [[np.cos(t), -np.sin(t), 0], [np.sin(t), np.cos(t), 0], [0, 0, 1]]
+        affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+        image = torch.arange(24).view(1, 1, 4, 6).to(device=torch.device("cpu:0"))
+        xform = AffineTransform((3, 4), padding_mode="border", align_corners=True, mode="bilinear")
+        out = xform(image, affine)
+        out = out.detach().cpu().numpy()
+        expected = [
+            [
+                [
+                    [7.1525574e-07, 4.9999994e-01, 1.0000000e00, 1.4999999e00],
+                    [3.8660259e00, 1.3660253e00, 1.8660252e00, 2.3660252e00],
+                    [7.7320518e00, 3.0358994e00, 2.7320509e00, 3.2320507e00],
+                ]
+            ]
+        ]
+        np.testing.assert_allclose(out, expected, atol=1e-5)
+
+        if torch.cuda.is_available():
+            affine = torch.as_tensor(affine, device=torch.device("cuda:0"), dtype=torch.float32)
+            image = torch.arange(24).view(1, 1, 4, 6).to(device=torch.device("cuda:0"))
+            xform = AffineTransform(padding_mode="border", align_corners=True, mode="bilinear")
+            out = xform(image, affine, (3, 4))
+            out = out.detach().cpu().numpy()
+            expected = [
+                [
+                    [
+                        [7.1525574e-07, 4.9999994e-01, 1.0000000e00, 1.4999999e00],
+                        [3.8660259e00, 1.3660253e00, 1.8660252e00, 2.3660252e00],
+                        [7.7320518e00, 3.0358994e00, 2.7320509e00, 3.2320507e00],
+                    ]
+                ]
+            ]
+            np.testing.assert_allclose(out, expected, atol=1e-4)
+
+    def test_affine_transform_3d(self):
+        t = np.pi / 3
+        affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+        affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+        image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+        xform = AffineTransform((3, 4, 2), padding_mode="border", align_corners=False, mode="bilinear")
+        out = xform(image, affine)
+        out = out.detach().cpu().numpy()
+        expected = [
+            [
+                [
+                    [[0.00000006, 0.5000001], [2.3660254, 1.3660254], [4.732051, 2.4019241], [5.0, 3.9019237]],
+                    [[6.0, 6.5], [8.366026, 7.3660254], [10.732051, 8.401924], [11.0, 9.901924]],
+                    [[12.0, 12.5], [14.366026, 13.366025], [16.732052, 14.401924], [17.0, 15.901923]],
+                ]
+            ],
+            [
+                [
+                    [[24.0, 24.5], [26.366024, 25.366024], [28.732052, 26.401924], [29.0, 27.901924]],
+                    [[30.0, 30.5], [32.366028, 31.366026], [34.732048, 32.401924], [35.0, 33.901924]],
+                    [[36.0, 36.5], [38.366024, 37.366024], [40.73205, 38.401924], [41.0, 39.901924]],
+                ]
+            ],
+        ]
+        np.testing.assert_allclose(out, expected, atol=1e-4)
+
+        if torch.cuda.is_available():
+            affine = torch.as_tensor(affine, device=torch.device("cuda:0"), dtype=torch.float32)
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cuda:0"))
+            xform = AffineTransform(padding_mode="border", align_corners=False, mode="bilinear")
+            out = xform(image, affine, (3, 4, 2))
+            out = out.detach().cpu().numpy()
+            expected = [
+                [
+                    [
+                        [[0.00000006, 0.5000001], [2.3660254, 1.3660254], [4.732051, 2.4019241], [5.0, 3.9019237]],
+                        [[6.0, 6.5], [8.366026, 7.3660254], [10.732051, 8.401924], [11.0, 9.901924]],
+                        [[12.0, 12.5], [14.366026, 13.366025], [16.732052, 14.401924], [17.0, 15.901923]],
+                    ]
+                ],
+                [
+                    [
+                        [[24.0, 24.5], [26.366024, 25.366024], [28.732052, 26.401924], [29.0, 27.901924]],
+                        [[30.0, 30.5], [32.366028, 31.366026], [34.732048, 32.401924], [35.0, 33.901924]],
+                        [[36.0, 36.5], [38.366024, 37.366024], [40.73205, 38.401924], [41.0, 39.901924]],
+                    ]
+                ],
+            ]
+            np.testing.assert_allclose(out, expected, atol=1e-4)
+
+    def test_ill_affine_transform(self):
+        with self.assertRaises(ValueError):  # image too small
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            xform = AffineTransform((3, 4, 2), padding_mode="border", align_corners=False, mode="bilinear")
+            xform(torch.as_tensor([1, 2, 3]), affine)
+
+        with self.assertRaises(ValueError):  # output shape too small
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+            xform = AffineTransform((3, 4), padding_mode="border", align_corners=False, mode="bilinear")
+            xform(image, affine)
+
+        with self.assertRaises(ValueError):  # incorrect affine
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            affine = affine.unsqueeze(0).unsqueeze(0)
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+            xform = AffineTransform((2, 3, 4), padding_mode="border", align_corners=False, mode="bilinear")
+            xform(image, affine)
+
+        with self.assertRaises(ValueError):  # batch doesn't match
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            affine = affine.unsqueeze(0)
+            affine = affine.repeat(3, 1, 1)
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+            xform = AffineTransform((2, 3, 4), padding_mode="border", align_corners=False, mode="bilinear")
+            xform(image, affine)
+
+        with self.assertRaises(ValueError):  # wrong affine
+            affine = torch.as_tensor([[1, 0, 0, 0], [0, 0, 0, 1]])
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+            xform = AffineTransform((2, 3, 4), padding_mode="border", align_corners=False, mode="bilinear")
+            xform(image, affine)
+
+    def test_forward_2d(self):
+        x = torch.rand(2, 1, 4, 4)
+        theta = torch.Tensor([[[0, -1, 0], [1, 0, 0]]]).repeat(2, 1, 1)
+        grid = torch.nn.functional.affine_grid(theta, x.size(), align_corners=False)
+        expected = torch.nn.functional.grid_sample(x, grid, align_corners=False)
+        expected = expected.detach().cpu().numpy()
+
+        actual = AffineTransform(normalized=True, reverse_indexing=False)(x, theta)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [2, 2, 3])
+
+        theta = torch.Tensor([[0, -1, 0], [1, 0, 0]])
+        actual = AffineTransform(normalized=True, reverse_indexing=False)(x, theta)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [2, 3])
+
+        theta = torch.Tensor([[[0, -1, 0], [1, 0, 0]]])
+        actual = AffineTransform(normalized=True, reverse_indexing=False)(x, theta)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [1, 2, 3])
+
+    def test_forward_3d(self):
+        x = torch.rand(2, 1, 4, 4, 4)
+        theta = torch.Tensor([[[0, 0, -1, 0], [1, 0, 0, 0], [0, 0, 1, 0]]]).repeat(2, 1, 1)
+        grid = torch.nn.functional.affine_grid(theta, x.size(), align_corners=False)
+        expected = torch.nn.functional.grid_sample(x, grid, align_corners=False)
+        expected = expected.detach().cpu().numpy()
+
+        actual = AffineTransform(normalized=True, reverse_indexing=False)(x, theta)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [2, 3, 4])
+
+        theta = torch.Tensor([[0, 0, -1, 0], [1, 0, 0, 0], [0, 0, 1, 0]])
+        actual = AffineTransform(normalized=True, reverse_indexing=False)(x, theta)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [3, 4])
+
+        theta = torch.Tensor([[[0, 0, -1, 0], [1, 0, 0, 0], [0, 0, 1, 0]]])
+        actual = AffineTransform(normalized=True, reverse_indexing=False)(x, theta)
+        actual = actual.detach().cpu().numpy()
+        np.testing.assert_allclose(actual, expected)
+        np.testing.assert_allclose(list(theta.shape), [1, 3, 4])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gaussian_filter.py
+++ b/tests/test_gaussian_filter.py
@@ -60,7 +60,7 @@ class GaussianFilterTestCase(unittest.TestCase):
         np.testing.assert_allclose(g(a).cpu().numpy(), expected, rtol=1e-5)
         if torch.cuda.is_available():
             g = GaussianFilter(2, 3, 3).to(torch.device("cuda:0"))
-            np.testing.assert_allclose(g(a).cpu().numpy(), expected, rtol=1e-2)
+            np.testing.assert_allclose(g(a.cuda()).cpu().numpy(), expected, rtol=1e-2)
 
     def test_3d(self):
         a = torch.ones(1, 1, 4, 3, 4)
@@ -113,7 +113,7 @@ class GaussianFilterTestCase(unittest.TestCase):
         np.testing.assert_allclose(g(a).cpu().numpy(), expected, rtol=1e-5)
         if torch.cuda.is_available():
             g = GaussianFilter(3, [3, 2, 1], 3).to(torch.device("cuda:0"))
-            np.testing.assert_allclose(g(a).cpu().numpy(), expected, rtol=1e-2)
+            np.testing.assert_allclose(g(a.cuda()).cpu().numpy(), expected, rtol=1e-2)
 
     def test_wrong_args(self):
         with self.assertRaisesRegex(ValueError, ""):

--- a/tests/test_integration_stn.py
+++ b/tests/test_integration_stn.py
@@ -107,6 +107,7 @@ class TestSpatialTransformerCore(unittest.TestCase):
         """
         check that the quality AffineTransform backpropagation
         """
+        atol = 1e-5
         set_determinism(seed=0)
         out_ref, loss_ref, init_loss_ref = compare_2d(True, self.device)
         print(out_ref.shape, loss_ref, init_loss_ref)
@@ -114,16 +115,16 @@ class TestSpatialTransformerCore(unittest.TestCase):
         set_determinism(seed=0)
         out, loss, init_loss = compare_2d(False, self.device)
         print(out.shape, loss, init_loss)
-        np.testing.assert_allclose(out_ref, out)
-        np.testing.assert_allclose(init_loss_ref, init_loss)
-        np.testing.assert_allclose(loss_ref, loss)
+        np.testing.assert_allclose(out_ref, out, atol=atol)
+        np.testing.assert_allclose(init_loss_ref, init_loss, atol=atol)
+        np.testing.assert_allclose(loss_ref, loss, atol=atol)
 
         set_determinism(seed=0)
         out, loss, init_loss = compare_2d(False, self.device, True)
         print(out.shape, loss, init_loss)
-        np.testing.assert_allclose(out_ref, out)
-        np.testing.assert_allclose(init_loss_ref, init_loss)
-        np.testing.assert_allclose(loss_ref, loss)
+        np.testing.assert_allclose(out_ref, out, atol=atol)
+        np.testing.assert_allclose(init_loss_ref, init_loss, atol=atol)
+        np.testing.assert_allclose(loss_ref, loss, atol=atol)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration_stn.py
+++ b/tests/test_integration_stn.py
@@ -1,0 +1,115 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+
+from monai.data import create_test_image_2d
+from monai.networks.layers import AffineTransform
+from monai.utils import set_determinism
+
+
+class STNBenchmark(nn.Module):
+    """
+    adapted from https://pytorch.org/tutorials/intermediate/spatial_transformer_tutorial.html
+    """
+
+    def __init__(self, is_ref=True):
+        super().__init__()
+        self.is_ref = is_ref
+        self.localization = nn.Sequential(
+            nn.Conv2d(1, 8, kernel_size=7),
+            nn.MaxPool2d(2, stride=2),
+            nn.ReLU(True),
+            nn.Conv2d(8, 10, kernel_size=5),
+            nn.MaxPool2d(2, stride=2),
+            nn.ReLU(True),
+        )
+        # Regressor for the 3 * 2 affine matrix
+        self.fc_loc = nn.Sequential(nn.Linear(10 * 3 * 3, 32), nn.ReLU(True), nn.Linear(32, 3 * 2))
+        # Initialize the weights/bias with identity transformation
+        self.fc_loc[2].weight.data.zero_()
+        self.fc_loc[2].bias.data.copy_(torch.tensor([1, 0, 0, 0, 1, 0], dtype=torch.float))
+        if not self.is_ref:
+            self.xform = AffineTransform(normalized=True, reverse_indexing=False)
+
+    # Spatial transformer network forward function
+    def stn_ref(self, x):
+        xs = self.localization(x)
+        xs = xs.view(-1, 10 * 3 * 3)
+        theta = self.fc_loc(xs)
+        theta = theta.view(-1, 2, 3)
+
+        grid = F.affine_grid(theta, x.size())
+        x = F.grid_sample(x, grid)
+        return x
+
+    def stn(self, x):
+        xs = self.localization(x)
+        xs = xs.view(-1, 10 * 3 * 3)
+        theta = self.fc_loc(xs)
+        theta = theta.view(-1, 2, 3)
+        x = self.xform(x, theta, spatial_size=x.size()[2:])
+        return x
+
+    def forward(self, x):
+        if self.is_ref:
+            return self.stn_ref(x)
+        return self.stn(x)
+
+
+def compare_2d(is_ref=True, device=None):
+    batch_size = 32
+    img_a = [create_test_image_2d(28, 28, 5, rad_max=6, noise_max=1)[0][None] for _ in range(batch_size)]
+    img_b = [create_test_image_2d(28, 28, 5, rad_max=6, noise_max=1)[0][None] for _ in range(batch_size)]
+    img_a = np.stack(img_a, axis=0)
+    img_b = np.stack(img_b, axis=0)
+    img_a = torch.as_tensor(img_a)
+    img_b = torch.as_tensor(img_b)
+    model = STNBenchmark(is_ref=is_ref).to(device)
+    optimizer = optim.SGD(model.parameters(), lr=0.001)
+    model.train()
+    for _ in range(20):
+        optimizer.zero_grad()
+        output_a = model(img_a)
+        loss = torch.mean((output_a - img_b) ** 2)
+        loss.backward()
+        optimizer.step()
+    return model(img_a).detach().cpu().numpy(), loss.item()
+
+
+class TestSpatialTransformerCore(unittest.TestCase):
+    def setUp(self):
+        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu:0")
+
+    def tearDown(self):
+        set_determinism(seed=None)
+
+    def test_training(self):
+        set_determinism(seed=0)
+        out_ref, loss_ref = compare_2d(True, self.device)
+        print(out_ref.shape, loss_ref)
+        set_determinism(seed=0)
+        out, loss = compare_2d(False, self.device)
+        print(out.shape, loss)
+        np.testing.assert_allclose(out_ref, out)
+        np.testing.assert_allclose(loss_ref, loss)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
subtask of #232, revisit #270 as PR270 is out-of-date
adds an affine transform module, which can be configured to
- be a part of the spatial transformer network (tested against the implementation from https://pytorch.org/tutorials/intermediate/spatial_transformer_tutorial.html)
- partly replicate the result of scipy.ndimage.affine_transform using pytorch (tested against cases generated with scipy; prefiltering not implemented, pytorch resampler currently supports linear interpolation)

this PR also fixes a few minor documentation issues

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
