### PR TITLE
476 Add type hints to monai/engines/

### DIFF
--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -9,18 +9,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional
+from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ignite.engine
+    import ignite.metrics
 
 import torch
-from monai.inferers import SimpleInferer
-from monai.utils import exact_version, optional_import
+from torch.utils.data import DataLoader
+
+from monai.inferers import Inferer, SimpleInferer
+from monai.transforms import Transform
 
 from monai.engines.utils import CommonKeys as Keys
 from monai.engines.utils import default_prepare_batch
 from monai.engines.workflow import Workflow
-
-Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
-Metric, _ = optional_import("ignite.metrics", "0.3.0", exact_version, "Metric")
 
 
 class Evaluator(Workflow):
@@ -28,14 +31,14 @@ class Evaluator(Workflow):
     Base class for all kinds of evaluators, inherits from Workflow.
 
     Args:
-        device (torch.device): an object representing the device on which to run.
-        val_data_loader (torch.DataLoader): Ignite engine use data_loader to run, must be torch.DataLoader.
+        device: an object representing the device on which to run.
+        val_data_loader: Ignite engine use data_loader to run, must be torch.DataLoader.
         prepare_batch: function to parse image and label for current iteration.
         iteration_update: the callable function for every iteration, expect to accept `engine`
             and `batchdata` as input parameters. if not provided, use `self._iteration()` instead.
-        post_transform (Transform): execute additional transformation for the model output data.
+        post_transform: execute additional transformation for the model output data.
             Typically, several Tensor based transforms composed by `Compose`.
-        key_val_metric (ignite.metric): compute metric when every iteration completed, and save average value to
+        key_val_metric: compute metric when every iteration completed, and save average value to
             engine.state.metrics when epoch completed. key_val_metric is the main metric to compare and save the
             checkpoint into files.
         additional_metrics (dict): more Ignite metrics that also attach to Ignite Engine.
@@ -47,14 +50,14 @@ class Evaluator(Workflow):
     def __init__(
         self,
         device: torch.device,
-        val_data_loader,
+        val_data_loader: DataLoader,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
-        post_transform=None,
-        key_val_metric: Optional[Metric] = None,
+        post_transform: Optional[Transform] = None,
+        key_val_metric: Optional["ignite.metrics.Metric"] = None,
         additional_metrics=None,
         val_handlers=None,
-    ):
+    ) -> None:
         super().__init__(
             device=device,
             max_epochs=1,
@@ -68,7 +71,7 @@ class Evaluator(Workflow):
             handlers=val_handlers,
         )
 
-    def run(self, global_epoch: int = 1):
+    def run(self, global_epoch: int = 1) -> None:
         """
         Execute validation/evaluation based on Ignite Engine.
 
@@ -82,7 +85,7 @@ class Evaluator(Workflow):
         self.state.iteration = 0
         super().run()
 
-    def get_validation_stats(self):
+    def get_validation_stats(self) -> Dict[str, Any]:
         return {"best_validation_metric": self.state.best_metric, "best_validation_epoch": self.state.best_metric_epoch}
 
 
@@ -91,16 +94,16 @@ class SupervisedEvaluator(Evaluator):
     Standard supervised evaluation method with image and label(optional), inherits from evaluator and Workflow.
 
     Args:
-        device (torch.device): an object representing the device on which to run.
-        val_data_loader (torch.DataLoader): Ignite engine use data_loader to run, must be torch.DataLoader.
+        device: an object representing the device on which to run.
+        val_data_loader: Ignite engine use data_loader to run, must be torch.DataLoader.
         network (Network): use the network to run model forward.
         prepare_batch: function to parse image and label for current iteration.
         iteration_update: the callable function for every iteration, expect to accept `engine`
             and `batchdata` as input parameters. if not provided, use `self._iteration()` instead.
-        inferer (Inferer): inference method that execute model forward on input data, like: SlidingWindow, etc.
-        post_transform (Transform): execute additional transformation for the model output data.
+        inferer: inference method that execute model forward on input data, like: SlidingWindow, etc.
+        post_transform: execute additional transformation for the model output data.
             Typically, several Tensor based transforms composed by `Compose`.
-        key_val_metric (ignite.metric): compute metric when every iteration completed, and save average value to
+        key_val_metric: compute metric when every iteration completed, and save average value to
             engine.state.metrics when epoch completed. key_val_metric is the main metric to compare and save the
             checkpoint into files.
         additional_metrics (dict): more Ignite metrics that also attach to Ignite Engine.
@@ -112,13 +115,13 @@ class SupervisedEvaluator(Evaluator):
     def __init__(
         self,
         device: torch.device,
-        val_data_loader,
+        val_data_loader: DataLoader,
         network,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
-        inferer=SimpleInferer(),
-        post_transform=None,
-        key_val_metric=None,
+        inferer: Inferer = SimpleInferer(),
+        post_transform: Optional[Transform] = None,
+        key_val_metric: Optional["ignite.metrics.Metric"] = None,
         additional_metrics=None,
         val_handlers=None,
     ):
@@ -136,7 +139,7 @@ class SupervisedEvaluator(Evaluator):
         self.network = network
         self.inferer = inferer
 
-    def _iteration(self, engine: Engine, batchdata):
+    def _iteration(self, engine: "ignite.engine.Engine", batchdata) -> Dict[str, Any]:
         """
         callback function for the Supervised Evaluation processing logic of 1 iteration in Ignite Engine.
         Return below items in a dictionary:

--- a/monai/engines/multi_gpu_supervised_trainer.py
+++ b/monai/engines/multi_gpu_supervised_trainer.py
@@ -9,7 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
+from typing import Callable, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ignite.metrics
+
 import torch
 
 from monai.utils import exact_version, optional_import
@@ -30,7 +34,7 @@ def _default_eval_transform(x, y, y_pred):
 
 def create_multigpu_supervised_trainer(
     net: torch.nn.Module,
-    optimizer,
+    optimizer: torch.optim.Optimizer,
     loss_fn,
     devices=None,
     non_blocking: bool = False,
@@ -43,8 +47,8 @@ def create_multigpu_supervised_trainer(
     Factory function for creating a trainer for supervised models.
 
     Args:
-        net (`torch.nn.Module`): the network to train.
-        optimizer (`torch.optim.Optimizer`): the optimizer to use.
+        net: the network to train.
+        optimizer: the optimizer to use.
         loss_fn (`torch.nn` loss function): the loss function to use.
         devices (list, optional): device(s) type specification (default: None).
             Applies to both model and batches. None is all devices used, empty list is CPU only.
@@ -73,7 +77,7 @@ def create_multigpu_supervised_trainer(
 
 def create_multigpu_supervised_evaluator(
     net: torch.nn.Module,
-    metrics=None,
+    metrics: Optional[Dict[str, "ignite.metrics.Metric"]] = None,
     devices=None,
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,
@@ -85,8 +89,8 @@ def create_multigpu_supervised_evaluator(
     Factory function for creating an evaluator for supervised models.
 
     Args:
-        net (`torch.nn.Module`): the model to train.
-        metrics (dict of str - :class:`~ignite.metrics.Metric`): a map of metric names to Metrics.
+        net: the model to train.
+        metrics: a map of metric names to Metrics.
         devices (list, optional): device(s) type specification (default: None).
             Applies to both model and batches. None is all devices used, empty list is CPU only.
         non_blocking: if True and this copy is between CPU and GPU, the copy may occur asynchronously

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -9,10 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional
-import torch
+from typing import Callable, Optional, TYPE_CHECKING
 
-from monai.transforms import apply_transform
+if TYPE_CHECKING:
+    import ignite.engine
+    import ignite.metrics
+
+import torch
+from torch.utils.data import DataLoader
+
+from monai.transforms import apply_transform, Transform
 from monai.utils import exact_version, optional_import, ensure_tuple
 from monai.engines.utils import default_prepare_batch
 
@@ -32,16 +38,16 @@ class Workflow(Engine):
     Users should consider to inherit from `trainer` or `evaluator` to develop more trainers or evaluators.
 
     Args:
-        device (torch.device): an object representing the device on which to run.
+        device: an object representing the device on which to run.
         max_epochs: the total epoch number for engine to run, validator and evaluator have only 1 epoch.
         amp: whether to enable auto-mixed-precision training, reserved.
-        data_loader (torch.DataLoader): Ignite engine use data_loader to run, must be torch.DataLoader.
+        data_loader: Ignite engine use data_loader to run, must be torch.DataLoader.
         prepare_batch: function to parse image and label for every iteration.
         iteration_update: the callable function for every iteration, expect to accept `engine`
             and `batchdata` as input parameters. if not provided, use `self._iteration()` instead.
-        post_transform (Transform): execute additional transformation for the model output data.
+        post_transform: execute additional transformation for the model output data.
             Typically, several Tensor based transforms composed by `Compose`.
-        key_metric (ignite.metric): compute metric when every iteration completed, and save average value to
+        key_metric: compute metric when every iteration completed, and save average value to
             engine.state.metrics when epoch completed. key_metric is the main metric to compare and save the
             checkpoint into files.
         additional_metrics (dict): more Ignite metrics that also attach to Ignite Engine.
@@ -52,17 +58,17 @@ class Workflow(Engine):
 
     def __init__(
         self,
-        device,
+        device: torch.device,
         max_epochs: int,
         amp: bool,
-        data_loader,
+        data_loader: DataLoader,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
-        post_transform=None,
-        key_metric=None,
+        post_transform: Optional[Transform] = None,
+        key_metric: Optional["ignite.metrics.Metric"] = None,
         additional_metrics=None,
         handlers=None,
-    ):
+    ) -> None:
         # pytype: disable=invalid-directive
         # pytype: disable=wrong-arg-count
         super().__init__(iteration_update if iteration_update is not None else self._iteration)
@@ -73,7 +79,7 @@ class Workflow(Engine):
             self.logger.info("Will add AMP support when PyTorch v1.6 released.")
         if not isinstance(device, torch.device):
             raise ValueError("device must be PyTorch device object.")
-        if not isinstance(data_loader, torch.utils.data.DataLoader):  # type: ignore
+        if not isinstance(data_loader, DataLoader):
             raise ValueError("data_loader must be PyTorch DataLoader.")
 
         # set all sharable data for the workflow based on Ignite engine.state
@@ -99,7 +105,7 @@ class Workflow(Engine):
         if post_transform is not None:
 
             @self.on(Events.ITERATION_COMPLETED)
-            def run_post_transform(engine):
+            def run_post_transform(engine: "ignite.engine.Engine"):
                 engine.state.output = apply_transform(post_transform, engine.state.output)
 
         if key_metric is not None:
@@ -116,7 +122,7 @@ class Workflow(Engine):
                 metric.attach(self, name)
 
             @self.on(Events.EPOCH_COMPLETED)
-            def _compare_metrics(engine):
+            def _compare_metrics(engine: "ignite.engine.Engine"):
                 if engine.state.key_metric_name is not None:
                     current_val_metric = engine.state.metrics[engine.state.key_metric_name]
                     if current_val_metric > engine.state.best_metric:
@@ -136,7 +142,7 @@ class Workflow(Engine):
         """
         super().run(data=self.data_loader, epoch_length=len(self.data_loader))
 
-    def _iteration(self, engine: Engine, batchdata):
+    def _iteration(self, engine: "ignite.engine.Engine", batchdata):
         """
         Abstract callback function for the processing logic of 1 iteration in Ignite Engine.
         Need subclass to implement different logics, like SupervisedTrainer/Evaluator, GANTrainer, etc.


### PR DESCRIPTION
### Description

Iteration of #476

- remove unused imports
- reorder imports
- use 'if TYPE_CHECKING:' for optional imports
- add type hints
- fix type hints
- remove docstring type hints

optional_import does not enable correct type hinting
so 'if TYPE_CHECKING:' is used. The type annotation must
then be a forward reference i.e. it must be in quotes.

### Status

**Ready**

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated

