### PR TITLE
improve documentation docs/source

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,7 +95,7 @@ extensions = [
 ]
 
 autoclass_content = "both"
-add_module_names = False
+add_module_names = True
 autosectionlabel_prefix_document = True
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -7,8 +7,7 @@ Data
 
 Generic Interfaces
 ------------------
-.. automodule:: monai.data.dataset
-.. currentmodule:: monai.data.dataset
+.. currentmodule:: monai.data
 
 `Dataset`
 ~~~~~~~~~
@@ -46,8 +45,6 @@ Patch-based dataset
 
 `GridPatchDataset`
 ~~~~~~~~~~~~~~~~~~
-.. automodule:: monai.data.grid_dataset
-.. currentmodule:: monai.data.grid_dataset
 .. autoclass:: GridPatchDataset
   :members:
 
@@ -57,15 +54,15 @@ Nifti format handling
 
 Reading
 ~~~~~~~
-.. automodule:: monai.data.nifti_reader
+.. automodule:: monai.data.NiftiDataset
   :members:
 
 Writing Nifti
 ~~~~~~~~~~~~~
-.. automodule:: monai.data.nifti_saver
+.. automodule:: monai.data.NiftiSaver
   :members:
 
-.. automodule:: monai.data.nifti_writer
+.. automodule:: monai.data.write_nifti
   :members:
 
 
@@ -74,10 +71,10 @@ PNG format handling
 
 Writing PNG
 ~~~~~~~~~~~
-.. automodule:: monai.data.png_saver
+.. automodule:: monai.data.PNGSaver
   :members:
 
-.. automodule:: monai.data.png_writer
+.. automodule:: monai.data.write_png
   :members:
 
 

--- a/docs/source/engines.rst
+++ b/docs/source/engines.rst
@@ -23,8 +23,7 @@ Workflows
 .. autoclass:: Workflow
     :members:
 
-.. automodule:: monai.engines.trainer
-.. currentmodule:: monai.engines.trainer
+.. currentmodule:: monai.engines
 
 `Trainer`
 ~~~~~~~~~
@@ -35,9 +34,6 @@ Workflows
 ~~~~~~~~~~~~~~~~~~~
 .. autoclass:: SupervisedTrainer
     :members:
-
-.. automodule:: monai.engines.evaluator
-.. currentmodule:: monai.engines.evaluator
 
 `Evaluator`
 ~~~~~~~~~~~

--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -4,66 +4,67 @@
 
 Event handlers
 ==============
+.. currentmodule:: monai.handlers
 
 Model checkpoint loader
 -----------------------
-.. automodule:: monai.handlers.checkpoint_loader
+.. autoclass:: CheckpointLoader
   :members:
 
 Model checkpoint saver
 ----------------------
-.. automodule:: monai.handlers.checkpoint_saver
+.. autoclass:: CheckpointSaver
   :members:
 
 CSV saver
 ---------
-.. automodule:: monai.handlers.classification_saver
+.. autoclass:: ClassificationSaver
     :members:
 
 
 Mean Dice metrics handler
 -------------------------
-.. automodule:: monai.handlers.mean_dice
+.. autoclass:: MeanDice
     :members:
 
 
 ROC AUC metrics handler
 -----------------------
-.. automodule:: monai.handlers.roc_auc
+.. autoclass:: ROCAUC
     :members:
 
 
 Metric logger
 -------------
-.. automodule:: monai.handlers.metric_logger
+.. autoclass:: MetricLogger
     :members:
 
 
 Segmentation saver
 ------------------
-.. automodule:: monai.handlers.segmentation_saver
+.. autoclass:: SegmentationSaver
     :members:
 
 
 Training stats handler
 ----------------------
-.. automodule:: monai.handlers.stats_handler
+.. autoclass:: StatsHandler
     :members:
 
 
 Tensorboard handler
 -------------------
-.. automodule:: monai.handlers.tensorboard_handlers
+.. autoclass:: TensorBoardStatsHandler
     :members:
 
 
 LR Schedule handler
 -------------------
-.. automodule:: monai.handlers.lr_schedule_handler
+.. autoclass:: LrScheduleHandler
     :members:
 
 
 Validation handler
 ------------------
-.. automodule:: monai.handlers.validation_handler
+.. autoclass:: ValidationHandler
     :members:

--- a/docs/source/inferers.rst
+++ b/docs/source/inferers.rst
@@ -8,15 +8,15 @@ Inference methods
 Sliding Window Inference
 ------------------------
 
-.. automodule:: monai.inferers.sliding_window_inference
-  :members:
+.. autofunction:: monai.inferers.sliding_window_inference
 
 
 Inferers
 --------
 
-.. automodule:: monai.inferers.inferer
-.. currentmodule:: monai.inferers.inferer
+.. currentmodule:: monai.inferers
+.. autoclass:: Inferer
+    :members:
 
 `SimpleInferer`
 ~~~~~~~~~~~~~~~

--- a/docs/source/losses.rst
+++ b/docs/source/losses.rst
@@ -8,8 +8,8 @@ Loss functions
 Segmentation Losses
 -------------------
 
-.. automodule:: monai.losses.dice
-.. currentmodule:: monai.losses.dice
+.. automodule:: monai.losses
+.. currentmodule:: monai.losses
 
 `DiceLoss`
 ~~~~~~~~~~
@@ -23,11 +23,8 @@ Segmentation Losses
 
 `FocalLoss`
 ~~~~~~~~~~~
-.. autoclass:: monai.losses.focal_loss.FocalLoss
+.. autoclass:: FocalLoss
     :members:
-
-.. automodule:: monai.losses.tversky
-.. currentmodule:: monai.losses.tversky
 
 `TverskyLoss`
 ~~~~~~~~~~~~~

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -4,14 +4,12 @@
 
 Metrics
 =======
+.. currentmodule:: monai.metrics
 
 `Mean Dice`
 -----------
-.. automodule:: monai.metrics.meandice
-  :members:
-
+.. autofunction:: compute_meandice
 
 `Area under the ROC curve`
 --------------------------
-.. automodule:: monai.metrics.rocauc
-  :members:
+.. autofunction:: compute_roc_auc

--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -7,8 +7,8 @@ Network architectures
 
 Blocks
 ------
-.. automodule:: monai.networks.blocks.convolutions
-.. currentmodule:: monai.networks.blocks.convolutions
+.. automodule:: monai.networks.blocks
+.. currentmodule:: monai.networks.blocks
 
 `Convolution`
 ~~~~~~~~~~~~~
@@ -27,14 +27,11 @@ Layers
 `Factories`
 ~~~~~~~~~~~
 .. automodule:: monai.networks.layers.factories
-.. currentmodule:: monai.networks.layers.factories
+.. currentmodule:: monai.networks.layers
 
 `LayerFactory`
 ##############
 .. autoclass:: LayerFactory
-
-.. automodule:: monai.networks.layers.simplelayers
-.. currentmodule:: monai.networks.layers.simplelayers
 
 `SkipConnection`
 ~~~~~~~~~~~~~~~~
@@ -59,29 +56,30 @@ Layers
 
 Nets
 ----
-
-.. automodule:: monai.networks.nets
 .. currentmodule:: monai.networks.nets
 
 `Densenet3D`
 ~~~~~~~~~~~~
-.. automodule:: monai.networks.nets.densenet
+.. autoclass:: DenseNet
   :members:
-.. autofunction:: monai.networks.nets.densenet.densenet121
-.. autofunction:: monai.networks.nets.densenet.densenet169
-.. autofunction:: monai.networks.nets.densenet.densenet201
-.. autofunction:: monai.networks.nets.densenet.densenet264
+.. autofunction:: densenet121
+.. autofunction:: densenet169
+.. autofunction:: densenet201
+.. autofunction:: densenet264
 
 `Highresnet`
 ~~~~~~~~~~~~
-.. automodule:: monai.networks.nets.highresnet
+.. autoclass:: HighResNet
+  :members:
+.. autoclass:: HighResBlock
   :members:
 
 `Unet`
 ~~~~~~
-.. automodule:: monai.networks.nets.unet
+.. autoclass:: UNet
   :members:
-
+.. autoclass:: Unet
+.. autoclass:: unet
 
 Utilities
 ---------

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -7,9 +7,8 @@ Transforms
 
 Generic Interfaces
 ------------------
-
-.. automodule:: monai.transforms.compose
-.. currentmodule:: monai.transforms.compose
+.. automodule:: monai.transforms
+.. currentmodule:: monai.transforms
 
 `Transform`
 ~~~~~~~~~~~
@@ -37,9 +36,6 @@ Generic Interfaces
 
 Vanilla Transforms
 ------------------
-
-.. automodule:: monai.transforms
-.. currentmodule:: monai.transforms
 
 `Spacing`
 ~~~~~~~~~
@@ -582,7 +578,6 @@ Dictionary-based Transforms
 
 Transform Adaptors
 ------------------
-
 .. automodule:: monai.transforms.adaptors
 
 `adaptor`

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -44,11 +44,12 @@ class CheckpointSaver:
     Note:
         CheckpointHandler can be used during training, validation or evaluation.
         example of saved files:
-            checkpoint_iteration=400.pth
-            checkpoint_iteration=800.pth
-            checkpoint_epoch=1.pth
-            checkpoint_final_iteration=1000.pth
-            checkpoint_key_metric=0.9387.pth
+
+            - checkpoint_iteration=400.pth
+            - checkpoint_iteration=800.pth
+            - checkpoint_epoch=1.pth
+            - checkpoint_final_iteration=1000.pth
+            - checkpoint_key_metric=0.9387.pth
 
     """
 

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -15,20 +15,18 @@ from .utils import sliding_window_inference
 
 class Inferer(ABC):
     """
-    Inferer is the base class of all kinds of inferers, which execute inference on model.
-    It can support complicated operations during inference, like SlidingWindow.
-
+    A base class for model inference.
+    Extend this class to support operations during inference, e.g. a sliding window method.
     """
 
     @abstractmethod
     def __call__(self, inputs, network):
         """
-        Unified callable function API of Inferers.
+        Run inference on `inputs` with the `network` model.
 
         Args:
-            inputs (torch.tensor): model input data for inference.
-            network (Network): target model to execute inference.
-
+            inputs (torch.tensor): input of the model inference.
+            network (Network): model for inference.
         """
         raise NotImplementedError("subclass will implement the operations.")
 
@@ -55,7 +53,8 @@ class SimpleInferer(Inferer):
 
 class SlidingWindowInferer(Inferer):
     """
-    Use SlidingWindow method to execute inference, run windows on model based on sw_batch_size.
+    Sliding window method for model inference,
+    with `sw_batch_size` windows for every model.forward().
 
     Args:
         roi_size (list, tuple): the window size to execute SlidingWindow evaluation.


### PR DESCRIPTION
improving usability, show module names properly in the documentation,
for example  `MapTransform` -> `monai.transforms.MapTransform`
### current:
![Screenshot 2020-05-27 at 20 15 15](https://user-images.githubusercontent.com/831580/83063150-9fb10980-a057-11ea-9af4-66d906dd83e4.png)
### after this pr:
![Screenshot 2020-05-27 at 20 16 33](https://user-images.githubusercontent.com/831580/83063155-a2136380-a057-11ea-8b97-e750c0e71d10.png)






### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated
