### PR TITLE
BUG: Type mismatch for test_gpu_zoom

### DIFF
--- a/tests/test_rand_zoomd.py
+++ b/tests/test_rand_zoomd.py
@@ -75,7 +75,7 @@ class TestRandZoomd(NumpyImageTestCase2D):
                     zoom_scipy(channel, zoom=random_zoom._zoom, mode=mode, order=order, cval=cval, prefilter=prefilter)
                 )
             expected = np.stack(expected).astype(np.float32)
-            self.assertTrue(np.allclose(expected, zoomed))
+            self.assertTrue(np.allclose(expected, zoomed[key]))
 
     def test_keep_size(self):
         key = "img"


### PR DESCRIPTION

Fixes #454 .

### Status
Ready

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

The expected value needs to be compared to the image from the dictionary
rather than the dictionary itself.

### To Reproduce

% python -m tests.test_rand_zoomd -v

test_correct_results_0 (__main__.TestRandZoomd) ... ok
test_gpu_zoom_0 (__main__.TestRandZoomd) ... ERROR
test_invalid_inputs_0_no_min_zoom (__main__.TestRandZoomd) ... ok
test_invalid_inputs_1_invalid_order (__main__.TestRandZoomd) ... ok
test_keep_size (__main__.TestRandZoomd) ... ok

======================================================================
ERROR: test_gpu_zoom_0 (__main__.TestRandZoomd)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "python3.6/site-packages/parameterized/parameterized.py", line 530, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "monai/tests/test_rand_zoomd.py", line 78, in test_gpu_zoom
    self.assertTrue(np.allclose(expected, zoomed))
  File "<__array_function__ internals>", line 6, in allclose
  File "python3.6/site-packages/numpy/core/numeric.py", line 2159, in allclose
    res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
  File "<__array_function__ internals>", line 6, in isclose
  File "python3.6/site-packages/numpy/core/numeric.py", line 2258, in isclose
    yfin = isfinite(y)
TypeError: ufunc 'isfinite' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''

