### PR TITLE
Unify dictionary & array format for metadata

### DIFF
--- a/examples/classification_3d/densenet_evaluation_dict.py
+++ b/examples/classification_3d/densenet_evaluation_dict.py
@@ -72,7 +72,7 @@ def main():
             value = torch.eq(val_outputs, val_labels)
             metric_count += len(value)
             num_correct += value.sum().item()
-            saver.save_batch(val_outputs, {"filename_or_obj": val_data["img.filename_or_obj"]})
+            saver.save_batch(val_outputs, val_data["img_meta"])
         metric = num_correct / metric_count
         print("evaluation metric:", metric)
         saver.finalize()

--- a/examples/classification_3d_ignite/densenet_evaluation_dict.py
+++ b/examples/classification_3d_ignite/densenet_evaluation_dict.py
@@ -79,7 +79,7 @@ def main():
     prediction_saver = ClassificationSaver(
         output_dir="tempdir",
         name="evaluator",
-        batch_transform=lambda batch: {"filename_or_obj": batch["img.filename_or_obj"]},
+        batch_transform=lambda batch: batch["img_meta"],
         output_transform=lambda output: output[0].argmax(1),
     )
     prediction_saver.attach(evaluator)

--- a/examples/segmentation_3d/unet_evaluation_dict.py
+++ b/examples/segmentation_3d/unet_evaluation_dict.py
@@ -90,9 +90,7 @@ def main():
             metric_count += len(value)
             metric_sum += value.sum().item()
             val_outputs = (val_outputs.sigmoid() >= 0.5).float()
-            saver.save_batch(
-                val_outputs, {"filename_or_obj": val_data["img.filename_or_obj"], "affine": val_data["img.affine"]}
-            )
+            saver.save_batch(val_outputs, val_data["img_meta"])
         metric = metric_sum / metric_count
         print("evaluation metric:", metric)
     shutil.rmtree(tempdir)

--- a/examples/segmentation_3d_ignite/unet_evaluation_dict.py
+++ b/examples/segmentation_3d_ignite/unet_evaluation_dict.py
@@ -101,7 +101,7 @@ def main():
         output_ext=".nii.gz",
         output_postfix="seg",
         name="evaluator",
-        batch_transform=lambda batch: {"filename_or_obj": batch["img.filename_or_obj"], "affine": batch["img.affine"]},
+        batch_transform=lambda batch: batch["img_meta"],
         output_transform=lambda output: predict_segmentation(output[0]),
     ).attach(evaluator)
     # the model was trained by "unet_training_dict" example

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -28,11 +28,11 @@ class LoadNiftid(MapTransform):
     stack them together and add a new dimension as the first dimension, and use the
     meta data of the first image to represent the stacked result. Note that the affine
     transform of all the stacked images should be same. The output metadata field will
-    be created as ``self.meta_key_format(key, metadata_key)``.
+    be created as ``key_{meta_key_postfix}``.
     """
 
     def __init__(
-        self, keys, as_closest_canonical=False, dtype=np.float32, meta_key_format="{}.{}", overwriting_keys=False
+        self, keys, as_closest_canonical=False, dtype=np.float32, meta_key_postfix="meta", overwriting=False
     ):
         """
         Args:
@@ -40,15 +40,17 @@ class LoadNiftid(MapTransform):
                 See also: :py:class:`monai.transforms.compose.MapTransform`
             as_closest_canonical (bool): if True, load the image as closest to canonical axis format.
             dtype (np.dtype, optional): if not None convert the loaded image to this data type.
-            meta_key_format (str): key format to store meta data of the nifti image.
-                it must contain 2 fields for the key of this image and the key of every meta data item.
-            overwriting_keys (bool): whether allow to overwrite existing keys of meta data.
+            meta_key_postfix (str): use `key_{postfix}` to to store meta data of the nifti image, default is `meta`.
+                for example, load nifti file for `image`, store the metadata into `image_meta`.
+            overwriting (bool): whether allow to overwrite existing meta data of same key.
                 default is False, which will raise exception if encountering existing key.
         """
         super().__init__(keys)
         self.loader = LoadNifti(as_closest_canonical, False, dtype)
-        self.meta_key_format = meta_key_format
-        self.overwriting_keys = overwriting_keys
+        if not isinstance(meta_key_postfix, str):
+            raise ValueError("meta_key_postfix must be a string.")
+        self.meta_key_postfix = meta_key_postfix
+        self.overwriting = overwriting
 
     def __call__(self, data):
         d = dict(data)
@@ -57,11 +59,10 @@ class LoadNiftid(MapTransform):
             assert isinstance(data, (tuple, list)), "loader must return a tuple or list."
             d[key] = data[0]
             assert isinstance(data[1], dict), "metadata must be a dict."
-            for k in sorted(data[1]):
-                key_to_add = self.meta_key_format.format(key, k)
-                if key_to_add in d and not self.overwriting_keys:
-                    raise KeyError(f"meta data key {key_to_add} already exists.")
-                d[key_to_add] = data[1][k]
+            key_to_add = f"{key}_{self.meta_key_postfix}"
+            if key_to_add in d and not self.overwriting:
+                raise KeyError(f"meta data with key {key_to_add} already exists.")
+            d[key_to_add] = data[1]
         return d
 
 
@@ -70,18 +71,23 @@ class LoadPNGd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.LoadPNG`.
     """
 
-    def __init__(self, keys, dtype=np.float32, meta_key_format="{}.{}"):
+    def __init__(self, keys, dtype=np.float32, meta_key_postfix="meta", overwriting=False):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
                 See also: :py:class:`monai.transforms.compose.MapTransform`
             dtype (np.dtype, optional): if not None convert the loaded image to this data type.
-            meta_key_format (str): key format to store meta data of the loaded image.
-                it must contain 2 fields for the key of this image and the key of every meta data item.
+            meta_key_postfix (str): use `key_{postfix}` to to store meta data of the png image, default is `meta`.
+                for example, load png file for `image`, store the metadata into `image_meta`.
+            overwriting (bool): whether allow to overwrite existing meta data of same key.
+                default is False, which will raise exception if encountering existing key.
         """
         super().__init__(keys)
         self.loader = LoadPNG(False, dtype)
-        self.meta_key_format = meta_key_format
+        if not isinstance(meta_key_postfix, str):
+            raise ValueError("meta_key_postfix must be a string.")
+        self.meta_key_postfix = meta_key_postfix
+        self.overwriting = overwriting
 
     def __call__(self, data):
         d = dict(data)
@@ -90,9 +96,10 @@ class LoadPNGd(MapTransform):
             assert isinstance(data, (tuple, list)), "loader must return a tuple or list."
             d[key] = data[0]
             assert isinstance(data[1], dict), "metadata must be a dict."
-            for k in sorted(data[1]):
-                key_to_add = self.meta_key_format.format(key, k)
-                d[key_to_add] = data[1][k]
+            key_to_add = f"{key}_{self.meta_key_postfix}"
+            if key_to_add in d and not self.overwriting:
+                raise KeyError(f"meta data with key {key_to_add} already exists.")
+            d[key_to_add] = data[1]
         return d
 
 

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -41,17 +41,17 @@ class Spacingd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.Spacing`.
 
     This transform assumes the ``data`` dictionary has a key for the input
-    data's affine.  The key is formed by ``meta_key_format.format(key, 'affine')``.
+    data's metadata and contains `affine` field.  The key is formed by ``key_{meta_key_postfix}``.
 
     After resampling the input array, this transform will write the new affine
-     to the key formed by ``meta_key_format.format(key, 'affine')``.
+    to the `affine` field of metadata which is formed by ``key_{meta_key_postfix}``.
 
     see also:
         :py:class:`monai.transforms.Spacing`
     """
 
     def __init__(
-        self, keys, pixdim, diagonal=False, interp_order=3, mode="nearest", cval=0, dtype=None, meta_key_format="{}.{}"
+        self, keys, pixdim, diagonal=False, interp_order=3, mode="nearest", cval=0, dtype=None, meta_key_postfix="meta"
     ):
         """
         Args:
@@ -76,9 +76,14 @@ class Spacingd(MapTransform):
                 Available options are `reflect|constant|nearest|mirror|wrap`.
                 The mode parameter determines how the input array is extended beyond its boundaries.
                 Default is 'nearest'.
-            cval (scalar or sequence of scalars): Value to fill past edges of input if mode is "constant". Default is 0.0.
-            dtype (None or np.dtype or sequence of np.dtype): output array data type, defaults to None to use input data's dtype.
-            meta_key_format (str): key format to read/write affine matrices to the data dictionary.
+            cval (scalar or sequence of scalars): Value to fill past edges of input if mode is "constant".
+                Default is 0.0.
+            dtype (None or np.dtype or sequence of np.dtype): output array data type, defaults to None to
+                use input data's dtype.
+            meta_key_postfix (str): use `key_{postfix}` to to fetch meta data of the key data, default is `meta`.
+                for example, to handle key `image`,  read/write affine matrices from the
+                metadata `image_meta` dictionary's `affine`.
+
         """
         super().__init__(keys)
         self.spacing_transform = Spacing(pixdim, diagonal=diagonal)
@@ -86,24 +91,26 @@ class Spacingd(MapTransform):
         self.mode = ensure_tuple_rep(mode, len(self.keys))
         self.cval = ensure_tuple_rep(cval, len(self.keys))
         self.dtype = ensure_tuple_rep(dtype, len(self.keys))
-        self.meta_key_format = meta_key_format
+        if not isinstance(meta_key_postfix, str):
+            raise ValueError("meta_key_postfix must be a string.")
+        self.meta_key_postfix = meta_key_postfix
 
     def __call__(self, data):
         d = dict(data)
         for idx, key in enumerate(self.keys):
-            affine_key = self.meta_key_format.format(key, "affine")
+            meta_data = d[f"{key}_{self.meta_key_postfix}"]
             # resample array of each corresponding key
             # using affine fetched from d[affine_key]
             d[key], _, new_affine = self.spacing_transform(
                 data_array=d[key],
-                affine=d[affine_key],
+                affine=meta_data["affine"],
                 interp_order=self.interp_order[idx],
                 mode=self.mode[idx],
                 cval=self.cval[idx],
                 dtype=self.dtype[idx],
             )
             # set the 'affine' key
-            d[affine_key] = new_affine
+            meta_data["affine"] = new_affine
         return d
 
 
@@ -112,14 +119,14 @@ class Orientationd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.Orientation`.
 
     This transform assumes the ``data`` dictionary has a key for the input
-    data's affine.  The key is formed by ``meta_key_format.format(key, 'affine')``.
+    data's metadata and contains `affine` field.  The key is formed by ``key_{meta_key_postfix}``.
 
     After reorienting the input array, this transform will write the new affine
-     to the key formed by ``meta_key_format.format(key, 'affine')``.
+    to the `affine` field of metadata which is formed by ``key_{meta_key_postfix}``.
     """
 
     def __init__(
-        self, keys, axcodes=None, as_closest_canonical=False, labels=tuple(zip("LPI", "RAS")), meta_key_format="{}.{}"
+        self, keys, axcodes=None, as_closest_canonical=False, labels=tuple(zip("LPI", "RAS")), meta_key_postfix="meta"
     ):
         """
         Args:
@@ -132,21 +139,25 @@ class Orientationd(MapTransform):
             labels : optional, None or sequence of (2,) sequences
                 (2,) sequences are labels for (beginning, end) of output axis.
                 Defaults to ``(('L', 'R'), ('P', 'A'), ('I', 'S'))``.
-            meta_key_format (str): key format to read/write affine matrices to the data dictionary.
+            meta_key_postfix (str): use `key_{postfix}` to to fetch meta data of the key data, default is `meta`.
+                for example, to handle key `image`,  read/write affine matrices from the
+                metadata `image_meta` dictionary's `affine`.
 
         See Also:
             `nibabel.orientations.ornt2axcodes`.
         """
         super().__init__(keys)
         self.ornt_transform = Orientation(axcodes=axcodes, as_closest_canonical=as_closest_canonical, labels=labels)
-        self.meta_key_format = meta_key_format
+        if not isinstance(meta_key_postfix, str):
+            raise ValueError("meta_key_postfix must be a string.")
+        self.meta_key_postfix = meta_key_postfix
 
     def __call__(self, data):
         d = dict(data)
         for key in self.keys:
-            affine_key = self.meta_key_format.format(key, "affine")
-            d[key], _, new_affine = self.ornt_transform(d[key], affine=d[affine_key])
-            d[affine_key] = new_affine
+            meta_data = d[f"{key}_{self.meta_key_postfix}"]
+            d[key], _, new_affine = self.ornt_transform(d[key], affine=meta_data["affine"])
+            meta_data["affine"] = new_affine
         return d
 
 

--- a/tests/test_integration_segmentation_3d.py
+++ b/tests/test_integration_segmentation_3d.py
@@ -216,9 +216,7 @@ def run_inference_test(root_dir, device=torch.device("cuda:0")):
             metric_count += len(value)
             metric_sum += value.sum().item()
             val_outputs = (val_outputs.sigmoid() >= 0.5).float()
-            saver.save_batch(
-                val_outputs, {"filename_or_obj": val_data["img.filename_or_obj"], "affine": val_data["img.affine"]}
-            )
+            saver.save_batch(val_outputs, val_data["img_meta"])
         metric = metric_sum / metric_count
     return metric
 

--- a/tests/test_load_spacing_orientation.py
+++ b/tests/test_load_spacing_orientation.py
@@ -32,10 +32,9 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
         res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=True, mode="constant")(data_dict)
-        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
-        anat = nibabel.Nifti1Image(data_dict["image"][0], data_dict["image.affine"])
+        anat = nibabel.Nifti1Image(data_dict["image"][0], data_dict["image_meta"]["original_affine"])
         ref = resample_to_output(anat, (1, 2, 3))
-        np.testing.assert_allclose(res_dict["image.affine"], ref.affine)
+        np.testing.assert_allclose(res_dict["image_meta"]["affine"], ref.affine)
         np.testing.assert_allclose(res_dict["image"].shape[1:], ref.shape)
         np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0])
 
@@ -44,15 +43,14 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data = {"image": filename}
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
-        affine = data_dict["image.affine"]
-        data_dict["image.original_affine"] = data_dict["image.affine"] = (
+        affine = data_dict["image_meta"]["affine"]
+        data_dict["image_meta"]["original_affine"] = data_dict["image_meta"]["affine"] = (
             np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) @ affine
         )
         res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=True, mode="constant")(data_dict)
-        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
-        anat = nibabel.Nifti1Image(data_dict["image"][0], data_dict["image.affine"])
+        anat = nibabel.Nifti1Image(data_dict["image"][0], data_dict["image_meta"]["original_affine"])
         ref = resample_to_output(anat, (1, 2, 3))
-        np.testing.assert_allclose(res_dict["image.affine"], ref.affine)
+        np.testing.assert_allclose(res_dict["image_meta"]["affine"], ref.affine)
         if "anatomical" not in filename:
             np.testing.assert_allclose(res_dict["image"].shape[1:], ref.shape)
             np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0])
@@ -65,14 +63,13 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data = {"image": FILES[1]}
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
-        affine = data_dict["image.affine"]
-        data_dict["image.original_affine"] = data_dict["image.affine"] = (
+        affine = data_dict["image_meta"]["affine"]
+        data_dict["image_meta"]["original_affine"] = data_dict["image_meta"]["affine"] = (
             np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) @ affine
         )
         res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="constant")(data_dict)
-        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
-            res_dict["image.affine"],
+            res_dict["image_meta"]["affine"],
             np.array(
                 [
                     [0.0, 0.0, 3.0, -27.599409],
@@ -88,9 +85,8 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
         res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="nearest")(data_dict)
-        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
-            res_dict["image.affine"],
+            res_dict["image_meta"]["affine"],
             np.array([[-1.0, 0.0, 0.0, 32.0], [0.0, 2.0, 0.0, -40.0], [0.0, 0.0, 3.0, -16.0], [0.0, 0.0, 0.0, 1.0]]),
         )
 
@@ -100,9 +96,8 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data_dict = AddChanneld(keys="image")(data_dict)
         res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="nearest")(data_dict)
         res_dict = Orientationd(keys="image", axcodes="LPI")(res_dict)
-        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
-            res_dict["image.affine"],
+            res_dict["image_meta"]["affine"],
             np.array([[-1.0, 0.0, 0.0, 32.0], [0.0, -2.0, 0.0, 40.0], [0.0, 0.0, -3.0, 32.0], [0.0, 0.0, 0.0, 1.0]]),
         )
 
@@ -110,15 +105,14 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data = {"image": FILES[1]}
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
-        affine = data_dict["image.affine"]
-        data_dict["image.original_affine"] = data_dict["image.affine"] = (
+        affine = data_dict["image_meta"]["affine"]
+        data_dict["image_meta"]["original_affine"] = data_dict["image_meta"]["affine"] = (
             np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) @ affine
         )
         res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="constant")(data_dict)
         res_dict = Orientationd(keys="image", axcodes="LPI")(res_dict)
-        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
-            res_dict["image.affine"],
+            res_dict["image_meta"]["affine"],
             np.array(
                 [
                     [-3.0, 0.0, 0.0, 56.4005909],

--- a/tests/test_orientationd.py
+++ b/tests/test_orientationd.py
@@ -19,63 +19,73 @@ from monai.transforms import Orientationd
 
 class TestOrientationdCase(unittest.TestCase):
     def test_orntd(self):
-        data = {"seg": np.ones((2, 1, 2, 3)), "seg.affine": np.eye(4)}
+        data = {"seg": np.ones((2, 1, 2, 3)), "seg_meta": {"affine": np.eye(4)}}
         ornt = Orientationd(keys="seg", axcodes="RAS")
         res = ornt(data)
         np.testing.assert_allclose(res["seg"].shape, (2, 1, 2, 3))
-        code = nib.aff2axcodes(res["seg.affine"], ornt.ornt_transform.labels)
+        code = nib.aff2axcodes(res["seg_meta"]["affine"], ornt.ornt_transform.labels)
         self.assertEqual(code, ("R", "A", "S"))
 
     def test_orntd_3d(self):
         data = {
             "seg": np.ones((2, 1, 2, 3)),
             "img": np.ones((2, 1, 2, 3)),
-            "seg.affine": np.eye(4),
-            "img.affine": np.eye(4),
+            "seg_meta": {"affine": np.eye(4)},
+            "img_meta": {"affine": np.eye(4)},
         }
         ornt = Orientationd(keys=("img", "seg"), axcodes="PLI")
         res = ornt(data)
         np.testing.assert_allclose(res["img"].shape, (2, 2, 1, 3))
         np.testing.assert_allclose(res["seg"].shape, (2, 2, 1, 3))
-        code = nib.aff2axcodes(res["seg.affine"], ornt.ornt_transform.labels)
+        code = nib.aff2axcodes(res["seg_meta"]["affine"], ornt.ornt_transform.labels)
         self.assertEqual(code, ("P", "L", "I"))
-        code = nib.aff2axcodes(res["img.affine"], ornt.ornt_transform.labels)
+        code = nib.aff2axcodes(res["img_meta"]["affine"], ornt.ornt_transform.labels)
         self.assertEqual(code, ("P", "L", "I"))
 
     def test_orntd_2d(self):
-        data = {"seg": np.ones((2, 1, 3)), "img": np.ones((2, 1, 3)), "seg.affine": np.eye(4), "img.affine": np.eye(4)}
+        data = {
+            "seg": np.ones((2, 1, 3)),
+            "img": np.ones((2, 1, 3)),
+            "seg_meta": {"affine": np.eye(4)},
+            "img_meta": {"affine": np.eye(4)}
+        }
         ornt = Orientationd(keys=("img", "seg"), axcodes="PLI")
         res = ornt(data)
         np.testing.assert_allclose(res["img"].shape, (2, 3, 1))
-        code = nib.aff2axcodes(res["seg.affine"], ornt.ornt_transform.labels)
+        code = nib.aff2axcodes(res["seg_meta"]["affine"], ornt.ornt_transform.labels)
         self.assertEqual(code, ("P", "L", "S"))
-        code = nib.aff2axcodes(res["img.affine"], ornt.ornt_transform.labels)
+        code = nib.aff2axcodes(res["img_meta"]["affine"], ornt.ornt_transform.labels)
         self.assertEqual(code, ("P", "L", "S"))
 
     def test_orntd_1d(self):
-        data = {"seg": np.ones((2, 3)), "img": np.ones((2, 3)), "seg.affine": np.eye(4), "img.affine": np.eye(4)}
+        data = {
+            "seg": np.ones((2, 3)),
+            "img": np.ones((2, 3)),
+            "seg_meta": {"affine": np.eye(4)},
+            "img_meta": {"affine": np.eye(4)}
+        }
         ornt = Orientationd(keys=("img", "seg"), axcodes="L")
         res = ornt(data)
         np.testing.assert_allclose(res["img"].shape, (2, 3))
-        code = nib.aff2axcodes(res["seg.affine"], ornt.ornt_transform.labels)
+        code = nib.aff2axcodes(res["seg_meta"]["affine"], ornt.ornt_transform.labels)
         self.assertEqual(code, ("L", "A", "S"))
-        code = nib.aff2axcodes(res["img.affine"], ornt.ornt_transform.labels)
+        code = nib.aff2axcodes(res["img_meta"]["affine"], ornt.ornt_transform.labels)
         self.assertEqual(code, ("L", "A", "S"))
 
     def test_orntd_canonical(self):
         data = {
             "seg": np.ones((2, 1, 2, 3)),
             "img": np.ones((2, 1, 2, 3)),
-            "seg.affine": np.eye(4),
-            "img.affine": np.eye(4),
+            "seg_meta": {"affine": np.eye(4)},
+            "img_meta": {"affine": np.eye(4)},
         }
         ornt = Orientationd(keys=("img", "seg"), as_closest_canonical=True)
         res = ornt(data)
         np.testing.assert_allclose(res["img"].shape, (2, 1, 2, 3))
         np.testing.assert_allclose(res["seg"].shape, (2, 1, 2, 3))
-        code = nib.aff2axcodes(res["seg.affine"], ornt.ornt_transform.labels)
+        code = nib.aff2axcodes(res["seg_meta"]["affine"], ornt.ornt_transform.labels)
         self.assertEqual(code, ("R", "A", "S"))
-        code = nib.aff2axcodes(res["img.affine"], ornt.ornt_transform.labels)
+        code = nib.aff2axcodes(res["img_meta"]["affine"], ornt.ornt_transform.labels)
         self.assertEqual(code, ("R", "A", "S"))
 
 

--- a/tests/test_spacingd.py
+++ b/tests/test_spacingd.py
@@ -18,51 +18,56 @@ from monai.transforms import Spacingd
 
 class TestSpacingDCase(unittest.TestCase):
     def test_spacingd_3d(self):
-        data = {"image": np.ones((2, 10, 15, 20)), "image.affine": np.eye(4)}
+        data = {"image": np.ones((2, 10, 15, 20)), "image_meta": {"affine": np.eye(4)}}
         spacing = Spacingd(keys="image", pixdim=(1, 2, 1.4))
         res = spacing(data)
-        self.assertEqual(("image", "image.affine"), tuple(sorted(res)))
+        self.assertEqual(("image", "image_meta"), tuple(sorted(res)))
         np.testing.assert_allclose(res["image"].shape, (2, 10, 8, 15))
-        np.testing.assert_allclose(res["image.affine"], np.diag([1, 2, 1.4, 1.0]))
+        np.testing.assert_allclose(res["image_meta"]["affine"], np.diag([1, 2, 1.4, 1.0]))
 
     def test_spacingd_2d(self):
-        data = {"image": np.ones((2, 10, 20)), "image.affine": np.eye(3)}
+        data = {"image": np.ones((2, 10, 20)), "image_meta": {"affine": np.eye(3)}}
         spacing = Spacingd(keys="image", pixdim=(1, 2, 1.4))
         res = spacing(data)
-        self.assertEqual(("image", "image.affine"), tuple(sorted(res)))
+        self.assertEqual(("image", "image_meta"), tuple(sorted(res)))
         np.testing.assert_allclose(res["image"].shape, (2, 10, 10))
-        np.testing.assert_allclose(res["image.affine"], np.diag((1, 2, 1)))
+        np.testing.assert_allclose(res["image_meta"]["affine"], np.diag((1, 2, 1)))
 
     def test_spacingd_1d(self):
-        data = {"image": np.arange(20).reshape((2, 10)), "image.original_affine": np.diag((3, 2, 1, 1))}
-        data["image.affine"] = data["image.original_affine"]
+        data = {"image": np.arange(20).reshape((2, 10)), "image_meta": {"original_affine": np.diag((3, 2, 1, 1))}}
+        data["image_meta"]["affine"] = data["image_meta"]["original_affine"]
         spacing = Spacingd(keys="image", pixdim=(0.2,))
         res = spacing(data)
-        self.assertEqual(("image", "image.affine", "image.original_affine"), tuple(sorted(res)))
+        self.assertEqual(("image", "image_meta"), tuple(sorted(res)))
         np.testing.assert_allclose(res["image"].shape, (2, 136))
-        np.testing.assert_allclose(res["image.affine"], np.diag((0.2, 2, 1, 1)))
-        np.testing.assert_allclose(res["image.original_affine"], np.diag((3, 2, 1, 1)))
+        np.testing.assert_allclose(res["image_meta"]["affine"], np.diag((0.2, 2, 1, 1)))
+        np.testing.assert_allclose(res["image_meta"]["original_affine"], np.diag((3, 2, 1, 1)))
 
     def test_interp_all(self):
         data = {
             "image": np.arange(20).reshape((2, 10)),
             "seg": np.ones((2, 10)),
-            "image.affine": np.eye(4),
-            "seg.affine": np.eye(4),
+            "image_meta": {"affine": np.eye(4)},
+            "seg_meta": {"affine": np.eye(4)}
         }
         spacing = Spacingd(keys=("image", "seg"), interp_order=0, pixdim=(0.2,))
         res = spacing(data)
-        self.assertEqual(("image", "image.affine", "seg", "seg.affine"), tuple(sorted(res)))
+        self.assertEqual(("image", "image_meta", "seg", "seg_meta"), tuple(sorted(res)))
         np.testing.assert_allclose(res["image"].shape, (2, 46))
-        np.testing.assert_allclose(res["image.affine"], np.diag((0.2, 1, 1, 1)))
+        np.testing.assert_allclose(res["image_meta"]["affine"], np.diag((0.2, 1, 1, 1)))
 
     def test_interp_sep(self):
-        data = {"image": np.ones((2, 10)), "seg": np.ones((2, 10)), "image.affine": np.eye(4), "seg.affine": np.eye(4)}
+        data = {
+            "image": np.ones((2, 10)),
+            "seg": np.ones((2, 10)),
+            "image_meta": {"affine": np.eye(4)},
+            "seg_meta": {"affine": np.eye(4)}
+        }
         spacing = Spacingd(keys=("image", "seg"), interp_order=(2, 0), pixdim=(0.2,))
         res = spacing(data)
-        self.assertEqual(("image", "image.affine", "seg", "seg.affine"), tuple(sorted(res)))
+        self.assertEqual(("image", "image_meta", "seg", "seg_meta"), tuple(sorted(res)))
         np.testing.assert_allclose(res["image"].shape, (2, 46))
-        np.testing.assert_allclose(res["image.affine"], np.diag((0.2, 1, 1, 1)))
+        np.testing.assert_allclose(res["image_meta"]["affine"], np.diag((0.2, 1, 1, 1)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
This PR changed the metadata format of dictionary level.
From: `image.affine`, `image.original_affine`, `image.original_shape`, `image.file_or_objs`, etc.
To: `image_meta`.

1. It makes the metadata keys keep the original as loaded from Nifti or PNG.
2. Now it's the keys are same as Array level.
3. Makes it easier to share metadata together.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [x] Docstrings/Documentation updated
