### PR TITLE
461 add support to load decathalon datalist

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -87,3 +87,7 @@ Utilities
 .. automodule:: monai.data.utils
   :members:
 
+
+Decathalon DataLoader
+~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: monai.data.load_decathalon_datalist

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -19,3 +19,4 @@ from .synthetic import *
 from .utils import *
 from .png_saver import PNGSaver
 from .png_writer import write_png
+from .decathalon_dataloader import load_decathalon_datalist

--- a/monai/data/decathalon_dataloader.py
+++ b/monai/data/decathalon_dataloader.py
@@ -28,7 +28,7 @@ def _compute_path(base_dir, element):
 def _append_paths(base_dir, is_segmentation, items):
     for item in items:
         if not isinstance(item, dict):
-            raise ValueError('data item must be dict.')
+            raise ValueError("data item must be dict.")
         for k, v in item.items():
             if k == "image":
                 item[k] = _compute_path(base_dir, v)

--- a/monai/data/decathalon_dataloader.py
+++ b/monai/data/decathalon_dataloader.py
@@ -37,7 +37,12 @@ def _append_paths(base_dir, is_segmentation, items):
     return items
 
 
-def load_decathalon_datalist(is_segmentation, data_list_key, data_list_file_path, base_dir=None):
+def load_decathalon_datalist(
+    data_list_file_path,
+    is_segmentation=True,
+    data_list_key='training',
+    base_dir=None
+):
     """Load image/label paths of decathalon challenge from JSON file
 
     Json file is similar to what you get from http://medicaldecathlon.com/
@@ -49,7 +54,12 @@ def load_decathalon_datalist(is_segmentation, data_list_key, data_list_file_path
         data_list_file_path (str): the path to the json file of datalist
         base_dir (str): the base directory of the dataset, if None, use the datalist directory
 
-    Returns a list of data items, each of which is a dict keyed by element names
+    Returns a list of data items, each of which is a dict keyed by element names, for example:
+
+        [
+            {'image': '/workspace/data/chest_19.nii.gz',  'label': 0}, 
+            {'image': '/workspace/data/chest_31.nii.gz',  'label': 1}
+        ]
 
     """
     if not os.path.isfile(data_list_file_path):

--- a/monai/data/decathalon_dataloader.py
+++ b/monai/data/decathalon_dataloader.py
@@ -54,11 +54,15 @@ def load_decathalon_datalist(is_segmentation, data_list_key, data_list_file_path
     """
     if not os.path.isfile(data_list_file_path):
         raise ValueError(f"data list file {data_list_file_path} does not exist.")
-    json_data = json.load(open(data_list_file_path))
+    with open(data_list_file_path) as json_file:
+        json_data = json.load(json_file)
     if data_list_key not in json_data:
         raise ValueError(f"data list {data_list_key} not specified in '{data_list_file_path}'.")
+    expected_data = json_data[data_list_key]
+    if data_list_key == "test":
+        expected_data = [{"image": i} for i in expected_data]
 
     if base_dir is None:
         base_dir = os.path.dirname(data_list_file_path)
 
-    return _append_paths(base_dir, is_segmentation, json_data[data_list_key])
+    return _append_paths(base_dir, is_segmentation, expected_data)

--- a/monai/data/decathalon_dataloader.py
+++ b/monai/data/decathalon_dataloader.py
@@ -44,9 +44,9 @@ def load_decathalon_datalist(data_list_file_path, is_segmentation=True, data_lis
     Those dataset.json files
 
     Args:
-        is_segmentation (str): whether the datalist is for segmentation task
-        data_list_key (str): the key to get a list of dictionary to be used
         data_list_file_path (str): the path to the json file of datalist
+        is_segmentation (bool): whether the datalist is for segmentation task, default is True
+        data_list_key (str): the key to get a list of dictionary to be used, default is "training"
         base_dir (str): the base directory of the dataset, if None, use the datalist directory
 
     Returns a list of data items, each of which is a dict keyed by element names, for example:

--- a/monai/data/decathalon_dataloader.py
+++ b/monai/data/decathalon_dataloader.py
@@ -1,0 +1,64 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+
+
+def _compute_path(base_dir, element):
+    if isinstance(element, str):
+        return os.path.normpath(os.path.join(base_dir, element))
+    elif isinstance(element, list):
+        for e in element:
+            if not isinstance(e, str):
+                raise ValueError("file path must be a string.")
+        return [os.path.normpath(os.path.join(base_dir, e)) for e in element]
+    else:
+        raise ValueError("file path must be a string or a list of string.")
+
+
+def _append_paths(base_dir, is_segmentation, items):
+    for item in items:
+        if not isinstance(item, dict):
+            raise ValueError('data item must be dict.')
+        for k, v in item.items():
+            if k == "image":
+                item[k] = _compute_path(base_dir, v)
+            elif is_segmentation and k == "label":
+                item[k] = _compute_path(base_dir, v)
+    return items
+
+
+def load_decathalon_datalist(is_segmentation, data_list_key, data_list_file_path, base_dir=None):
+    """Load image/label paths of decathalon challenge from JSON file
+
+    Json file is similar to what you get from http://medicaldecathlon.com/
+    Those dataset.json files
+
+    Args:
+        is_segmentation (str): whether the datalist is for segmentation task
+        data_list_key (str): the key to get a list of dictionary to be used
+        data_list_file_path (str): the path to the json file of datalist
+        base_dir (str): the base directory of the dataset, if None, use the datalist directory
+
+    Returns a list of data items, each of which is a dict keyed by element names
+
+    """
+    if not os.path.isfile(data_list_file_path):
+        raise ValueError(f"data list file {data_list_file_path} does not exist.")
+    json_data = json.load(open(data_list_file_path))
+    if data_list_key not in json_data:
+        raise ValueError(f"data list {data_list_key} not specified in '{data_list_file_path}'.")
+
+    if base_dir is None:
+        base_dir = os.path.dirname(data_list_file_path)
+
+    return _append_paths(base_dir, is_segmentation, json_data[data_list_key])

--- a/monai/data/decathalon_dataloader.py
+++ b/monai/data/decathalon_dataloader.py
@@ -37,12 +37,7 @@ def _append_paths(base_dir, is_segmentation, items):
     return items
 
 
-def load_decathalon_datalist(
-    data_list_file_path,
-    is_segmentation=True,
-    data_list_key='training',
-    base_dir=None
-):
+def load_decathalon_datalist(data_list_file_path, is_segmentation=True, data_list_key="training", base_dir=None):
     """Load image/label paths of decathalon challenge from JSON file
 
     Json file is similar to what you get from http://medicaldecathlon.com/

--- a/monai/data/decathalon_dataloader.py
+++ b/monai/data/decathalon_dataloader.py
@@ -51,6 +51,8 @@ def load_decathalon_datalist(data_list_file_path, is_segmentation=True, data_lis
 
     Returns a list of data items, each of which is a dict keyed by element names, for example:
 
+    .. code-block::
+
         [
             {'image': '/workspace/data/chest_19.nii.gz',  'label': 0}, 
             {'image': '/workspace/data/chest_31.nii.gz',  'label': 1}

--- a/tests/test_load_decathalon_datalist.py
+++ b/tests/test_load_decathalon_datalist.py
@@ -25,23 +25,14 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
             "description": "Spleen Segmentation",
             "labels": {"0": "background", "1": "spleen"},
             "training": [
-                {
-                    "image": "spleen_19.nii.gz",
-                    "label": "spleen_19.nii.gz"
-                },
-                {
-                    "image": "spleen_31.nii.gz",
-                    "label": "spleen_31.nii.gz"
-                }
+                {"image": "spleen_19.nii.gz", "label": "spleen_19.nii.gz"},
+                {"image": "spleen_31.nii.gz", "label": "spleen_31.nii.gz"},
             ],
-            "test": [
-                "spleen_15.nii.gz",
-                "spleen_23.nii.gz"
-            ]
+            "test": ["spleen_15.nii.gz", "spleen_23.nii.gz"],
         }
         json_str = json.dumps(test_data)
         file_path = os.path.join(tempdir, "test_data.json")
-        with open(file_path, 'w') as json_file:
+        with open(file_path, "w") as json_file:
             json_file.write(json_str)
         result = load_decathalon_datalist(True, "training", file_path, tempdir)
         self.assertEqual(result[0]["image"], os.path.join(tempdir, "spleen_19.nii.gz"))
@@ -54,24 +45,12 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
             "name": "ChestXRay",
             "description": "Chest X-ray classification",
             "labels": {"0": "background", "1": "chest"},
-            "training": [
-                {
-                    "image": "chest_19.nii.gz",
-                    "label": 0
-                },
-                {
-                    "image": "chest_31.nii.gz",
-                    "label": 1
-                }
-            ],
-            "test": [
-                "chest_15.nii.gz",
-                "chest_23.nii.gz"
-            ]
+            "training": [{"image": "chest_19.nii.gz", "label": 0}, {"image": "chest_31.nii.gz", "label": 1}],
+            "test": ["chest_15.nii.gz", "chest_23.nii.gz"],
         }
         json_str = json.dumps(test_data)
         file_path = os.path.join(tempdir, "test_data.json")
-        with open(file_path, 'w') as json_file:
+        with open(file_path, "w") as json_file:
             json_file.write(json_str)
         result = load_decathalon_datalist(False, "training", file_path, tempdir)
         self.assertEqual(result[0]["image"], os.path.join(tempdir, "chest_19.nii.gz"))
@@ -87,21 +66,18 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
             "training": [
                 {
                     "image": os.path.join(tempdir, "spleen_19.nii.gz"),
-                    "label": os.path.join(tempdir, "spleen_19.nii.gz")
+                    "label": os.path.join(tempdir, "spleen_19.nii.gz"),
                 },
                 {
                     "image": os.path.join(tempdir, "spleen_31.nii.gz"),
-                    "label": os.path.join(tempdir, "spleen_31.nii.gz")
-                }
+                    "label": os.path.join(tempdir, "spleen_31.nii.gz"),
+                },
             ],
-            "test": [
-                os.path.join(tempdir, "spleen_15.nii.gz"),
-                os.path.join(tempdir, "spleen_23.nii.gz")
-            ]
+            "test": [os.path.join(tempdir, "spleen_15.nii.gz"), os.path.join(tempdir, "spleen_23.nii.gz")],
         }
         json_str = json.dumps(test_data)
         file_path = os.path.join(tempdir, "test_data.json")
-        with open(file_path, 'w') as json_file:
+        with open(file_path, "w") as json_file:
             json_file.write(json_str)
         result = load_decathalon_datalist(True, "training", file_path, None)
         self.assertEqual(result[0]["image"], os.path.join(tempdir, "spleen_19.nii.gz"))
@@ -113,14 +89,11 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
             "name": "Spleen",
             "description": "Spleen Segmentation",
             "labels": {"0": "background", "1": "spleen"},
-            "test": [
-                "spleen_15.nii.gz",
-                "spleen_23.nii.gz"
-            ]
+            "test": ["spleen_15.nii.gz", "spleen_23.nii.gz"],
         }
         json_str = json.dumps(test_data)
         file_path = os.path.join(tempdir, "test_data.json")
-        with open(file_path, 'w') as json_file:
+        with open(file_path, "w") as json_file:
             json_file.write(json_str)
         result = load_decathalon_datalist(True, "test", file_path, tempdir)
         self.assertEqual(result[0]["image"], os.path.join(tempdir, "spleen_15.nii.gz"))

--- a/tests/test_load_decathalon_datalist.py
+++ b/tests/test_load_decathalon_datalist.py
@@ -1,0 +1,54 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import os
+import shutil
+import numpy as np
+import tempfile
+from PIL import Image
+from monai.data import load_decathalon_datalist
+
+
+class TestLoadDecathalonDatalist(unittest.TestCase):
+    def test_values(self):
+        test_data = {
+            "name": "Spleen",
+            "description": "Spleen Segmentation",
+            "labels": {"0": "background", "1": "spleen"},
+            "training": [
+                {
+                    "image": "./imagesTr/spleen_19.nii.gz",
+                    "label": "./labelsTr/spleen_19.nii.gz"
+                },
+                {
+                    "image": "./imagesTr/spleen_31.nii.gz",
+                    "label": "./labelsTr/spleen_31.nii.gz"
+                }
+            ],
+            "test": [
+                "./imagesTs/spleen_15.nii.gz",
+                "./imagesTs/spleen_23.nii.gz"
+            ]
+        }
+        test_image = np.random.randint(0, 256, size=data_shape)
+        tempdir = tempfile.mkdtemp()
+        for i, name in enumerate(filenames):
+            filenames[i] = os.path.join(tempdir, name)
+            Image.fromarray(test_image.astype("uint8")).save(filenames[i])
+        result = LoadPNG()(filenames)
+        self.assertTupleEqual(result[1]["spatial_shape"], meta_shape)
+        self.assertTupleEqual(result[0].shape, expected_shape)
+        shutil.rmtree(tempdir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_load_decathalon_datalist.py
+++ b/tests/test_load_decathalon_datalist.py
@@ -34,7 +34,7 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
         file_path = os.path.join(tempdir, "test_data.json")
         with open(file_path, "w") as json_file:
             json_file.write(json_str)
-        result = load_decathalon_datalist(True, "training", file_path, tempdir)
+        result = load_decathalon_datalist(file_path, True, "training", tempdir)
         self.assertEqual(result[0]["image"], os.path.join(tempdir, "spleen_19.nii.gz"))
         self.assertEqual(result[0]["label"], os.path.join(tempdir, "spleen_19.nii.gz"))
         shutil.rmtree(tempdir)
@@ -52,7 +52,7 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
         file_path = os.path.join(tempdir, "test_data.json")
         with open(file_path, "w") as json_file:
             json_file.write(json_str)
-        result = load_decathalon_datalist(False, "training", file_path, tempdir)
+        result = load_decathalon_datalist(file_path, False, "training", tempdir)
         self.assertEqual(result[0]["image"], os.path.join(tempdir, "chest_19.nii.gz"))
         self.assertEqual(result[0]["label"], 0)
         shutil.rmtree(tempdir)
@@ -79,7 +79,7 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
         file_path = os.path.join(tempdir, "test_data.json")
         with open(file_path, "w") as json_file:
             json_file.write(json_str)
-        result = load_decathalon_datalist(True, "training", file_path, None)
+        result = load_decathalon_datalist(file_path, True, "training", None)
         self.assertEqual(result[0]["image"], os.path.join(tempdir, "spleen_19.nii.gz"))
         self.assertEqual(result[0]["label"], os.path.join(tempdir, "spleen_19.nii.gz"))
 
@@ -95,7 +95,7 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
         file_path = os.path.join(tempdir, "test_data.json")
         with open(file_path, "w") as json_file:
             json_file.write(json_str)
-        result = load_decathalon_datalist(True, "test", file_path, tempdir)
+        result = load_decathalon_datalist(file_path, True, "test", tempdir)
         self.assertEqual(result[0]["image"], os.path.join(tempdir, "spleen_15.nii.gz"))
         shutil.rmtree(tempdir)
 

--- a/tests/test_load_decathalon_datalist.py
+++ b/tests/test_load_decathalon_datalist.py
@@ -26,17 +26,17 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
             "labels": {"0": "background", "1": "spleen"},
             "training": [
                 {
-                    "image": "./imagesTr/spleen_19.nii.gz",
-                    "label": "./labelsTr/spleen_19.nii.gz"
+                    "image": "spleen_19.nii.gz",
+                    "label": "spleen_19.nii.gz"
                 },
                 {
-                    "image": "./imagesTr/spleen_31.nii.gz",
-                    "label": "./labelsTr/spleen_31.nii.gz"
+                    "image": "spleen_31.nii.gz",
+                    "label": "spleen_31.nii.gz"
                 }
             ],
             "test": [
-                "./imagesTs/spleen_15.nii.gz",
-                "./imagesTs/spleen_23.nii.gz"
+                "spleen_15.nii.gz",
+                "spleen_23.nii.gz"
             ]
         }
         json_str = json.dumps(test_data)
@@ -44,8 +44,8 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
         with open(file_path, 'w') as json_file:
             json_file.write(json_str)
         result = load_decathalon_datalist(True, "training", file_path, tempdir)
-        self.assertEqual(result[0]["image"], os.path.join(tempdir, "imagesTr/spleen_19.nii.gz"))
-        self.assertEqual(result[0]["label"], os.path.join(tempdir, "labelsTr/spleen_19.nii.gz"))
+        self.assertEqual(result[0]["image"], os.path.join(tempdir, "spleen_19.nii.gz"))
+        self.assertEqual(result[0]["label"], os.path.join(tempdir, "spleen_19.nii.gz"))
         shutil.rmtree(tempdir)
 
     def test_cls_values(self):
@@ -56,17 +56,17 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
             "labels": {"0": "background", "1": "chest"},
             "training": [
                 {
-                    "image": "./imagesTr/chest_19.nii.gz",
+                    "image": "chest_19.nii.gz",
                     "label": 0
                 },
                 {
-                    "image": "./imagesTr/chest_31.nii.gz",
+                    "image": "chest_31.nii.gz",
                     "label": 1
                 }
             ],
             "test": [
-                "./imagesTs/chest_15.nii.gz",
-                "./imagesTs/chest_23.nii.gz"
+                "chest_15.nii.gz",
+                "chest_23.nii.gz"
             ]
         }
         json_str = json.dumps(test_data)
@@ -74,7 +74,7 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
         with open(file_path, 'w') as json_file:
             json_file.write(json_str)
         result = load_decathalon_datalist(False, "training", file_path, tempdir)
-        self.assertEqual(result[0]["image"], os.path.join(tempdir, "imagesTr/chest_19.nii.gz"))
+        self.assertEqual(result[0]["image"], os.path.join(tempdir, "chest_19.nii.gz"))
         self.assertEqual(result[0]["label"], 0)
         shutil.rmtree(tempdir)
 
@@ -86,17 +86,17 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
             "labels": {"0": "background", "1": "spleen"},
             "training": [
                 {
-                    "image": os.path.join(tempdir, "imagesTr/spleen_19.nii.gz"),
-                    "label": os.path.join(tempdir, "labelsTr/spleen_19.nii.gz")
+                    "image": os.path.join(tempdir, "spleen_19.nii.gz"),
+                    "label": os.path.join(tempdir, "spleen_19.nii.gz")
                 },
                 {
-                    "image": os.path.join(tempdir, "imagesTr/spleen_31.nii.gz"),
-                    "label": os.path.join(tempdir, "labelsTr/spleen_31.nii.gz")
+                    "image": os.path.join(tempdir, "spleen_31.nii.gz"),
+                    "label": os.path.join(tempdir, "spleen_31.nii.gz")
                 }
             ],
             "test": [
-                os.path.join(tempdir, "imagesTs/spleen_15.nii.gz"),
-                os.path.join(tempdir, "imagesTs/spleen_23.nii.gz")
+                os.path.join(tempdir, "spleen_15.nii.gz"),
+                os.path.join(tempdir, "spleen_23.nii.gz")
             ]
         }
         json_str = json.dumps(test_data)
@@ -104,8 +104,8 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
         with open(file_path, 'w') as json_file:
             json_file.write(json_str)
         result = load_decathalon_datalist(True, "training", file_path, None)
-        self.assertEqual(result[0]["image"], os.path.join(tempdir, "imagesTr/spleen_19.nii.gz"))
-        self.assertEqual(result[0]["label"], os.path.join(tempdir, "labelsTr/spleen_19.nii.gz"))
+        self.assertEqual(result[0]["image"], os.path.join(tempdir, "spleen_19.nii.gz"))
+        self.assertEqual(result[0]["label"], os.path.join(tempdir, "spleen_19.nii.gz"))
 
     def test_seg_no_labels(self):
         tempdir = tempfile.mkdtemp()
@@ -114,8 +114,8 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
             "description": "Spleen Segmentation",
             "labels": {"0": "background", "1": "spleen"},
             "test": [
-                "./imagesTs/spleen_15.nii.gz",
-                "./imagesTs/spleen_23.nii.gz"
+                "spleen_15.nii.gz",
+                "spleen_23.nii.gz"
             ]
         }
         json_str = json.dumps(test_data)
@@ -123,7 +123,7 @@ class TestLoadDecathalonDatalist(unittest.TestCase):
         with open(file_path, 'w') as json_file:
             json_file.write(json_str)
         result = load_decathalon_datalist(True, "test", file_path, tempdir)
-        self.assertEqual(result[0]["image"], os.path.join(tempdir, "imagesTs/spleen_15.nii.gz"))
+        self.assertEqual(result[0]["image"], os.path.join(tempdir, "spleen_15.nii.gz"))
         shutil.rmtree(tempdir)
 
 


### PR DESCRIPTION
Fixes #461 .

### Description
As Decathalon challenge dataset is very rich and very popular in medical domain, many researchers and students use Decathalon dataset to learn medical DL skills, and we also have notebooks and examples based on Decathalon dataset.
So this PR added support to load Decathalon datalist from the JSON config file.
Users can also convert their own datalist to Decathalon format and use this tool.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
