### PR TITLE
505 squeezedim for torch

### DIFF
--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -148,25 +148,25 @@ class Transpose(Transform):
 
 class SqueezeDim(Transform):
     """
-    Squeeze undesired unitary dimensions
+    Squeeze a unitary dimension.
     """
 
-    def __init__(self, dim: Optional[int] = None):
+    def __init__(self, dim: Optional[int] = 0):
         """
         Args:
-            dim (int): dimension to be squeezed.
-                Default: None (all dimensions of size 1 will be removed)
+            dim (int or None): dimension to be squeezed. Default = 0
+                "None" works when the input is numpy array.
         """
-        if dim is not None:
-            assert isinstance(dim, int) and dim >= -1, "invalid channel dimension."
+        if dim is not None and not isinstance(dim, int):
+            raise ValueError(f"Invalid channel dimension {dim}")
         self.dim = dim
 
-    def __call__(self, img: np.ndarray):  # type: ignore # see issue #495
+    def __call__(self, img):  # type: ignore # see issue #495
         """
         Args:
             img (ndarray): numpy arrays with required dimension `dim` removed
         """
-        return np.squeeze(img, self.dim)
+        return img.squeeze(self.dim)
 
 
 class DataStats(Transform):

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -193,8 +193,7 @@ class SqueezeDimd(MapTransform):
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.
                 See also: :py:class:`monai.transforms.compose.MapTransform`
-            dim (int): dimension to be squeezed.
-                Default: None (all dimensions of size 1 will be removed)
+            dim (int): dimension to be squeezed. Default: 0 (the first dimension)
         """
         super().__init__(keys)
         self.converter = SqueezeDim(dim=dim)

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -188,7 +188,7 @@ class SqueezeDimd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.SqueezeDim`.
     """
 
-    def __init__(self, keys: Hashable, dim: Optional[int] = None):
+    def __init__(self, keys: Hashable, dim: Optional[int] = 0):
         """
         Args:
             keys (hashable items): keys of the corresponding items to be transformed.

--- a/tests/test_squeezedim.py
+++ b/tests/test_squeezedim.py
@@ -10,8 +10,11 @@
 # limitations under the License.
 
 import unittest
+
 import numpy as np
+import torch
 from parameterized import parameterized
+
 from monai.transforms import SqueezeDim
 
 TEST_CASE_1 = [{"dim": None}, np.random.rand(1, 2, 1, 3), (2, 3)]
@@ -20,7 +23,9 @@ TEST_CASE_2 = [{"dim": 2}, np.random.rand(1, 2, 1, 8, 16), (1, 2, 8, 16)]
 
 TEST_CASE_3 = [{"dim": -1}, np.random.rand(1, 1, 16, 8, 1), (1, 1, 16, 8)]
 
-TEST_CASE_4 = [{}, np.random.rand(1, 2, 1, 3), (2, 3)]
+TEST_CASE_4 = [{}, np.random.rand(1, 2, 1, 3), (2, 1, 3)]
+
+TEST_CASE_4_PT = [{}, torch.rand(1, 2, 1, 3), (2, 1, 3)]
 
 TEST_CASE_5 = [
     {"dim": -2},
@@ -34,15 +39,15 @@ TEST_CASE_6 = [
 
 
 class TestSqueezeDim(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_4_PT])
     def test_shape(self, input_param, test_data, expected_shape):
         result = SqueezeDim(**input_param)(test_data)
         self.assertTupleEqual(result.shape, expected_shape)
 
     @parameterized.expand([TEST_CASE_5, TEST_CASE_6])
     def test_invalid_inputs(self, input_param, test_data):
-        with self.assertRaises(AssertionError):
-            result = SqueezeDim(**input_param)(test_data)
+        with self.assertRaises(ValueError):
+            SqueezeDim(**input_param)(test_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_squeezedimd.py
+++ b/tests/test_squeezedimd.py
@@ -38,7 +38,7 @@ TEST_CASE_3 = [
 TEST_CASE_4 = [
     {"keys": ["img", "seg"]},
     {"img": np.random.rand(1, 2, 1, 3), "seg": np.random.randint(0, 2, size=[1, 2, 1, 3])},
-    (2, 3),
+    (2, 1, 3),
 ]
 
 TEST_CASE_4_PT = [

--- a/tests/test_squeezedimd.py
+++ b/tests/test_squeezedimd.py
@@ -10,10 +10,12 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
-from parameterized import parameterized
-from monai.transforms import SqueezeDimd
 
+import numpy as np
+import torch
+from parameterized import parameterized
+
+from monai.transforms import SqueezeDimd
 
 TEST_CASE_1 = [
     {"keys": ["img", "seg"], "dim": None},
@@ -39,6 +41,12 @@ TEST_CASE_4 = [
     (2, 3),
 ]
 
+TEST_CASE_4_PT = [
+    {"keys": ["img", "seg"], "dim": 0},
+    {"img": torch.rand(1, 2, 1, 3), "seg": torch.randint(0, 2, size=[1, 2, 1, 3])},
+    (2, 1, 3),
+]
+
 TEST_CASE_5 = [
     {"keys": ["img", "seg"], "dim": -2},
     {"img": np.random.rand(1, 1, 16, 8, 1), "seg": np.random.randint(0, 2, size=[1, 1, 16, 8, 1])},
@@ -51,7 +59,7 @@ TEST_CASE_6 = [
 
 
 class TestSqueezeDim(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_4_PT])
     def test_shape(self, input_param, test_data, expected_shape):
         result = SqueezeDimd(**input_param)(test_data)
         self.assertTupleEqual(result["img"].shape, expected_shape)
@@ -59,8 +67,8 @@ class TestSqueezeDim(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_5, TEST_CASE_6])
     def test_invalid_inputs(self, input_param, test_data):
-        with self.assertRaises(AssertionError):
-            result = SqueezeDimd(**input_param)(test_data)
+        with self.assertRaises(ValueError):
+            SqueezeDimd(**input_param)(test_data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #505 

### Description
- updates SqueezeDim to support tensor
- changes the default to squeeze dim 0 for compatibility

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
