### PR TITLE
adds sphinx_autodoc_typehints to conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,11 +92,13 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
+    "sphinx_autodoc_typehints",
 ]
 
 autoclass_content = "both"
 add_module_names = True
 autosectionlabel_prefix_document = True
+napoleon_use_param = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -115,9 +115,10 @@ class LoadPNG(Transform):
     """
 
     def __init__(self, image_only: bool = False, dtype: Optional[np.dtype] = np.float32):
-        """Args:
+        """
+        Args:
             image_only: if True return only the image volume, otherwise return image data array and metadata.
-            dtype (np.dtype, optional): if not None convert the loaded image to this data type.
+            dtype: if not None convert the loaded image to this data type.
         """
         self.image_only = image_only
         self.dtype = dtype


### PR DESCRIPTION
part of #476

### Description
display type hints in the parameters section instead of the function signature.

no need to write parameter types in the docstring if the signature has type hinting

before:
![Screenshot 2020-06-13 at 13 19 32](https://user-images.githubusercontent.com/831580/84568706-287ab580-ad79-11ea-8bfc-889dd7dd5083.png)
after:
![Screenshot 2020-06-13 at 13 19 03](https://user-images.githubusercontent.com/831580/84568717-3af4ef00-ad79-11ea-8216-4f6ccec36c67.png)



### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated
