### PR TITLE
470-default behaviour of arraydataset when the input is single sequence

### DIFF
--- a/monai/data/dataloader.py
+++ b/monai/data/dataloader.py
@@ -12,6 +12,8 @@
 import torch
 from monai.data import list_data_collate, worker_init_fn
 
+__all__ = ["DataLoader"]
+
 
 class DataLoader(torch.utils.data.DataLoader):
     """Generates images/labels for train/validation/testing from dataset.

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -9,23 +9,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Callable
-import sys
 import hashlib
 import json
-from pathlib import Path
-
-import torch
-import numpy as np
-
-from multiprocessing.pool import ThreadPool
+import sys
 import threading
+from multiprocessing.pool import ThreadPool
+from pathlib import Path
+from typing import Callable, Optional
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset as _TorchDataset
 
 from monai.transforms import Compose, Randomizable
 from monai.transforms.utils import apply_transform
-from monai.utils import process_bar, get_seed
-
-from torch.utils.data import Dataset as _TorchDataset
+from monai.utils import get_seed, process_bar
 
 
 class Dataset(_TorchDataset):
@@ -321,11 +319,10 @@ class ZipDataset(_TorchDataset):
             datasets (list or tuple): list of datasets to zip together.
         """
         self.datasets = list(datasets)
-        self.len = min([len(dataset) for dataset in self.datasets])
         self.transform = transform
 
     def __len__(self):
-        return self.len
+        return min([len(dataset) for dataset in self.datasets])
 
     def __getitem__(self, index: int):
         def to_list(x):
@@ -339,10 +336,10 @@ class ZipDataset(_TorchDataset):
         return data
 
 
-class ArrayDataset(ZipDataset, Randomizable):
+class ArrayDataset(Randomizable):
     """
     Dataset for segmentation and classification tasks based on array format input data and transforms.
-    It can apply same random operations for both image transforms and segmentation label transforms.
+    It ensures the same random seeds in the randomised transforms defined for image, segmentation and label.
     The `transform` can be :py:class:`monai.transforms.Compose` or any other callable object.
     For example:
     If train based on Nifti format images without metadata, all transforms can be composed::
@@ -354,8 +351,9 @@ class ArrayDataset(ZipDataset, Randomizable):
                 RandAdjustContrast()
             ]
         )
+        ArrayDataset(img_file_list, img_transform=img_transform)
 
-    If train based on Nifti format images and the metadata, the array transforms can not be composed
+    If training based on images and the metadata, the array transforms can not be composed
     because several transforms receives multiple parameters or return multiple values. Then Users need
     to define their own callable method to parse metadata from `LoadNifti` or set `affine` matrix
     to `Spacing` transform::
@@ -374,15 +372,25 @@ class ArrayDataset(ZipDataset, Randomizable):
                 RandAdjustContrast()
             ]
         )
+        ArrayDataset(img_file_list, img_transform=img_transform)
 
-    Recommend to use dictionary Datasets for complicated data pre-processing.
+    Examples::
+
+        >>> ds = ArrayDataset([1, 2, 3, 4], lambda x: x + 0.1)
+        >>> print(ds[0])
+        1.1
+
+        >>> ds = ArrayDataset(img=[1, 2, 3, 4], seg=[5, 6, 7, 8])
+        >>> print(ds[0])
+        [1, 5]
+
     """
 
     def __init__(
         self,
-        img_files,
+        img,
         img_transform: Optional[Callable] = None,
-        seg_files=None,
+        seg=None,
         seg_transform: Optional[Callable] = None,
         labels=None,
         label_transform: Optional[Callable] = None,
@@ -390,25 +398,32 @@ class ArrayDataset(ZipDataset, Randomizable):
         """
         Initializes the dataset with the filename lists. The transform `img_transform` is applied
         to the images and `seg_transform` to the segmentations.
+
         Args:
-            img_files (iterable, list of str): list of image filenames
-            img_transform (Callable, optional): transform to apply to image arrays
-            seg_files (iterable, list of str): if in segmentation task, list of segmentation filenames
-            seg_transform (Callable, optional): transform to apply to segmentation arrays
-            labels (iterable, list or array): if in classification task, list of classification labels
-            label_transform (Callable, optional): transform to apply to label arrays
+            img (Sequence): sequence of images.
+            img_transform (Callable, optional): transform to apply to each element in `img`.
+            seg (Sequence, optional): sequence of segmentations.
+            seg_transform (Callable, optional): transform to apply to each element in `seg`.
+            labels (Sequence, optional): sequence of labels.
+            label_transform (Callable, optional): transform to apply to each element in `labels`.
 
         """
-        items = [(img_files, img_transform), (seg_files, seg_transform), (labels, label_transform)]
+        items = [(img, img_transform), (seg, seg_transform), (labels, label_transform)]
         self.set_random_state(seed=get_seed())
-        super().__init__([Dataset(x[0], x[1]) for x in items if x[0] is not None])
+        datasets = [Dataset(x[0], x[1]) for x in items if x[0] is not None]
+        self.dataset = datasets[0] if len(datasets) == 1 else ZipDataset(datasets)
+
+        self._seed = 0  # transform synchronization seed
 
     def randomize(self):
-        self.seed = self.R.randint(np.iinfo(np.int32).max)
+        self._seed = self.R.randint(np.iinfo(np.int32).max)
 
     def __getitem__(self, index: int):
         self.randomize()
-        for dataset in self.datasets:
-            if isinstance(dataset.transform, Randomizable):
-                dataset.transform.set_random_state(seed=self.seed)
-        return super().__getitem__(index)
+        if isinstance(self.dataset, ZipDataset):
+            for dataset in self.dataset.datasets:
+                if isinstance(getattr(dataset, "transform", None), Randomizable):
+                    dataset.transform.set_random_state(seed=self._seed)
+        if isinstance(getattr(self.dataset, "transform", None), Randomizable):
+            self.dataset.transform.set_random_state(seed=self._seed)  # noqa: T484
+        return self.dataset[index]

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -317,6 +317,7 @@ class ZipDataset(Dataset):
         """
         Args:
             datasets (list or tuple): list of datasets to zip together.
+            transform (Callable): a callable data transform operates on the zipped item from `datasets`.
         """
         super().__init__(list(datasets), transform=transform)
 

--- a/monai/data/synthetic.py
+++ b/monai/data/synthetic.py
@@ -13,6 +13,8 @@ import numpy as np
 
 from monai.transforms.utils import rescale_array
 
+__all__ = ["create_test_image_2d", "create_test_image_3d"]
+
 
 def create_test_image_2d(
     width, height, num_objs=12, rad_max=30, noise_max=0.0, num_seg_classes=5, channel_dim=None, random_state=None

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -237,23 +237,25 @@ def generate_pos_neg_label_crop_centers(
     return centers
 
 
-def apply_transform(transform: Callable, data):
+def apply_transform(transform: Callable, data, map_items: bool = True):
     """
     Transform `data` with `transform`.
-    If `data` is a list or tuple, each item of `data` will be transformed
+    If `data` is a list or tuple and `map_data` is True, each item of `data` will be transformed
     and this method returns a list of outcomes.
     otherwise transform will be applied once with `data` as the argument.
 
     Args:
         transform (callable): a callable to be used to transform `data`
         data (object): an object to be transformed.
+        map_item (bool): whether to apply transform to each item in `data`,
+            if `data` is a list or tuple. Defaults to True.
     """
     try:
-        if isinstance(data, (list, tuple)):
+        if isinstance(data, (list, tuple)) and map_items:
             return [transform(item) for item in data]
         return transform(data)
     except Exception as e:
-        raise Exception(f"applying transform {transform}.").with_traceback(e.__traceback__)
+        raise type(e)(f"applying transform {transform}.").with_traceback(e.__traceback__)
 
 
 def create_grid(spatial_size, spacing=None, homogeneous: bool = True, dtype: np.dtype = float):

--- a/tests/test_arraydataset.py
+++ b/tests/test_arraydataset.py
@@ -9,19 +9,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import os
 import shutil
-import numpy as np
 import tempfile
+import unittest
+
 import nibabel as nib
+import numpy as np
 from parameterized import parameterized
+
 from monai.data import ArrayDataset
-from monai.transforms import Compose, LoadNifti, AddChannel, RandAdjustContrast, Spacing
+from monai.transforms import AddChannel, Compose, LoadNifti, RandAdjustContrast, Spacing, RandGaussianNoise
 
 TEST_CASE_1 = [
-    Compose([LoadNifti(image_only=True), AddChannel(), RandAdjustContrast()]),
-    Compose([LoadNifti(image_only=True), AddChannel(), RandAdjustContrast()]),
+    Compose([LoadNifti(image_only=True), AddChannel(), RandGaussianNoise(prob=1.0)]),
+    Compose([LoadNifti(image_only=True), AddChannel(), RandGaussianNoise(prob=1.0)]),
+    (0, 1),
+    (1, 128, 128, 128),
+]
+
+TEST_CASE_2 = [
+    Compose([LoadNifti(image_only=True), AddChannel(), RandAdjustContrast(prob=1.0)]),
+    Compose([LoadNifti(image_only=True), AddChannel(), RandAdjustContrast(prob=1.0)]),
     (0, 1),
     (1, 128, 128, 128),
 ]
@@ -35,16 +44,21 @@ class TestCompose(Compose):
         return self.transforms[3](img), metadata
 
 
-TEST_CASE_2 = [
-    TestCompose([LoadNifti(image_only=False), AddChannel(), Spacing(pixdim=(2, 2, 4)), RandAdjustContrast()]),
-    TestCompose([LoadNifti(image_only=False), AddChannel(), Spacing(pixdim=(2, 2, 4)), RandAdjustContrast()]),
+TEST_CASE_3 = [
+    TestCompose([LoadNifti(image_only=False), AddChannel(), Spacing(pixdim=(2, 2, 4)), RandAdjustContrast(prob=1.0)]),
+    TestCompose([LoadNifti(image_only=False), AddChannel(), Spacing(pixdim=(2, 2, 4)), RandAdjustContrast(prob=1.0)]),
     (0, 2),
     (1, 64, 64, 33),
 ]
 
+TEST_CASE_4 = [
+    Compose([LoadNifti(image_only=True), AddChannel(), RandGaussianNoise(prob=1.0)]),
+    (1, 128, 128, 128),
+]
+
 
 class TestArrayDataset(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_shape(self, img_transform, label_transform, indexes, expected_shape):
         test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(128, 128, 128)), np.eye(4))
         tempdir = tempfile.mkdtemp()
@@ -60,6 +74,7 @@ class TestArrayDataset(unittest.TestCase):
         test_segs = [test_seg1, test_seg2]
         test_labels = [1, 1]
         dataset = ArrayDataset(test_images, img_transform, test_segs, label_transform, test_labels, None)
+        dataset.set_random_state(1234)
         data1 = dataset[0]
         data2 = dataset[1]
 
@@ -69,6 +84,35 @@ class TestArrayDataset(unittest.TestCase):
         self.assertTupleEqual(data2[indexes[0]].shape, expected_shape)
         self.assertTupleEqual(data2[indexes[1]].shape, expected_shape)
         np.testing.assert_allclose(data2[indexes[0]], data2[indexes[0]])
+
+        dataset = ArrayDataset(test_images, img_transform, test_segs, label_transform, test_labels, None)
+        dataset.set_random_state(1234)
+        _ = dataset[0]
+        data2_new = dataset[1]
+        np.testing.assert_allclose(data2[indexes[0]], data2_new[indexes[0]], atol=1e-3)
+        shutil.rmtree(tempdir)
+
+    @parameterized.expand([TEST_CASE_4])
+    def test_default_none(self, img_transform, expected_shape):
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(128, 128, 128)), np.eye(4))
+        tempdir = tempfile.mkdtemp()
+        test_image1 = os.path.join(tempdir, "test_image1.nii.gz")
+        test_image2 = os.path.join(tempdir, "test_image2.nii.gz")
+        nib.save(test_image, test_image1)
+        nib.save(test_image, test_image2)
+        test_images = [test_image1, test_image2]
+        dataset = ArrayDataset(test_images, img_transform)
+        dataset.set_random_state(1234)
+        data1 = dataset[0]
+        data2 = dataset[1]
+        self.assertTupleEqual(data1.shape, expected_shape)
+        self.assertTupleEqual(data2.shape, expected_shape)
+
+        dataset = ArrayDataset(test_images, img_transform)
+        dataset.set_random_state(1234)
+        _ = dataset[0]
+        data2_new = dataset[1]
+        np.testing.assert_allclose(data2, data2_new, atol=1e-3)
         shutil.rmtree(tempdir)
 
 

--- a/tests/test_nifti_dataset.py
+++ b/tests/test_nifti_dataset.py
@@ -1,0 +1,123 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import nibabel as nib
+import numpy as np
+
+from monai.data import NiftiDataset
+from monai.transforms import Randomizable
+
+FILENAMES = ["test1.nii.gz", "test2.nii", "test3.nii.gz"]
+
+
+class RandTest(Randomizable):
+    """
+    randomisable transform for testing.
+    """
+
+    def randomize(self):
+        self._a = self.R.random()
+
+    def __call__(self, data):
+        self.randomize()
+        return data + self._a
+
+
+class TestNiftiDataset(unittest.TestCase):
+    def test_dataset(self):
+        tempdir = tempfile.mkdtemp()
+        full_names, ref_data = [], []
+        for filename in FILENAMES:
+            test_image = np.random.randint(0, 2, size=(4, 4, 4))
+            ref_data.append(test_image)
+            save_path = os.path.join(tempdir, filename)
+            full_names.append(save_path)
+            nib.save(nib.Nifti1Image(test_image, np.eye(4)), save_path)
+
+        # default loading no meta
+        dataset = NiftiDataset(full_names)
+        for d, ref in zip(dataset, ref_data):
+            np.testing.assert_allclose(d, ref, atol=1e-3)
+
+        # loading no meta, int
+        dataset = NiftiDataset(full_names, dtype=np.float16)
+        for d, ref in zip(dataset, ref_data):
+            self.assertEqual(d.dtype, np.float16)
+
+        # loading with meta, no transform
+        dataset = NiftiDataset(full_names, image_only=False)
+        for d_tuple, ref in zip(dataset, ref_data):
+            d, meta = d_tuple
+            np.testing.assert_allclose(d, ref, atol=1e-3)
+            np.testing.assert_allclose(meta["original_affine"], np.eye(4))
+
+        # loading image/label, no meta
+        dataset = NiftiDataset(full_names, seg_files=full_names, image_only=True)
+        for d_tuple, ref in zip(dataset, ref_data):
+            img, seg = d_tuple
+            np.testing.assert_allclose(img, ref, atol=1e-3)
+            np.testing.assert_allclose(seg, ref, atol=1e-3)
+
+        # loading image/label, no meta
+        dataset = NiftiDataset(full_names, transform=lambda x: x + 1, image_only=True)
+        for d, ref in zip(dataset, ref_data):
+            np.testing.assert_allclose(d, ref + 1, atol=1e-3)
+
+        # set seg transform, but no seg_files
+        with self.assertRaises(TypeError):
+            dataset = NiftiDataset(full_names, seg_transform=lambda x: x + 1, image_only=True)
+            _ = dataset[0]
+
+        # set seg transform, but no seg_files
+        with self.assertRaises(TypeError):
+            dataset = NiftiDataset(full_names, seg_transform=lambda x: x + 1, image_only=True)
+            _ = dataset[0]
+
+        # loading image/label, with meta
+        dataset = NiftiDataset(
+            full_names, transform=lambda x: x + 1, seg_files=full_names, seg_transform=lambda x: x + 2, image_only=False
+        )
+        for d_tuple, ref in zip(dataset, ref_data):
+            img, seg, meta = d_tuple
+            np.testing.assert_allclose(img, ref + 1, atol=1e-3)
+            np.testing.assert_allclose(seg, ref + 2, atol=1e-3)
+            np.testing.assert_allclose(meta["original_affine"], np.eye(4), atol=1e-3)
+
+        # loading image/label, with meta
+        dataset = NiftiDataset(
+            full_names, transform=lambda x: x + 1, seg_files=full_names, labels=[1, 2, 3], image_only=False
+        )
+        for idx, (d_tuple, ref) in enumerate(zip(dataset, ref_data)):
+            img, seg, label, meta = d_tuple
+            np.testing.assert_allclose(img, ref + 1, atol=1e-3)
+            np.testing.assert_allclose(seg, ref, atol=1e-3)
+            np.testing.assert_allclose(idx + 1, label)
+            np.testing.assert_allclose(meta["original_affine"], np.eye(4), atol=1e-3)
+
+        # loading image/label, with sync. transform
+        dataset = NiftiDataset(
+            full_names, transform=RandTest(), seg_files=full_names, seg_transform=RandTest(), image_only=False
+        )
+        for d_tuple, ref in zip(dataset, ref_data):
+            img, seg, meta = d_tuple
+            np.testing.assert_allclose(img, seg, atol=1e-3)
+            self.assertTrue(not np.allclose(img, ref))
+            np.testing.assert_allclose(meta["original_affine"], np.eye(4), atol=1e-3)
+        shutil.rmtree(tempdir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #470.

### Description
when the input is a single sequence (such as `img`, instead of multiple sequences such as `img`, `seg`, `labels`), ArrayDataset becomes a randomizable version of `monai.data.Dataset`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
