### PR TITLE
class DiceMetric 

### DIFF
--- a/monai/metrics/__init__.py
+++ b/monai/metrics/__init__.py
@@ -9,5 +9,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .meandice import compute_meandice
+from .meandice import compute_meandice, DiceMetric
 from .rocauc import compute_roc_auc

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -10,10 +10,95 @@
 # limitations under the License.
 
 import warnings
-
 import torch
-
 from monai.networks.utils import one_hot
+
+
+class DiceMetric:
+    """
+    Compute average Dice loss between two tensors. It can support both multi-classes and multi-labels tasks.
+    Input logits `input` (BNHW[D] where N is number of classes) is compared with ground truth `target` (BNHW[D]).
+    Axis N of `input` is expected to have logit predictions for each class rather than being image channels,
+    while the same axis of `target` can be 1 or N (one-hot format). The `smooth` parameter is a value added to the
+    intersection and union components of the inter-over-union calculation to smooth results and prevent divide by 0,
+    this value should be small. The `include_background` class attribute can be set to False for an instance of
+    DiceLoss to exclude the first category (channel index 0) which is by convention assumed to be background.
+    If the non-background segmentations are small compared to the total image size they can get overwhelmed by
+    the signal from the background so excluding it in such cases helps convergence.
+
+    """
+
+    def __init__(
+        self,
+        include_background: bool = True,
+        to_onehot_y: bool = False,
+        mutually_exclusive: bool = False,
+        sigmoid: bool = False,
+        logit_thresh: float = 0.5,
+        reduction: str = "mean",
+    ):
+        super().__init__()
+
+        if reduction not in ["none", "mean", "sum", "mean_batch", "sum_batch"]:
+            raise ValueError(f"reduction={reduction} is invalid. Valid options are: none, mean or sum.")
+
+        self.include_background = include_background
+        self.to_onehot_y = to_onehot_y
+        self.mutually_exclusive = mutually_exclusive
+        self.sigmoid = sigmoid
+        self.logit_thresh = logit_thresh
+        self.reduction = reduction
+
+        self.not_nans = None  # keep track for valid elements in the batch
+
+    def __call__(self, input: torch.Tensor, target: torch.Tensor):
+
+        # compute dice (BxC) for each channel for each batch
+        f = compute_meandice(
+            y_pred=input,
+            y=target,
+            include_background=self.include_background,
+            to_onehot_y=self.to_onehot_y,
+            mutually_exclusive=self.mutually_exclusive,
+            sigmoid=self.sigmoid,
+            logit_thresh=self.logit_thresh,
+        )
+
+        # some dice elements might be Nan (if ground truth y was missing (zeros))
+        # we need to account for it
+
+        nans = torch.isnan(f)
+        not_nans = (~nans).float()
+        f[nans] = 0
+
+        t_zero = torch.zeros(1, device=f.device, dtype=torch.float)
+
+        if self.reduction == "mean":
+            # 2 steps, first, mean by  batch (accounting for nans), then by channel
+
+            not_nans = not_nans.sum(dim=0)
+            f = torch.where(not_nans > 0, f.sum(dim=0) / not_nans, t_zero)  # batch average
+
+            not_nans = not_nans.sum()
+            f = torch.where(not_nans > 0, f.sum() / not_nans, t_zero)  # channel average
+
+        elif self.reduction == "sum":
+            not_nans = not_nans.sum()
+            f = torch.sum(f)  # sum over the batch and channel dims
+        elif self.reduction == "mean_batch":
+            not_nans = not_nans.sum(dim=0)
+            f = torch.where(not_nans > 0, f.sum(dim=0) / not_nans, t_zero)  # batch average
+        elif self.reduction == "sum_batch":
+            not_nans = not_nans.sum(dim=0)
+            f = f.sum(dim=0)  # the batch sum
+        elif self.reduction == "none":
+            pass
+        else:
+            raise ValueError(f"reduction={self.reduction} is invalid.")
+
+        self.not_nans = not_nans  # preserve, since we may need it later to know how many elements were valid
+
+        return f
 
 
 def compute_meandice(
@@ -74,11 +159,11 @@ def compute_meandice(
             if sigmoid:
                 raise ValueError("sigmoid=True is incompatible with mutually_exclusive=True.")
             y_pred = torch.argmax(y_pred, dim=1, keepdim=True)
-            y_pred = one_hot(y_pred, n_classes)
+            y_pred = one_hot(y_pred, num_classes=n_classes)
         else:
             y_pred = (y_pred >= logit_thresh).float()
         if to_onehot_y:
-            y = one_hot(y, n_classes)
+            y = one_hot(y, num_classes=n_classes)
 
     if not include_background:
         y = y[:, 1:] if y.shape[1] > 1 else y
@@ -91,11 +176,11 @@ def compute_meandice(
 
     # reducing only spatial dimensions (not batch nor channels)
     reduce_axis = list(range(2, n_len))
-    intersection = torch.sum(y * y_pred, reduce_axis)
+    intersection = torch.sum(y * y_pred, dim=reduce_axis)
 
     y_o = torch.sum(y, reduce_axis)
-    y_pred_o = torch.sum(y_pred, reduce_axis)
+    y_pred_o = torch.sum(y_pred, dim=reduce_axis)
     denominator = y_o + y_pred_o
 
-    f = torch.where(y_o > 0, (2.0 * intersection) / denominator, torch.tensor(float("nan")).to(y_o.float()))
+    f = torch.where(y_o > 0, (2.0 * intersection) / denominator, torch.tensor(float("nan"), device=y_o.device))
     return f  # returns array of Dice shape: [Batch, n_classes]


### PR DESCRIPTION
Adding class DiceMetric based on compute_meandice func, and account for nans

Here is my attempt on DiceMetric class, which is currently missing. 
It uses compute_meandice existing func, that computes individual dice (but can output Nan if the class is missing). So, DiceMetric class needs to handle the nans. 

I've added 4 reduction options: mean, sum, mean_batch, sum_batch. And nans are handled for each of them. Then we probably need to track the number of non-nans used (to later properly updated the overall average metric), for which I use self.not_nans var. Alternatively one can return a tumble (dice, non_nans) instead of just dice value. 

plz take a look
