### PR TITLE
488 simplify some arg names to the same

### DIFF
--- a/examples/classification_3d/densenet_training_dict.py
+++ b/examples/classification_3d/densenet_training_dict.py
@@ -132,7 +132,7 @@ def main():
 
                 acc_value = torch.eq(y_pred.argmax(dim=1), y)
                 acc_metric = acc_value.sum().item() / len(acc_value)
-                auc_metric = compute_roc_auc(y_pred, y, to_onehot_y=True, add_softmax=True)
+                auc_metric = compute_roc_auc(y_pred, y, to_onehot_y=True, softmax=True)
                 if acc_metric > best_metric:
                     best_metric = acc_metric
                     best_metric_epoch = epoch + 1

--- a/examples/classification_3d_ignite/densenet_training_dict.py
+++ b/examples/classification_3d_ignite/densenet_training_dict.py
@@ -118,7 +118,7 @@ def main():
 
     metric_name = "Accuracy"
     # add evaluation metric to the evaluator engine
-    val_metrics = {metric_name: Accuracy(), "AUC": ROCAUC(to_onehot_y=True, add_softmax=True)}
+    val_metrics = {metric_name: Accuracy(), "AUC": ROCAUC(to_onehot_y=True, softmax=True)}
     # Ignite evaluator expects batch=(img, label) and returns output=(y_pred, y) at every iteration,
     # user can add output_transform to return other values
     evaluator = create_supervised_evaluator(net, val_metrics, device, True, prepare_batch=prepare_batch)

--- a/examples/notebooks/cache_dataset_speed.ipynb
+++ b/examples/notebooks/cache_dataset_speed.ipynb
@@ -150,7 +150,7 @@
     "    device = torch.device('cuda:0')\n",
     "    model = UNet(dimensions=3, in_channels=1, out_channels=2, channels=(16, 32, 64, 128, 256),\n",
     "                 strides=(2, 2, 2, 2), num_res_units=2, norm=Norm.BATCH).to(device)\n",
-    "    loss_function = DiceLoss(to_onehot_y=True, do_softmax=True)\n",
+    "    loss_function = DiceLoss(to_onehot_y=True, softmax=True)\n",
     "    optimizer = torch.optim.Adam(model.parameters(), 1e-4)\n",
     "\n",
     "    epoch_num = 2\n",

--- a/examples/notebooks/mednist_tutorial.ipynb
+++ b/examples/notebooks/mednist_tutorial.ipynb
@@ -358,7 +358,7 @@
     "                val_images, val_labels = val_data[0].to(device), val_data[1].to(device)\n",
     "                y_pred = torch.cat([y_pred, model(val_images)], dim=0)\n",
     "                y = torch.cat([y, val_labels], dim=0)\n",
-    "            auc_metric = compute_roc_auc(y_pred, y, to_onehot_y=True, add_softmax=True)\n",
+    "            auc_metric = compute_roc_auc(y_pred, y, to_onehot_y=True, softmax=True)\n",
     "            metric_values.append(auc_metric)\n",
     "            acc_value = torch.eq(y_pred.argmax(dim=1), y)\n",
     "            acc_metric = acc_value.sum().item() / len(acc_value)\n",

--- a/examples/notebooks/persistent_dataset_speed.ipynb
+++ b/examples/notebooks/persistent_dataset_speed.ipynb
@@ -83,7 +83,7 @@
     "    device = torch.device('cuda:0')\n",
     "    model = UNet(dimensions=3, in_channels=1, out_channels=2, channels=(16, 32, 64, 128, 256),\n",
     "                 strides=(2, 2, 2, 2), num_res_units=2, norm=Norm.BATCH).to(device)\n",
-    "    loss_function = DiceLoss(to_onehot_y=True, do_softmax=True)\n",
+    "    loss_function = DiceLoss(to_onehot_y=True, softmax=True)\n",
     "    optimizer = torch.optim.Adam(model.parameters(), 1e-4)\n",
     "\n",
     "    epoch_num = 600\n",

--- a/examples/notebooks/spleen_segmentation_3d.ipynb
+++ b/examples/notebooks/spleen_segmentation_3d.ipynb
@@ -265,7 +265,7 @@
     "device = torch.device('cuda:0')\n",
     "model = monai.networks.nets.UNet(dimensions=3, in_channels=1, out_channels=2, channels=(16, 32, 64, 128, 256),\n",
     "                                 strides=(2, 2, 2, 2), num_res_units=2, norm=Norm.BATCH).to(device)\n",
-    "loss_function = monai.losses.DiceLoss(to_onehot_y=True, do_softmax=True)\n",
+    "loss_function = monai.losses.DiceLoss(to_onehot_y=True, softmax=True)\n",
     "optimizer = torch.optim.Adam(model.parameters(), 1e-4)"
    ]
   },

--- a/examples/notebooks/spleen_segmentation_3d_lightning.ipynb
+++ b/examples/notebooks/spleen_segmentation_3d_lightning.ipynb
@@ -114,7 +114,7 @@
     "        self._model = monai.networks.nets.UNet(dimensions=3, in_channels=1, out_channels=2,\n",
     "                                               channels=(16, 32, 64, 128, 256),strides=(2, 2, 2, 2),\n",
     "                                               num_res_units=2, norm=Norm.BATCH)\n",
-    "        self.loss_function = monai.losses.DiceLoss(to_onehot_y=True, do_softmax=True)\n",
+    "        self.loss_function = monai.losses.DiceLoss(to_onehot_y=True, softmax=True)\n",
     "        self.best_val_dice = 0\n",
     "        self.best_val_epoch = 0\n",
     "\n",

--- a/examples/notebooks/unet_segmentation_3d_ignite.ipynb
+++ b/examples/notebooks/unet_segmentation_3d_ignite.ipynb
@@ -125,7 +125,7 @@
     "    num_res_units=2,\n",
     ")\n",
     "\n",
-    "loss = monai.losses.DiceLoss(do_sigmoid=True)\n",
+    "loss = monai.losses.DiceLoss(sigmoid=True)\n",
     "lr = 1e-3\n",
     "opt = torch.optim.Adam(net.parameters(), lr)"
    ]
@@ -197,7 +197,7 @@
     "# Set parameters for validation\n",
     "metric_name = 'Mean_Dice'\n",
     "# add evaluation metric to the evaluator engine\n",
-    "val_metrics = {metric_name: MeanDice(add_sigmoid=True, to_onehot_y=False)}\n",
+    "val_metrics = {metric_name: MeanDice(sigmoid=True, to_onehot_y=False)}\n",
     "\n",
     "# Ignite evaluator expects batch=(img, seg) and returns output=(y_pred, y) at every iteration,\n",
     "# user can add output_transform to return other values\n",

--- a/examples/segmentation_3d/unet_evaluation_array.py
+++ b/examples/segmentation_3d/unet_evaluation_array.py
@@ -76,7 +76,7 @@ def main():
             sw_batch_size = 4
             val_outputs = sliding_window_inference(val_images, roi_size, sw_batch_size, model)
             value = compute_meandice(
-                y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, add_sigmoid=True
+                y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, sigmoid=True
             )
             metric_count += len(value)
             metric_sum += value.sum().item()

--- a/examples/segmentation_3d/unet_evaluation_dict.py
+++ b/examples/segmentation_3d/unet_evaluation_dict.py
@@ -85,7 +85,7 @@ def main():
             sw_batch_size = 4
             val_outputs = sliding_window_inference(val_images, roi_size, sw_batch_size, model)
             value = compute_meandice(
-                y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, add_sigmoid=True
+                y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, sigmoid=True
             )
             metric_count += len(value)
             metric_sum += value.sum().item()

--- a/examples/segmentation_3d/unet_training_array.py
+++ b/examples/segmentation_3d/unet_training_array.py
@@ -92,7 +92,7 @@ def main():
         strides=(2, 2, 2, 2),
         num_res_units=2,
     ).to(device)
-    loss_function = monai.losses.DiceLoss(do_sigmoid=True)
+    loss_function = monai.losses.DiceLoss(sigmoid=True)
     optimizer = torch.optim.Adam(model.parameters(), 1e-3)
 
     # start a typical PyTorch training
@@ -138,7 +138,7 @@ def main():
                     sw_batch_size = 4
                     val_outputs = sliding_window_inference(val_images, roi_size, sw_batch_size, model)
                     value = compute_meandice(
-                        y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, add_sigmoid=True
+                        y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, sigmoid=True
                     )
                     metric_count += len(value)
                     metric_sum += value.sum().item()

--- a/examples/segmentation_3d/unet_training_dict.py
+++ b/examples/segmentation_3d/unet_training_dict.py
@@ -116,7 +116,7 @@ def main():
         strides=(2, 2, 2, 2),
         num_res_units=2,
     ).to(device)
-    loss_function = monai.losses.DiceLoss(do_sigmoid=True)
+    loss_function = monai.losses.DiceLoss(sigmoid=True)
     optimizer = torch.optim.Adam(model.parameters(), 1e-3)
 
     # start a typical PyTorch training
@@ -162,7 +162,7 @@ def main():
                     sw_batch_size = 4
                     val_outputs = sliding_window_inference(val_images, roi_size, sw_batch_size, model)
                     value = compute_meandice(
-                        y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, add_sigmoid=True
+                        y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, sigmoid=True
                     )
                     metric_count += len(value)
                     metric_sum += value.sum().item()

--- a/examples/segmentation_3d_ignite/unet_evaluation_array.py
+++ b/examples/segmentation_3d_ignite/unet_evaluation_array.py
@@ -78,7 +78,7 @@ def main():
     evaluator = Engine(_sliding_window_processor)
 
     # add evaluation metric to the evaluator engine
-    MeanDice(add_sigmoid=True, to_onehot_y=False).attach(evaluator, "Mean_Dice")
+    MeanDice(sigmoid=True, to_onehot_y=False).attach(evaluator, "Mean_Dice")
 
     # StatsHandler prints loss at every iteration and print metrics at every epoch,
     # we don't need to print loss for evaluator, so just print metrics, user can also customize print functions

--- a/examples/segmentation_3d_ignite/unet_evaluation_dict.py
+++ b/examples/segmentation_3d_ignite/unet_evaluation_dict.py
@@ -85,7 +85,7 @@ def main():
     evaluator = Engine(_sliding_window_processor)
 
     # add evaluation metric to the evaluator engine
-    MeanDice(add_sigmoid=True, to_onehot_y=False).attach(evaluator, "Mean_Dice")
+    MeanDice(sigmoid=True, to_onehot_y=False).attach(evaluator, "Mean_Dice")
 
     # StatsHandler prints loss at every iteration and print metrics at every epoch,
     # we don't need to print loss for evaluator, so just print metrics, user can also customize print functions

--- a/examples/segmentation_3d_ignite/unet_training_array.py
+++ b/examples/segmentation_3d_ignite/unet_training_array.py
@@ -84,7 +84,7 @@ def main():
         strides=(2, 2, 2, 2),
         num_res_units=2,
     )
-    loss = monai.losses.DiceLoss(do_sigmoid=True)
+    loss = monai.losses.DiceLoss(sigmoid=True)
     lr = 1e-3
     opt = torch.optim.Adam(net.parameters(), lr)
     device = torch.device("cuda:0")
@@ -113,7 +113,7 @@ def main():
     # Set parameters for validation
     metric_name = "Mean_Dice"
     # add evaluation metric to the evaluator engine
-    val_metrics = {metric_name: MeanDice(add_sigmoid=True, to_onehot_y=False)}
+    val_metrics = {metric_name: MeanDice(sigmoid=True, to_onehot_y=False)}
 
     # Ignite evaluator expects batch=(img, seg) and returns output=(y_pred, y) at every iteration,
     # user can add output_transform to return other values

--- a/examples/segmentation_3d_ignite/unet_training_dict.py
+++ b/examples/segmentation_3d_ignite/unet_training_dict.py
@@ -121,7 +121,7 @@ def main():
         strides=(2, 2, 2, 2),
         num_res_units=2,
     )
-    loss = monai.losses.DiceLoss(do_sigmoid=True)
+    loss = monai.losses.DiceLoss(sigmoid=True)
     lr = 1e-3
     opt = torch.optim.Adam(net.parameters(), lr)
     device = torch.device("cuda:0")
@@ -153,7 +153,7 @@ def main():
     # set parameters for validation
     metric_name = "Mean_Dice"
     # add evaluation metric to the evaluator engine
-    val_metrics = {metric_name: MeanDice(add_sigmoid=True, to_onehot_y=False)}
+    val_metrics = {metric_name: MeanDice(sigmoid=True, to_onehot_y=False)}
 
     # Ignite evaluator expects batch=(img, seg) and returns output=(y_pred, y) at every iteration,
     # user can add output_transform to return other values

--- a/examples/workflows/unet_training_dict.py
+++ b/examples/workflows/unet_training_dict.py
@@ -106,7 +106,7 @@ def main():
         strides=(2, 2, 2, 2),
         num_res_units=2,
     ).to(device)
-    loss = monai.losses.DiceLoss(do_sigmoid=True)
+    loss = monai.losses.DiceLoss(sigmoid=True)
     opt = torch.optim.Adam(net.parameters(), 1e-3)
     lr_scheduler = torch.optim.lr_scheduler.StepLR(opt, step_size=2, gamma=0.1)
 

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -28,7 +28,7 @@ class MeanDice(Metric):
         include_background: bool = True,
         to_onehot_y: bool = False,
         mutually_exclusive: bool = False,
-        add_sigmoid: bool = False,
+        sigmoid: bool = False,
         logit_thresh: float = 0.5,
         output_transform: Callable = lambda x: x,
         device: Optional[torch.device] = None,
@@ -41,7 +41,7 @@ class MeanDice(Metric):
             to_onehot_y (Bool): whether to convert the output prediction into the one-hot format. Defaults to False.
             mutually_exclusive (Bool): if True, the output prediction will be converted into a binary matrix using
                 a combination of argmax and to_onehot. Defaults to False.
-            add_sigmoid (Bool): whether to add sigmoid function to the output prediction before computing Dice.
+            sigmoid (Bool): whether to add sigmoid function to the output prediction before computing Dice.
                 Defaults to False.
             logit_thresh (Float): the threshold value to round value to 0.0 and 1.0. Defaults to None (no thresholding).
             output_transform (Callable): transform the ignite.engine.state.output into [y_pred, y] pair.
@@ -54,7 +54,7 @@ class MeanDice(Metric):
         self.include_background = include_background
         self.to_onehot_y = to_onehot_y
         self.mutually_exclusive = mutually_exclusive
-        self.add_sigmoid = add_sigmoid
+        self.sigmoid = sigmoid
         self.logit_thresh = logit_thresh
 
         self._sum = 0
@@ -76,7 +76,7 @@ class MeanDice(Metric):
             self.include_background,
             self.to_onehot_y,
             self.mutually_exclusive,
-            self.add_sigmoid,
+            self.sigmoid,
             self.logit_thresh,
         )
 

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -23,7 +23,7 @@ class ROCAUC(Metric):
 
     Args:
         to_onehot_y: whether to convert `y` into the one-hot format. Defaults to False.
-        add_softmax: whether to add softmax function to `y_pred` before computation. Defaults to False.
+        softmax: whether to add softmax function to `y_pred` before computation. Defaults to False.
         average (`macro|weighted|micro|None`): type of averaging performed if not binary classification.
             Default is 'macro'.
 
@@ -49,14 +49,14 @@ class ROCAUC(Metric):
     def __init__(
         self,
         to_onehot_y: bool = False,
-        add_softmax: bool = False,
+        softmax: bool = False,
         average: str = "macro",
         output_transform: Callable = lambda x: x,
         device: Optional[Union[str, torch.device]] = None,
     ):
         super().__init__(output_transform, device=device)
         self.to_onehot_y = to_onehot_y
-        self.add_softmax = add_softmax
+        self.softmax = softmax
         self.average = average
 
     def reset(self):
@@ -76,4 +76,4 @@ class ROCAUC(Metric):
     def compute(self):
         _prediction_tensor = torch.cat(self._predictions, dim=0)
         _target_tensor = torch.cat(self._targets, dim=0)
-        return compute_roc_auc(_prediction_tensor, _target_tensor, self.to_onehot_y, self.add_softmax, self.average)
+        return compute_roc_auc(_prediction_tensor, _target_tensor, self.to_onehot_y, self.softmax, self.average)

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -35,8 +35,8 @@ class DiceLoss(_Loss):
         self,
         include_background: bool = True,
         to_onehot_y: bool = False,
-        do_sigmoid: bool = False,
-        do_softmax: bool = False,
+        sigmoid: bool = False,
+        softmax: bool = False,
         squared_pred: bool = False,
         jaccard: bool = False,
         reduction: str = "mean",
@@ -45,8 +45,8 @@ class DiceLoss(_Loss):
         Args:
             include_background (bool): If False channel index 0 (background category) is excluded from the calculation.
             to_onehot_y (bool): whether to convert `y` into the one-hot format. Defaults to False.
-            do_sigmoid (bool): If True, apply a sigmoid function to the prediction.
-            do_softmax (bool): If True, apply a softmax function to the prediction.
+            sigmoid (bool): If True, apply a sigmoid function to the prediction.
+            softmax (bool): If True, apply a softmax function to the prediction.
             squared_pred (bool): use squared versions of targets and predictions in the denominator or not.
             jaccard (bool): compute Jaccard Index (soft IoU) instead of dice or not.
             reduction (`none|mean|sum`): Specifies the reduction to apply to the output:
@@ -58,10 +58,10 @@ class DiceLoss(_Loss):
         super().__init__(reduction=reduction)
         self.include_background = include_background
         self.to_onehot_y = to_onehot_y
-        if do_sigmoid and do_softmax:
-            raise ValueError("do_sigmoid=True and do_softmax=True are not compatible.")
-        self.do_sigmoid = do_sigmoid
-        self.do_softmax = do_softmax
+        if sigmoid and softmax:
+            raise ValueError("sigmoid=True and softmax=True are not compatible.")
+        self.sigmoid = sigmoid
+        self.softmax = softmax
         self.squared_pred = squared_pred
         self.jaccard = jaccard
 
@@ -72,18 +72,18 @@ class DiceLoss(_Loss):
             target (tensor): the shape should be BNH[WD].
             smooth (float): a small constant to avoid nan.
         """
-        if self.do_sigmoid:
+        if self.sigmoid:
             input = torch.sigmoid(input)
         n_pred_ch = input.shape[1]
         if n_pred_ch == 1:
-            if self.do_softmax:
-                warnings.warn("single channel prediction, `do_softmax=True` ignored.")
+            if self.softmax:
+                warnings.warn("single channel prediction, `softmax=True` ignored.")
             if self.to_onehot_y:
                 warnings.warn("single channel prediction, `to_onehot_y=True` ignored.")
             if not self.include_background:
                 warnings.warn("single channel prediction, `include_background=False` ignored.")
         else:
-            if self.do_softmax:
+            if self.softmax:
                 input = torch.softmax(input, 1)
             if self.to_onehot_y:
                 target = one_hot(target, n_pred_ch)
@@ -136,8 +136,8 @@ class GeneralizedDiceLoss(_Loss):
         self,
         include_background: bool = True,
         to_onehot_y: bool = False,
-        do_sigmoid: bool = False,
-        do_softmax: bool = False,
+        sigmoid: bool = False,
+        softmax: bool = False,
         w_type: str = "square",
         reduction: str = "mean",
     ):
@@ -145,8 +145,8 @@ class GeneralizedDiceLoss(_Loss):
         Args:
             include_background (bool): If False channel index 0 (background category) is excluded from the calculation.
             to_onehot_y (bool): whether to convert `y` into the one-hot format. Defaults to False.
-            do_sigmoid (bool): If True, apply a sigmoid function to the prediction.
-            do_softmax (bool): If True, apply a softmax function to the prediction.
+            sigmoid (bool): If True, apply a sigmoid function to the prediction.
+            softmax (bool): If True, apply a softmax function to the prediction.
             w_type ('square'|'simple'|'uniform'): type of function to transform ground truth volume to a weight factor.
                 Default: `'square'`
             reduction (`none|mean|sum`): Specifies the reduction to apply to the output:
@@ -158,10 +158,10 @@ class GeneralizedDiceLoss(_Loss):
         super().__init__(reduction=reduction)
         self.include_background = include_background
         self.to_onehot_y = to_onehot_y
-        if do_sigmoid and do_softmax:
-            raise ValueError("do_sigmoid=True and do_softmax=True are not compatible.")
-        self.do_sigmoid = do_sigmoid
-        self.do_softmax = do_softmax
+        if sigmoid and softmax:
+            raise ValueError("sigmoid=True and softmax=True are not compatible.")
+        self.sigmoid = sigmoid
+        self.softmax = softmax
         self.w_func: Callable = torch.ones_like
         if w_type == "simple":
             self.w_func = torch.reciprocal
@@ -175,18 +175,18 @@ class GeneralizedDiceLoss(_Loss):
             target (tensor): the shape should be BNH[WD].
             smooth (float): a small constant to avoid nan.
         """
-        if self.do_sigmoid:
+        if self.sigmoid:
             input = torch.sigmoid(input)
         n_pred_ch = input.shape[1]
         if n_pred_ch == 1:
-            if self.do_softmax:
-                warnings.warn("single channel prediction, `do_softmax=True` ignored.")
+            if self.softmax:
+                warnings.warn("single channel prediction, `softmax=True` ignored.")
             if self.to_onehot_y:
                 warnings.warn("single channel prediction, `to_onehot_y=True` ignored.")
             if not self.include_background:
                 warnings.warn("single channel prediction, `include_background=False` ignored.")
         else:
-            if self.do_softmax:
+            if self.softmax:
                 input = torch.softmax(input, 1)
             if self.to_onehot_y:
                 target = one_hot(target, n_pred_ch)

--- a/monai/losses/tversky.py
+++ b/monai/losses/tversky.py
@@ -34,8 +34,8 @@ class TverskyLoss(_Loss):
         self,
         include_background: bool = True,
         to_onehot_y: bool = False,
-        do_sigmoid: bool = False,
-        do_softmax: bool = False,
+        sigmoid: bool = False,
+        softmax: bool = False,
         alpha: float = 0.5,
         beta: float = 0.5,
         reduction: str = "mean",
@@ -45,8 +45,8 @@ class TverskyLoss(_Loss):
         Args:
             include_background (bool): If False channel index 0 (background category) is excluded from the calculation.
             to_onehot_y (bool): whether to convert `y` into the one-hot format. Defaults to False.
-            do_sigmoid (bool): If True, apply a sigmoid function to the prediction.
-            do_softmax (bool): If True, apply a softmax function to the prediction.
+            sigmoid (bool): If True, apply a sigmoid function to the prediction.
+            softmax (bool): If True, apply a softmax function to the prediction.
             alpha (float): weight of false positives
             beta  (float): weight of false negatives
             reduction (`none|mean|sum`): Specifies the reduction to apply to the output:
@@ -61,10 +61,10 @@ class TverskyLoss(_Loss):
         self.include_background = include_background
         self.to_onehot_y = to_onehot_y
 
-        if do_sigmoid and do_softmax:
-            raise ValueError("do_sigmoid=True and do_softmax=True are not compatible.")
-        self.do_sigmoid = do_sigmoid
-        self.do_softmax = do_softmax
+        if sigmoid and softmax:
+            raise ValueError("sigmoid=True and softmax=True are not compatible.")
+        self.sigmoid = sigmoid
+        self.softmax = softmax
         self.alpha = alpha
         self.beta = beta
 
@@ -75,18 +75,18 @@ class TverskyLoss(_Loss):
             target (tensor): the shape should be BNH[WD].
             smooth (float): a small constant to avoid nan.
         """
-        if self.do_sigmoid:
+        if self.sigmoid:
             input = torch.sigmoid(input)
         n_pred_ch = input.shape[1]
         if n_pred_ch == 1:
-            if self.do_softmax:
-                warnings.warn("single channel prediction, `do_softmax=True` ignored.")
+            if self.softmax:
+                warnings.warn("single channel prediction, `softmax=True` ignored.")
             if self.to_onehot_y:
                 warnings.warn("single channel prediction, `to_onehot_y=True` ignored.")
             if not self.include_background:
                 warnings.warn("single channel prediction, `include_background=False` ignored.")
         else:
-            if self.do_softmax:
+            if self.softmax:
                 input = torch.softmax(input, 1)
             if self.to_onehot_y:
                 target = one_hot(target, n_pred_ch)

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -22,7 +22,7 @@ def compute_meandice(
     include_background: bool = True,
     to_onehot_y: bool = False,
     mutually_exclusive: bool = False,
-    add_sigmoid: bool = False,
+    sigmoid: bool = False,
     logit_thresh: float = 0.5,
 ):
     """Computes Dice score metric from full size Tensor and collects average.
@@ -33,13 +33,13 @@ def compute_meandice(
         y (torch.Tensor): ground truth to compute mean dice metric, the first dim is batch.
             example shape: [16, 1, 32, 32] will be converted into [16, 3, 32, 32].
             alternative shape: [16, 3, 32, 32] and set `to_onehot_y=False` to use 3-class labels directly.
-        include_background (Bool): whether to skip Dice computation on the first channel of
+        include_background (bool): whether to skip Dice computation on the first channel of
             the predicted output. Defaults to True.
-        to_onehot_y (Bool): whether to convert `y` into the one-hot format. Defaults to False.
-        mutually_exclusive (Bool): if True, `y_pred` will be converted into a binary matrix using
+        to_onehot_y (bool): whether to convert `y` into the one-hot format. Defaults to False.
+        mutually_exclusive (bool): if True, `y_pred` will be converted into a binary matrix using
             a combination of argmax and to_onehot.  Defaults to False.
-        add_sigmoid (Bool): whether to add sigmoid function to y_pred before computation. Defaults to False.
-        logit_thresh (Float): the threshold value used to convert (after sigmoid if `add_sigmoid=True`)
+        sigmoid (bool): whether to add sigmoid function to y_pred before computation. Defaults to False.
+        logit_thresh (Float): the threshold value used to convert (after sigmoid if `sigmoid=True`)
             `y_pred` into a binary matrix. Defaults to 0.5.
 
     Returns:
@@ -55,7 +55,7 @@ def compute_meandice(
     n_classes = y_pred.shape[1]
     n_len = len(y_pred.shape)
 
-    if add_sigmoid:
+    if sigmoid:
         y_pred = y_pred.float().sigmoid()
 
     if n_classes == 1:
@@ -71,8 +71,8 @@ def compute_meandice(
     else:  # multi-channel y_pred
         # make both y and y_pred binary
         if mutually_exclusive:
-            if add_sigmoid:
-                raise ValueError("add_sigmoid=True is incompatible with mutually_exclusive=True.")
+            if sigmoid:
+                raise ValueError("sigmoid=True is incompatible with mutually_exclusive=True.")
             y_pred = torch.argmax(y_pred, dim=1, keepdim=True)
             y_pred = one_hot(y_pred, n_classes)
         else:

--- a/monai/metrics/rocauc.py
+++ b/monai/metrics/rocauc.py
@@ -54,7 +54,7 @@ def compute_roc_auc(
     y_pred: torch.Tensor,
     y: torch.Tensor,
     to_onehot_y: bool = False,
-    add_softmax: bool = False,
+    softmax: bool = False,
     average: Optional[str] = "macro",
 ):
     """Computes Area Under the Receiver Operating Characteristic Curve (ROC AUC). Referring to:
@@ -67,7 +67,7 @@ def compute_roc_auc(
         y (torch.Tensor): ground truth to compute ROC AUC metric, the first dim is batch.
             example shape: [16, 1] will be converted into [16, 2] (where `2` is inferred from `y_pred`).
         to_onehot_y (bool): whether to convert `y` into the one-hot format. Defaults to False.
-        add_softmax (bool): whether to add softmax function to `y_pred` before computation. Defaults to False.
+        softmax (bool): whether to add softmax function to `y_pred` before computation. Defaults to False.
         average (`macro|weighted|micro|None`): type of averaging performed if not binary
             classification. Default is 'macro'.
 
@@ -98,14 +98,14 @@ def compute_roc_auc(
     if y_pred_ndim == 1:
         if to_onehot_y:
             warnings.warn("y_pred has only one channel, to_onehot_y=True ignored.")
-        if add_softmax:
-            warnings.warn("y_pred has only one channel, add_softmax=True ignored.")
+        if softmax:
+            warnings.warn("y_pred has only one channel, softmax=True ignored.")
         return _calculate(y, y_pred)
     else:
         n_classes = y_pred.shape[1]
         if to_onehot_y:
             y = one_hot(y, n_classes)
-        if add_softmax:
+        if softmax:
             y_pred = y_pred.float().softmax(dim=1)
 
         assert y.shape == y_pred.shape, "data shapes of y_pred and y do not match."

--- a/tests/test_compute_meandice.py
+++ b/tests/test_compute_meandice.py
@@ -26,7 +26,7 @@ TEST_CASE_1 = [  # y (1, 1, 2, 2), y_pred (1, 1, 2, 2), expected out (1, 1)
         "to_onehot_y": False,
         "mutually_exclusive": False,
         "logit_thresh": 0.5,
-        "add_sigmoid": True,
+        "sigmoid": True,
     },
     [[0.8]],
 ]

--- a/tests/test_compute_roc_auc.py
+++ b/tests/test_compute_roc_auc.py
@@ -22,7 +22,7 @@ TEST_CASE_1 = [
         "y_pred": torch.tensor([[0.1, 0.9], [0.3, 1.4], [0.2, 0.1], [0.1, 0.5]]),
         "y": torch.tensor([[0], [1], [0], [1]]),
         "to_onehot_y": True,
-        "add_softmax": True,
+        "softmax": True,
     },
     0.75,
 ]
@@ -38,7 +38,7 @@ TEST_CASE_5 = [
         "y_pred": torch.tensor([[0.1, 0.9], [0.3, 1.4], [0.2, 0.1], [0.1, 0.5]]),
         "y": torch.tensor([[0], [1], [0], [1]]),
         "to_onehot_y": True,
-        "add_softmax": True,
+        "softmax": True,
         "average": None,
     },
     [0.75, 0.75],
@@ -48,7 +48,7 @@ TEST_CASE_6 = [
     {
         "y_pred": torch.tensor([[0.1, 0.9], [0.3, 1.4], [0.2, 0.1], [0.1, 0.5], [0.1, 0.5]]),
         "y": torch.tensor([[1, 0], [0, 1], [0, 0], [1, 1], [0, 1]]),
-        "add_softmax": True,
+        "softmax": True,
         "average": "weighted",
     },
     0.56667,
@@ -58,7 +58,7 @@ TEST_CASE_7 = [
     {
         "y_pred": torch.tensor([[0.1, 0.9], [0.3, 1.4], [0.2, 0.1], [0.1, 0.5], [0.1, 0.5]]),
         "y": torch.tensor([[1, 0], [0, 1], [0, 0], [1, 1], [0, 1]]),
-        "add_softmax": True,
+        "softmax": True,
         "average": "micro",
     },
     0.62,

--- a/tests/test_dice_loss.py
+++ b/tests/test_dice_loss.py
@@ -19,7 +19,7 @@ from monai.losses import DiceLoss
 
 TEST_CASES = [
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True},
+        {"include_background": True, "sigmoid": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 0.0], [1.0, 1.0]]]]),
@@ -28,7 +28,7 @@ TEST_CASES = [
         0.307576,
     ],
     [  # shape: (2, 1, 2, 2), (2, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True},
+        {"include_background": True, "sigmoid": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]], [[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 1.0], [1.0, 1.0]]], [[[1.0, 0.0], [1.0, 0.0]]]]),
@@ -46,7 +46,7 @@ TEST_CASES = [
         0.0,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_sigmoid": True},
+        {"include_background": True, "to_onehot_y": True, "sigmoid": True},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -55,7 +55,7 @@ TEST_CASES = [
         0.435050,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_sigmoid": True, "reduction": "none"},
+        {"include_background": True, "to_onehot_y": True, "sigmoid": True, "reduction": "none"},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -64,7 +64,7 @@ TEST_CASES = [
         [[0.296529, 0.415136], [0.599976, 0.428559]],
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_softmax": True},
+        {"include_background": True, "to_onehot_y": True, "softmax": True},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -73,7 +73,7 @@ TEST_CASES = [
         0.383713,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_softmax": True, "reduction": "sum"},
+        {"include_background": True, "to_onehot_y": True, "softmax": True, "reduction": "sum"},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -82,7 +82,7 @@ TEST_CASES = [
         1.534853,
     ],
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True},
+        {"include_background": True, "sigmoid": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 0.0], [1.0, 1.0]]]]),
@@ -91,7 +91,7 @@ TEST_CASES = [
         0.307576,
     ],
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True, "squared_pred": True},
+        {"include_background": True, "sigmoid": True, "squared_pred": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 0.0], [1.0, 1.0]]]]),
@@ -100,7 +100,7 @@ TEST_CASES = [
         0.178337,
     ],
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True, "jaccard": True},
+        {"include_background": True, "sigmoid": True, "jaccard": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 0.0], [1.0, 1.0]]]]),
@@ -124,7 +124,7 @@ class TestDiceLoss(unittest.TestCase):
 
     def test_ill_opts(self):
         with self.assertRaisesRegex(ValueError, ""):
-            DiceLoss(do_sigmoid=True, do_softmax=True)
+            DiceLoss(sigmoid=True, softmax=True)
         chn_input = torch.ones((1, 1, 3))
         chn_target = torch.ones((1, 1, 3))
         with self.assertRaisesRegex(ValueError, ""):
@@ -139,7 +139,7 @@ class TestDiceLoss(unittest.TestCase):
             loss = DiceLoss(include_background=False)
             loss.forward(chn_input, chn_target)
         with self.assertWarns(Warning):
-            loss = DiceLoss(do_softmax=True)
+            loss = DiceLoss(softmax=True)
             loss.forward(chn_input, chn_target)
         with self.assertWarns(Warning):
             loss = DiceLoss(to_onehot_y=True)

--- a/tests/test_generalized_dice_loss.py
+++ b/tests/test_generalized_dice_loss.py
@@ -19,7 +19,7 @@ from monai.losses import GeneralizedDiceLoss
 
 TEST_CASES = [
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True},
+        {"include_background": True, "sigmoid": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 0.0], [1.0, 1.0]]]]),
@@ -28,7 +28,7 @@ TEST_CASES = [
         0.307576,
     ],
     [  # shape: (2, 1, 2, 2), (2, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True},
+        {"include_background": True, "sigmoid": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]], [[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 1.0], [1.0, 1.0]]], [[[1.0, 0.0], [1.0, 0.0]]]]),
@@ -46,7 +46,7 @@ TEST_CASES = [
         0.0,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_sigmoid": True},
+        {"include_background": True, "to_onehot_y": True, "sigmoid": True},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -55,7 +55,7 @@ TEST_CASES = [
         0.469964,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_softmax": True},
+        {"include_background": True, "to_onehot_y": True, "softmax": True},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -64,7 +64,7 @@ TEST_CASES = [
         0.414507,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_softmax": True, "reduction": "sum"},
+        {"include_background": True, "to_onehot_y": True, "softmax": True, "reduction": "sum"},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -73,7 +73,7 @@ TEST_CASES = [
         0.829015,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_softmax": True, "reduction": "none"},
+        {"include_background": True, "to_onehot_y": True, "softmax": True, "reduction": "none"},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -91,7 +91,7 @@ TEST_CASES = [
         0.0,
     ],
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True},
+        {"include_background": True, "sigmoid": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 0.0], [1.0, 1.0]]]]),
@@ -100,7 +100,7 @@ TEST_CASES = [
         0.307576,
     ],
     [  # shape: (1, 2, 4), (1, 1, 4)
-        {"include_background": True, "to_onehot_y": True, "do_softmax": True, "w_type": "simple"},
+        {"include_background": True, "to_onehot_y": True, "softmax": True, "w_type": "simple"},
         {
             "input": torch.tensor([[[0.0, 10.0, 10.0, 10.0], [10.0, 0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1, 1, 0, 0]]]),
@@ -124,7 +124,7 @@ class TestGeneralizedDiceLoss(unittest.TestCase):
 
     def test_ill_opts(self):
         with self.assertRaisesRegex(ValueError, ""):
-            GeneralizedDiceLoss(do_sigmoid=True, do_softmax=True)
+            GeneralizedDiceLoss(sigmoid=True, softmax=True)
         chn_input = torch.ones((1, 1, 3))
         chn_target = torch.ones((1, 1, 3))
         with self.assertRaisesRegex(ValueError, ""):
@@ -139,7 +139,7 @@ class TestGeneralizedDiceLoss(unittest.TestCase):
             loss = GeneralizedDiceLoss(include_background=False)
             loss.forward(chn_input, chn_target)
         with self.assertWarns(Warning):
-            loss = GeneralizedDiceLoss(do_softmax=True)
+            loss = GeneralizedDiceLoss(softmax=True)
             loss.forward(chn_input, chn_target)
         with self.assertWarns(Warning):
             loss = GeneralizedDiceLoss(to_onehot_y=True)

--- a/tests/test_handler_mean_dice.py
+++ b/tests/test_handler_mean_dice.py
@@ -18,7 +18,7 @@ from monai.handlers import MeanDice
 
 TEST_CASE_1 = [{"to_onehot_y": True, "mutually_exclusive": True}, 0.75]
 TEST_CASE_2 = [{"include_background": False, "to_onehot_y": True, "mutually_exclusive": False}, 0.66666]
-TEST_CASE_3 = [{"mutually_exclusive": True, "add_sigmoid": True}]
+TEST_CASE_3 = [{"mutually_exclusive": True, "sigmoid": True}]
 
 
 class TestHandlerMeanDice(unittest.TestCase):

--- a/tests/test_handler_rocauc.py
+++ b/tests/test_handler_rocauc.py
@@ -18,7 +18,7 @@ from monai.handlers import ROCAUC
 
 class TestHandlerROCAUC(unittest.TestCase):
     def test_compute(self):
-        auc_metric = ROCAUC(to_onehot_y=True, add_softmax=True)
+        auc_metric = ROCAUC(to_onehot_y=True, softmax=True)
 
         y_pred = torch.Tensor([[0.1, 0.9], [0.3, 1.4]])
         y = torch.Tensor([[0], [1]])

--- a/tests/test_integration_classification_2d.py
+++ b/tests/test_integration_classification_2d.py
@@ -117,7 +117,7 @@ def run_training_test(root_dir, train_x, train_y, val_x, val_y, device=torch.dev
                     val_images, val_labels = val_data[0].to(device), val_data[1].to(device)
                     y_pred = torch.cat([y_pred, model(val_images)], dim=0)
                     y = torch.cat([y, val_labels], dim=0)
-                auc_metric = compute_roc_auc(y_pred, y, to_onehot_y=True, add_softmax=True)
+                auc_metric = compute_roc_auc(y_pred, y, to_onehot_y=True, softmax=True)
                 metric_values.append(auc_metric)
                 acc_value = torch.eq(y_pred.argmax(dim=1), y)
                 acc_metric = acc_value.sum().item() / len(acc_value)

--- a/tests/test_integration_determinism.py
+++ b/tests/test_integration_determinism.py
@@ -43,7 +43,7 @@ def run_test(batch_size=64, train_steps=200, device=torch.device("cuda:0")):
         dimensions=2, in_channels=1, out_channels=1, channels=(4, 8, 16, 32), strides=(2, 2, 2), num_res_units=2,
     ).to(device)
 
-    loss = DiceLoss(do_sigmoid=True)
+    loss = DiceLoss(sigmoid=True)
     opt = torch.optim.Adam(net.parameters(), 1e-2)
     train_transforms = Compose(
         [AddChannel(), ScaleIntensity(), RandSpatialCrop((96, 96), random_size=False), RandRotate90(), ToTensor()]

--- a/tests/test_integration_segmentation_3d.py
+++ b/tests/test_integration_segmentation_3d.py
@@ -99,7 +99,7 @@ def run_training_test(root_dir, device=torch.device("cuda:0"), cachedataset=Fals
         strides=(2, 2, 2, 2),
         num_res_units=2,
     ).to(device)
-    loss_function = monai.losses.DiceLoss(do_sigmoid=True)
+    loss_function = monai.losses.DiceLoss(sigmoid=True)
     optimizer = torch.optim.Adam(model.parameters(), 5e-4)
 
     # start a typical PyTorch training
@@ -144,7 +144,7 @@ def run_training_test(root_dir, device=torch.device("cuda:0"), cachedataset=Fals
                     sw_batch_size, roi_size = 4, (96, 96, 96)
                     val_outputs = sliding_window_inference(val_images, roi_size, sw_batch_size, model)
                     value = compute_meandice(
-                        y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, add_sigmoid=True
+                        y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, sigmoid=True
                     )
                     metric_count += len(value)
                     metric_sum += value.sum().item()
@@ -211,7 +211,7 @@ def run_inference_test(root_dir, device=torch.device("cuda:0")):
             sw_batch_size, roi_size = 4, (96, 96, 96)
             val_outputs = sliding_window_inference(val_images, roi_size, sw_batch_size, model)
             value = compute_meandice(
-                y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, add_sigmoid=True
+                y_pred=val_outputs, y=val_labels, include_background=True, to_onehot_y=False, sigmoid=True
             )
             metric_count += len(value)
             metric_sum += value.sum().item()

--- a/tests/test_integration_unet_2d.py
+++ b/tests/test_integration_unet_2d.py
@@ -34,7 +34,7 @@ def run_test(batch_size=64, train_steps=100, device=torch.device("cuda:0")):
         dimensions=2, in_channels=1, out_channels=1, channels=(4, 8, 16, 32), strides=(2, 2, 2), num_res_units=2,
     ).to(device)
 
-    loss = DiceLoss(do_sigmoid=True)
+    loss = DiceLoss(sigmoid=True)
     opt = torch.optim.Adam(net.parameters(), 1e-4)
     src = DataLoader(_TestBatch(), batch_size=batch_size)
 

--- a/tests/test_integration_workflows.py
+++ b/tests/test_integration_workflows.py
@@ -97,7 +97,7 @@ def run_training_test(root_dir, device=torch.device("cuda:0")):
         strides=(2, 2, 2, 2),
         num_res_units=2,
     ).to(device)
-    loss = monai.losses.DiceLoss(do_sigmoid=True)
+    loss = monai.losses.DiceLoss(sigmoid=True)
     opt = torch.optim.Adam(net.parameters(), 1e-3)
     lr_scheduler = torch.optim.lr_scheduler.StepLR(opt, step_size=2, gamma=0.1)
 

--- a/tests/test_seg_loss_integration.py
+++ b/tests/test_seg_loss_integration.py
@@ -21,16 +21,16 @@ from monai.losses import DiceLoss, FocalLoss, GeneralizedDiceLoss, TverskyLoss
 
 TEST_CASES = [
     [DiceLoss, {"to_onehot_y": True, "squared_pred": True}, {"smooth": 1e-4}],
-    [DiceLoss, {"to_onehot_y": True, "do_sigmoid": True}, {}],
-    [DiceLoss, {"to_onehot_y": True, "do_softmax": True}, {}],
+    [DiceLoss, {"to_onehot_y": True, "sigmoid": True}, {}],
+    [DiceLoss, {"to_onehot_y": True, "softmax": True}, {}],
     [FocalLoss, {"gamma": 1.5, "weight": torch.tensor([1, 2])}, {}],
     [FocalLoss, {"gamma": 1.5}, {}],
-    [GeneralizedDiceLoss, {"to_onehot_y": True, "do_softmax": True}, {}],
-    [GeneralizedDiceLoss, {"to_onehot_y": True, "do_sigmoid": True}, {}],
-    [GeneralizedDiceLoss, {"to_onehot_y": True, "do_sigmoid": True, "w_type": "simple"}, {}],
-    [GeneralizedDiceLoss, {"to_onehot_y": True, "do_sigmoid": True, "w_type": "uniform"}, {}],
-    [TverskyLoss, {"to_onehot_y": True, "do_softmax": True, "alpha": 0.8, "beta": 0.2}, {}],
-    [TverskyLoss, {"to_onehot_y": True, "do_softmax": True, "alpha": 1.0, "beta": 0.0}, {}],
+    [GeneralizedDiceLoss, {"to_onehot_y": True, "softmax": True}, {}],
+    [GeneralizedDiceLoss, {"to_onehot_y": True, "sigmoid": True}, {}],
+    [GeneralizedDiceLoss, {"to_onehot_y": True, "sigmoid": True, "w_type": "simple"}, {}],
+    [GeneralizedDiceLoss, {"to_onehot_y": True, "sigmoid": True, "w_type": "uniform"}, {}],
+    [TverskyLoss, {"to_onehot_y": True, "softmax": True, "alpha": 0.8, "beta": 0.2}, {}],
+    [TverskyLoss, {"to_onehot_y": True, "softmax": True, "alpha": 1.0, "beta": 0.0}, {}],
 ]
 
 

--- a/tests/test_tversky_loss.py
+++ b/tests/test_tversky_loss.py
@@ -19,7 +19,7 @@ from monai.losses import TverskyLoss
 
 TEST_CASES = [
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True},
+        {"include_background": True, "sigmoid": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 0.0], [1.0, 1.0]]]]),
@@ -28,7 +28,7 @@ TEST_CASES = [
         0.307576,
     ],
     [  # shape: (2, 1, 2, 2), (2, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True},
+        {"include_background": True, "sigmoid": True},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]], [[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 1.0], [1.0, 1.0]]], [[[1.0, 0.0], [1.0, 0.0]]]]),
@@ -46,7 +46,7 @@ TEST_CASES = [
         0.0,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_sigmoid": True},
+        {"include_background": True, "to_onehot_y": True, "sigmoid": True},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -55,7 +55,7 @@ TEST_CASES = [
         0.435050,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_sigmoid": True, "reduction": "sum"},
+        {"include_background": True, "to_onehot_y": True, "sigmoid": True, "reduction": "sum"},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -64,7 +64,7 @@ TEST_CASES = [
         1.74013,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_softmax": True},
+        {"include_background": True, "to_onehot_y": True, "softmax": True},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -73,7 +73,7 @@ TEST_CASES = [
         0.383713,
     ],
     [  # shape: (2, 2, 3), (2, 1, 3)
-        {"include_background": True, "to_onehot_y": True, "do_softmax": True, "reduction": "none"},
+        {"include_background": True, "to_onehot_y": True, "softmax": True, "reduction": "none"},
         {
             "input": torch.tensor([[[-1.0, 0.0, 1.0], [1.0, 0.0, -1.0]], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]),
             "target": torch.tensor([[[1.0, 0.0, 0.0]], [[1.0, 1.0, 0.0]]]),
@@ -82,7 +82,7 @@ TEST_CASES = [
         [[0.210961, 0.295339], [0.599952, 0.428547]],
     ],
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True, "alpha": 0.3, "beta": 0.7},
+        {"include_background": True, "sigmoid": True, "alpha": 0.3, "beta": 0.7},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 0.0], [1.0, 1.0]]]]),
@@ -91,7 +91,7 @@ TEST_CASES = [
         0.3589,
     ],
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
-        {"include_background": True, "do_sigmoid": True, "alpha": 0.7, "beta": 0.3},
+        {"include_background": True, "sigmoid": True, "alpha": 0.7, "beta": 0.3},
         {
             "input": torch.tensor([[[[1.0, -1.0], [-1.0, 1.0]]]]),
             "target": torch.tensor([[[[1.0, 0.0], [1.0, 1.0]]]]),
@@ -126,7 +126,7 @@ class TestTverskyLoss(unittest.TestCase):
             loss = TverskyLoss(include_background=False)
             loss.forward(chn_input, chn_target)
         with self.assertWarns(Warning):
-            loss = TverskyLoss(do_softmax=True)
+            loss = TverskyLoss(softmax=True)
             loss.forward(chn_input, chn_target)
         with self.assertWarns(Warning):
             loss = TverskyLoss(to_onehot_y=True)


### PR DESCRIPTION
Fixes #488 .

### Description
This PR changed sigmoid and softmax related args in `loss` and `metrics` and `post_transforms`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [x] Docstrings/Documentation updated
