### PR TITLE
198 optional import

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -57,11 +57,12 @@ jobs:
       name: Install torch cpu from pytorch.org (Windows only)
       run: |
         python -m pip install torch==1.4 -f https://download.pytorch.org/whl/cpu/torch_stable.html
+        # min. requirements for windows instances
+        python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); print(txt); f=open('requirements-dev.txt', 'w'); f.writelines(txt[1:9]); f.close()"
     - name: Install the dependencies
       run: |
         python -m pip install torch==1.4
-        python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); f=open('temp.txt', 'w'); f.writelines([x for x in txt[1:5]]); f.close()"
-        python -m pip install -r temp.txt
+        python -m pip install -r requirements-dev.txt
         python -m pip list
     - name: Run quick tests (CPU ${{ runner.os }})
       run: |

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         python -m pip install torch==1.4 -f https://download.pytorch.org/whl/cpu/torch_stable.html
         # min. requirements for windows instances
-        python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); print(txt); f=open('requirements-dev.txt', 'w'); f.writelines(txt[1:9]); f.close()"
+        python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); print(txt); f=open('requirements-dev.txt', 'w'); f.writelines(txt[1:10]); f.close()"
     - name: Install the dependencies
       run: |
         python -m pip install torch==1.4

--- a/.gitignore
+++ b/.gitignore
@@ -119,5 +119,4 @@ temp/
 *.orig
 *.bak
 *.swp
-*~
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV PYTHONPATH=$PYTHONPATH:/opt/monai
 ENV PATH=/opt/tools:$PATH
 
 RUN python -m pip install --no-cache-dir -U pip wheel \
-  && python -m pip install --no-cache-dir -r requirements.txt
+  && python -m pip install --no-cache-dir -r requirements-dev.txt
 
 # NGC Client
 WORKDIR /opt/tools

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![codecov](https://codecov.io/gh/Project-MONAI/MONAI/branch/master/graph/badge.svg)](https://codecov.io/gh/Project-MONAI/MONAI)
 [![PyPI version](https://badge.fury.io/py/monai.svg)](https://badge.fury.io/py/monai)
 
-MONAI is a [PyTorch](https://pytorch.org/)-based, [open-source](https://github.com/Project-MONAI/MONAI/blob/master/LICENSE) framework for deep learning in healthcare imaging, part of [PyTorch Ecosystem](https://pytorch.org/ecosystem/).  
+MONAI is a [PyTorch](https://pytorch.org/)-based, [open-source](https://github.com/Project-MONAI/MONAI/blob/master/LICENSE) framework for deep learning in healthcare imaging, part of [PyTorch Ecosystem](https://pytorch.org/ecosystem/).
 Its ambitions are:
 - developing a community of academic, industrial and clinical researchers collaborating on a common foundation;
 - creating state-of-the-art, end-to-end training workflows for healthcare imaging;
@@ -42,6 +42,8 @@ Alternatively, pre-built Docker image is available via [DockerHub](https://hub.d
   # with docker v19.03+
   docker run --gpus all --rm -ti --ipc=host projectmonai/monai:latest
   ```
+
+For more details, please refer to [the installation guide](https://monai.readthedocs.io/en/latest/installation.html).
 
 ## Getting Started
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,6 +60,12 @@ Technical documentation is available via `Read the Docs <https://monai.readthedo
    visualize
    utils
 
+.. toctree::
+  :maxdepth: 1
+  :caption: Installation
+
+  installation
+
 
 Contributing
 ------------

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -94,7 +94,7 @@ docker run --gpus all --rm -ti --ipc=host projectmonai/monai:latest
 
 You can also run a milestone release docker image by specifying the image tag, for example:
 ```
-docker run --gpus all --rm -ti --ipc=host projectmonai/monai:latest
+docker run --gpus all --rm -ti --ipc=host projectmonai/monai:0.1.0
 ```
 
 ## Installing the recommended dependencies

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,0 +1,123 @@
+# Installation guide
+
+MONAI's core functionality is written in Python 3 (>= 3.6) and only requires [Numpy](https://numpy.org/) and [Pytorch](https://pytorch.org/).
+
+The package is currently distributed via Github as the primary source code repository,
+and the Python package index (PyPI). The pre-built Docker images are made available on DockerHub.
+
+This page provides steps to:
+- [Install MONAI from PyPI](#from-pypi)
+- [Install MONAI from GitHub](#from-github)
+- [Validate the install](#validating-the-install)
+- [Understand MONAI version string](#monai-version-string)
+- [Run MONAI From DockerHub](#from-dockerhub)
+
+To install optional features such as handling the NIfTI files using
+[Nibabel](https://nipy.org/nibabel/), or building workflows using [Pytorch
+Ignite](https://pytorch.org/ignite/), please follow the instructions:
+- [Installing the recommended dependencies](#installing-the-recommended-dependencies)
+
+---
+
+
+## From PyPI
+To install the [current milestone release](https://pypi.org/project/monai/):
+```bash
+pip install monai
+```
+
+## From GitHub
+(_If you have installed the
+PyPI release version using ``pip install monai``, please run ``pip uninstall
+monai`` before using the commands from this section. Because ``pip`` by
+default prefers the milestone release_.)
+
+The milestone versions are currently planned and released every few months.  As the
+codebase is under active development, you may want to install MONAI from GitHub
+for the latest features:
+
+### Option 1 (as a part of your system-wide module):
+```bash
+pip install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
+```
+this command will download and install the current master branch of [MONAI from
+GitHub](https://github.com/Project-MONAI/MONAI).
+
+This documentation website by default shows the information for the latest version.
+
+### Option 2 (editable installation):
+To install an editable version of MONAI, it is recommended to clone the codebase directly:
+```bash
+git clone https://github.com/Project-MONAI/MONAI.git
+```
+This command will create a ``MONAI/`` folder in your current directory.
+You can install it by running:
+```bash
+cd MONAI/
+pip install -e .
+```
+or simply adding the root directory of the cloned source code (e.g., ``/workspace/Documents/MONAI``) to your ``$PYTHONPATH``
+and the codebase is ready to use.
+
+
+## Validating the install
+You can verify the installation by:
+```bash
+python -c 'import monai; monai.config.print_config()'
+```
+If the installation is successful, this command will print out the MONAI version information, and this confirms the core
+modules of MONAI are ready-to-use.
+
+
+## MONAI version string
+The MONAI version string shows the current status of your local installation. For example:
+```
+MONAI version: 0.1.0+144.g52c763d.dirty
+```
+- ``0.1.0`` indicates that your installation is based on the ``0.1.0`` milestone release.
+- ``+144`` indicates that your installation is 144 git commits ahead of the milestone release.
+- ``g52c763d`` indicates that your installation corresponds to the git commit hash ``52c763d``.
+- ``dirty`` indicates that you have modified the codebase locally, and the codebase is inconsistent with ``52c763d``.
+
+
+## From DockerHub
+Make sure you have installed the NVIDIA driver and Docker 19.03+ for your Linux distribution.
+Note that you do not need to install the CUDA toolkit on the host, but the driver needs to be installed.
+Please find out more information on [nvidia-docker](https://github.com/NVIDIA/nvidia-docker).
+
+Assuming that you have the Nvidia driver and Docker 19.03+ installed, running the following command will
+download and start a container with the latest version of MONAI. The latest master branch of MONAI from GitHub
+is included in the image.
+```bash
+docker run --gpus all --rm -ti --ipc=host projectmonai/monai:latest
+```
+
+You can also run a milestone release docker image by specifying the image tag, for example:
+```
+docker run --gpus all --rm -ti --ipc=host projectmonai/monai:latest
+```
+
+## Installing the recommended dependencies
+By default, the installation steps will only download and install the minimal requirements of MONAI.
+Optional dependencies can be installed using [the extras syntax](https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras) to support additional features.
+
+For example, to install MONAI with Nibabel and Scikit-image support:
+```
+git clone https://github.com/Project-MONAI/MONAI.git
+cd MONAI/
+pip install -e '.[nibabel,skimage]'
+```
+
+Alternatively, to install all optional dependencies:
+```
+git clone https://github.com/Project-MONAI/MONAI.git
+cd MONAI/
+pip install -e '.[all]'
+```
+
+To install all optional dependencies for MONAI development:
+```
+git clone https://github.com/Project-MONAI/MONAI.git
+cd MONAI/
+pip install -r requirements-dev.txt
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,35 +9,42 @@ python -m pip install -U matplotlib
 python -m pip install -U notebook
 ```
 
+Some of the examples may require optional dependencies. In case of any optional import errors,
+please install the relevant packages according to the error message.
+Or install all optional requirements by:
+```
+pip install -r https://raw.githubusercontent.com/Project-MONAI/MONAI/master/requirements-dev.txt
+```
+
 ### 2. List of examples
 #### [classification_3d](./classification_3d)
-Training and evaluation examples of 3D classification based on DenseNet3D and [IXI dataset](https://brain-development.org/ixi-dataset).  
+Training and evaluation examples of 3D classification based on DenseNet3D and [IXI dataset](https://brain-development.org/ixi-dataset).
 The examples are standard PyTorch programs and have both dictionary-based and array-based transformation versions.
 #### [classification_3d_ignite](./classification_3d_ignite)
-Training and evaluation examples of 3D classification based on DenseNet3D and [IXI dataset](https://brain-development.org/ixi-dataset).  
+Training and evaluation examples of 3D classification based on DenseNet3D and [IXI dataset](https://brain-development.org/ixi-dataset).
 The examples are PyTorch Ignite programs and have both dictionary-based and array-based transformation versions.
 #### [notebooks/3d_image_transforms](./notebooks/3d_image_transforms.ipynb)
 This notebook demonstrates the transformations on volumetric images.
 #### [notebooks/cache_dataset_speed](./notebooks/cache_dataset_speed.ipynb)
 This tutorial shows how to accelerate PyTorch medical DL program based on MONAI `CacheDataset`.
 #### [notebooks/integrate_3rd_party_transforms](./notebooks/integrate_3rd_party_transforms.ipynb)
-This tutorial shows how to integrate 3rd party transforms into MONAI program.  
+This tutorial shows how to integrate 3rd party transforms into MONAI program.
 Mainly shows transforms from BatchGenerator, TorchIO and Rising.
 #### [notebooks/mednist_tutorial](./notebooks/mednist_tutorial.ipynb)
-This notebook shows how to easily integrate MONAI features into existing PyTorch programs.  
-It's based on the MedNIST dataset which is very suitable for beginners as a tutorial.  
+This notebook shows how to easily integrate MONAI features into existing PyTorch programs.
+It's based on the MedNIST dataset which is very suitable for beginners as a tutorial.
 The content is also available as [a Colab tutorial](https://colab.research.google.com/drive/1wy8XUSnNWlhDNazFdvGBHLfdkGvOHBKe).
 #### [notebooks/multi_gpu_test](./notebooks/multi_gpu_test.ipynb)
 This notebook is a quick demo for devices, run the Ignite trainer engine on CPU, GPU and multiple GPUs.
 #### [notebooks/nifti_read_example](./notebooks/nifti_read_example.ipynb)
 Illustrate reading NIfTI files and iterating over image patches of the volumes loaded from them.
 #### [notebooks/persistent_dataset_speed](./notebooks/persistent_dataset_speed.ipynb)
-This notebook shows `PersistentDataset` that processes original data sources through the non-random transforms on first use.  
-And stores these intermediate tensor values to an on-disk persistence representation.  
+This notebook shows `PersistentDataset` that processes original data sources through the non-random transforms on first use.
+And stores these intermediate tensor values to an on-disk persistence representation.
 The intermediate processed tensors are loaded from disk on each use for processing by the random-transforms for each analysis request.
 #### [notebooks/spleen_segmentation_3d](./notebooks/spleen_segmentation_3d.ipynb)
-This notebook is an end-to-end training and evaluation example of 3D segmentation based on [MSD Spleen dataset](http://medicaldecathlon.com).  
-The example shows the flexibility of MONAI modules in a PyTorch-based program:  
+This notebook is an end-to-end training and evaluation example of 3D segmentation based on [MSD Spleen dataset](http://medicaldecathlon.com).
+The example shows the flexibility of MONAI modules in a PyTorch-based program:
 - Transforms for dictionary-based training data structure.
 - Load NIfTI images with metadata.
 - Scale medical image intensity with expected range.
@@ -54,14 +61,14 @@ Illustrate reading NIfTI files and test speed of different transforms on differe
 This notebook demonstrates the image transformations on histology images using
 [the GlaS Contest dataset](https://warwick.ac.uk/fac/sci/dcs/research/tia/glascontest/download/).
 #### [notebooks/unet_segmentation_3d_ignite](./notebooks/unet_segmentation_3d_ignite.ipynb)
-This notebook is an end-to-end training & evaluation example of 3D segmentation based on synthetic dataset.  
+This notebook is an end-to-end training & evaluation example of 3D segmentation based on synthetic dataset.
 The example is a PyTorch Ignite program and shows several key features of MONAI, especially with medical domain specific transforms and event handlers.
 #### [segmentation_3d](./segmentation_3d)
-Training and evaluation examples of 3D segmentation based on UNet3D and synthetic dataset.  
+Training and evaluation examples of 3D segmentation based on UNet3D and synthetic dataset.
 The examples are standard PyTorch programs and have both dictionary-based and array-based versions.
 #### [segmentation_3d_ignite](./segmentation_3d_ignite)
-Training and evaluation examples of 3D segmentation based on UNet3D and synthetic dataset.  
+Training and evaluation examples of 3D segmentation based on UNet3D and synthetic dataset.
 The examples are PyTorch Ignite programs and have both dictionary-base and array-based transformations.
 #### [workflows](./workflows)
-Training and evaluation examples of 3D segmentation based on UNet3D and synthetic dataset.  
+Training and evaluation examples of 3D segmentation based on UNet3D and synthetic dataset.
 The examples are built with MONAI workflows, mainly contain: trainer/evaluator, handlers, post_transforms, etc.

--- a/monai/README.md
+++ b/monai/README.md
@@ -6,9 +6,11 @@
 
 * **data**: for the datasets, readers/writers, and synthetic data
 
-* **engine**: engine-derived classes for extending Ignite behaviour.
+* **engines**: engine-derived classes for extending Ignite behaviour.
 
 * **handlers**: defines handlers for implementing functionality at various stages in the training process.
+
+* **inferers**: defines model inference methods. 
 
 * **losses**: classes defining loss functions.
 

--- a/monai/__init__.py
+++ b/monai/__init__.py
@@ -23,9 +23,9 @@ __copyright__ = "(c) 2020 MONAI Consortium"
 __basedir__ = os.path.dirname(__file__)
 
 excludes = "^(handlers)"  # the handlers have some external decorators the users may not have installed
-load_submodules(
-    sys.modules[__name__], False, exclude_pattern=excludes
-)  # load directory modules only, skip loading individual files
-load_submodules(
-    sys.modules[__name__], True, exclude_pattern=excludes
-)  # load all modules, this will trigger all export decorations
+
+# load directory modules only, skip loading individual files
+load_submodules(sys.modules[__name__], False, exclude_pattern=excludes)
+
+# load all modules, this will trigger all export decorations
+load_submodules(sys.modules[__name__], True, exclude_pattern=excludes)

--- a/monai/__init__.py
+++ b/monai/__init__.py
@@ -22,5 +22,10 @@ __copyright__ = "(c) 2020 MONAI Consortium"
 
 __basedir__ = os.path.dirname(__file__)
 
-load_submodules(sys.modules[__name__], False)  # load directory modules only, skip loading individual files
-load_submodules(sys.modules[__name__], True)  # load all modules, this will trigger all export decorations
+excludes = "^(handlers)"  # the handlers have some external decorators the users may not have installed
+load_submodules(
+    sys.modules[__name__], False, exclude_pattern=excludes
+)  # load directory modules only, skip loading individual files
+load_submodules(
+    sys.modules[__name__], True, exclude_pattern=excludes
+)  # load all modules, this will trigger all export decorations

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -13,10 +13,49 @@ import os
 import sys
 from collections import OrderedDict
 
+import monai
 import numpy as np
 import torch
 
-import monai
+try:
+    import ignite
+
+    ignite_version = ignite.__version__
+    del ignite
+except (ImportError, AttributeError):
+    ignite_version = "NOT INSTALLED or UNKNOWN VERSION."
+
+try:
+    import nibabel
+
+    nibabel_version = nibabel.__version__
+    del nibabel
+except (ImportError, AttributeError):
+    nibabel_version = "NOT INSTALLED or UNKNOWN VERSION."
+
+try:
+    import skimage
+
+    skimage_version = skimage.__version__
+    del skimage
+except (ImportError, AttributeError):
+    skimage_version = "NOT INSTALLED or UNKNOWN VERSION."
+
+try:
+    import PIL
+
+    PIL_version = PIL.__version__
+    del PIL
+except (ImportError, AttributeError):
+    PIL_version = "NOT INSTALLED or UNKNOWN VERSION."
+
+try:
+    import tensorboard
+
+    tensorboard_version = tensorboard.__version__
+    del tensorboard
+except (ImportError, AttributeError):
+    tensorboard_version = "NOT INSTALLED or UNKNOWN VERSION."
 
 
 def get_config_values():
@@ -25,10 +64,26 @@ def get_config_values():
     """
     output = OrderedDict()
 
-    output["MONAI version"] = monai.__version__
-    output["Python version"] = sys.version.replace("\n", " ")
-    output["Numpy version"] = np.version.full_version
-    output["Pytorch version"] = torch.__version__
+    output["MONAI"] = monai.__version__
+    output["Python"] = sys.version.replace("\n", " ")
+    output["Numpy"] = np.version.full_version
+    output["Pytorch"] = torch.__version__
+
+    return output
+
+
+def get_optional_config_values():
+    """
+    Read the optional package versions into a dictionary.
+    """
+    output = OrderedDict()
+
+    output["Pytorch Ignite"] = ignite_version
+    output["Nibabel"] = nibabel_version
+    output["scikit-image"] = skimage_version
+    output["Pillow"] = PIL_version
+    output["Tensorboard"] = tensorboard_version
+
     return output
 
 
@@ -38,7 +93,11 @@ def print_config(file=sys.stdout):
     Defaults to `sys.stdout`.
     """
     for k, v in get_config_values().items():
-        print(f"{k}: {v}", file=file, flush=True)
+        print(f"{k} version: {v}", file=file, flush=True)
+
+    print("\nOptional dependencies:", file=file, flush=True)
+    for k, v in get_optional_config_values().items():
+        print(f"{k} version: {v}", file=file, flush=True)
 
 
 def set_visible_devices(*dev_inds):

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -18,13 +18,6 @@ import torch
 
 import monai
 
-try:
-    import ignite
-
-    ignite_version = ignite.__version__
-except ImportError:
-    ignite_version = "NOT INSTALLED"
-
 
 def get_config_values():
     """
@@ -36,8 +29,6 @@ def get_config_values():
     output["Python version"] = sys.version.replace("\n", " ")
     output["Numpy version"] = np.version.full_version
     output["Pytorch version"] = torch.__version__
-    output["Ignite version"] = ignite_version
-
     return output
 
 

--- a/monai/data/nifti_writer.py
+++ b/monai/data/nifti_writer.py
@@ -9,12 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import nibabel as nib
 import numpy as np
 import torch
 
 from monai.data.utils import compute_shape_offset, to_affine_nd
 from monai.networks.layers import AffineTransform
+from monai.utils import optional_import
+
+nib, _ = optional_import("nibabel")
 
 
 def write_nifti(

--- a/monai/data/png_writer.py
+++ b/monai/data/png_writer.py
@@ -9,8 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 import numpy as np
 
 from monai.transforms import Resize

--- a/monai/data/png_writer.py
+++ b/monai/data/png_writer.py
@@ -12,10 +12,11 @@
 from typing import Optional
 
 import numpy as np
-from PIL import Image
 
 from monai.transforms import Resize
-from monai.utils.misc import ensure_tuple_rep
+from monai.utils import ensure_tuple_rep, min_version, optional_import
+
+Image, _ = optional_import("PIL", name="Image")
 
 
 def write_png(data, file_name: str, output_shape=None, interp_order: str = "bicubic", scale=None):

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -14,13 +14,14 @@ from typing import Optional
 import os
 import warnings
 import math
-import nibabel as nib
 from itertools import starmap, product
 import torch
 from torch.utils.data._utils.collate import default_collate
 import numpy as np
-from monai.utils import ensure_tuple_size
+from monai.utils import ensure_tuple_size, optional_import
 from monai.networks.layers.simplelayers import GaussianFilter
+
+nib, _ = optional_import("nibabel")
 
 
 def get_random_patch(dims, patch_size, rand_state: Optional[np.random.RandomState] = None):

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -9,15 +9,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Callable
+from typing import Callable, Optional
 
 import torch
+
 from monai.inferers.inferer import SimpleInferer
-from ignite.metrics import Metric
-from ignite.engine import Engine
-from .workflow import Workflow
-from .utils import default_prepare_batch
+from monai.utils import exact_version, optional_import
+
 from .utils import CommonKeys as Keys
+from .utils import default_prepare_batch
+from .workflow import Workflow
+
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class Evaluator(Workflow):
@@ -48,7 +51,7 @@ class Evaluator(Workflow):
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
         post_transform=None,
-        key_val_metric: Optional[Metric] = None,
+        key_val_metric=None,
         additional_metrics=None,
         val_handlers=None,
     ):

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -12,7 +12,6 @@
 from typing import Callable, Optional
 
 import torch
-
 from monai.inferers.inferer import SimpleInferer
 from monai.utils import exact_version, optional_import
 
@@ -21,6 +20,7 @@ from .utils import default_prepare_batch
 from .workflow import Workflow
 
 Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
+Metric, _ = optional_import("ignite.metrics", "0.3.0", exact_version, "Metric")
 
 
 class Evaluator(Workflow):
@@ -51,7 +51,7 @@ class Evaluator(Workflow):
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
         post_transform=None,
-        key_val_metric=None,
+        key_val_metric: Optional[Metric] = None,
         additional_metrics=None,
         val_handlers=None,
     ):

--- a/monai/engines/multi_gpu_supervised_trainer.py
+++ b/monai/engines/multi_gpu_supervised_trainer.py
@@ -12,8 +12,14 @@
 from typing import Callable
 
 import torch
-from ignite.engine import create_supervised_trainer, create_supervised_evaluator, _prepare_batch
+
+from monai.utils import exact_version, optional_import
+
 from .utils import get_devices_spec
+
+create_supervised_trainer, _ = optional_import("ignite.engine", "0.3.0", exact_version, "create_supervised_trainer")
+create_supervised_evaluator, _ = optional_import("ignite.engine", "0.3.0", exact_version, "create_supervised_evaluator")
+_prepare_batch, _ = optional_import("ignite.engine", "0.3.0", exact_version, "_prepare_batch")
 
 
 def _default_transform(_x, _y, _y_pred, loss):

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -21,6 +21,7 @@ from .utils import default_prepare_batch
 from .workflow import Workflow
 
 Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
+Metric, _ = optional_import("ignite.metrics", "0.3.0", exact_version, "Metric")
 
 
 class Trainer(Workflow):
@@ -83,7 +84,7 @@ class SupervisedTrainer(Trainer):
         inferer=SimpleInferer(),
         amp: bool = True,
         post_transform=None,
-        key_train_metric=None,
+        key_train_metric: Optional[Metric] = None,
         additional_metrics=None,
         train_handlers=None,
     ):

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -12,12 +12,15 @@
 from typing import Callable, Optional
 
 import torch
-from ignite.metrics import Metric
-from ignite.engine import Engine
+
 from monai.inferers.inferer import SimpleInferer
-from .workflow import Workflow
-from .utils import default_prepare_batch
+from monai.utils import exact_version, optional_import
+
 from .utils import CommonKeys as Keys
+from .utils import default_prepare_batch
+from .workflow import Workflow
+
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class Trainer(Workflow):
@@ -80,7 +83,7 @@ class SupervisedTrainer(Trainer):
         inferer=SimpleInferer(),
         amp: bool = True,
         post_transform=None,
-        key_train_metric: Optional[Metric] = None,
+        key_train_metric=None,
         additional_metrics=None,
         train_handlers=None,
     ):

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -9,20 +9,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Callable
+from abc import ABC, abstractmethod
+from typing import Callable, Optional
 
 import torch
-from .utils import default_prepare_batch
 from monai.transforms import apply_transform
-
 from monai.utils import exact_version, optional_import
+
+from .utils import default_prepare_batch
 
 Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 State, _ = optional_import("ignite.engine", "0.3.0", exact_version, "State")
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
 
 
-class Workflow(Engine):
+class Workflow(ABC, Engine):
     """
     Workflow defines the core work process inheriting from Ignite engine.
     All trainer, validator and evaluator share this same workflow as base class,
@@ -136,6 +137,7 @@ class Workflow(Engine):
         """
         super().run(data=self.data_loader, epoch_length=len(self.data_loader))
 
+    @abstractmethod
     def _iteration(self, engine: Engine, batchdata):
         """
         Abstract callback function for the processing logic of 1 iteration in Ignite Engine.

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -11,7 +11,6 @@
 
 from typing import Optional, Callable
 
-from abc import ABC, abstractmethod
 import torch
 from .utils import default_prepare_batch
 from monai.transforms import apply_transform
@@ -23,7 +22,7 @@ State, _ = optional_import("ignite.engine", "0.3.0", exact_version, "State")
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
 
 
-class Workflow(ABC, Engine):
+class Workflow(Engine):
     """
     Workflow defines the core work process inheriting from Ignite engine.
     All trainer, validator and evaluator share this same workflow as base class,
@@ -137,7 +136,6 @@ class Workflow(ABC, Engine):
         """
         super().run(data=self.data_loader, epoch_length=len(self.data_loader))
 
-    @abstractmethod
     def _iteration(self, engine: Engine, batchdata):
         """
         Abstract callback function for the processing logic of 1 iteration in Ignite Engine.

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
 from typing import Callable, Optional
 
 import torch
@@ -23,7 +22,7 @@ State, _ = optional_import("ignite.engine", "0.3.0", exact_version, "State")
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
 
 
-class Workflow(ABC, Engine):
+class Workflow(Engine):
     """
     Workflow defines the core work process inheriting from Ignite engine.
     All trainer, validator and evaluator share this same workflow as base class,
@@ -137,7 +136,6 @@ class Workflow(ABC, Engine):
         """
         super().run(data=self.data_loader, epoch_length=len(self.data_loader))
 
-    @abstractmethod
     def _iteration(self, engine: Engine, batchdata):
         """
         Abstract callback function for the processing logic of 1 iteration in Ignite Engine.

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -13,9 +13,14 @@ from typing import Optional, Callable
 
 from abc import ABC, abstractmethod
 import torch
-from ignite.engine import Engine, State, Events
 from .utils import default_prepare_batch
 from monai.transforms import apply_transform
+
+from monai.utils import exact_version, optional_import
+
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
+State, _ = optional_import("ignite.engine", "0.3.0", exact_version, "State")
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
 
 
 class Workflow(ABC, Engine):

--- a/monai/handlers/__init__.py
+++ b/monai/handlers/__init__.py
@@ -12,12 +12,12 @@
 from .checkpoint_loader import CheckpointLoader
 from .checkpoint_saver import CheckpointSaver
 from .classification_saver import ClassificationSaver
+from .lr_schedule_handler import LrScheduleHandler
 from .mean_dice import MeanDice
-from .roc_auc import ROCAUC
 from .metric_logger import *
+from .roc_auc import ROCAUC
 from .segmentation_saver import SegmentationSaver
 from .stats_handler import StatsHandler
-from .validation_handler import ValidationHandler
 from .tensorboard_handlers import TensorBoardImageHandler, TensorBoardStatsHandler
-from .lr_schedule_handler import LrScheduleHandler
 from .utils import *
+from .validation_handler import ValidationHandler

--- a/monai/handlers/checkpoint_loader.py
+++ b/monai/handlers/checkpoint_loader.py
@@ -9,12 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Optional
 
-import logging
 import torch
-from ignite.engine import Events, Engine
-from ignite.handlers import Checkpoint
+
+from monai.utils import exact_version, optional_import
+
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
+Checkpoint, _ = optional_import("ignite.handlers", "0.3.0", exact_version, "Checkpoint")
 
 
 class CheckpointLoader:

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -9,10 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Optional
 
-import logging
-from ignite.engine import Events, Engine
+from ignite.engine import Engine, Events
 from ignite.handlers import ModelCheckpoint
 
 

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -12,8 +12,11 @@
 import logging
 from typing import Optional
 
-from ignite.engine import Engine, Events
-from ignite.handlers import ModelCheckpoint
+from monai.utils import exact_version, optional_import
+
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
+ModelCheckpoint, _ = optional_import("ignite.handlers", "0.3.0", exact_version, "ModelCheckpoint")
 
 
 class CheckpointSaver:

--- a/monai/handlers/classification_saver.py
+++ b/monai/handlers/classification_saver.py
@@ -9,11 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Callable
-
-from ignite.engine import Events, Engine
 import logging
+from typing import Callable, Optional
+
 from monai.data import CSVSaver
+from monai.utils import exact_version, optional_import
+
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class ClassificationSaver:
@@ -52,7 +55,7 @@ class ClassificationSaver:
         self.logger = None if name is None else logging.getLogger(name)
         self._name = name
 
-    def attach(self, engine: Engine):
+    def attach(self, engine):
         if self._name is None:
             self.logger = engine.logger
         if not engine.has_event_handler(self, Events.ITERATION_COMPLETED):
@@ -60,7 +63,7 @@ class ClassificationSaver:
         if not engine.has_event_handler(self.saver.finalize, Events.COMPLETED):
             engine.add_event_handler(Events.COMPLETED, lambda engine: self.saver.finalize())
 
-    def __call__(self, engine: Engine):
+    def __call__(self, engine):
         """
         This method assumes self.batch_transform will extract metadata from the input batch.
 

--- a/monai/handlers/classification_saver.py
+++ b/monai/handlers/classification_saver.py
@@ -55,7 +55,7 @@ class ClassificationSaver:
         self.logger = None if name is None else logging.getLogger(name)
         self._name = name
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         if self._name is None:
             self.logger = engine.logger
         if not engine.has_event_handler(self, Events.ITERATION_COMPLETED):
@@ -63,7 +63,7 @@ class ClassificationSaver:
         if not engine.has_event_handler(self.saver.finalize, Events.COMPLETED):
             engine.add_event_handler(Events.COMPLETED, lambda engine: self.saver.finalize())
 
-    def __call__(self, engine):
+    def __call__(self, engine: Engine):
         """
         This method assumes self.batch_transform will extract metadata from the input batch.
 

--- a/monai/handlers/lr_schedule_handler.py
+++ b/monai/handlers/lr_schedule_handler.py
@@ -9,11 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Callable
-
 import logging
-from ignite.engine import Events, Engine
-from monai.utils import ensure_tuple
+from typing import Callable, Optional
+
+from monai.utils import ensure_tuple, exact_version, optional_import
+
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class LrScheduleHandler:

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -12,11 +12,14 @@
 from typing import Callable, Optional, Sequence, Union
 
 import torch
-from ignite.exceptions import NotComputableError
-from ignite.metrics import Metric
-from ignite.metrics.metric import reinit__is_reduced, sync_all_reduce
 
 from monai.metrics import compute_meandice
+from monai.utils import exact_version, optional_import
+
+NotComputableError, _ = optional_import("ignite.exceptions", "0.3.0", exact_version, "NotComputableError")
+Metric, _ = optional_import("ignite.metrics", "0.3.0", exact_version, "Metric")
+reinit__is_reduced, _ = optional_import("ignite.metrics.metric", "0.3.0", exact_version, "reinit__is_reduced")
+sync_all_reduce, _ = optional_import("ignite.metrics.metric", "0.3.0", exact_version, "sync_all_reduce")
 
 
 class MeanDice(Metric):

--- a/monai/handlers/metric_logger.py
+++ b/monai/handlers/metric_logger.py
@@ -25,10 +25,10 @@ class MetricLogger:
         self.loss: list = []
         self.metrics: defaultdict = defaultdict(list)
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         return engine.add_event_handler(Events.ITERATION_COMPLETED, self)
 
-    def __call__(self, engine):
+    def __call__(self, engine: Engine):
         self.loss.append(self.loss_transform(engine.state.output))
 
         for m, v in engine.state.metrics.items():

--- a/monai/handlers/metric_logger.py
+++ b/monai/handlers/metric_logger.py
@@ -12,7 +12,10 @@
 from collections import defaultdict
 from typing import Callable
 
-from ignite.engine import Events, Engine
+from monai.utils import exact_version, optional_import
+
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class MetricLogger:
@@ -22,10 +25,10 @@ class MetricLogger:
         self.loss: list = []
         self.metrics: defaultdict = defaultdict(list)
 
-    def attach(self, engine: Engine):
+    def attach(self, engine):
         return engine.add_event_handler(Events.ITERATION_COMPLETED, self)
 
-    def __call__(self, engine: Engine):
+    def __call__(self, engine):
         self.loss.append(self.loss_transform(engine.state.output))
 
         for m, v in engine.state.metrics.items():

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -9,12 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Union, Callable
+from typing import Callable, Optional, Sequence, Union
 
 import torch
-from ignite.metrics import Metric
 
 from monai.metrics import compute_roc_auc
+from monai.utils import exact_version, optional_import
+
+Metric, _ = optional_import("ignite.metrics", "0.3.0", exact_version, "Metric")
 
 
 class ROCAUC(Metric):

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -13,9 +13,12 @@ import logging
 from typing import Callable, Optional, Union
 
 import numpy as np
-from ignite.engine import Engine, Events
 
 from monai.data import NiftiSaver, PNGSaver
+from monai.utils import exact_version, optional_import
+
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class SegmentationSaver:

--- a/monai/handlers/stats_handler.py
+++ b/monai/handlers/stats_handler.py
@@ -9,13 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 import logging
+import warnings
 from typing import Callable, Optional
 
 import torch
-from ignite.engine import Engine, Events
-from monai.utils import is_scalar
+
+from monai.utils import exact_version, is_scalar, optional_import
+
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 DEFAULT_KEY_VAL_FORMAT = "{}: {:.4f} "
 DEFAULT_TAG = "Loss"

--- a/monai/handlers/tensorboard_handlers.py
+++ b/monai/handlers/tensorboard_handlers.py
@@ -14,7 +14,6 @@ from typing import Callable, Optional
 
 import numpy as np
 import torch
-from torch.utils.tensorboard import SummaryWriter
 
 from monai.utils import exact_version, optional_import
 from monai.utils.misc import is_scalar
@@ -22,6 +21,7 @@ from monai.visualize import plot_2d_or_3d_image
 
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
 Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
+SummaryWriter, _ = optional_import("torch.utils.tensorboard", name="SummaryWriter")
 
 DEFAULT_TAG = "Loss"
 

--- a/monai/handlers/tensorboard_handlers.py
+++ b/monai/handlers/tensorboard_handlers.py
@@ -9,15 +9,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Callable
+import warnings
+from typing import Callable, Optional
 
 import numpy as np
-import warnings
 import torch
 from torch.utils.tensorboard import SummaryWriter
-from ignite.engine import Engine, Events
-from monai.visualize import plot_2d_or_3d_image
+
+from monai.utils import exact_version, optional_import
 from monai.utils.misc import is_scalar
+from monai.visualize import plot_2d_or_3d_image
+
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 DEFAULT_TAG = "Loss"
 

--- a/monai/handlers/validation_handler.py
+++ b/monai/handlers/validation_handler.py
@@ -38,11 +38,11 @@ class ValidationHandler:
         self.interval = interval
         self.epoch_level = epoch_level
 
-    def attach(self, engine):
+    def attach(self, engine: Engine):
         if self.epoch_level:
             engine.add_event_handler(Events.EPOCH_COMPLETED(every=self.interval), self)
         else:
             engine.add_event_handler(Events.ITERATION_COMPLETED(every=self.interval), self)
 
-    def __call__(self, engine):
+    def __call__(self, engine: Engine):
         self.validator.run(engine.state.epoch)

--- a/monai/handlers/validation_handler.py
+++ b/monai/handlers/validation_handler.py
@@ -9,8 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ignite.engine import Events, Engine
 from monai.engines import Evaluator
+from monai.utils import exact_version, optional_import
+
+Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
+Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class ValidationHandler:
@@ -35,11 +38,11 @@ class ValidationHandler:
         self.interval = interval
         self.epoch_level = epoch_level
 
-    def attach(self, engine: Engine):
+    def attach(self, engine):
         if self.epoch_level:
             engine.add_event_handler(Events.EPOCH_COMPLETED(every=self.interval), self)
         else:
             engine.add_event_handler(Events.ITERATION_COMPLETED(every=self.interval), self)
 
-    def __call__(self, engine: Engine):
+    def __call__(self, engine):
         self.validator.run(engine.state.epoch)

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -9,18 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
 from .utils import sliding_window_inference
 import torch
 
 
-class Inferer(ABC):
+class Inferer:
     """
     A base class for model inference.
     Extend this class to support operations during inference, e.g. a sliding window method.
     """
 
-    @abstractmethod
     def __call__(self, inputs: torch.Tensor, network):
         """
         Run inference on `inputs` with the `network` model.

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -9,16 +9,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .utils import sliding_window_inference
+from abc import ABC, abstractmethod
+
 import torch
 
+from .utils import sliding_window_inference
 
-class Inferer:
+
+class Inferer(ABC):
     """
     A base class for model inference.
     Extend this class to support operations during inference, e.g. a sliding window method.
     """
 
+    @abstractmethod
     def __call__(self, inputs: torch.Tensor, network):
         """
         Run inference on `inputs` with the `network` model.

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -16,13 +16,16 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 from typing import Optional
 
 import numpy as np
-import nibabel as nib
-from PIL import Image
+
 from torch.utils.data._utils.collate import np_str_obj_array_pattern
 
 from monai.data.utils import correct_nifti_header_if_necessary
 from monai.transforms.compose import Transform
 from monai.utils.misc import ensure_tuple
+from monai.utils import optional_import
+
+nib, _ = optional_import("nibabel")
+Image, _ = optional_import("PIL.Image")
 
 
 class LoadNifti(Transform):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -16,7 +16,6 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 import warnings
 from typing import List, Optional, Union
 
-import nibabel as nib
 import numpy as np
 import torch
 
@@ -33,6 +32,9 @@ from monai.transforms.utils import (
     create_translate,
 )
 from monai.utils.misc import ensure_tuple, ensure_tuple_rep, ensure_tuple_size
+from monai.utils import optional_import
+
+nib, _ = optional_import("nibabel")
 
 if get_torch_version_tuple() >= (1, 5):
     # additional argument since torch 1.5 (to avoid warnings)

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -15,10 +15,11 @@ from typing import Optional, Callable
 
 import torch
 import numpy as np
-from skimage import measure
 
 from monai.config.type_definitions import IndexSelection
-from monai.utils.misc import ensure_tuple
+from monai.utils import ensure_tuple, optional_import, min_version
+
+measure, _ = optional_import("skimage.measure", "0.14.2", min_version)
 
 
 def rand_choice(prob=0.5):

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -10,6 +10,6 @@
 # limitations under the License.
 
 # have to explicitly bring these in here to resolve circular import issues
-from .module import export
+from .module import export, optional_import, min_version, exact_version
 from .decorators import *
 from .misc import *

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -158,7 +158,7 @@ def optional_import(
     # preparing lazy error message
     msg = descriptor.format(actual_cmd)
     if version and tb is None:  # a pure version issue
-        msg += f" (requires version '{version}' by '{version_checker.__name__}')"
+        msg += f" (requires '{module} {version}' by '{version_checker.__name__}')"
     if exception_str:
         msg += f" ({exception_str})"
 

--- a/monai/visualize/img2tensorboard.py
+++ b/monai/visualize/img2tensorboard.py
@@ -9,17 +9,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
+from typing import Optional, Sequence, Union
+
 import numpy as np
-from torch.utils.tensorboard import SummaryWriter
+import torch
+
 from monai.transforms.utils import rescale_array
 from monai.utils import optional_import
 
-from typing import Sequence, Union, Optional
-
 PIL, _ = optional_import("PIL")
 GifImage, _ = optional_import("PIL.GifImagePlugin", name="Image")
-summary_pb2, _ = optional_import("tensorboard.compat.proto", name="summary_pb2")
+summary_pb2, _ = optional_import("tensorboard.compat.proto.summary_pb2")
+SummaryWriter, _ = optional_import("torch.utils.tensorboard", name="SummaryWriter")
 
 
 def _image3_animated_gif(tag: str, image: Union[np.ndarray, torch.Tensor], scale_factor: float = 1.0):
@@ -95,7 +96,7 @@ def make_animated_gif_summary(
 
 
 def add_animated_gif(
-    writer: SummaryWriter,
+    writer,
     tag: str,
     image_tensor: Union[np.ndarray, torch.Tensor],
     max_out: int,
@@ -122,7 +123,7 @@ def add_animated_gif(
 
 
 def add_animated_gif_no_channels(
-    writer: SummaryWriter,
+    writer,
     tag: str,
     image_tensor: Union[np.ndarray, torch.Tensor],
     max_out: int,
@@ -153,7 +154,7 @@ def add_animated_gif_no_channels(
 def plot_2d_or_3d_image(
     data: Union[torch.Tensor, np.ndarray],
     step: int,
-    writer: SummaryWriter,
+    writer,
     index: int = 0,
     max_channels: int = 1,
     max_frames: int = 64,

--- a/monai/visualize/img2tensorboard.py
+++ b/monai/visualize/img2tensorboard.py
@@ -11,13 +11,15 @@
 
 import torch
 import numpy as np
-import PIL
-from PIL.GifImagePlugin import Image as GifImage
 from torch.utils.tensorboard import SummaryWriter
-from tensorboard.compat.proto import summary_pb2
 from monai.transforms.utils import rescale_array
+from monai.utils import optional_import
 
 from typing import Sequence, Union, Optional
+
+PIL, _ = optional_import("PIL")
+GifImage, _ = optional_import("PIL.GifImagePlugin", name="Image")
+summary_pb2, _ = optional_import("tensorboard.compat.proto", name="summary_pb2")
 
 
 def _image3_animated_gif(tag: str, image: Union[np.ndarray, torch.Tensor], scale_factor: float = 1.0):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ exclude = '''
     | \.mypy_cache
     | \.tox
     | \.venv
-    | \.mypy_cache
     | \.pytype
     | _build
     | buck-out

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 coverage
 parameterized
 pytorch-ignite==0.3.0
+scipy
 nibabel
 pillow
 tensorboard

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,12 @@
 # Requirements for testing
 -r requirements.txt
-scipy
 coverage
 parameterized
+pytorch-ignite==0.3.0
+nibabel
+pillow
+tensorboard
+scikit-image>=0.14.2
 flake8>=3.8.1
 flake8-bugbear
 flake8-comprehensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,2 @@
 torch>=1.4
-pytorch-ignite==0.3.0
 numpy>=1.17
-nibabel
-tensorboard
-pillow
-scikit-image>=0.14.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,20 +12,26 @@ license = Apache License 2.0
 [options]
 python_requires = >= 3.6
 install_requires =
-    torch >=1.4
-    numpy >=1.17
+    torch>=1.4
+    numpy>=1.17
 
 [options.extras_require]
+all =
+    nibabel
+    scikit-image>=0.14.2
+    pillow
+    tensorboard
+    pytorch-ignite==0.3.0
 nibabel =
     nibabel
 skimage =
-    scikit-image >= 0.14.2
-PIL =
+    scikit-image>=0.14.2
+pillow =
     pillow
 tensorboard =
     tensorboard
 ignite =
-    pytorch-ignite ==0.3.0
+    pytorch-ignite==0.3.0
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9
@@ -120,11 +126,11 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-monai.handlers.*]
-# Always ignore any type issues in the monai/handlers file
+# Always ignore any type issues in the monai/handlers files
 ignore_errors = True
 
 [mypy-monai.engines.*]
-# Always ignore any type issues in the monai/handlers file
+# Always ignore any type issues in the monai/engines files
 ignore_errors = True
 
 [pytype]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,12 +13,19 @@ license = Apache License 2.0
 python_requires = >= 3.6
 install_requires =
     torch >=1.4
-    pytorch-ignite ==0.3.0
     numpy >=1.17
+
+[options.extras_require]
+nibabel =
     nibabel
-    tensorboard
+skimage =
+    scikit-image >= 0.14.2
+PIL =
     pillow
-    scikit-image >=0.14.2
+tensorboard =
+    tensorboard
+ignite =
+    pytorch-ignite ==0.3.0
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9
@@ -107,15 +114,24 @@ follow_imports_for_stubs = True
 [mypy-versioneer]
 # Always ignore any type issues in the versioneer.py file
 ignore_errors = True
+
 [mypy-monai._version]
 # Always ignore any type issues in the monai/._version.py file
+ignore_errors = True
+
+[mypy-monai.handlers.*]
+# Always ignore any type issues in the monai/handlers file
+ignore_errors = True
+
+[mypy-monai.engines.*]
+# Always ignore any type issues in the monai/handlers file
 ignore_errors = True
 
 [pytype]
 # NOTE: All relative paths are relative to the location of this file.
 # Space-separated list of files or directories to exclude.
 #  i.e. exclude = **/*_test.py **/test_*.py
-exclude = **/versioneer.py _version.py
+exclude = **/versioneer.py _version.py monai/handlers monai/engines
 # Space-separated list of files or directories to process.
 inputs = monai
 # Keep going past errors to analyze as many files as possible.

--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -73,6 +73,16 @@ class TestOptionalImport(unittest.TestCase):
         self.assertTrue(flag)
         print(nn.functional)
 
+    def test_additional(self):
+        test_args = {"a": "test", "b": "test"}
+
+        def versioning(module, ver, a):
+            self.assertEqual(a, test_args)
+            return True
+
+        nn, flag = optional_import("torch", "1.1", version_checker=versioning, name="nn", version_args=test_args)
+        self.assertTrue(flag)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -1,0 +1,73 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from monai.utils import exact_version, optional_import
+
+
+class TestOptionalImport(unittest.TestCase):
+    def test_default(self):
+        my_module, flag = optional_import("not_a_module")
+        self.assertFalse(flag)
+        with self.assertRaises(AttributeError):
+            my_module.test
+
+        my_module, flag = optional_import("torch.randint")
+        with self.assertRaises(AttributeError):
+            self.assertFalse(flag)
+            print(my_module.test)
+
+    def test_import_valid(self):
+        my_module, flag = optional_import("torch")
+        self.assertTrue(flag)
+        print(my_module.randint(1, 2, (1, 2)))
+
+    def test_import_wrong_number(self):
+        my_module, flag = optional_import("torch", "42")
+        with self.assertRaisesRegex(AttributeError, "version"):
+            my_module.nn
+        self.assertFalse(flag)
+        with self.assertRaisesRegex(AttributeError, "version"):
+            my_module.randint(1, 2, (1, 2))
+
+    def test_import_good_number(self):
+        my_module, flag = optional_import("torch", "0")
+        my_module.nn
+        self.assertTrue(flag)
+        print(my_module.randint(1, 2, (1, 2)))
+
+        my_module, flag = optional_import("torch", "0.0.0.1")
+        my_module.nn
+        self.assertTrue(flag)
+        print(my_module.randint(1, 2, (1, 2)))
+
+        my_module, flag = optional_import("torch", "1.1.0")
+        my_module.nn
+        self.assertTrue(flag)
+        print(my_module.randint(1, 2, (1, 2)))
+
+    def test_import_exact(self):
+        my_module, flag = optional_import("torch", "0", exact_version)
+        with self.assertRaisesRegex(AttributeError, "exact_version"):
+            my_module.nn
+        self.assertFalse(flag)
+        with self.assertRaisesRegex(AttributeError, "exact_version"):
+            my_module.randint(1, 2, (1, 2))
+
+    def test_import_method(self):
+        nn, flag = optional_import("torch", "1.1", name="nn")
+        self.assertTrue(flag)
+        print(nn.functional)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -38,6 +38,11 @@ class TestOptionalImport(unittest.TestCase):
         self.assertFalse(flag)
         with self.assertRaisesRegex(AttributeError, "version"):
             my_module.randint(1, 2, (1, 2))
+        with self.assertRaisesRegex(ValueError, "invalid literal"):
+            my_module, flag = optional_import("torch", "test")  # version should be number.number
+            my_module.nn
+            self.assertTrue(flag)
+            print(my_module.randint(1, 2, (1, 2)))
 
     def test_import_good_number(self):
         my_module, flag = optional_import("torch", "0")


### PR DESCRIPTION
Fixes #198.

### Description
The PR makes the core codebase only depends on pytorch and numpy.
All references to optional packages (such as skimage) will raise exceptions lazily if the users don't have the packages installed beforehand

currently these packages are made optional to monai:

- pytorch-ignite==0.3.0
- nibabel
- pillow
- tensorboard
- scikit-image>=0.14.2

#### Known issue: 
type checking tools may not be fully aware of the module alias by optional import, we might lose some type hinting here.

#### TODOs:
~This is a work in progress, if we agree with this approach I'll take another a few hours to polish the code~
- [x] check packaging related commands
- [x] update contributing.md to reflect the changes
~- [ ] workaround for type hinting with optional modules~
- [x] integration tests

### Status
**ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated
