### PR TITLE
Runtest typo

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -55,7 +55,7 @@ do
         ;;
         --codeformat)
           doBlackFormat=true
-          doFlakeFormat=true
+          doFlake8Format=true
           doPytypeFormat=true
           doMypyFormat=true
         ;;

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ ignore =
     F401
 # ^^^^^^^^^ Temporary disabling to allow smaller PRs
 per-file-ignores = __init__.py: F401
-exclude = *.pyi,.git,monai/_version.py,versioneer.py
+exclude = *.pyi,.git,monai/_version.py,versioneer.py,venv
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
### Description
- fixes typo in ``--codeformat``
- excludes ``venv`` from flake8

### Status
**Ready**

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
