### PR TITLE
232 revise spacing transform

### DIFF
--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -86,16 +86,16 @@ def normalize_transform(shape, device=None, dtype=None, align_corners=False):
             corner pixels rather than the image corners.
             See also: https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.grid_sample
     """
-    norm = torch.tensor(shape, dtype=torch.float32, device=device)  # no in-place change
+    norm = torch.tensor(shape, dtype=torch.float64, device=device)  # no in-place change
     if align_corners:
         norm[norm <= 1.0] = 2.0
         norm = 2.0 / (norm - 1.0)
-        norm = torch.diag(torch.cat((norm, torch.ones((1,)))))
+        norm = torch.diag(torch.cat((norm, torch.ones((1,), dtype=torch.float64, device=device))))
         norm[:-1, -1] = -1.0
     else:
         norm[norm <= 0.0] = 2.0
         norm = 2.0 / norm
-        norm = torch.diag(torch.cat((norm, torch.ones((1,)))))
+        norm = torch.diag(torch.cat((norm, torch.ones((1,), dtype=torch.float64, device=device))))
         norm[:-1, -1] = 1.0 / torch.tensor(shape, dtype=torch.float32, device=device) - 1.0
     norm = norm.unsqueeze(0).to(dtype=dtype)
     norm.requires_grad = False

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -13,7 +13,6 @@ Utilities and types for defining networks, these depend on PyTorch.
 """
 
 import warnings
-
 import torch
 import torch.nn.functional as f
 
@@ -87,18 +86,18 @@ def normalize_transform(shape, device=None, dtype=None, align_corners=False):
             corner pixels rather than the image corners.
             See also: https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.grid_sample
     """
-    shape_ = list(shape)[::-1]
+    norm = torch.tensor(shape, dtype=torch.float32, device=device)  # no in-place change
     if align_corners:
-        norm = torch.as_tensor(shape_ + [1.0], dtype=dtype, device=device)
-        norm[:-1] = 2.0 / (norm[:-1] - 1.0)
-        norm = torch.diag(norm)
+        norm[norm <= 1.0] = 2.0
+        norm = 2.0 / (norm - 1.0)
+        norm = torch.diag(torch.cat((norm, torch.ones((1,)))))
         norm[:-1, -1] = -1.0
     else:
-        norm = torch.as_tensor(shape_ + [1.0], dtype=dtype, device=device)
-        norm[:-1] = 2.0 / norm[:-1]
-        norm = torch.diag(norm)
-        norm[:-1, -1] = 1.0 / torch.as_tensor(shape_, dtype=dtype, device=device) - 1.0
-    norm = norm.unsqueeze(0)  # adds a batch dim.
+        norm[norm <= 0.0] = 2.0
+        norm = 2.0 / norm
+        norm = torch.diag(torch.cat((norm, torch.ones((1,)))))
+        norm[:-1, -1] = 1.0 / torch.tensor(shape, dtype=torch.float32, device=device) - 1.0
+    norm = norm.unsqueeze(0).to(dtype=dtype)
     norm.requires_grad = False
     return norm
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -13,18 +13,18 @@ A collection of "vanilla" transforms for spatial operations
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Optional, Union, List
-
 import warnings
+from typing import List, Optional, Union
+
+import nibabel as nib
 import numpy as np
 import scipy.ndimage
-import nibabel as nib
 import torch
 from skimage.transform import resize
 
-from monai.data.utils import zoom_affine, compute_shape_offset, to_affine_nd, InterpolationCode
-from monai.networks.layers.simplelayers import GaussianFilter
-from monai.transforms.compose import Transform, Randomizable
+from monai.data.utils import InterpolationCode, compute_shape_offset, to_affine_nd, zoom_affine
+from monai.networks.layers import AffineTransform, GaussianFilter
+from monai.transforms.compose import Randomizable, Transform
 from monai.transforms.utils import (
     create_control_grid,
     create_grid,
@@ -45,9 +45,8 @@ class Spacing(Transform):
         self,
         pixdim,
         diagonal: bool = False,
-        interp_order=3,
-        mode: str = "nearest",
-        cval: Union[int, float] = 0,
+        interp_order: str = "bilinear",
+        mode: str = "border",
         dtype: Optional[np.dtype] = None,
     ):
         """
@@ -64,28 +63,25 @@ class Spacing(Transform):
                 If False, this transform preserves the axes orientation, orthogonal rotation and
                 translation components from the original affine. This option will not flip/swap axes
                 of the original data.
-            interp_order (int): The order of the spline interpolation, default is InterpolationCode.SPLINE3.
-                The order has to be in the range 0-5.
-                https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.zoom.html
-            mode (`reflect|constant|nearest|mirror|wrap`):
+            interp_order (`nearest|bilinear`): The order of the spline interpolation, default is `bilinear`.
+                See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample.
+            mode (`zeros|border|reflection`):
                 The mode parameter determines how the input array is extended beyond its boundaries.
-            cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
-            dtype (None or np.dtype): output array data type, defaults to None to use input data's dtype.
+                Defaults to `border`.
+            dtype (None or np.dtype): output array data type, defaults to np.float32.
         """
         self.pixdim = np.array(ensure_tuple(pixdim), dtype=np.float64)
         self.diagonal = diagonal
         self.interp_order = interp_order
         self.mode = mode
-        self.cval = cval
         self.dtype = dtype
 
     def __call__(  # type: ignore # see issue #495
         self,
         data_array: np.ndarray,
         affine=None,
-        interp_order=None,
+        interp_order: Optional[str] = None,
         mode: Optional[str] = None,
-        cval: Union[int, float] = None,
         dtype: Optional[np.dtype] = None,
     ):
         """
@@ -117,19 +113,21 @@ class Spacing(Transform):
         # adapt to the actual rank
         transform_ = to_affine_nd(sr, transform)
         # resample
-        _dtype = dtype or self.dtype or data_array.dtype
-        output_data = []
-        for data in data_array:
-            data_ = scipy.ndimage.affine_transform(
-                data.astype(_dtype),
-                matrix=transform_,
-                output_shape=output_shape,
-                order=self.interp_order if interp_order is None else interp_order,
-                mode=mode or self.mode,
-                cval=self.cval if cval is None else cval,
-            )
-            output_data.append(data_)
-        output_data = np.stack(output_data)
+        _dtype = dtype or self.dtype or np.float32
+
+        affine_xform = AffineTransform(
+            normalized=False,
+            mode=interp_order or self.interp_order,
+            padding_mode=mode or self.mode,
+            align_corners=False,
+            reverse_indexing=True,
+        )
+        output_data = affine_xform(
+            torch.from_numpy((data_array.astype(_dtype))[None]),  # AffineTransform requires a batch dim
+            torch.from_numpy(transform_.astype(_dtype)),
+            spatial_size=output_shape,
+        )
+        output_data = output_data.squeeze(0).detach().cpu().numpy().astype(_dtype)
         new_affine = to_affine_nd(affine, new_affine)
         return output_data, affine, new_affine
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -119,12 +119,12 @@ class Spacing(Transform):
             normalized=False,
             mode=interp_order or self.interp_order,
             padding_mode=mode or self.mode,
-            align_corners=False,
+            align_corners=True,
             reverse_indexing=True,
         )
         output_data = affine_xform(
-            torch.from_numpy((data_array.astype(_dtype))[None]),  # AffineTransform requires a batch dim
-            torch.from_numpy(transform_.astype(_dtype)),
+            torch.from_numpy((data_array.astype(np.float64))[None]),  # AffineTransform requires a batch dim
+            torch.from_numpy(transform_.astype(np.float64)),
             spatial_size=output_shape,
         )
         output_data = output_data.squeeze(0).detach().cpu().numpy().astype(_dtype)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -112,9 +112,15 @@ class Spacing(Transform):
         transform = np.linalg.inv(affine_) @ new_affine
         # adapt to the actual rank
         transform_ = to_affine_nd(sr, transform)
-        # resample
         _dtype = dtype or self.dtype or np.float32
 
+        # no resampling if it's identity transform
+        if np.allclose(transform_, np.diag(np.ones(len(transform_))), atol=1e-3):
+            output_data = data_array.copy().astype(_dtype)
+            new_affine = to_affine_nd(affine, new_affine)
+            return output_data, affine, new_affine
+
+        # resample
         affine_xform = AffineTransform(
             normalized=False,
             mode=interp_order or self.interp_order,

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -63,7 +63,7 @@ class Spacing(Transform):
                 If False, this transform preserves the axes orientation, orthogonal rotation and
                 translation components from the original affine. This option will not flip/swap axes
                 of the original data.
-            interp_order (`nearest|bilinear`): The order of the spline interpolation, default is `bilinear`.
+            interp_order (`nearest|bilinear`): The interpolation mode, default is `bilinear`.
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample.
             mode (`zeros|border|reflection`):
                 The mode parameter determines how the input array is extended beyond its boundaries.

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -58,9 +58,8 @@ class Spacingd(MapTransform):
         keys: Hashable,
         pixdim,
         diagonal: bool = False,
-        interp_order=3,
-        mode="nearest",
-        cval=0,
+        interp_order: str = "bilinear",
+        mode: str = "border",
         dtype: Optional[np.dtype] = None,
         meta_key_format: str = "{}.{}",
     ):
@@ -79,23 +78,22 @@ class Spacingd(MapTransform):
                 translations components from the original affine will be
                 preserved in the target affine. This option will not flip/swap
                 axes against the original ones.
-            interp_order (int or sequence of ints): int: the same interpolation order
-                for all data indexed by `self.keys`; sequence of ints, should
+            interp_order (`nearest|bilinear` or a squence of str): str: the same interpolation order
+                for all data indexed by `self.keys`; sequence of str, should
                 correspond to an interpolation order for each data item indexed
-                by `self.keys` respectively.
+                by `self.keys` respectively. Defaults to `bilinear`.
             mode (str or sequence of str):
-                Available options are `reflect|constant|nearest|mirror|wrap`.
+                Available options are `zeros|border|reflection`.
                 The mode parameter determines how the input array is extended beyond its boundaries.
-                Default is 'nearest'.
-            cval (scalar or sequence of scalars): Value to fill past edges of input if mode is "constant". Default is 0.0.
-            dtype (None or np.dtype or sequence of np.dtype): output array data type, defaults to None to use input data's dtype.
+                Default is 'border'.
+            dtype (None or np.dtype or sequence of np.dtype): output array data type.
+                Defaults to None to use input data's dtype.
             meta_key_format (str): key format to read/write affine matrices to the data dictionary.
         """
         super().__init__(keys)
         self.spacing_transform = Spacing(pixdim, diagonal=diagonal)
         self.interp_order = ensure_tuple_rep(interp_order, len(self.keys))
         self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.cval = ensure_tuple_rep(cval, len(self.keys))
         self.dtype = ensure_tuple_rep(dtype, len(self.keys))
         self.meta_key_format = meta_key_format
 
@@ -110,7 +108,6 @@ class Spacingd(MapTransform):
                 affine=d[affine_key],
                 interp_order=self.interp_order[idx],
                 mode=self.mode[idx],
-                cval=self.cval[idx],
                 dtype=self.dtype[idx],
             )
             # set the 'affine' key

--- a/tests/test_affine_transform.py
+++ b/tests/test_affine_transform.py
@@ -19,14 +19,14 @@ from monai.networks.layers import AffineTransform
 from monai.networks.utils import normalize_transform, to_norm_affine
 
 TEST_NORM_CASES = [
-    [(4, 5), True, [[[0.5, 0, -1], [0, 0.666667, -1], [0, 0, 1]]]],
+    [(4, 5), True, [[[0.666667, 0, -1], [0, 0.5, -1], [0, 0, 1]]]],
     [
         (2, 4, 5),
         True,
-        [[[0.5, 0.0, 0.0, -1.0], [0.0, 0.6666667, 0.0, -1.0], [0.0, 0.0, 2.0, -1.0], [0.0, 0.0, 0.0, 1.0]]],
+        [[[2.0, 0.0, 0.0, -1.0], [0.0, 0.6666667, 0.0, -1.0], [0.0, 0.0, 0.5, -1.0], [0.0, 0.0, 0.0, 1.0]]],
     ],
-    [(4, 5), False, [[[0.4, 0.0, -0.8], [0.0, 0.5, -0.75], [0.0, 0.0, 1.0]]]],
-    [(2, 4, 5), False, [[[0.4, 0.0, 0.0, -0.8], [0.0, 0.5, 0.0, -0.75], [0.0, 0.0, 1.0, -0.5], [0.0, 0.0, 0.0, 1.0]]]],
+    [(4, 5), False, [[[0.5, 0.0, -0.75], [0.0, 0.4, -0.8], [0.0, 0.0, 1.0]]]],
+    [(2, 4, 5), False, [[[1.0, 0.0, 0.0, -0.5], [0.0, 0.5, 0.0, -0.75], [0.0, 0.0, 0.4, -0.8], [0.0, 0.0, 0.0, 1.0]]]],
 ]
 
 TEST_TO_NORM_AFFINE_CASES = [
@@ -35,28 +35,28 @@ TEST_TO_NORM_AFFINE_CASES = [
         (4, 6),
         (5, 3),
         True,
-        [[[0.4, 0.0, -0.6], [0.0, 1.3333334, 0.33333337], [0.0, 0.0, 1.0]]],
+        [[[1.3333334, 0.0, 0.33333337], [0.0, 0.4, -0.6], [0.0, 0.0, 1.0]]],
     ],
     [
         [[[1, 0, 0], [0, 1, 0], [0, 0, 1]]],
         (4, 6),
         (5, 3),
         False,
-        [[[0.5, 0.0, -0.5], [0.0, 1.25, 0.25], [0.0, 0.0, 1.0]]],
+        [[[1.25, 0.0, 0.25], [0.0, 0.5, -0.5], [0.0, 0.0, 1.0]]],
     ],
     [
         [[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]],
         (2, 4, 6),
         (3, 5, 3),
         True,
-        [[[0.4, 0.0, 0.0, -0.6], [0.0, 1.3333334, 0.0, 0.33333337], [0.0, 0.0, 2.0, 1.0], [0.0, 0.0, 0.0, 1.0]]],
+        [[[2.0, 0.0, 0.0, 1.0], [0.0, 1.3333334, 0.0, 0.33333337], [0.0, 0.0, 0.4, -0.6], [0.0, 0.0, 0.0, 1.0]]],
     ],
     [
         [[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]],
         (2, 4, 6),
         (3, 5, 3),
         False,
-        [[[0.5, 0.0, 0.0, -0.5], [0.0, 1.25, 0.0, 0.25], [0.0, 0.0, 1.5, 0.5], [0.0, 0.0, 0.0, 1.0]]],
+        [[[1.5, 0.0, 0.0, 0.5], [0.0, 1.25, 0.0, 0.25], [0.0, 0.0, 0.5, -0.5], [0.0, 0.0, 0.0, 1.0]]],
     ],
 ]
 
@@ -108,46 +108,46 @@ class TestToNormAffine(unittest.TestCase):
 
 class TestAffineTransform(unittest.TestCase):
     def test_affine_shift(self):
-        affine = torch.as_tensor([[1, 0, 0], [0, 1, -1]])
-        image = torch.as_tensor([[[[4, 1, 3, 2], [7, 6, 8, 5], [3, 5, 3, 6]]]])
+        affine = torch.as_tensor([[1.0, 0.0, 0.0], [0.0, 1.0, -1.0]])
+        image = torch.as_tensor([[[[4.0, 1.0, 3.0, 2.0], [7.0, 6.0, 8.0, 5.0], [3.0, 5.0, 3.0, 6.0]]]])
         out = AffineTransform()(image, affine)
         out = out.detach().cpu().numpy()
         expected = [[[[0, 4, 1, 3], [0, 7, 6, 8], [0, 3, 5, 3]]]]
         np.testing.assert_allclose(out, expected, atol=1e-5)
 
     def test_affine_shift_1(self):
-        affine = torch.as_tensor([[1, 0, -1], [0, 1, -1]])
-        image = torch.as_tensor([[[[4, 1, 3, 2], [7, 6, 8, 5], [3, 5, 3, 6]]]])
+        affine = torch.as_tensor([[1.0, 0.0, -1.0], [0.0, 1.0, -1.0]])
+        image = torch.as_tensor([[[[4.0, 1.0, 3.0, 2.0], [7.0, 6.0, 8.0, 5.0], [3.0, 5.0, 3.0, 6.0]]]])
         out = AffineTransform()(image, affine)
         out = out.detach().cpu().numpy()
         expected = [[[[0, 0, 0, 0], [0, 4, 1, 3], [0, 7, 6, 8]]]]
         np.testing.assert_allclose(out, expected, atol=1e-5)
 
     def test_affine_shift_2(self):
-        affine = torch.as_tensor([[1, 0, -1], [0, 1, 0]])
-        image = torch.as_tensor([[[[4, 1, 3, 2], [7, 6, 8, 5], [3, 5, 3, 6]]]])
+        affine = torch.as_tensor([[1.0, 0.0, -1.0], [0.0, 1.0, 0.0]])
+        image = torch.as_tensor([[[[4.0, 1.0, 3.0, 2.0], [7.0, 6.0, 8.0, 5.0], [3.0, 5.0, 3.0, 6.0]]]])
         out = AffineTransform()(image, affine)
         out = out.detach().cpu().numpy()
         expected = [[[[0, 0, 0, 0], [4, 1, 3, 2], [7, 6, 8, 5]]]]
         np.testing.assert_allclose(out, expected, atol=1e-5)
 
     def test_zoom(self):
-        affine = torch.as_tensor([[1, 0, 0], [0, 2, 0]])
-        image = torch.arange(1, 13).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+        affine = torch.as_tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]])
+        image = torch.arange(1.0, 13.0).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
         out = AffineTransform((3, 2))(image, affine)
         expected = [[[[1, 3], [5, 7], [9, 11]]]]
         np.testing.assert_allclose(out, expected, atol=1e-5)
 
     def test_zoom_1(self):
-        affine = torch.as_tensor([[2, 0, 0], [0, 1, 0]])
-        image = torch.arange(1, 13).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+        affine = torch.as_tensor([[2.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        image = torch.arange(1.0, 13.0).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
         out = AffineTransform()(image, affine, (1, 4))
         expected = [[[[1, 2, 3, 4]]]]
         np.testing.assert_allclose(out, expected, atol=1e-5)
 
     def test_zoom_2(self):
-        affine = torch.as_tensor([[2, 0, 0], [0, 2, 0]])
-        image = torch.arange(1, 13).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+        affine = torch.as_tensor([[2.0, 0.0, 0.0], [0.0, 2.0, 0.0]], dtype=torch.float32)
+        image = torch.arange(1.0, 13.0).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
         out = AffineTransform((1, 2))(image, affine)
         expected = [[[[1, 3]]]]
         np.testing.assert_allclose(out, expected, atol=1e-5)
@@ -156,7 +156,7 @@ class TestAffineTransform(unittest.TestCase):
         t = np.pi / 3
         affine = [[np.cos(t), -np.sin(t), 0], [np.sin(t), np.cos(t), 0], [0, 0, 1]]
         affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
-        image = torch.arange(24).view(1, 1, 4, 6).to(device=torch.device("cpu:0"))
+        image = torch.arange(24.0).view(1, 1, 4, 6).to(device=torch.device("cpu:0"))
         out = AffineTransform()(image, affine)
         out = out.detach().cpu().numpy()
         expected = [
@@ -175,7 +175,7 @@ class TestAffineTransform(unittest.TestCase):
         t = np.pi / 3
         affine = [[np.cos(t), -np.sin(t), 0], [np.sin(t), np.cos(t), 0], [0, 0, 1]]
         affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
-        image = torch.arange(24).view(1, 1, 4, 6).to(device=torch.device("cpu:0"))
+        image = torch.arange(24.0).view(1, 1, 4, 6).to(device=torch.device("cpu:0"))
         xform = AffineTransform((3, 4), padding_mode="border", align_corners=True, mode="bilinear")
         out = xform(image, affine)
         out = out.detach().cpu().numpy()
@@ -211,7 +211,7 @@ class TestAffineTransform(unittest.TestCase):
         t = np.pi / 3
         affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
         affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
-        image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
+        image = torch.arange(48.0).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
         xform = AffineTransform((3, 4, 2), padding_mode="border", align_corners=False, mode="bilinear")
         out = xform(image, affine)
         out = out.detach().cpu().numpy()
@@ -263,7 +263,7 @@ class TestAffineTransform(unittest.TestCase):
             affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
             affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
             xform = AffineTransform((3, 4, 2), padding_mode="border", align_corners=False, mode="bilinear")
-            xform(torch.as_tensor([1, 2, 3]), affine)
+            xform(torch.as_tensor([1.0, 2.0, 3.0]), affine)
 
         with self.assertRaises(ValueError):  # output shape too small
             t = np.pi / 3
@@ -292,11 +292,26 @@ class TestAffineTransform(unittest.TestCase):
             xform = AffineTransform((2, 3, 4), padding_mode="border", align_corners=False, mode="bilinear")
             xform(image, affine)
 
+        with self.assertRaises(RuntimeError):  # input grid dtypes different
+            t = np.pi / 3
+            affine = [[1, 0, 0, 0], [0.0, np.cos(t), -np.sin(t), 0], [0, np.sin(t), np.cos(t), 0], [0, 0, 0, 1]]
+            affine = torch.as_tensor(affine, device=torch.device("cpu:0"), dtype=torch.float32)
+            affine = affine.unsqueeze(0)
+            affine = affine.repeat(2, 1, 1)
+            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"), dtype=torch.int32)
+            xform = AffineTransform((2, 3, 4), padding_mode="border", mode="bilinear", normalized=True)
+            xform(image, affine)
+
         with self.assertRaises(ValueError):  # wrong affine
             affine = torch.as_tensor([[1, 0, 0, 0], [0, 0, 0, 1]])
             image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cpu:0"))
             xform = AffineTransform((2, 3, 4), padding_mode="border", align_corners=False, mode="bilinear")
             xform(image, affine)
+
+        with self.assertRaises(RuntimeError):  # dtype doesn't match
+            affine = torch.as_tensor([[2.0, 0.0, 0.0], [0.0, 2.0, 0.0]], dtype=torch.float64)
+            image = torch.arange(1.0, 13.0).view(1, 1, 3, 4).to(device=torch.device("cpu:0"))
+            out = AffineTransform((1, 2))(image, affine)
 
     def test_forward_2d(self):
         x = torch.rand(2, 1, 4, 4)

--- a/tests/test_affine_transform.py
+++ b/tests/test_affine_transform.py
@@ -192,7 +192,7 @@ class TestAffineTransform(unittest.TestCase):
 
         if torch.cuda.is_available():
             affine = torch.as_tensor(affine, device=torch.device("cuda:0"), dtype=torch.float32)
-            image = torch.arange(24).view(1, 1, 4, 6).to(device=torch.device("cuda:0"))
+            image = torch.arange(24.0).view(1, 1, 4, 6).to(device=torch.device("cuda:0"))
             xform = AffineTransform(padding_mode="border", align_corners=True, mode="bilinear")
             out = xform(image, affine, (3, 4))
             out = out.detach().cpu().numpy()
@@ -235,7 +235,7 @@ class TestAffineTransform(unittest.TestCase):
 
         if torch.cuda.is_available():
             affine = torch.as_tensor(affine, device=torch.device("cuda:0"), dtype=torch.float32)
-            image = torch.arange(48).view(2, 1, 4, 2, 3).to(device=torch.device("cuda:0"))
+            image = torch.arange(48.0).view(2, 1, 4, 2, 3).to(device=torch.device("cuda:0"))
             xform = AffineTransform(padding_mode="border", align_corners=False, mode="bilinear")
             out = xform(image, affine, (3, 4, 2))
             out = out.detach().cpu().numpy()

--- a/tests/test_integration_segmentation_3d.py
+++ b/tests/test_integration_segmentation_3d.py
@@ -328,7 +328,7 @@ class IntegrationSegmentation3D(unittest.TestCase):
             ]
             for (output, s) in zip(output_files, sums):
                 ave = np.mean(nib.load(output).get_fdata())
-                np.testing.assert_allclose(ave, s, rtol=1e-3)
+                np.testing.assert_allclose(ave, s, rtol=5e-3)
                 repeated[i].append(ave)
         np.testing.assert_allclose(repeated[0], repeated[1])
         np.testing.assert_allclose(repeated[0], repeated[2])

--- a/tests/test_integration_segmentation_3d.py
+++ b/tests/test_integration_segmentation_3d.py
@@ -33,6 +33,7 @@ from monai.transforms import (
     RandCropByPosNegLabeld,
     RandRotate90d,
     ScaleIntensityd,
+    Spacingd,
     ToTensord,
 )
 from monai.visualize import plot_2d_or_3d_image
@@ -51,6 +52,7 @@ def run_training_test(root_dir, device=torch.device("cuda:0"), cachedataset=Fals
     train_transforms = Compose(
         [
             LoadNiftid(keys=["img", "seg"]),
+            Spacingd(keys=["img", "seg"], pixdim=[1.2, 0.8, 0.7], interp_order=["bilinear", "nearest"]),
             AsChannelFirstd(keys=["img", "seg"], channel_dim=-1),
             ScaleIntensityd(keys=["img", "seg"]),
             RandCropByPosNegLabeld(
@@ -64,6 +66,7 @@ def run_training_test(root_dir, device=torch.device("cuda:0"), cachedataset=Fals
     val_transforms = Compose(
         [
             LoadNiftid(keys=["img", "seg"]),
+            Spacingd(keys=["img", "seg"], pixdim=[1.2, 0.8, 0.7], interp_order=["bilinear", "nearest"]),
             AsChannelFirstd(keys=["img", "seg"], channel_dim=-1),
             ScaleIntensityd(keys=["img", "seg"]),
             ToTensord(keys=["img", "seg"]),
@@ -179,6 +182,7 @@ def run_inference_test(root_dir, device=torch.device("cuda:0")):
         [
             LoadNiftid(keys=["img", "seg"]),
             AsChannelFirstd(keys=["img", "seg"], channel_dim=-1),
+            Spacingd(keys=["img", "seg"], pixdim=[1.2, 0.8, 0.7], interp_order=["bilinear", "nearest"]),
             ScaleIntensityd(keys=["img", "seg"]),
             ToTensord(keys=["img", "seg"]),
         ]
@@ -256,18 +260,18 @@ class IntegrationSegmentation3D(unittest.TestCase):
             np.testing.assert_allclose(
                 losses,
                 [
-                    0.5241468191146851,
-                    0.4485286593437195,
-                    0.42851402163505553,
-                    0.4130884766578674,
-                    0.39990419149398804,
-                    0.38985557556152345,
+                    0.5480509608983993,
+                    0.46773012578487394,
+                    0.4449450016021729,
+                    0.4429117202758789,
+                    0.4266220510005951,
+                    0.4189875662326813,
                 ],
-                rtol=1e-4,
+                rtol=1e-3,
             )
             repeated[i].extend(losses)
             print("best metric", best_metric)
-            np.testing.assert_allclose(best_metric, 0.936915835738182, rtol=1e-4)
+            np.testing.assert_allclose(best_metric, 0.9281478852033616, rtol=1e-3)
             repeated[i].append(best_metric)
             np.testing.assert_allclose(best_metric_epoch, 6)
             self.assertTrue(len(glob(os.path.join(self.data_dir, "runs"))) > 0)
@@ -277,50 +281,50 @@ class IntegrationSegmentation3D(unittest.TestCase):
             infer_metric = run_inference_test(self.data_dir, device=self.device)
 
             # check inference properties
-            np.testing.assert_allclose(infer_metric, 0.9382847994565964, rtol=1e-4)
+            np.testing.assert_allclose(infer_metric, 0.9276287078857421, rtol=1e-3)
             repeated[i].append(infer_metric)
             output_files = sorted(glob(os.path.join(self.data_dir, "output", "img*", "*.nii.gz")))
             sums = [
-                0.14089012145996094,
-                0.15014171600341797,
-                0.14881277084350586,
-                0.1385650634765625,
-                0.1845254898071289,
-                0.16743040084838867,
-                0.14531803131103516,
-                0.16558170318603516,
-                0.15594959259033203,
-                0.17697954177856445,
-                0.1602783203125,
-                0.16418695449829102,
-                0.14412164688110352,
-                0.11254501342773438,
-                0.1596541404724121,
-                0.19611215591430664,
-                0.17372655868530273,
-                0.09818077087402344,
-                0.19010257720947266,
-                0.19887447357177734,
-                0.19475173950195312,
-                0.2032027244567871,
-                0.15918874740600586,
-                0.1304488182067871,
-                0.1496739387512207,
-                0.1408066749572754,
-                0.22757959365844727,
-                0.1601700782775879,
-                0.14635848999023438,
-                0.10335826873779297,
-                0.11824846267700195,
-                0.12940073013305664,
-                0.11342906951904297,
-                0.15047359466552734,
-                0.16041946411132812,
-                0.18996095657348633,
-                0.21734333038330078,
-                0.17714214324951172,
-                0.1853632926940918,
-                0.079422,
+                0.14357540823662318,
+                0.15269879069528602,
+                0.15276683013248435,
+                0.14079445671151278,
+                0.18878697237342096,
+                0.17095550477559823,
+                0.1482579336551299,
+                0.1690032222450447,
+                0.15854729382766766,
+                0.18061742579850057,
+                0.16381168481051658,
+                0.16860525572558283,
+                0.14595678853856425,
+                0.11642670997227073,
+                0.16255648557050426,
+                0.20181780835986443,
+                0.17686017253774264,
+                0.1015966801889699,
+                0.19381932320016432,
+                0.2030797473554483,
+                0.19752939817192153,
+                0.20913782479203039,
+                0.1633029937352367,
+                0.13320356629351957,
+                0.14912896682756496,
+                0.1435551889699086,
+                0.23132670483721884,
+                0.16242907209612817,
+                0.14929296754647223,
+                0.10485583341891754,
+                0.120152831981103,
+                0.13234087758036356,
+                0.11596583906747458,
+                0.15332719266714595,
+                0.16359472886926157,
+                0.19406291722296395,
+                0.22271971603163193,
+                0.18138928828181164,
+                0.19065260090376912,
+                0.08892593971449111,
             ]
             for (output, s) in zip(output_files, sums):
                 ave = np.mean(nib.load(output).get_fdata())

--- a/tests/test_load_spacing_orientation.py
+++ b/tests/test_load_spacing_orientation.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import os
+import time
 import unittest
 
 import nibabel
@@ -31,13 +32,19 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data = {"image": filename}
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=True, mode="constant")(data_dict)
-        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
+        t = time.time()
+        res_dict = Spacingd(keys="image", pixdim=(1, 0.2, 1), diagonal=True, mode="zeros")(data_dict)
+        t1 = time.time()
+        print(f"time monai: {t1 - t}")
         anat = nibabel.Nifti1Image(data_dict["image"][0], data_dict["image.affine"])
-        ref = resample_to_output(anat, (1, 2, 3))
+        ref = resample_to_output(anat, (1, 0.2, 1), order=1)
+        t2 = time.time()
+        print(f"time scipy: {t2 - t1}")
+        self.assertTrue(t2 > t1)
+        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(res_dict["image.affine"], ref.affine)
         np.testing.assert_allclose(res_dict["image"].shape[1:], ref.shape)
-        np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0])
+        np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0], atol=0.05)
 
     @parameterized.expand(FILES)
     def test_load_spacingd_rotate(self, filename):
@@ -48,18 +55,24 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data_dict["image.original_affine"] = data_dict["image.affine"] = (
             np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) @ affine
         )
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=True, mode="constant")(data_dict)
-        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
+        t = time.time()
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=True, mode="zeros")(data_dict)
+        t1 = time.time()
+        print(f"time monai: {t1 - t}")
         anat = nibabel.Nifti1Image(data_dict["image"][0], data_dict["image.affine"])
-        ref = resample_to_output(anat, (1, 2, 3))
+        ref = resample_to_output(anat, (1, 2, 3), order=1)
+        t2 = time.time()
+        print(f"time scipy: {t2 - t1}")
+        self.assertTrue(t2 > t1)
+        np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(res_dict["image.affine"], ref.affine)
         if "anatomical" not in filename:
             np.testing.assert_allclose(res_dict["image"].shape[1:], ref.shape)
-            np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0])
+            np.testing.assert_allclose(ref.get_fdata(), res_dict["image"][0], atol=0.05)
         else:
             # different from the ref implementation (shape computed by round
             # instead of ceil)
-            np.testing.assert_allclose(ref.get_fdata()[..., :-1], res_dict["image"][0])
+            np.testing.assert_allclose(ref.get_fdata()[..., :-1], res_dict["image"][0], atol=0.05)
 
     def test_load_spacingd_non_diag(self):
         data = {"image": FILES[1]}
@@ -69,7 +82,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data_dict["image.original_affine"] = data_dict["image.affine"] = (
             np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) @ affine
         )
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="constant")(data_dict)
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="zeros")(data_dict)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
             res_dict["image.affine"],
@@ -87,7 +100,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data = {"image": FILES[0]}
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="nearest")(data_dict)
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="border")(data_dict)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
             res_dict["image.affine"],
@@ -98,7 +111,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data = {"image": FILES[0]}
         data_dict = LoadNiftid(keys="image")(data)
         data_dict = AddChanneld(keys="image")(data_dict)
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="nearest")(data_dict)
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="border")(data_dict)
         res_dict = Orientationd(keys="image", axcodes="LPI")(res_dict)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(
@@ -114,7 +127,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         data_dict["image.original_affine"] = data_dict["image.affine"] = (
             np.array([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) @ affine
         )
-        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="constant")(data_dict)
+        res_dict = Spacingd(keys="image", pixdim=(1, 2, 3), diagonal=False, mode="border")(data_dict)
         res_dict = Orientationd(keys="image", axcodes="LPI")(res_dict)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(

--- a/tests/test_load_spacing_orientation.py
+++ b/tests/test_load_spacing_orientation.py
@@ -40,7 +40,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         ref = resample_to_output(anat, (1, 0.2, 1), order=1)
         t2 = time.time()
         print(f"time scipy: {t2 - t1}")
-        self.assertTrue(t2 > t1)
+        self.assertTrue(t2 >= t1)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(res_dict["image.affine"], ref.affine)
         np.testing.assert_allclose(res_dict["image"].shape[1:], ref.shape)
@@ -63,7 +63,7 @@ class TestLoadSpacingOrientation(unittest.TestCase):
         ref = resample_to_output(anat, (1, 2, 3), order=1)
         t2 = time.time()
         print(f"time scipy: {t2 - t1}")
-        self.assertTrue(t2 > t1)
+        self.assertTrue(t2 >= t1)
         np.testing.assert_allclose(data_dict["image.affine"], res_dict["image.original_affine"])
         np.testing.assert_allclose(res_dict["image.affine"], ref.affine)
         if "anatomical" not in filename:

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -40,7 +40,7 @@ TEST_CASES = [
         {"pixdim": (1.0, 0.2, 1.5), "diagonal": False, "mode": "zeros"},
         np.ones((1, 2, 1, 2)),  # data
         {"affine": np.array([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2.0, 5], [0, 0, 0, 1]])},
-        np.ones((1, 3, 1, 2)),
+        np.array([[[[0.95527864, 0.95527864]], [[1.0, 1.0]], [[1.0, 1.0]]]]),
     ],
     [
         {"pixdim": (3.0, 1.0), "mode": "zeros"},
@@ -93,19 +93,19 @@ TEST_CASES = [
         ),
     ],
     [
-        {"pixdim": (2.0, 5.0, 6.0), "mode": "zeros", "diagonal": True},
+        {"pixdim": (1.9, 4.0, 5.0), "mode": "zeros", "diagonal": True},
         np.arange(24).reshape((1, 4, 6)),  # data
         {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": "nearest"},
         np.array(
             [
                 [
-                    [18, 19, 20, 21, 22, 23],
-                    [12, 13, 14, 15, 16, 17],
-                    [12, 13, 14, 15, 16, 17],
-                    [12, 13, 14, 15, 16, 17],
-                    [6, 7, 8, 9, 10, 11],
-                    [6, 7, 8, 9, 10, 11],
-                    [0, 1, 2, 3, 4, 5],
+                    [18.0, 19.0, 20.0, 20.0, 21.0, 22.0, 23.0],
+                    [18.0, 19.0, 20.0, 20.0, 21.0, 22.0, 23.0],
+                    [12.0, 13.0, 14.0, 14.0, 15.0, 16.0, 17.0],
+                    [12.0, 13.0, 14.0, 14.0, 15.0, 16.0, 17.0],
+                    [6.0, 7.0, 8.0, 8.0, 9.0, 10.0, 11.0],
+                    [6.0, 7.0, 8.0, 8.0, 9.0, 10.0, 11.0],
+                    [0.0, 1.0, 2.0, 2.0, 3.0, 4.0, 5.0],
                 ]
             ]
         ),
@@ -165,12 +165,16 @@ class TestSpacingCase(unittest.TestCase):
     def test_spacing(self, init_param, img, data_param, expected_output):
         res = Spacing(**init_param)(img, **data_param)
         np.testing.assert_allclose(res[0], expected_output, atol=1e-6)
+        sr = len(res[0].shape) - 1
+        if isinstance(init_param["pixdim"], float):
+            init_param["pixdim"] = [init_param["pixdim"]] * sr
         init_pixdim = ensure_tuple(init_param["pixdim"])
-        np.testing.assert_allclose(init_pixdim, np.sqrt(np.sum(np.square(res[2]), axis=0))[: len(init_pixdim)])
+        init_pixdim = init_param["pixdim"][:sr]
+        np.testing.assert_allclose(init_pixdim[:sr], np.sqrt(np.sum(np.square(res[2]), axis=0))[:sr])
 
     def test_ill_pixdim(self):
         with self.assertRaises(ValueError):
-            res = Spacing(pixdim=(-1, 2.0))(np.zeros((1, 1)))
+            Spacing(pixdim=(-1, 2.0))(np.zeros((1, 1)))
 
 
 if __name__ == "__main__":

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -15,35 +15,47 @@ import numpy as np
 from parameterized import parameterized
 
 from monai.transforms import Spacing
+from monai.utils import ensure_tuple
 
 TEST_CASES = [
-    [{"pixdim": (2.0,), "mode": "constant"}, np.ones((1, 2)), {"affine": np.eye(4)}, np.array([[1.0, 0.0]])],  # data
     [
-        {"pixdim": (1.0, 0.2, 1.5), "mode": "constant"},
+        {"pixdim": (1.0, 1.5, 1.0), "mode": "zeros", "dtype": np.float},
+        np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
+        {"affine": np.eye(4)},
+        np.array([[[1.0, 1.0], [3.0, 2.0]]]),
+    ],
+    [
+        {"pixdim": 1.0, "mode": "zeros", "dtype": np.float},
         np.ones((1, 2, 1, 2)),  # data
         {"affine": np.eye(4)},
-        np.array([[[[1.0, 0.0]], [[1.0, 0.0]]]]),
+        np.array([[[[1.0, 1.0]], [[1.0, 1.0]]]]),
     ],
     [
-        {"pixdim": (1.0, 0.2, 1.5), "diagonal": False, "mode": "constant"},
+        {"pixdim": (1.0, 1.0, 1.0), "mode": "zeros", "dtype": np.float},
+        np.ones((1, 2, 1, 2)),  # data
+        {"affine": np.eye(4)},
+        np.array([[[[1.0, 1.0]], [[1.0, 1.0]]]]),
+    ],
+    [
+        {"pixdim": (1.0, 0.2, 1.5), "diagonal": False, "mode": "zeros"},
         np.ones((1, 2, 1, 2)),  # data
         {"affine": np.array([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2.0, 5], [0, 0, 0, 1]])},
-        np.zeros((1, 3, 1, 2)),
+        np.ones((1, 3, 1, 2)),
     ],
     [
-        {"pixdim": (3.0, 1.0), "mode": "constant"},
+        {"pixdim": (3.0, 1.0), "mode": "zeros"},
         np.arange(24).reshape((2, 3, 4)),  # data
         {"affine": np.diag([-3.0, 0.2, 1.5, 1])},
         np.array([[[0, 0], [4, 0], [8, 0]], [[12, 0], [16, 0], [20, 0]]]),
     ],
     [
-        {"pixdim": (3.0, 1.0), "mode": "constant"},
+        {"pixdim": (3.0, 1.0), "mode": "zeros"},
         np.arange(24).reshape((2, 3, 4)),  # data
         {},
         np.array([[[0, 1, 2, 3], [0, 0, 0, 0]], [[12, 13, 14, 15], [0, 0, 0, 0]]]),
     ],
     [
-        {"pixdim": (1.0, 1.0), "mode": "constant"},
+        {"pixdim": (1.0, 1.0)},
         np.arange(24).reshape((2, 3, 4)),  # data
         {},
         np.array(
@@ -51,13 +63,13 @@ TEST_CASES = [
         ),
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0), "mode": "constant"},
+        {"pixdim": (4.0, 5.0, 6.0)},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
         {"affine": np.array([[-4, 0, 0, 4], [0, 5, 0, -5], [0, 0, 6, -6], [0, 0, 0, 1]])},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0), "diagonal": True, "mode": "constant"},
+        {"pixdim": (4.0, 5.0, 6.0), "diagonal": True},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
         {"affine": np.array([[-4, 0, 0, 4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
         np.array(
@@ -65,7 +77,7 @@ TEST_CASES = [
         ),
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0), "mode": "nearest", "diagonal": True},
+        {"pixdim": (4.0, 5.0, 6.0), "mode": "border", "diagonal": True},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
         {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]])},
         np.array(
@@ -73,22 +85,22 @@ TEST_CASES = [
         ),
     ],
     [
-        {"pixdim": (4.0, 5.0, 6.0), "mode": "nearest", "diagonal": True},
+        {"pixdim": (4.0, 5.0, 6.0), "mode": "border", "diagonal": True},
         np.arange(24).reshape((1, 2, 3, 4)),  # data
-        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
+        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": "nearest"},
         np.array(
             [[[[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]], [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]]]
         ),
     ],
     [
-        {"pixdim": (2.0, 5.0, 6.0), "mode": "constant", "diagonal": True},
+        {"pixdim": (2.0, 5.0, 6.0), "mode": "zeros", "diagonal": True},
         np.arange(24).reshape((1, 4, 6)),  # data
-        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
+        {"affine": np.array([[-4, 0, 0, -4], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": "nearest"},
         np.array(
             [
                 [
                     [18, 19, 20, 21, 22, 23],
-                    [18, 19, 20, 21, 22, 23],
+                    [12, 13, 14, 15, 16, 17],
                     [12, 13, 14, 15, 16, 17],
                     [12, 13, 14, 15, 16, 17],
                     [6, 7, 8, 9, 10, 11],
@@ -99,31 +111,50 @@ TEST_CASES = [
         ),
     ],
     [
-        {"pixdim": (5.0, 3.0, 6.0), "mode": "constant", "diagonal": True, "dtype": np.float32},
+        {"pixdim": (5.0, 3.0, 6.0), "mode": "border", "diagonal": True, "dtype": np.float32},
         np.arange(24).reshape((1, 4, 6)),  # data
-        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 0},
+        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": "bilinear"},
         np.array(
             [
                 [
-                    [18.0, 19.0, 19.0, 20.0, 20.0, 21.0, 22.0, 22.0, 23],
-                    [12.0, 13.0, 13.0, 14.0, 14.0, 15.0, 16.0, 16.0, 17.0],
-                    [6.0, 7.0, 7.0, 8.0, 8.0, 9.0, 10.0, 10.0, 11.0],
+                    [18.0, 18.6, 19.2, 19.8, 20.400002, 21.0, 21.6, 22.2, 22.8],
+                    [10.5, 11.1, 11.700001, 12.299999, 12.900001, 13.5, 14.1, 14.700001, 15.3],
+                    [3.0, 3.6000001, 4.2000003, 4.8, 5.4000006, 6.0, 6.6000004, 7.200001, 7.8],
                 ]
-            ],
+            ]
         ),
     ],
     [
-        {"pixdim": (5.0, 3.0, 6.0), "mode": "constant", "diagonal": True, "dtype": np.float32},
+        {"pixdim": (5.0, 3.0, 6.0), "mode": "zeros", "diagonal": True, "dtype": np.float32},
         np.arange(24).reshape((1, 4, 6)),  # data
-        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": 2},
+        {"affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]), "interp_order": "bilinear"},
         np.array(
             [
                 [
-                    [18.0, 18.492683, 19.22439, 19.80683, 20.398048, 21.0, 21.570732, 22.243902, 22.943415],
-                    [10.392858, 10.88554, 11.617248, 12.199686, 12.790906, 13.392858, 13.963589, 14.63676, 15.336272],
-                    [2.142857, 2.63554, 3.3672473, 3.9496865, 4.540906, 5.142857, 5.7135887, 6.3867598, 7.086272],
+                    [18.0000, 18.6000, 19.2000, 19.8000, 20.4000, 21.0000, 21.6000, 22.2000, 22.8000],
+                    [10.5000, 11.1000, 11.7000, 12.3000, 12.9000, 13.5000, 14.1000, 14.7000, 15.3000],
+                    [3.0000, 3.6000, 4.2000, 4.8000, 5.4000, 6.0000, 6.6000, 7.2000, 7.8000],
                 ]
-            ],
+            ]
+        ),
+    ],
+    [
+        {"pixdim": (5.0, 3.0, 6.0), "diagonal": True, "mode": "test", "interp_order": "test"},
+        np.arange(24).reshape((1, 4, 6)),  # data
+        {
+            "affine": np.array([[-4, 0, 0, 0], [0, 5, 0, 0], [0, 0, 6, 0], [0, 0, 0, 1]]),
+            "interp_order": "bilinear",
+            "mode": "zeros",
+            "dtype": np.float64,
+        },
+        np.array(
+            [
+                [
+                    [18.0000, 18.6000, 19.2000, 19.8000, 20.4000, 21.0000, 21.6000, 22.2000, 22.8000],
+                    [10.5000, 11.1000, 11.7000, 12.3000, 12.9000, 13.5000, 14.1000, 14.7000, 15.3000],
+                    [3.0000, 3.6000, 4.2000, 4.8000, 5.4000, 6.0000, 6.6000, 7.2000, 7.8000],
+                ]
+            ]
         ),
     ],
 ]
@@ -134,11 +165,12 @@ class TestSpacingCase(unittest.TestCase):
     def test_spacing(self, init_param, img, data_param, expected_output):
         res = Spacing(**init_param)(img, **data_param)
         np.testing.assert_allclose(res[0], expected_output, atol=1e-6)
-        if "original_affine" in data_param:
-            np.testing.assert_allclose(res[1], data_param["original_affine"])
-        np.testing.assert_allclose(
-            init_param["pixdim"], np.sqrt(np.sum(np.square(res[2]), axis=0))[: len(init_param["pixdim"])]
-        )
+        init_pixdim = ensure_tuple(init_param["pixdim"])
+        np.testing.assert_allclose(init_pixdim, np.sqrt(np.sum(np.square(res[2]), axis=0))[: len(init_pixdim)])
+
+    def test_ill_pixdim(self):
+        with self.assertRaises(ValueError):
+            res = Spacing(pixdim=(-1, 2.0))(np.zeros((1, 1)))
 
 
 if __name__ == "__main__":

--- a/tests/test_spacingd.py
+++ b/tests/test_spacingd.py
@@ -33,36 +33,31 @@ class TestSpacingDCase(unittest.TestCase):
         np.testing.assert_allclose(res["image"].shape, (2, 10, 10))
         np.testing.assert_allclose(res["image.affine"], np.diag((1, 2, 1)))
 
-    def test_spacingd_1d(self):
-        data = {"image": np.arange(20).reshape((2, 10)), "image.original_affine": np.diag((3, 2, 1, 1))}
-        data["image.affine"] = data["image.original_affine"]
-        spacing = Spacingd(keys="image", pixdim=(0.2,))
-        res = spacing(data)
-        self.assertEqual(("image", "image.affine", "image.original_affine"), tuple(sorted(res)))
-        np.testing.assert_allclose(res["image"].shape, (2, 136))
-        np.testing.assert_allclose(res["image.affine"], np.diag((0.2, 2, 1, 1)))
-        np.testing.assert_allclose(res["image.original_affine"], np.diag((3, 2, 1, 1)))
-
     def test_interp_all(self):
         data = {
-            "image": np.arange(20).reshape((2, 10)),
-            "seg": np.ones((2, 10)),
+            "image": np.arange(20).reshape((2, 1, 10)),
+            "seg": np.ones((2, 1, 10)),
             "image.affine": np.eye(4),
             "seg.affine": np.eye(4),
         }
-        spacing = Spacingd(keys=("image", "seg"), interp_order=0, pixdim=(0.2,))
+        spacing = Spacingd(keys=("image", "seg"), interp_order="nearest", pixdim=(1, 0.2,))
         res = spacing(data)
         self.assertEqual(("image", "image.affine", "seg", "seg.affine"), tuple(sorted(res)))
-        np.testing.assert_allclose(res["image"].shape, (2, 46))
-        np.testing.assert_allclose(res["image.affine"], np.diag((0.2, 1, 1, 1)))
+        np.testing.assert_allclose(res["image"].shape, (2, 1, 46))
+        np.testing.assert_allclose(res["image.affine"], np.diag((1, 0.2, 1, 1)))
 
     def test_interp_sep(self):
-        data = {"image": np.ones((2, 10)), "seg": np.ones((2, 10)), "image.affine": np.eye(4), "seg.affine": np.eye(4)}
-        spacing = Spacingd(keys=("image", "seg"), interp_order=(2, 0), pixdim=(0.2,))
+        data = {
+            "image": np.ones((2, 1, 10)),
+            "seg": np.ones((2, 1, 10)),
+            "image.affine": np.eye(4),
+            "seg.affine": np.eye(4),
+        }
+        spacing = Spacingd(keys=("image", "seg"), interp_order=("bilinear", "nearest"), pixdim=(1, 0.2,))
         res = spacing(data)
         self.assertEqual(("image", "image.affine", "seg", "seg.affine"), tuple(sorted(res)))
-        np.testing.assert_allclose(res["image"].shape, (2, 46))
-        np.testing.assert_allclose(res["image.affine"], np.diag((0.2, 1, 1, 1)))
+        np.testing.assert_allclose(res["image"].shape, (2, 1, 46))
+        np.testing.assert_allclose(res["image.affine"], np.diag((1, 0.2, 1, 1)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
subtask of #232, revisit #270 as PR270 is out-of-date

revise spacing transform to use affine transform instead of scipy.ndimage.affine_transform

- [x] do some performance profiling
looks like it's faster than scipy (on linux and mac)

time monai: 5.108487129211426
time scipy: 8.076294898986816

time monai: 13.104552984237671
time scipy: 22.991212129592896

time monai: 0.0038220882415771484
time scipy: 0.0066759586334228516

time monai: 0.006756782531738281
time scipy: 0.009568929672241211

there are tiny implementation gaps (quantisation errors) for now:
linear:
<img width="1108" alt="Screenshot 2020-06-06 at 17 29 34" src="https://user-images.githubusercontent.com/831580/83949378-6462c780-a81b-11ea-9fa4-6114a568543a.png">

nearest:
<img width="1248" alt="Screenshot 2020-06-06 at 17 32 32" src="https://user-images.githubusercontent.com/831580/83949458-cde2d600-a81b-11ea-8710-b2e82536d4c4.png">

it works fine for the identity cases
<img width="1092" alt="Screenshot 2020-06-06 at 17 29 23" src="https://user-images.githubusercontent.com/831580/83949392-6dec2f80-a81b-11ea-8728-452544050566.png">

### Status
**ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
