### PR TITLE
232 revises resize/zoom

### DIFF
--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -52,3 +52,11 @@ def print_config(file=sys.stdout):
 
 def set_visible_devices(*dev_inds):
     os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, dev_inds))
+
+
+def get_torch_version_tuple():
+    """
+    Returns:
+        tuple of ints represents the pytorch major/minor version.
+    """
+    return tuple([int(x) for x in torch.__version__.split(".")[:2]])

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -75,7 +75,7 @@ class PersistentDataset(Dataset):
 
     For a composite transform like
 
-        .. code-block:: python
+    .. code-block:: python
 
         [ LoadNiftid(keys=['image', 'label']),
           Orientationd(keys=['image', 'label'], axcodes='RAS'),

--- a/monai/data/nifti_saver.py
+++ b/monai/data/nifti_saver.py
@@ -61,17 +61,20 @@ class NiftiSaver:
         self.dtype = dtype
         self._data_index = 0
 
-    def save(self, data: Union[torch.Tensor, np.ndarray], meta_data=None):
+    def save(self, data: Union[torch.Tensor, np.ndarray], meta_data: dict = None):
         """
         Save data into a Nifti file.
-        The metadata could optionally have the following keys:
+        The meta_data could optionally have the following keys:
 
             - ``'filename_or_obj'`` -- for output file name creation, corresponding to filename or object.
             - ``'original_affine'`` -- for data orientation handling, defaulting to an identity matrix.
             - ``'affine'`` -- for data output affine, defaulting to an identity matrix.
             - ``'spatial_shape'`` -- for data output shape.
 
-        If meta_data is None, use the default index from 0 to save data instead.
+        When meta_data is specified, the saver will try to resample batch data from the space
+        defined by "affine" to the space defined by "original_affine".
+
+        If meta_data is None, use the default index (starting from 0) as the filename.
 
         args:
             data (Tensor or ndarray): target data content that to be saved as a NIfTI format file.

--- a/monai/data/png_saver.py
+++ b/monai/data/png_saver.py
@@ -57,15 +57,15 @@ class PNGSaver:
 
         self._data_index = 0
 
-    def save(self, data: Union[torch.Tensor, np.ndarray], meta_data=None):
+    def save(self, data: Union[torch.Tensor, np.ndarray], meta_data: dict = None):
         """
         Save data into a png file.
-        The metadata could optionally have the following keys:
+        The meta_data could optionally have the following keys:
 
             - ``'filename_or_obj'`` -- for output file name creation, corresponding to filename or object.
             - ``'spatial_shape'`` -- for data output shape.
 
-        If meta_data is None, use the default index from 0 to save data instead.
+        If meta_data is None, use the default index (starting from 0) as the filename.
 
         args:
             data (Tensor or ndarray): target data content that to be saved as a png format file.

--- a/monai/data/png_saver.py
+++ b/monai/data/png_saver.py
@@ -33,7 +33,7 @@ class PNGSaver:
         output_postfix: str = "seg",
         output_ext: str = ".png",
         resample: bool = True,
-        interp_order: str = "bicubic",
+        interp_order: str = "nearest",
         scale: bool = False,
     ):
         """
@@ -42,8 +42,8 @@ class PNGSaver:
             output_postfix (str): a string appended to all output file names.
             output_ext (str): output file extension name.
             resample (bool): whether to resample and resize if providing spatial_shape in the metadata.
-            interp_order (`nearest|linear|bilinear|bicubic|trilinear|area`):
-                the interpolation mode. Default="bicubic".
+            interp_order (`nearest|bilinear|bicubic|area`):
+                the interpolation mode. Default="nearest".
                 See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
             scale (bool): whether to scale data with 255 and convert to uint8 for data in range [0, 1].
 

--- a/monai/data/png_saver.py
+++ b/monai/data/png_saver.py
@@ -11,9 +11,11 @@
 
 from typing import Union
 
-import torch
 import numpy as np
+import torch
+
 from monai.data.png_writer import write_png
+
 from .utils import create_file_basename
 
 
@@ -31,9 +33,7 @@ class PNGSaver:
         output_postfix: str = "seg",
         output_ext: str = ".png",
         resample: bool = True,
-        interp_order: int = 3,
-        mode: str = "constant",
-        cval: Union[int, float] = 0,
+        interp_order: str = "bicubic",
         scale: bool = False,
     ):
         """
@@ -41,18 +41,11 @@ class PNGSaver:
             output_dir (str): output image directory.
             output_postfix (str): a string appended to all output file names.
             output_ext (str): output file extension name.
-            resample: whether to resample and resize if providing spatial_shape in the metadata.
-                Defaults to True.
-            interp_order (int): the order of the spline interpolation, default is InterpolationCode.SPLINE3.
-                This option is used when spatial_shape is specified and different from the data shape.
-                The order has to be in the range 0 - 5. Defaults to 3.
-            mode (`constant|edge|symmetric|reflect|wrap`):
-                The mode parameter determines how the input array is extended beyond its boundaries.
-                This option is used when spatial_shape is specified and different from the data shape.
-                Defaults to "constant".
-            cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
-                This option is used when spatial_shape is specified and different from the data shape.
-            scale: whether to scale data with 255 and convert to uint8 for data in range [0, 1].
+            resample (bool): whether to resample and resize if providing spatial_shape in the metadata.
+            interp_order (`nearest|linear|bilinear|bicubic|trilinear|area`):
+                the interpolation mode. Default="bicubic".
+                See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+            scale (bool): whether to scale data with 255 and convert to uint8 for data in range [0, 1].
 
         """
         self.output_dir = output_dir
@@ -60,9 +53,8 @@ class PNGSaver:
         self.output_ext = output_ext
         self.resample = resample
         self.interp_order = interp_order
-        self.mode = mode
-        self.cval = cval
         self.scale = scale
+
         self._data_index = 0
 
     def save(self, data: Union[torch.Tensor, np.ndarray], meta_data=None):
@@ -103,13 +95,7 @@ class PNGSaver:
             raise ValueError("PNG image should only have 1, 3 or 4 channels.")
 
         write_png(
-            data,
-            file_name=filename,
-            output_shape=spatial_shape,
-            interp_order=self.interp_order,
-            mode=self.mode,
-            cval=self.cval,
-            scale=self.scale,
+            data, file_name=filename, output_shape=spatial_shape, interp_order=self.interp_order, scale=self.scale,
         )
 
     def save_batch(self, batch_data: Union[torch.Tensor, np.ndarray], meta_data=None):

--- a/monai/data/png_writer.py
+++ b/monai/data/png_writer.py
@@ -17,7 +17,7 @@ from monai.utils.misc import ensure_tuple_rep
 
 
 def write_png(
-    data, file_name, output_shape=None, interp_order: str = "bicubic", scale=False, plugin=None, **plugin_args,
+    data, file_name, output_shape=None, interp_order: str = "bicubic", scale: bool = False, plugin=None, **plugin_args,
 ):
     """
     Write numpy data into png files to disk.
@@ -47,9 +47,9 @@ def write_png(
             data = np.moveaxis(data, -1, 0)  # to channel first
             data = xform(data)
             data = np.moveaxis(data, 0, -1)
-        else:
+        else:  # (H, W)
             data = np.expand_dims(data, 0)  # make a channel
-            data = xform(data)[0]  # first batch first channel
+            data = xform(data)[0]  # first channel
         if interp_order != "nearest":
             data = np.clip(data, _min, _max)
 

--- a/monai/data/png_writer.py
+++ b/monai/data/png_writer.py
@@ -10,22 +10,17 @@
 # limitations under the License.
 
 import numpy as np
-from skimage import io, transform
+from skimage import io
+
+from monai.transforms import Resize
+from monai.utils.misc import ensure_tuple_rep
 
 
 def write_png(
-    data,
-    file_name,
-    output_shape=None,
-    interp_order: int = 3,
-    mode="constant",
-    cval=0,
-    scale: bool = False,
-    plugin=None,
-    **plugin_args,
+    data, file_name, output_shape=None, interp_order: str = "bicubic", scale=False, plugin=None, **plugin_args,
 ):
     """
-    Write numpy data into png files to disk.  
+    Write numpy data into png files to disk.
     Spatially it supports HW for 2D.(H,W) or (H,W,3) or (H,W,4)
     It's based on skimage library: https://scikit-image.org/docs/dev/api/skimage
 
@@ -33,15 +28,10 @@ def write_png(
         data (numpy.ndarray): input data to write to file.
         file_name (string): expected file name that saved on disk.
         output_shape (None or tuple of ints): output image shape.
-        interp_order (int): the order of the spline interpolation, default is InterpolationCode.SPLINE3.
-            The order has to be in the range 0 - 5. Defaults to 3.
-            this option is used when `output_shape != None`.
-        mode (`constant|edge|symmetric|reflect|wrap`):
-            The mode parameter determines how the input array is extended beyond its boundaries.
-            This option is used when `output_shape != None`. Defaults to "constant".
-        cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
-            this option is used when `output_shape != None`.
-        scale: whether to scale data with 255 and convert to uint8 for data in range [0, 1].
+        interp_order (`nearest|linear|bilinear|bicubic|trilinear|area`):
+            the interpolation mode. Default="bicubic".
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        scale (bool): whether to postprocess data by clipping to [0, 1] and scaling [0, 255] (uint8).
         plugin (string): name of plugin to use in `imsave`. By default, the different plugins
             are tried(starting with imageio) until a suitable candidate is found.
         plugin_args (keywords): arguments passed to the given plugin.
@@ -50,17 +40,21 @@ def write_png(
     assert isinstance(data, np.ndarray), "input data must be numpy array."
 
     if output_shape is not None:
-        assert (
-            isinstance(output_shape, (list, tuple)) and len(output_shape) == 2
-        ), "output_shape must be a list of 2 values (H, W)."
-
+        output_shape = ensure_tuple_rep(output_shape, 2)
+        xform = Resize(spatial_size=output_shape, interp_order=interp_order)
+        _min, _max = np.min(data), np.max(data)
         if len(data.shape) == 3:
-            output_shape = tuple(output_shape) + (data.shape[2],)
-
-        data = transform.resize(data, output_shape, order=interp_order, mode=mode, cval=cval, preserve_range=True)
+            data = np.moveaxis(data, -1, 0)  # to channel first
+            data = xform(data)
+            data = np.moveaxis(data, 0, -1)
+        else:
+            data = np.expand_dims(data, 0)  # make a channel
+            data = xform(data)[0]  # first batch first channel
+        if interp_order != "nearest":
+            data = np.clip(data, _min, _max)
 
     if scale:
-        assert np.min(data) >= 0 and np.max(data) <= 1, "png writer only can scale data in range [0, 1]."
+        data = np.clip(data, 0.0, 1.0)  # png writer only can scale data in range [0, 1].
         data = 255 * data
     data = data.astype(np.uint8)
     io.imsave(file_name, data, plugin=plugin, **plugin_args)

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -82,8 +82,8 @@ class SegmentationSaver:
             )
         elif output_ext == ".png":
             # handling the function's default
-            interp_order = 1 if interp_order == "bilinear" else interp_order
-            mode = "edge" if mode == "border" else mode
+            interp_order = 0 if interp_order == "nearest" else interp_order
+            mode = "nearest" if mode == "border" else mode
             self.saver = PNGSaver(
                 output_dir=output_dir,
                 output_postfix=output_postfix,

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -29,7 +29,7 @@ class SegmentationSaver:
         output_postfix: str = "seg",
         output_ext: str = ".nii.gz",
         resample: bool = True,
-        interp_order="nearest",
+        interp_order: str = "nearest",
         mode: str = "border",
         scale: bool = False,
         dtype: Optional[np.dtype] = None,

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -82,8 +82,8 @@ class SegmentationSaver:
             )
         elif output_ext == ".png":
             # handling the function's default
-            interp_order = 0 if interp_order == "nearest" else interp_order
-            mode = "nearest" if mode == "border" else mode
+            interp_order = 1 if interp_order == "bilinear" else interp_order
+            mode = "edge" if mode == "border" else mode
             self.saver = PNGSaver(
                 output_dir=output_dir,
                 output_postfix=output_postfix,

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -9,11 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union, Callable
+import logging
+from typing import Callable, Optional, Union
 
 import numpy as np
-from ignite.engine import Events, Engine
-import logging
+from ignite.engine import Engine, Events
+
 from monai.data import NiftiSaver, PNGSaver
 
 
@@ -28,9 +29,8 @@ class SegmentationSaver:
         output_postfix: str = "seg",
         output_ext: str = ".nii.gz",
         resample: bool = True,
-        interp_order="bilinear",
+        interp_order="nearest",
         mode: str = "border",
-        cval: Union[int, float] = 0,
         scale: bool = False,
         dtype: Optional[np.dtype] = None,
         batch_transform: Callable = lambda x: x,
@@ -43,19 +43,16 @@ class SegmentationSaver:
             output_postfix (str): a string appended to all output file names.
             output_ext (str): output file extension name.
             resample (bool): whether to resample before saving the data array.
-            interp_order (int or str):
-                The interpolation mode. This option is used when `resample = True`.
-                When saving NIfTI files, the options are "nearest", "bilinear". Defaults to "bilinear".
-                See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
-                When saving PNG files, this sets the order of the spline interpolation.
-                The order has to be in the range 0 - 5.
-                https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.affine_transform.html
+            interp_order (str):
+                The interpolation mode. Defaults to "nearest". This option is used when `resample = True`.
+                When saving NIfTI files, the available options are "nearest", "bilinear"
+                See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample.
+                When saving PNG files, the available options are "nearest", "bilinear", "bicubic", "area".
+                See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate.
             mode (str): The mode parameter determines how the input array is extended beyond its boundaries.
                 This option is used when `resample = True`.
                 When saving NIfTI files, the options are "zeros", "border", "reflection". Default is "border".
-                When saving PNG files, the options are "reflect", "constant", "nearest", "mirror", "wrap".
-            cval (scalar): Value to fill past edges of input if mode is "constant". Default is 0.0.
-                this option is used when `resample = True`. It's used for PNG format only.
+                When saving PNG files, the options is ignored.
             scale (bool): whether to scale data with 255 and convert to uint8 for data in range [0, 1].
                 It's used for PNG format only.
             dtype (np.dtype, optional): convert the image data to save to this data type.
@@ -81,17 +78,12 @@ class SegmentationSaver:
                 dtype=dtype,
             )
         elif output_ext == ".png":
-            # handling the function's default
-            interp_order = 1 if interp_order == "bilinear" else interp_order
-            mode = "edge" if mode == "border" else mode
             self.saver = PNGSaver(
                 output_dir=output_dir,
                 output_postfix=output_postfix,
                 output_ext=output_ext,
                 resample=resample,
                 interp_order=interp_order,
-                mode=mode,
-                cval=cval,
                 scale=scale,
             )
         self.batch_transform = batch_transform

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -270,7 +270,6 @@ class Resize(Transform):
             size=self.spatial_size,
             mode=interp_order or self.interp_order,
             align_corners=self.align_corners,
-            recompute_scale_factor=True,
         )
         resized = resized.squeeze(0).detach().cpu().numpy()
         return resized
@@ -381,7 +380,6 @@ class Zoom(Transform):
             scale_factor=list(self.zoom),
             mode=interp_order or self.interp_order,
             align_corners=self.align_corners,
-            recompute_scale_factor=False,
         )
         zoomed = zoomed.squeeze(0).detach().cpu().numpy()
         if not self.keep_size or np.allclose(img.shape, zoomed.shape):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -20,7 +20,7 @@ import nibabel as nib
 import numpy as np
 import scipy.ndimage
 import torch
-from skimage.transform import resize
+import torch.nn.functional as F
 
 from monai.data.utils import InterpolationCode, compute_shape_offset, to_affine_nd, zoom_affine
 from monai.networks.layers import AffineTransform, GaussianFilter
@@ -33,7 +33,7 @@ from monai.transforms.utils import (
     create_shear,
     create_translate,
 )
-from monai.utils.misc import ensure_tuple
+from monai.utils.misc import ensure_tuple, ensure_tuple_size, ensure_tuple_rep
 
 
 class Spacing(Transform):
@@ -230,70 +230,50 @@ class Flip(Transform):
 
 class Resize(Transform):
     """
-    Resize the input image to given resolution. Uses skimage.transform.resize underneath.
-    For additional details, see https://scikit-image.org/docs/dev/api/skimage.transform.html#skimage.transform.resize.
+    Resize the input image to given spatial size.
+    Implemented using :py:class:`torch.nn.functional.interpolate`.
 
     Args:
         spatial_size (tuple or list): expected shape of spatial dimensions after resize operation.
-        interp_order: Order of spline interpolation. Default=InterpolationCode.LINEAR.
-        mode (str): Points outside boundaries are filled according to given mode.
-            Options are 'constant', 'edge', 'symmetric', 'reflect', 'wrap'.
-        cval (float): Used with mode 'constant', the value outside image boundaries.
-        clip: Whether to clip range of output values after interpolation. Default: True.
-        preserve_range: Whether to keep original range of values. Default is True.
-            If False, input is converted according to conventions of img_as_float. See
-            https://scikit-image.org/docs/dev/user_guide/data_types.html.
-        anti_aliasing: Whether to apply a gaussian filter to image before down-scaling.
-            Default is True.
+        interp_order (`nearest|linear|bilinear|bicubic|trilinear|area`):
+            the interpolation mode. Default="area".
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        align_corners (optional bool): This only has an effect when mode is
+            'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
     """
 
-    def __init__(
-        self,
-        spatial_size,
-        interp_order=InterpolationCode.LINEAR,
-        mode: str = "reflect",
-        cval: Union[int, float] = 0,
-        clip: bool = True,
-        preserve_range: bool = True,
-        anti_aliasing: bool = True,
-    ):
-        self.spatial_size = spatial_size
+    def __init__(self, spatial_size, interp_order: str = "area", align_corners: Optional[bool] = None):
+        self.spatial_size = ensure_tuple(spatial_size)
         self.interp_order = interp_order
-        self.mode = mode
-        self.cval = cval
-        self.clip = clip
-        self.preserve_range = preserve_range
-        self.anti_aliasing = anti_aliasing
+        self.align_corners = align_corners
 
     def __call__(  # type: ignore # see issue #495
-        self,
-        img,
-        order=None,
-        mode: Optional[str] = None,
-        cval: Optional[Union[int, float]] = None,
-        clip: Optional[bool] = None,
-        preserve_range: Optional[bool] = None,
-        anti_aliasing: Optional[bool] = None,
+        self, img, interp_order: Optional[str] = None
     ):
         """
         Args:
             img (ndarray): channel first array, must have shape: (num_channels, H[, W, ..., ]),
         """
-        resized = list()
-        for channel in img:
-            resized.append(
-                resize(
-                    image=channel,
-                    output_shape=self.spatial_size,
-                    order=self.interp_order if order is None else order,
-                    mode=mode or self.mode,
-                    cval=self.cval if cval is None else cval,
-                    clip=self.clip if clip is None else clip,
-                    preserve_range=self.preserve_range if preserve_range is None else preserve_range,
-                    anti_aliasing=self.anti_aliasing if anti_aliasing is None else anti_aliasing,
-                )
+        input_ndim = img.ndim - 1  # spatial ndim
+        output_ndim = len(self.spatial_size)
+        if output_ndim > input_ndim:
+            input_shape = ensure_tuple_size(img.shape, output_ndim + 1, 1)
+            img = img.reshape(input_shape)
+        elif output_ndim < input_ndim:
+            raise ValueError(
+                "len(spatial_size) cannot be smaller than the image spatial dimensions, "
+                f"got {output_ndim} and {input_ndim}."
             )
-        return np.stack(resized).astype(img.dtype)
+        resized = F.interpolate(
+            input=torch.as_tensor(img[None], dtype=torch.float),
+            size=self.spatial_size,
+            mode=interp_order or self.interp_order,
+            align_corners=self.align_corners,
+            recompute_scale_factor=True,
+        )
+        resized = resized.squeeze(0).detach().cpu().numpy()
+        return resized
 
 
 class Rotate(Transform):
@@ -363,87 +343,47 @@ class Rotate(Transform):
 
 
 class Zoom(Transform):
-    """ Zooms a nd image. Uses scipy.ndimage.zoom or cupyx.scipy.ndimage.zoom in case of gpu.
-    For details, please see https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.zoom.html.
+    """
+    Zooms an ND image using :py:class:`torch.nn.functional.interpolate`.
+    For details, please see https://pytorch.org/docs/stable/nn.functional.html#interpolate.
 
     Args:
         zoom (float or sequence): The zoom factor along the spatial axes.
             If a float, zoom is the same for each spatial axis.
             If a sequence, zoom should contain one value for each spatial axis.
-        interp_order: order of interpolation. Default=InterpolationCode.SPLINE3.
-        mode (str): Determines how input is extended beyond boundaries. Default is 'constant'.
-        cval (scalar, optional): Value to fill past edges. Default is 0.
-        prefilter: Apply spline_filter before interpolation. Default: True.
-        use_gpu: Should use cpu or gpu. Uses cupyx which doesn't support order > 1 and modes
-            'wrap' and 'reflect'. Defaults to cpu for these cases or if cupyx not found.
-        keep_size: Should keep original size (pad if needed), default is True.
+        interp_order (`nearest|linear|bilinear|bicubic|trilinear|area`):
+            the interpolation mode. Default="area".
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        align_corners (optional bool): This only has an effect when mode is
+            'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        keep_size (bool): Should keep original size (pad if needed), default is True.
     """
 
     def __init__(
-        self,
-        zoom,
-        interp_order=InterpolationCode.SPLINE3,
-        mode: str = "constant",
-        cval: Union[int, float] = 0,
-        prefilter: bool = True,
-        use_gpu: bool = False,
-        keep_size: bool = True,
+        self, zoom, interp_order: str = "area", align_corners: Optional[bool] = None, keep_size: bool = True,
     ):
         self.zoom = zoom
         self.interp_order = interp_order
-        self.mode = mode
-        self.cval = cval
-        self.prefilter = prefilter
-        self.use_gpu = use_gpu
+        self.align_corners = align_corners
         self.keep_size = keep_size
 
-        if self.use_gpu:
-            try:
-                from cupyx.scipy.ndimage import zoom as zoom_gpu  # type: ignore
-
-                self._zoom = zoom_gpu
-            except ImportError:
-                print("For GPU zoom, please install cupy. Defaulting to cpu.")
-                self._zoom = scipy.ndimage.zoom
-                self.use_gpu = False
-        else:
-            self._zoom = scipy.ndimage.zoom
-
-    def __call__(
-        self, img, order=None, mode=None, cval=None, prefilter=None,
+    def __call__(  # type: ignore # see issue #495
+        self, img, interp_order: Optional[str] = None
     ):
         """
         Args:
             img (ndarray): channel first array, must have shape: (num_channels, H[, W, ..., ]),
         """
-        zoomed = list()
-        if self.use_gpu:
-            import cupy  # type: ignore
-
-            for channel in cupy.array(img):
-                zoom_channel = self._zoom(
-                    channel,
-                    zoom=self.zoom,
-                    order=self.interp_order if order is None else order,
-                    mode=self.mode if mode is None else mode,
-                    cval=self.cval if cval is None else cval,
-                    prefilter=self.prefilter if prefilter is None else prefilter,
-                )
-                zoomed.append(cupy.asnumpy(zoom_channel))
-        else:
-            for channel in img:
-                zoomed.append(
-                    self._zoom(
-                        channel,
-                        zoom=self.zoom,
-                        order=self.interp_order if order is None else order,
-                        mode=mode or self.mode,
-                        cval=self.cval if cval is None else cval,
-                        prefilter=self.prefilter if prefilter is None else prefilter,
-                    )
-                )
-        zoomed = np.stack(zoomed).astype(img.dtype)
-
+        self.zoom = ensure_tuple_rep(self.zoom, img.ndim - 1)  # match the spatial image dim
+        zoomed = F.interpolate(
+            input=torch.as_tensor(img[None], dtype=torch.float),
+            scale_factor=list(self.zoom),
+            mode=interp_order or self.interp_order,
+            align_corners=self.align_corners,
+            recompute_scale_factor=False,
+        )
+        zoomed = zoomed.squeeze(0).detach().cpu().numpy()
         if not self.keep_size or np.allclose(img.shape, zoomed.shape):
             return zoomed
 
@@ -630,14 +570,13 @@ class RandZoom(Randomizable, Transform):
         max_zoom (float or sequence): Max zoom factor. Can be float or sequence same size as image.
             If a float, max_zoom is the same for each spatial axis.
             If a sequence, max_zoom should contain one value for each spatial axis.
-        interp_order: order of interpolation. Default=InterpolationCode.SPLINE3.
-        mode ('reflect', 'constant', 'nearest', 'mirror', 'wrap'): Determines how input is
-            extended beyond boundaries. Default: 'constant'.
-        cval (scalar, optional): Value to fill past edges. Default is 0.
-        prefilter: Apply spline_filter before interpolation. Default: True.
-        use_gpu: Should use cpu or gpu. Uses cupyx which doesn't support order > 1 and modes
-            'wrap' and 'reflect'. Defaults to cpu for these cases or if cupyx not found.
-        keep_size: Should keep original size (pad if needed), default is True.
+        interp_order (`nearest|linear|bilinear|bicubic|trilinear|area`):
+            the interpolation mode. Default="area".
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        align_corners (optional bool): This only has an effect when mode is
+            'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        keep_size (bool): Should keep original size (pad if needed), default is True.
     """
 
     def __init__(
@@ -645,11 +584,8 @@ class RandZoom(Randomizable, Transform):
         prob: float = 0.1,
         min_zoom=0.9,
         max_zoom=1.1,
-        interp_order=InterpolationCode.SPLINE3,
-        mode: str = "constant",
-        cval: Union[int, float] = 0,
-        prefilter: bool = True,
-        use_gpu: bool = False,
+        interp_order: str = "area",
+        align_corners: Optional[bool] = None,
         keep_size: bool = True,
     ):
         if hasattr(min_zoom, "__iter__") and hasattr(max_zoom, "__iter__"):
@@ -657,13 +593,9 @@ class RandZoom(Randomizable, Transform):
         self.min_zoom = min_zoom
         self.max_zoom = max_zoom
         self.prob = prob
-        self.use_gpu = use_gpu
-        self.keep_size = keep_size
-
         self.interp_order = interp_order
-        self.mode = mode
-        self.cval = cval
-        self.prefilter = prefilter
+        self.align_corners = align_corners
+        self.keep_size = keep_size
 
         self._do_transform = False
         self._zoom = None
@@ -676,24 +608,14 @@ class RandZoom(Randomizable, Transform):
             self._zoom = self.R.uniform(self.min_zoom, self.max_zoom)
 
     def __call__(  # type: ignore # see issue #495
-        self,
-        img,
-        order=None,
-        mode: Optional[str] = None,
-        cval: Union[int, float] = None,
-        prefilter: Optional[bool] = None,
+        self, img, interp_order=None
     ):
         self.randomize()
+        _dtype = np.float32
         if not self._do_transform:
-            return img
-        zoomer = Zoom(self._zoom, use_gpu=self.use_gpu, keep_size=self.keep_size)
-        return zoomer(
-            img,
-            order=self.interp_order if order is None else order,
-            mode=mode or self.mode,
-            cval=self.cval if cval is None else cval,
-            prefilter=self.prefilter if prefilter is None else prefilter,
-        )
+            return img.astype(_dtype)
+        zoomer = Zoom(self._zoom, align_corners=self.align_corners, keep_size=self.keep_size)
+        return zoomer(img, interp_order=interp_order or self.interp_order).astype(_dtype)
 
 
 class AffineGrid(Transform):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -355,6 +355,9 @@ class Zoom(Transform):
     Zooms an ND image using :py:class:`torch.nn.functional.interpolate`.
     For details, please see https://pytorch.org/docs/stable/nn.functional.html#interpolate.
 
+    Different from :py:class:`monai.transforms.resize`, this transform takes scaling factors
+    as input, and provides an option of preserving the input spatial size.
+
     Args:
         zoom (float or sequence): The zoom factor along the spatial axes.
             If a float, zoom is the same for each spatial axis.
@@ -365,7 +368,7 @@ class Zoom(Transform):
         align_corners (optional bool): This only has an effect when mode is
             'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
             See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
-        keep_size (bool): Should keep original size (pad if needed), default is True.
+        keep_size (bool): Should keep original size (padding/slicing if needed), default is True.
     """
 
     def __init__(

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -34,6 +34,7 @@ from monai.transforms.spatial.array import (
     Rotate90,
     Spacing,
     Zoom,
+    _torch_interp,
 )
 from monai.transforms.utils import create_grid
 from monai.utils.misc import ensure_tuple_rep
@@ -411,7 +412,7 @@ class Rand2DElasticd(Randomizable, MapTransform):
         if self.rand_2d_elastic.do_transform:
             grid = self.rand_2d_elastic.deform_grid(spatial_size)
             grid = self.rand_2d_elastic.rand_affine_grid(grid=grid)
-            grid = torch.nn.functional.interpolate(grid[None], spatial_size, mode="bicubic", align_corners=False)[0]
+            grid = _torch_interp(input=grid[None], size=spatial_size, mode="bicubic", align_corners=False)[0]
         else:
             grid = create_grid(spatial_size)
 

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -78,7 +78,7 @@ class Spacingd(MapTransform):
                 translations components from the original affine will be
                 preserved in the target affine. This option will not flip/swap
                 axes against the original ones.
-            interp_order (`nearest|bilinear` or a squence of str): str: the same interpolation order
+            interp_order (`nearest|bilinear` or a sequence of str): str: the same interpolation order
                 for all data indexed by `self.keys`; sequence of str, should
                 correspond to an interpolation order for each data item indexed
                 by `self.keys` respectively. Defaults to `bilinear`.
@@ -236,51 +236,24 @@ class Resized(MapTransform):
         keys (hashable items): keys of the corresponding items to be transformed.
             See also: :py:class:`monai.transforms.compose.MapTransform`
         spatial_size (tuple or list): expected shape of spatial dimensions after resize operation.
-        interp_order (int or sequence of int): Order of spline interpolation. Default=InterpolationCode.LINEAR.
-        mode (str or sequence of str): Points outside boundaries are filled according to given mode.
-            Options are 'constant', 'edge', 'symmetric', 'reflect', 'wrap'.
-        cval (float or sequence of float): Used with mode 'constant', the value outside image boundaries.
-        clip (bool or sequence of bool): Whether to clip range of output values after interpolation. Default: True.
-        preserve_range (bool or sequence of bool): Whether to keep original range of values. Default is True.
-            If False, input is converted according to conventions of img_as_float. See
-            https://scikit-image.org/docs/dev/user_guide/data_types.html.
-        anti_aliasing (bool or sequence of bool): Whether to apply a gaussian filter to image before down-scaling.
-            Default is True.
+        interp_order (str of sequence of str):
+            the interpolation mode. Available options are nearest, linear, bilinear, bicubic,
+            trilinear, area. Default="area".
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        align_corners (optional bool): This only has an effect when mode is
+            'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
     """
 
-    def __init__(
-        self,
-        keys: Hashable,
-        spatial_size,
-        interp_order=1,
-        mode="reflect",
-        cval=0,
-        clip=True,
-        preserve_range=True,
-        anti_aliasing=True,
-    ):
+    def __init__(self, keys: Hashable, spatial_size, interp_order: str = "area", align_corners: Optional[bool] = None):
         super().__init__(keys)
         self.interp_order = ensure_tuple_rep(interp_order, len(self.keys))
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.cval = ensure_tuple_rep(cval, len(self.keys))
-        self.clip = ensure_tuple_rep(clip, len(self.keys))
-        self.preserve_range = ensure_tuple_rep(preserve_range, len(self.keys))
-        self.anti_aliasing = ensure_tuple_rep(anti_aliasing, len(self.keys))
-
-        self.resizer = Resize(spatial_size=spatial_size)
+        self.resizer = Resize(spatial_size=spatial_size, align_corners=align_corners)
 
     def __call__(self, data):
         d = dict(data)
         for idx, key in enumerate(self.keys):
-            d[key] = self.resizer(
-                d[key],
-                order=self.interp_order[idx],
-                mode=self.mode[idx],
-                cval=self.cval[idx],
-                clip=self.clip[idx],
-                preserve_range=self.preserve_range[idx],
-                anti_aliasing=self.anti_aliasing[idx],
-            )
+            d[key] = self.resizer(d[key], interp_order=self.interp_order[idx])
         return d
 
 
@@ -722,44 +695,26 @@ class Zoomd(MapTransform):
         zoom (float or sequence): The zoom factor along the spatial axes.
             If a float, zoom is the same for each spatial axis.
             If a sequence, zoom should contain one value for each spatial axis.
-        interp_order (int or sequence of int): order of interpolation. Default=InterpolationCode.SPLINE3.
-        mode (str or sequence of str): Determines how input is extended beyond boundaries. Default is 'constant'.
-        cval (scalar or sequence of scalar): Value to fill past edges. Default is 0.
-        prefilter (bool or sequence of bool): Apply spline_filter before interpolation. Default: True.
-        use_gpu: Should use cpu or gpu. Uses cupyx which doesn't support order > 1 and modes
-            'wrap' and 'reflect'. Defaults to cpu for these cases or if cupyx not found.
-        keep_size: Should keep original size (pad if needed), default is True.
+        interp_order (str or sequence of str): the interpolation mode. Default="area".
+            Available options are nearest, linear, bilinear, bicubic, trilinear, area.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        align_corners (optional bool): This only has an effect when mode is
+            'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        keep_size (bool): Should keep original size (pad if needed), default is True.
     """
 
     def __init__(
-        self,
-        keys: Hashable,
-        zoom,
-        interp_order=InterpolationCode.SPLINE3,
-        mode="constant",
-        cval=0,
-        prefilter=True,
-        use_gpu: bool = False,
-        keep_size: bool = True,
+        self, keys: Hashable, zoom, interp_order: str = "area", align_corners: Optional[bool] = None, keep_size=True,
     ):
         super().__init__(keys)
-        self.zoomer = Zoom(zoom=zoom, use_gpu=use_gpu, keep_size=keep_size)
-
+        self.zoomer = Zoom(zoom=zoom, align_corners=align_corners, keep_size=keep_size)
         self.interp_order = ensure_tuple_rep(interp_order, len(self.keys))
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.cval = ensure_tuple_rep(cval, len(self.keys))
-        self.prefilter = ensure_tuple_rep(prefilter, len(self.keys))
 
     def __call__(self, data):
         d = dict(data)
         for idx, key in enumerate(self.keys):
-            d[key] = self.zoomer(
-                d[key],
-                order=self.interp_order[idx],
-                mode=self.mode[idx],
-                cval=self.cval[idx],
-                prefilter=self.prefilter[idx],
-            )
+            d[key] = self.zoomer(d[key], interp_order=self.interp_order[idx])
         return d
 
 
@@ -775,14 +730,13 @@ class RandZoomd(Randomizable, MapTransform):
         max_zoom (float or sequence): Max zoom factor. Can be float or sequence same size as image.
             If a float, max_zoom is the same for each spatial axis.
             If a sequence, max_zoom should contain one value for each spatial axis.
-        interp_order (int or sequence of int): order of interpolation. Default=InterpolationCode.SPLINE3.
-        mode (str or sequence of str): Available options are 'reflect', 'constant', 'nearest', 'mirror', 'wrap'.
-            Determines how input is extended beyond boundaries. Default: 'constant'.
-        cval (scalar or sequence of scalar): Value to fill past edges. Default is 0.
-        prefilter (bool or sequence of bool): Apply spline_filter before interpolation. Default: True.
-        use_gpu: Should use cpu or gpu. Uses cupyx which doesn't support order > 1 and modes
-            'wrap' and 'reflect'. Defaults to cpu for these cases or if cupyx not found.
-        keep_size: Should keep original size (pad if needed), default is True.
+        interp_order (str or sequence of str): the interpolation mode. Default="area".
+            Available options are nearest, linear, bilinear, bicubic, trilinear, area.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        align_corners (optional bool): This only has an effect when mode is
+            'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
+            See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
+        keep_size (bool): Should keep original size (pad if needed), default is True.
     """
 
     def __init__(
@@ -791,11 +745,8 @@ class RandZoomd(Randomizable, MapTransform):
         prob: float = 0.1,
         min_zoom=0.9,
         max_zoom=1.1,
-        interp_order=InterpolationCode.SPLINE3,
-        mode="constant",
-        cval=0,
-        prefilter=True,
-        use_gpu: bool = False,
+        interp_order: str = "area",
+        align_corners: Optional[bool] = None,
         keep_size: bool = True,
     ):
         super().__init__(keys)
@@ -804,13 +755,10 @@ class RandZoomd(Randomizable, MapTransform):
         self.min_zoom = min_zoom
         self.max_zoom = max_zoom
         self.prob = prob
-        self.use_gpu = use_gpu
-        self.keep_size = keep_size
 
         self.interp_order = ensure_tuple_rep(interp_order, len(self.keys))
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.cval = ensure_tuple_rep(cval, len(self.keys))
-        self.prefilter = ensure_tuple_rep(prefilter, len(self.keys))
+        self.align_corners = align_corners
+        self.keep_size = keep_size
 
         self._do_transform = False
         self._zoom = None
@@ -827,15 +775,9 @@ class RandZoomd(Randomizable, MapTransform):
         d = dict(data)
         if not self._do_transform:
             return d
-        zoomer = Zoom(self._zoom, use_gpu=self.use_gpu, keep_size=self.keep_size)
+        zoomer = Zoom(self._zoom, align_corners=self.align_corners, keep_size=self.keep_size)
         for idx, key in enumerate(self.keys):
-            d[key] = zoomer(
-                d[key],
-                order=self.interp_order[idx],
-                mode=self.mode[idx],
-                cval=self.cval[idx],
-                prefilter=self.prefilter[idx],
-            )
+            d[key] = zoomer(d[key], interp_order=self.interp_order[idx])
         return d
 
 

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -57,9 +57,9 @@ def ensure_tuple(vals):
     return tuple(vals)
 
 
-def ensure_tuple_size(tup, dim):
-    """Returns a copy of `tup` with `dim` values by either shortened or padded with zeros as necessary."""
-    tup = tuple(tup) + (0,) * dim
+def ensure_tuple_size(tup, dim, pad_val=0):
+    """Returns a copy of `tup` with `dim` values by either shortened or padded with `pad_val` as necessary."""
+    tup = tuple(tup) + (pad_val,) * dim
     return tup[:dim]
 
 

--- a/tests/test_integration_classification_2d.py
+++ b/tests/test_integration_classification_2d.py
@@ -221,11 +221,11 @@ class IntegrationClassification2D(unittest.TestCase):
 
             # check training properties
             np.testing.assert_allclose(
-                losses, [0.8009556981788319, 0.16794362251356149, 0.07708252014912617, 0.04769148252856959], rtol=1e-3
+                losses, [0.8184022269431194, 0.17296756841954153, 0.07789294457264767, 0.04796914244960448], rtol=1e-3
             )
             repeated[i].extend(losses)
             print("best metric", best_metric)
-            np.testing.assert_allclose(best_metric, 0.9999460507942981, rtol=1e-4)
+            np.testing.assert_allclose(best_metric, 0.9999440132655022, rtol=1e-4)
             repeated[i].append(best_metric)
             np.testing.assert_allclose(best_metric_epoch, 4)
             model_file = os.path.join(self.data_dir, "best_metric_model.pth")
@@ -234,7 +234,7 @@ class IntegrationClassification2D(unittest.TestCase):
             infer_metric = run_inference_test(self.data_dir, self.test_x, self.test_y, device=self.device)
 
             # check inference properties
-            np.testing.assert_allclose(np.asarray(infer_metric), [1034, 895, 982, 1033, 961, 1047], atol=1)
+            np.testing.assert_allclose(np.asarray(infer_metric), [1032, 895, 982, 1033, 959, 1047], atol=1)
             repeated[i].extend(infer_metric)
 
         np.testing.assert_allclose(repeated[0], repeated[1])

--- a/tests/test_png_rw.py
+++ b/tests/test_png_rw.py
@@ -10,46 +10,47 @@
 # limitations under the License.
 
 import os
+import shutil
 import tempfile
 import unittest
 
-from monai.data import write_png, InterpolationCode
-from skimage import io, transform
 import numpy as np
+from skimage import io
+
+from monai.data import write_png
 
 
 class TestPngWrite(unittest.TestCase):
     def test_write_gray(self):
-        with tempfile.TemporaryDirectory() as out_dir:
-            image_name = os.path.join(out_dir, "test.png")
-            img = np.random.rand(2, 3, 1)
-            img_save_val = 255 * img
-            # saving with io.imsave (h, w, 1) will only give us (h,w) while reading it back.
-            img_save_val = img_save_val[:, :, 0].astype(np.uint8)
-            write_png(img, image_name, scale=True)
-            out = io.imread(image_name)
-            np.testing.assert_allclose(out, img_save_val)
+        out_dir = tempfile.mkdtemp()
+        image_name = os.path.join(out_dir, "test.png")
+        img = np.random.rand(2, 3, 1)
+        img_save_val = 255 * img
+        # saving with io.imsave (h, w, 1) will only give us (h,w) while reading it back.
+        img_save_val = img_save_val[:, :, 0].astype(np.uint8)
+        write_png(img, image_name, scale=True)
+        out = io.imread(image_name)
+        np.testing.assert_allclose(out, img_save_val)
+        shutil.rmtree(out_dir)
 
     def test_write_rgb(self):
-        with tempfile.TemporaryDirectory() as out_dir:
-            image_name = os.path.join(out_dir, "test.png")
-            img = np.random.rand(2, 3, 3)
-            img_save_val = (255 * img).astype(np.uint8)
-            write_png(img, image_name, scale=True)
-            out = io.imread(image_name)
-            np.testing.assert_allclose(out, img_save_val)
+        out_dir = tempfile.mkdtemp()
+        image_name = os.path.join(out_dir, "test.png")
+        img = np.random.rand(2, 3, 3)
+        img_save_val = (255 * img).astype(np.uint8)
+        write_png(img, image_name, scale=True)
+        out = io.imread(image_name)
+        np.testing.assert_allclose(out, img_save_val)
+        shutil.rmtree(out_dir)
 
     def test_write_output_shape(self):
-        with tempfile.TemporaryDirectory() as out_dir:
-            image_name = os.path.join(out_dir, "test.png")
-            img = np.random.rand(2, 2, 3)
-            write_png(img, image_name, (4, 4), scale=True)
-            img_save_val = transform.resize(
-                img, (4, 4), order=InterpolationCode.SPLINE3, mode="constant", cval=0, preserve_range=True
-            )
-            img_save_val = (255 * img_save_val).astype(np.uint8)
-            out = io.imread(image_name)
-            np.testing.assert_allclose(out, img_save_val)
+        out_dir = tempfile.mkdtemp()
+        image_name = os.path.join(out_dir, "test.png")
+        img = np.random.rand(2, 2, 3)
+        write_png(img, image_name, (4, 4), scale=True)
+        out = io.imread(image_name)
+        np.testing.assert_allclose(out.shape, (4, 4, 3))
+        shutil.rmtree(out_dir)
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_zoom.py
+++ b/tests/test_rand_zoom.py
@@ -12,77 +12,43 @@
 import unittest
 
 import numpy as np
-import importlib
-
-from scipy.ndimage import zoom as zoom_scipy
 from parameterized import parameterized
-
-from monai.transforms import RandZoom
+from scipy.ndimage import zoom as zoom_scipy
 from tests.utils import NumpyImageTestCase2D
 
-VALID_CASES = [(0.9, 1.1, 3, "constant", 0, True, False, False)]
+from monai.transforms import RandZoom
+
+VALID_CASES = [(0.9, 1.1, "nearest", False)]
 
 
 class TestRandZoom(NumpyImageTestCase2D):
     @parameterized.expand(VALID_CASES)
-    def test_correct_results(self, min_zoom, max_zoom, order, mode, cval, prefilter, use_gpu, keep_size):
-        random_zoom = RandZoom(
-            prob=1.0,
-            min_zoom=min_zoom,
-            max_zoom=max_zoom,
-            interp_order=order,
-            mode=mode,
-            cval=cval,
-            prefilter=prefilter,
-            use_gpu=use_gpu,
-            keep_size=keep_size,
-        )
-        random_zoom.set_random_state(234)
+    def test_correct_results(self, min_zoom, max_zoom, order, keep_size):
+        random_zoom = RandZoom(prob=1.0, min_zoom=min_zoom, max_zoom=max_zoom, interp_order=order, keep_size=keep_size,)
+        random_zoom.set_random_state(1234)
         zoomed = random_zoom(self.imt[0])
         expected = list()
         for channel in self.imt[0]:
-            expected.append(
-                zoom_scipy(channel, zoom=random_zoom._zoom, mode=mode, order=order, cval=cval, prefilter=prefilter)
-            )
+            expected.append(zoom_scipy(channel, zoom=random_zoom._zoom, mode="nearest", order=0, prefilter=False))
         expected = np.stack(expected).astype(np.float32)
-        self.assertTrue(np.allclose(expected, zoomed))
-
-    @parameterized.expand([(0.8, 1.2, 1, "constant", 0, True)])
-    def test_gpu_zoom(self, min_zoom, max_zoom, order, mode, cval, prefilter):
-        if importlib.util.find_spec("cupy"):
-            random_zoom = RandZoom(
-                prob=1.0,
-                min_zoom=min_zoom,
-                max_zoom=max_zoom,
-                interp_order=order,
-                mode=mode,
-                cval=cval,
-                prefilter=prefilter,
-                use_gpu=True,
-                keep_size=False,
-            )
-            random_zoom.set_random_state(234)
-
-            zoomed = random_zoom(self.imt[0])
-            expected = list()
-            for channel in self.imt[0]:
-                expected.append(
-                    zoom_scipy(channel, zoom=random_zoom._zoom, mode=mode, order=order, cval=cval, prefilter=prefilter)
-                )
-            expected = np.stack(expected).astype(np.float32)
-
-            self.assertTrue(np.allclose(expected, zoomed))
+        np.testing.assert_allclose(zoomed, expected, atol=1.0)
 
     def test_keep_size(self):
         random_zoom = RandZoom(prob=1.0, min_zoom=0.6, max_zoom=0.7, keep_size=True)
         zoomed = random_zoom(self.imt[0])
         self.assertTrue(np.array_equal(zoomed.shape, self.imt.shape[1:]))
+        zoomed = random_zoom(self.imt[0])
+        self.assertTrue(np.array_equal(zoomed.shape, self.imt.shape[1:]))
+        zoomed = random_zoom(self.imt[0])
+        self.assertTrue(np.array_equal(zoomed.shape, self.imt.shape[1:]))
 
-    @parameterized.expand([("no_min_zoom", None, 1.1, 1, TypeError), ("invalid_order", 0.9, 1.1, "s", TypeError)])
+    @parameterized.expand(
+        [("no_min_zoom", None, 1.1, "bilinear", TypeError), ("invalid_order", 0.9, 1.1, "s", NotImplementedError)]
+    )
     def test_invalid_inputs(self, _, min_zoom, max_zoom, order, raises):
         with self.assertRaises(raises):
             random_zoom = RandZoom(prob=1.0, min_zoom=min_zoom, max_zoom=max_zoom, interp_order=order)
-            zoomed = random_zoom(self.imt[0])
+            random_zoom(self.imt[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_zoomd.py
+++ b/tests/test_rand_zoomd.py
@@ -12,20 +12,18 @@
 import unittest
 
 import numpy as np
-import importlib
-
-from scipy.ndimage import zoom as zoom_scipy
 from parameterized import parameterized
-
-from monai.transforms import RandZoomd
+from scipy.ndimage import zoom as zoom_scipy
 from tests.utils import NumpyImageTestCase2D
 
-VALID_CASES = [(0.9, 1.1, 3, "constant", 0, True, False, False)]
+from monai.transforms import RandZoomd
+
+VALID_CASES = [(0.9, 1.1, "nearest", None, False)]
 
 
 class TestRandZoomd(NumpyImageTestCase2D):
     @parameterized.expand(VALID_CASES)
-    def test_correct_results(self, min_zoom, max_zoom, order, mode, cval, prefilter, use_gpu, keep_size):
+    def test_correct_results(self, min_zoom, max_zoom, order, align_corners, keep_size):
         key = "img"
         random_zoom = RandZoomd(
             key,
@@ -33,49 +31,17 @@ class TestRandZoomd(NumpyImageTestCase2D):
             min_zoom=min_zoom,
             max_zoom=max_zoom,
             interp_order=order,
-            mode=mode,
-            cval=cval,
-            prefilter=prefilter,
-            use_gpu=use_gpu,
+            align_corners=align_corners,
             keep_size=keep_size,
         )
-        random_zoom.set_random_state(234)
+        random_zoom.set_random_state(1234)
 
         zoomed = random_zoom({key: self.imt[0]})
         expected = list()
         for channel in self.imt[0]:
-            expected.append(
-                zoom_scipy(channel, zoom=random_zoom._zoom, mode=mode, order=order, cval=cval, prefilter=prefilter)
-            )
+            expected.append(zoom_scipy(channel, zoom=random_zoom._zoom, mode="nearest", order=0, prefilter=False))
         expected = np.stack(expected).astype(np.float32)
-        self.assertTrue(np.allclose(expected, zoomed[key]))
-
-    @parameterized.expand([(0.8, 1.2, 1, "constant", 0, True)])
-    def test_gpu_zoom(self, min_zoom, max_zoom, order, mode, cval, prefilter):
-        key = "img"
-        if importlib.util.find_spec("cupy"):
-            random_zoom = RandZoomd(
-                key,
-                prob=1.0,
-                min_zoom=min_zoom,
-                max_zoom=max_zoom,
-                interp_order=order,
-                mode=mode,
-                cval=cval,
-                prefilter=prefilter,
-                use_gpu=True,
-                keep_size=False,
-            )
-            random_zoom.set_random_state(234)
-
-            zoomed = random_zoom({key: self.imt[0]})
-            expected = list()
-            for channel in self.imt[0]:
-                expected.append(
-                    zoom_scipy(channel, zoom=random_zoom._zoom, mode=mode, order=order, cval=cval, prefilter=prefilter)
-                )
-            expected = np.stack(expected).astype(np.float32)
-            self.assertTrue(np.allclose(expected, zoomed[key]))
+        np.testing.assert_allclose(expected, zoomed[key], atol=1.0)
 
     def test_keep_size(self):
         key = "img"
@@ -83,12 +49,14 @@ class TestRandZoomd(NumpyImageTestCase2D):
         zoomed = random_zoom({key: self.imt[0]})
         self.assertTrue(np.array_equal(zoomed[key].shape, self.imt.shape[1:]))
 
-    @parameterized.expand([("no_min_zoom", None, 1.1, 1, TypeError), ("invalid_order", 0.9, 1.1, "s", TypeError)])
+    @parameterized.expand(
+        [("no_min_zoom", None, 1.1, "bilinear", TypeError), ("invalid_order", 0.9, 1.1, "s", NotImplementedError)]
+    )
     def test_invalid_inputs(self, _, min_zoom, max_zoom, order, raises):
         key = "img"
         with self.assertRaises(raises):
             random_zoom = RandZoomd(key, prob=1.0, min_zoom=min_zoom, max_zoom=max_zoom, interp_order=order)
-            zoomed = random_zoom({key: self.imt[0]})
+            random_zoom({key: self.imt[0]})
 
 
 if __name__ == "__main__":

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -14,50 +14,37 @@ import unittest
 import numpy as np
 import skimage
 from parameterized import parameterized
+from tests.utils import NumpyImageTestCase2D
 
 from monai.transforms import Resize
-from tests.utils import NumpyImageTestCase2D
 
 
 class TestResize(NumpyImageTestCase2D):
     def test_invalid_inputs(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotImplementedError):
             resize = Resize(spatial_size=(128, 128, 3), interp_order="order")
             resize(self.imt[0])
 
-    @parameterized.expand(
-        [
-            ((64, 64), 1, "reflect", 0, True, True, True),
-            ((32, 32), 2, "constant", 3, False, False, False),
-            ((256, 256), 3, "constant", 3, False, False, False),
-        ]
-    )
-    def test_correct_results(self, spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing):
-        resize = Resize(
-            spatial_size,
-            interp_order=order,
-            mode=mode,
-            cval=cval,
-            clip=clip,
-            preserve_range=preserve_range,
-            anti_aliasing=anti_aliasing,
-        )
+        with self.assertRaises(ValueError):
+            resize = Resize(spatial_size=(128,), interp_order="order")
+            resize(self.imt[0])
+
+    @parameterized.expand([((32, 32), "area"), ((32, 32, 32), "trilinear"), ((256, 256), "bilinear")])
+    def test_correct_results(self, spatial_size, order):
+        resize = Resize(spatial_size, interp_order=order)
+        _order = 0
+        if order.endswith("linear"):
+            _order = 1
         expected = list()
         for channel in self.imt[0]:
             expected.append(
                 skimage.transform.resize(
-                    channel,
-                    spatial_size,
-                    order=order,
-                    mode=mode,
-                    cval=cval,
-                    clip=clip,
-                    preserve_range=preserve_range,
-                    anti_aliasing=anti_aliasing,
+                    channel, spatial_size, order=_order, clip=False, preserve_range=False, anti_aliasing=False
                 )
             )
         expected = np.stack(expected).astype(np.float32)
-        self.assertTrue(np.allclose(resize(self.imt[0]), expected))
+        out = resize(self.imt[0])
+        np.testing.assert_allclose(out, expected, atol=0.9)
 
 
 if __name__ == "__main__":

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -12,7 +12,7 @@
 import unittest
 
 import numpy as np
-import skimage
+import skimage.transform
 from parameterized import parameterized
 from tests.utils import NumpyImageTestCase2D
 

--- a/tests/test_resized.py
+++ b/tests/test_resized.py
@@ -12,7 +12,7 @@
 import unittest
 
 import numpy as np
-import skimage
+import skimage.transform
 from parameterized import parameterized
 from tests.utils import NumpyImageTestCase2D
 

--- a/tests/test_resized.py
+++ b/tests/test_resized.py
@@ -14,42 +14,37 @@ import unittest
 import numpy as np
 import skimage
 from parameterized import parameterized
+from tests.utils import NumpyImageTestCase2D
 
 from monai.transforms import Resized
-from tests.utils import NumpyImageTestCase2D
 
 
 class TestResized(NumpyImageTestCase2D):
     def test_invalid_inputs(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotImplementedError):
             resize = Resized(keys="img", spatial_size=(128, 128, 3), interp_order="order")
             resize({"img": self.imt[0]})
 
-    @parameterized.expand(
-        [
-            ((64, 64), 1, "reflect", 0, True, True, True),
-            ((32, 32), 2, "constant", 3, False, False, False),
-            ((256, 256), 3, "constant", 3, False, False, False),
-        ]
-    )
-    def test_correct_results(self, spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing):
-        resize = Resized("img", spatial_size, order, mode, cval, clip, preserve_range, anti_aliasing)
+        with self.assertRaises(ValueError):
+            resize = Resized(keys="img", spatial_size=(128,), interp_order="order")
+            resize({"img": self.imt[0]})
+
+    @parameterized.expand([((64, 64), "area"), ((32, 32, 32), "area"), ((256, 256), "bilinear")])
+    def test_correct_results(self, spatial_size, interp_order):
+        resize = Resized("img", spatial_size, interp_order)
+        _order = 0
+        if interp_order.endswith("linear"):
+            _order = 1
         expected = list()
         for channel in self.imt[0]:
             expected.append(
                 skimage.transform.resize(
-                    channel,
-                    spatial_size,
-                    order=order,
-                    mode=mode,
-                    cval=cval,
-                    clip=clip,
-                    preserve_range=preserve_range,
-                    anti_aliasing=anti_aliasing,
+                    channel, spatial_size, order=_order, clip=False, preserve_range=False, anti_aliasing=False,
                 )
             )
         expected = np.stack(expected).astype(np.float32)
-        self.assertTrue(np.allclose(resize({"img": self.imt[0]})["img"], expected))
+        out = resize({"img": self.imt[0]})["img"]
+        np.testing.assert_allclose(out, expected, atol=0.9)
 
 
 if __name__ == "__main__":

--- a/tests/test_zoom.py
+++ b/tests/test_zoom.py
@@ -12,71 +12,50 @@
 import unittest
 
 import numpy as np
-import importlib
-
-from scipy.ndimage import zoom as zoom_scipy
 from parameterized import parameterized
-
-from monai.transforms import Zoom
+from scipy.ndimage import zoom as zoom_scipy
 from tests.utils import NumpyImageTestCase2D
 
+from monai.transforms import Zoom
+
 VALID_CASES = [
-    (1.1, 3, "constant", 0, True, False, False),
-    (0.9, 3, "constant", 0, True, False, False),
-    (0.8, 1, "reflect", 0, False, False, False),
+    (1.5, "nearest"),
+    (1.5, "nearest"),
+    (0.8, "bilinear"),
+    (0.8, "area"),
 ]
 
-GPU_CASES = [("gpu_zoom", 0.6, 1, "constant", 0, True)]
-
-INVALID_CASES = [("no_zoom", None, 1, TypeError), ("invalid_order", 0.9, "s", TypeError)]
+INVALID_CASES = [((None, None), "bilinear", TypeError), ((0.9, 0.9), "s", NotImplementedError)]
 
 
 class TestZoom(NumpyImageTestCase2D):
     @parameterized.expand(VALID_CASES)
-    def test_correct_results(self, zoom, order, mode, cval, prefilter, use_gpu, keep_size):
-        zoom_fn = Zoom(
-            zoom=zoom,
-            interp_order=order,
-            mode=mode,
-            cval=cval,
-            prefilter=prefilter,
-            use_gpu=use_gpu,
-            keep_size=keep_size,
-        )
+    def test_correct_results(self, zoom, interp_order):
+        zoom_fn = Zoom(zoom=zoom, interp_order=interp_order, keep_size=False)
         zoomed = zoom_fn(self.imt[0])
+        _order = 0
+        if interp_order.endswith("linear"):
+            _order = 1
         expected = list()
         for channel in self.imt[0]:
-            expected.append(zoom_scipy(channel, zoom=zoom, mode=mode, order=order, cval=cval, prefilter=prefilter))
+            expected.append(zoom_scipy(channel, zoom=zoom, mode="nearest", order=_order, prefilter=False))
         expected = np.stack(expected).astype(np.float32)
-        self.assertTrue(np.allclose(expected, zoomed))
-
-    @parameterized.expand(GPU_CASES)
-    def test_gpu_zoom(self, _, zoom, order, mode, cval, prefilter):
-        if importlib.util.find_spec("cupy"):
-            zoom_fn = Zoom(
-                zoom=zoom, interp_order=order, mode=mode, cval=cval, prefilter=prefilter, use_gpu=True, keep_size=False
-            )
-            zoomed = zoom_fn(self.imt[0])
-            expected = list()
-            for channel in self.imt[0]:
-                expected.append(zoom_scipy(channel, zoom=zoom, mode=mode, order=order, cval=cval, prefilter=prefilter))
-            expected = np.stack(expected).astype(np.float32)
-            self.assertTrue(np.allclose(expected, zoomed))
+        np.testing.assert_allclose(zoomed, expected, atol=1.0)
 
     def test_keep_size(self):
-        zoom_fn = Zoom(zoom=0.6, keep_size=True)
-        zoomed = zoom_fn(self.imt[0])
-        self.assertTrue(np.array_equal(zoomed.shape, self.imt.shape[1:]))
+        zoom_fn = Zoom(zoom=[0.6, 0.6], keep_size=True, align_corners=True)
+        zoomed = zoom_fn(self.imt[0], interp_order="bilinear")
+        np.testing.assert_allclose(zoomed.shape, self.imt.shape[1:])
 
-        zoom_fn = Zoom(zoom=1.3, keep_size=True)
+        zoom_fn = Zoom(zoom=[1.3, 1.3], keep_size=True)
         zoomed = zoom_fn(self.imt[0])
-        self.assertTrue(np.array_equal(zoomed.shape, self.imt.shape[1:]))
+        np.testing.assert_allclose(zoomed.shape, self.imt.shape[1:])
 
     @parameterized.expand(INVALID_CASES)
-    def test_invalid_inputs(self, _, zoom, order, raises):
+    def test_invalid_inputs(self, zoom, order, raises):
         with self.assertRaises(raises):
             zoom_fn = Zoom(zoom=zoom, interp_order=order)
-            zoomed = zoom_fn(self.imt[0])
+            zoom_fn(self.imt[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
subtask of #232; fixes #290 

Revises zoom/zoomd, resize/resized, randzoom/randzoomd, png_saver to use torch interpolate instead of skimage.transform 

### Status
**ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
