### PR TITLE
remove flake8-mypy tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ scipy
 coverage
 parameterized
 flake8>=3.8.1
-flake8-mypy
 flake8-bugbear
 flake8-comprehensions
 flake8-executable


### PR DESCRIPTION
related to #476.

currently we have both flake8-mypy (as a plugin of flake8) and mypy package doing similar type checking. flake8-mypy has some issues and the error messages are not very straightforward. 

this PR proposes to remove flake8-mypy tests.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)

