### PR TITLE
Make classes match signature of the superclass

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -141,9 +141,7 @@ class MaskedDiceLoss(DiceLoss):
     Same as DiceLoss, but accepts a binary mask ([0,1]) indicating a region over which to compute the dice.
     """
 
-    def forward(  # type: ignore # see issue #495
-        self, input: torch.Tensor, target: torch.Tensor, mask: torch.Tensor = None, smooth: float = 1e-5
-    ):
+    def forward(self, input: torch.Tensor, target: torch.Tensor, smooth: float = 1e-5, mask: torch.Tensor = None):
         """
         Args:
             input (tensor): the shape should be BNH[WD].

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -42,7 +42,7 @@ class Transform(ABC):
     """
 
     @abstractmethod
-    def __call__(self, data, *args, **kwargs):
+    def __call__(self, data: Any):
         """
         ``data`` is an element which often comes from an iteration over an
         iterable, such as :py:class:`torch.utils.data.Dataset`. This method should
@@ -93,7 +93,7 @@ class Randomizable(ABC):
         return self
 
     @abstractmethod
-    def randomize(self, *args, **kwargs):
+    def randomize(self):
         """
         Within this method, :py:attr:`self.R` should be used, instead of `np.random`, to introduce random factors.
 

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -54,7 +54,7 @@ class SpatialPad(Transform):
         else:
             return [(0, max(self.spatial_size[i] - data_shape[i], 0)) for i in range(len(self.spatial_size))]
 
-    def __call__(self, img, mode: Optional[str] = None):  # type: ignore # see issue #495
+    def __call__(self, img, mode: Optional[str] = None):
         data_pad_width = self._determine_data_pad_width(img.shape[1:])
         all_pad_width = [(0, 0)] + data_pad_width
         img = np.pad(img, all_pad_width, mode=mode or self.mode)

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -37,7 +37,7 @@ class SplitChannel(Transform):
         self.to_onehot = to_onehot
         self.num_classes = num_classes
 
-    def __call__(self, img, to_onehot: Optional[bool] = None, num_classes: Optional[int] = None):  # type: ignore # see issue #495
+    def __call__(self, img, to_onehot: Optional[bool] = None, num_classes: Optional[int] = None):
         if to_onehot or self.to_onehot:
             if num_classes is None:
                 num_classes = self.num_classes
@@ -68,7 +68,7 @@ class Activations(Transform):
         self.softmax = softmax
         self.other = other
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self, img, sigmoid: Optional[bool] = None, softmax: Optional[bool] = None, other: Optional[Callable] = None
     ):
         if sigmoid is True and softmax is True:
@@ -117,7 +117,7 @@ class AsDiscrete(Transform):
         self.threshold_values = threshold_values
         self.logit_thresh = logit_thresh
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self,
         img,
         argmax: Optional[bool] = None,

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -85,7 +85,7 @@ class Spacing(Transform):
         self.mode = mode
         self.dtype = dtype
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self,
         data_array: np.ndarray,
         affine=None,
@@ -175,7 +175,7 @@ class Orientation(Transform):
         self.as_closest_canonical = as_closest_canonical
         self.labels = labels
 
-    def __call__(self, data_array: np.ndarray, affine=None):  # type: ignore # see issue #495
+    def __call__(self, data_array: np.ndarray, affine=None):
         """
         original orientation of `data_array` is defined by `affine`.
 
@@ -257,9 +257,7 @@ class Resize(Transform):
         self.interp_order = interp_order
         self.align_corners = align_corners
 
-    def __call__(  # type: ignore # see issue #495
-        self, img, interp_order: Optional[str] = None
-    ):
+    def __call__(self, img, interp_order: Optional[str] = None):
         """
         Args:
             img (ndarray): channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -321,7 +319,7 @@ class Rotate(Transform):
         self.cval = cval
         self.prefilter = prefilter
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self,
         img,
         order=None,
@@ -425,7 +423,7 @@ class Rotate90(Transform):
         self.k = k
         self.spatial_axes = spatial_axes
 
-    def __call__(self, img: np.ndarray):  # type: ignore # see issue #495
+    def __call__(self, img: np.ndarray):
         """
         Args:
             img (ndarray): channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -521,7 +519,7 @@ class RandRotate(Randomizable, Transform):
         self._do_transform = self.R.random_sample() < self.prob
         self.angle = self.R.uniform(low=self.degrees[0], high=self.degrees[1])
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self,
         img,
         order=None,
@@ -618,9 +616,7 @@ class RandZoom(Randomizable, Transform):
         else:
             self._zoom = self.R.uniform(self.min_zoom, self.max_zoom)
 
-    def __call__(  # type: ignore # see issue #495
-        self, img, interp_order: Optional[str] = None
-    ):
+    def __call__(self, img, interp_order: Optional[str] = None):
         self.randomize()
         _dtype = np.float32
         if not self._do_transform:
@@ -824,21 +820,23 @@ class Resample(Transform):
         self.as_tensor_output = as_tensor_output
         self.device = device
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self,
         img: Union[np.ndarray, torch.Tensor],
-        grid: Union[np.ndarray, torch.Tensor],
+        grid: Optional[Union[np.ndarray, torch.Tensor]] = None,
         padding_mode: Optional[str] = None,
-        mode: Optional[str] = None,
+        mode: str = "bilinear",
     ):
         """
         Args:
-            img (ndarray or tensor): shape must be (num_channels, H, W[, D]).
-            grid (ndarray or tensor): shape must be (3, H, W) for 2D or (4, H, W, D) for 3D.
+            img: shape must be (num_channels, H, W[, D]).
+            grid: shape must be (3, H, W) for 2D or (4, H, W, D) for 3D.
             mode ('nearest'|'bilinear'): interpolation order. Defaults to 'bilinear'.
         """
+
         if not torch.is_tensor(img):
             img = torch.as_tensor(np.ascontiguousarray(img))
+        assert grid is not None, "Error, grid argument must be supplied as an ndarray or tensor "
         grid = torch.tensor(grid) if not torch.is_tensor(grid) else grid.detach().clone()
         if self.device:
             img = img.to(self.device)
@@ -914,7 +912,7 @@ class Affine(Transform):
         self.padding_mode = padding_mode
         self.mode = mode
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self,
         img: Union[np.ndarray, torch.Tensor],
         spatial_size=None,
@@ -998,7 +996,7 @@ class RandAffine(Randomizable, Transform):
         self.do_transform = self.R.rand() < self.prob
         self.rand_affine_grid.randomize()
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self,
         img: Union[np.ndarray, torch.Tensor],
         spatial_size=None,
@@ -1095,7 +1093,7 @@ class Rand2DElastic(Randomizable, Transform):
         self.deform_grid.randomize(spatial_size)
         self.rand_affine_grid.randomize()
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self,
         img: Union[np.ndarray, torch.Tensor],
         spatial_size=None,

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -118,7 +118,7 @@ class CastToType(Transform):
         """
         self.dtype = dtype
 
-    def __call__(self, img: np.ndarray):  # type: ignore # see issue #495
+    def __call__(self, img: np.ndarray):
         assert isinstance(img, np.ndarray), "image must be numpy array."
         return img.astype(self.dtype)
 
@@ -172,7 +172,7 @@ class SqueezeDim(Transform):
             raise ValueError(f"Invalid channel dimension {dim}")
         self.dim = dim
 
-    def __call__(self, img):  # type: ignore # see issue #495
+    def __call__(self, img):
         """
         Args:
             img (ndarray): numpy arrays with required dimension `dim` removed
@@ -220,7 +220,7 @@ class DataStats(Transform):
         if logger_handler is not None:
             self._logger.addHandler(logger_handler)
 
-    def __call__(  # type: ignore # see issue #495
+    def __call__(
         self,
         img,
         prefix: Optional[str] = None,


### PR DESCRIPTION
Avoid linting warnings like: Overriding a method without ensuring that
both methods accept the same number and type of parameters has the
potential to cause an error when there is a mismatch.

Fixes #495 .

### Description
Superceeds #510 with a simpler solution to the mismatch supertype problem.

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated