### PR TITLE
Enhance docstring with code examples

### DIFF
--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -62,6 +62,18 @@ class Activations(Transform):
         other (Callable): callable function to execute other activation layers, for example:
             `other = lambda x: torch.tanh(x)`
 
+    For example:
+
+    .. code-block:: python
+
+        image = torch.tensor(
+            [[[[0.0, 1.0],
+               [2.0, 3.0]]]])  # 1x2x2, single channel 2x2 image
+        activator = Activations(sigmoid=True, softmax=False, other=None)
+        print(activator(image))
+        tensor([[[[0.5000, 0.7311],
+                  [0.8808, 0.9526]]]])
+
     """
 
     def __init__(self, sigmoid: bool = False, softmax: bool = False, other: Optional[Callable] = None):

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -63,6 +63,28 @@ class Activationsd(MapTransform):
     """
     Dictionary-based wrapper of :py:class:`monai.transforms.AddActivations`.
     Add activation layers to the input data specified by `keys`.
+
+    For example:
+
+    .. code-block:: python
+
+        input = {"pred": torch.tensor([[[[0.0, 1.0]], [[2.0, 3.0]]]]),
+                 "label": torch.tensor([[[[0.0, 1.0]], [[2.0, 3.0]]]])}
+        activator = Activationsd(keys=["pred", "label"],
+                                 output_postfix="act",
+                                 sigmoid=False,
+                                 softmax=[True, False],
+                                 other=None)
+        print(activator(input))
+        {'pred': tensor([[[[0., 1.]],
+                          [[2., 3.]]]]),
+         'label': tensor([[[[0., 1.]],
+                           [[2., 3.]]]]),
+         'pred_act': tensor([[[[0.1192, 0.1192]],
+                              [[0.8808, 0.8808]]]]),
+         'label_act': tensor([[[[0., 1.]],
+                               [[2., 3.]]]])}
+
     """
 
     def __init__(self, keys: Hashable, output_postfix: str = "act", sigmoid=False, softmax=False, other=None):

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -82,6 +82,18 @@ class AsChannelLastd(MapTransform):
 class AddChanneld(MapTransform):
     """
     Dictionary-based wrapper of :py:class:`monai.transforms.AddChannel`.
+
+    For example:
+
+    .. code-block:: python
+
+        image = {"img": np.array([[0, 1], [1, 2]]),
+                 "seg": np.array([[0, 1], [1, 2]])}
+        adder = AddChanneld(keys=["img", "seg"])
+        print(adder(image))
+        {'img': array([[[0, 1], [1, 2]]]),
+         'seg': array([[[0, 1], [1, 2]]])}
+
     """
 
     def __init__(self, keys: Hashable):


### PR DESCRIPTION
This PR adds examples in docstrings,
as an initial try to resolve #462.

Fixes part of # 462.

### Description
Add examples in array.py, post/dictionary.py, utility/dictionary.py

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [x] Docstrings/Documentation updated
