### PR TITLE
Adapt warning message to new parameter names

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -64,7 +64,7 @@ class DiceLoss(_Loss):
             raise ValueError(f"reduction={reduction} is invalid. Valid options are: none, mean or sum.")
 
         if sigmoid and softmax:
-            raise ValueError("do_sigmoid=True and do_softmax=True are not compatible.")
+            raise ValueError("sigmoid=True and softmax=True are not compatible.")
 
         self.include_background = include_background
         self.to_onehot_y = to_onehot_y


### PR DESCRIPTION
The parameters have been [renamed](https://github.com/Project-MONAI/MONAI/commit/fb5a8cb4fabf001b57006cbdd499f00c22f34408#diff-9bcb8276b322f1c61d0ceda577e05d7c) recently. This minor fix also renames them in the warning message.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [x ] Docstrings/Documentation updated
