### PR TITLE
476 Add type hints to monai/handlers/

### DIFF
--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -27,7 +27,7 @@ State, _ = optional_import("ignite.engine", "0.3.0", exact_version, "State")
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
 
 
-class Workflow(Engine):
+class Workflow(Engine):  # type: ignore # incorrectly typed due to optional_import
     """
     Workflow defines the core work process inheriting from Ignite engine.
     All trainer, validator and evaluator share this same workflow as base class,
@@ -64,7 +64,7 @@ class Workflow(Engine):
         data_loader: DataLoader,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
-        post_transform: Optional[Transform] = None,
+        post_transform: Optional[Callable] = None,
         key_metric: Optional["ignite.metrics.Metric"] = None,
         additional_metrics=None,
         handlers=None,
@@ -106,6 +106,7 @@ class Workflow(Engine):
 
             @self.on(Events.ITERATION_COMPLETED)
             def run_post_transform(engine: "ignite.engine.Engine"):
+                assert post_transform is not None
                 engine.state.output = apply_transform(post_transform, engine.state.output)
 
         if key_metric is not None:

--- a/monai/handlers/checkpoint_loader.py
+++ b/monai/handlers/checkpoint_loader.py
@@ -9,15 +9,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ignite.engine
+
 import logging
-from typing import Optional
 
 import torch
 
 from monai.utils import exact_version, optional_import
 
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
-Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 Checkpoint, _ = optional_import("ignite.handlers", "0.3.0", exact_version, "Checkpoint")
 
 
@@ -30,7 +33,7 @@ class CheckpointLoader:
 
     Args:
         load_path: the file path of checkpoint, it should be a PyTorch `pth` file.
-        load_dict (dict): target objects that load checkpoint to. examples::
+        load_dict: target objects that load checkpoint to. examples::
 
             {'network': net, 'optimizer': optimizer, 'lr_scheduler': lr_scheduler}
 
@@ -38,7 +41,7 @@ class CheckpointLoader:
 
     """
 
-    def __init__(self, load_path: str, load_dict, name: Optional[str] = None):
+    def __init__(self, load_path: str, load_dict: dict, name: Optional[str] = None) -> None:
         assert load_path is not None, "must provide clear path to load checkpoint."
         self.load_path = load_path
         assert load_dict is not None and len(load_dict) > 0, "must provide target objects to load."
@@ -50,12 +53,12 @@ class CheckpointLoader:
 
         self._name = name
 
-    def attach(self, engine: Engine):
+    def attach(self, engine: "ignite.engine.Engine"):
         if self._name is None:
             self.logger = engine.logger
         return engine.add_event_handler(Events.STARTED, self)
 
-    def __call__(self, engine):
+    def __call__(self, engine: "ignite.engine.Engine") -> None:
         checkpoint = torch.load(self.load_path)
         if len(self.load_dict) == 1:
             key = list(self.load_dict.keys())[0]

--- a/monai/handlers/classification_saver.py
+++ b/monai/handlers/classification_saver.py
@@ -9,14 +9,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ignite.engine
+
 import logging
-from typing import Callable, Optional
 
 from monai.data import CSVSaver
 from monai.utils import exact_version, optional_import
 
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
-Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class ClassificationSaver:
@@ -32,7 +35,7 @@ class ClassificationSaver:
         batch_transform: Callable = lambda x: x,
         output_transform: Callable = lambda x: x,
         name: Optional[str] = None,
-    ):
+    ) -> None:
         """
         Args:
             output_dir: output CSV file directory.
@@ -55,7 +58,7 @@ class ClassificationSaver:
         self.logger = None if name is None else logging.getLogger(name)
         self._name = name
 
-    def attach(self, engine: Engine):
+    def attach(self, engine: "ignite.engine.Engine") -> None:
         if self._name is None:
             self.logger = engine.logger
         if not engine.has_event_handler(self, Events.ITERATION_COMPLETED):
@@ -63,7 +66,7 @@ class ClassificationSaver:
         if not engine.has_event_handler(self.saver.finalize, Events.COMPLETED):
             engine.add_event_handler(Events.COMPLETED, lambda engine: self.saver.finalize())
 
-    def __call__(self, engine: Engine):
+    def __call__(self, engine: "ignite.engine.Engine") -> None:
         """
         This method assumes self.batch_transform will extract metadata from the input batch.
 

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -36,7 +36,7 @@ class MeanDice(Metric):
         logit_thresh: float = 0.5,
         output_transform: Callable = lambda x: x,
         device: Optional[torch.device] = None,
-    ):
+    ) -> None:
         """
 
         Args:
@@ -49,7 +49,7 @@ class MeanDice(Metric):
                 Defaults to False.
             logit_thresh: the threshold value to round value to 0.0 and 1.0. Defaults to None (no thresholding).
             output_transform: transform the ignite.engine.state.output into [y_pred, y] pair.
-            device (torch.device): device specification in case of distributed computation usage.
+            device: device specification in case of distributed computation usage.
 
         See also:
             :py:meth:`monai.metrics.meandice.compute_meandice`
@@ -67,12 +67,12 @@ class MeanDice(Metric):
         self._num_examples = 0
 
     @reinit__is_reduced
-    def reset(self):
+    def reset(self) -> None:
         self._sum = 0
         self._num_examples = 0
 
     @reinit__is_reduced
-    def update(self, output: Sequence[Union[torch.Tensor, dict]]):
+    def update(self, output: Sequence[Union[torch.Tensor, dict]]) -> None:
         if not len(output) == 2:
             raise ValueError("MeanDice metric can only support y_pred and y.")
         y_pred, y = output
@@ -84,7 +84,7 @@ class MeanDice(Metric):
         self._num_examples += not_nans
 
     @sync_all_reduce("_sum", "_num_examples")
-    def compute(self):
+    def compute(self) -> float:
         if self._num_examples == 0:
             raise NotComputableError("MeanDice must have at least one example before it can be computed.")
         return self._sum / self._num_examples

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -22,7 +22,7 @@ reinit__is_reduced, _ = optional_import("ignite.metrics.metric", "0.3.0", exact_
 sync_all_reduce, _ = optional_import("ignite.metrics.metric", "0.3.0", exact_version, "sync_all_reduce")
 
 
-class MeanDice(Metric):
+class MeanDice(Metric):  # type: ignore # incorrectly typed due to optional_import
     """
     Computes Dice score metric from full size Tensor and collects average over batch, class-channels, iterations.
     """
@@ -77,6 +77,7 @@ class MeanDice(Metric):
             raise ValueError("MeanDice metric can only support y_pred and y.")
         y_pred, y = output
         score = self.dice(y_pred, y)
+        assert self.dice.not_nans is not None
         not_nans = self.dice.not_nans.item()
 
         # add all items in current batch

--- a/monai/handlers/metric_logger.py
+++ b/monai/handlers/metric_logger.py
@@ -9,26 +9,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ignite.engine
+
 from collections import defaultdict
-from typing import Callable
 
 from monai.utils import exact_version, optional_import
 
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
-Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class MetricLogger:
-    def __init__(self, loss_transform: Callable = lambda x: x, metric_transform: Callable = lambda x: x):
+    def __init__(self, loss_transform: Callable = lambda x: x, metric_transform: Callable = lambda x: x) -> None:
         self.loss_transform = loss_transform
         self.metric_transform = metric_transform
         self.loss: list = []
         self.metrics: defaultdict = defaultdict(list)
 
-    def attach(self, engine: Engine):
+    def attach(self, engine: "ignite.engine.Engine"):
         return engine.add_event_handler(Events.ITERATION_COMPLETED, self)
 
-    def __call__(self, engine: Engine):
+    def __call__(self, engine: "ignite.engine.Engine") -> None:
         self.loss.append(self.loss_transform(engine.state.output))
 
         for m, v in engine.state.metrics.items():

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -19,7 +19,7 @@ from monai.utils import exact_version, optional_import, Average
 Metric, _ = optional_import("ignite.metrics", "0.3.0", exact_version, "Metric")
 
 
-class ROCAUC(Metric):
+class ROCAUC(Metric):  # type: ignore # incorrectly typed due to optional_import
     """
     Computes Area Under the Receiver Operating Characteristic Curve (ROC AUC).
     accumulating predictions and the ground-truth during an epoch and applying `compute_roc_auc`.

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional, Sequence, Union, List
+from typing import Callable, List, Optional, Sequence, Union
 
 import torch
 
@@ -56,7 +56,7 @@ class ROCAUC(Metric):
         average: Union[Average, str] = Average.MACRO,
         output_transform: Callable = lambda x: x,
         device: Optional[Union[str, torch.device]] = None,
-    ):
+    ) -> None:
         super().__init__(output_transform, device=device)
         self.to_onehot_y = to_onehot_y
         self.softmax = softmax
@@ -66,7 +66,7 @@ class ROCAUC(Metric):
         self._predictions: List[float] = []
         self._targets: List[float] = []
 
-    def update(self, output: Sequence[torch.Tensor]):
+    def update(self, output: Sequence[torch.Tensor]) -> None:
         y_pred, y = output
         if y_pred.ndimension() not in (1, 2):
             raise ValueError("predictions should be of shape (batch_size, n_classes) or (batch_size, ).")

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -9,8 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ignite.engine
+
 import logging
-from typing import Callable, Optional, Union
 
 import numpy as np
 
@@ -18,7 +22,6 @@ from monai.data import NiftiSaver, PNGSaver
 from monai.utils import exact_version, optional_import, GridSampleMode, GridSamplePadMode, InterpolateMode
 
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
-Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class SegmentationSaver:
@@ -34,12 +37,12 @@ class SegmentationSaver:
         resample: bool = True,
         mode: Union[GridSampleMode, InterpolateMode, str] = "nearest",
         padding_mode: Union[GridSamplePadMode, str] = GridSamplePadMode.BORDER,
-        scale=None,
+        scale: Optional[int] = None,
         dtype: Optional[np.dtype] = None,
         batch_transform: Callable = lambda x: x,
         output_transform: Callable = lambda x: x,
         name: Optional[str] = None,
-    ):
+    ) -> None:
         """
         Args:
             output_dir: output image directory.
@@ -63,10 +66,10 @@ class SegmentationSaver:
                 - PNG files
                     This option is ignored.
 
-            scale (255, 65535): postprocess data by clipping to [0, 1] and scaling
+            scale: {``255``, ``65535``} postprocess data by clipping to [0, 1] and scaling
                 [0, 255] (uint8) or [0, 65535] (uint16). Default is None to disable scaling.
                 It's used for PNG format only.
-            dtype (np.dtype, optional): convert the image data to save to this data type.
+            dtype: convert the image data to save to this data type.
                 If None, keep the original type of data. It's used for Nifti format only.
             batch_transform: a callable that is used to transform the
                 ignite.engine.batch into expected format to extract the meta_data dictionary.
@@ -103,13 +106,13 @@ class SegmentationSaver:
         self.logger = None if name is None else logging.getLogger(name)
         self._name = name
 
-    def attach(self, engine: Engine):
+    def attach(self, engine: "ignite.engine.Engine") -> None:
         if self._name is None:
             self.logger = engine.logger
         if not engine.has_event_handler(self, Events.ITERATION_COMPLETED):
             engine.add_event_handler(Events.ITERATION_COMPLETED, self)
 
-    def __call__(self, engine):
+    def __call__(self, engine: "ignite.engine.Engine") -> None:
         """
         This method assumes self.batch_transform will extract metadata from the input batch.
         Output file datatype is determined from ``engine.state.output.dtype``.

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -87,7 +87,7 @@ class SegmentationSaver:
                 output_postfix=output_postfix,
                 output_ext=output_ext,
                 resample=resample,
-                mode=mode,
+                mode=GridSampleMode(mode),
                 padding_mode=padding_mode,
                 dtype=dtype,
             )
@@ -97,13 +97,13 @@ class SegmentationSaver:
                 output_postfix=output_postfix,
                 output_ext=output_ext,
                 resample=resample,
-                mode=mode,
+                mode=InterpolateMode(mode),
                 scale=scale,
             )
         self.batch_transform = batch_transform
         self.output_transform = output_transform
 
-        self.logger = None if name is None else logging.getLogger(name)
+        self.logger = logging.getLogger(name)
         self._name = name
 
     def attach(self, engine: "ignite.engine.Engine") -> None:

--- a/monai/handlers/tensorboard_handlers.py
+++ b/monai/handlers/tensorboard_handlers.py
@@ -13,6 +13,7 @@ from typing import Callable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import ignite.engine
+    import torch.utils.tensorboard
 
 import warnings
 
@@ -44,7 +45,7 @@ class TensorBoardStatsHandler(object):
 
     def __init__(
         self,
-        summary_writer: Optional[SummaryWriter] = None,
+        summary_writer: Optional["torch.utils.tensorboard.SummaryWriter"] = None,
         log_dir: str = "./runs",
         epoch_event_writer: Optional[Callable] = None,
         iteration_event_writer: Optional[Callable] = None,
@@ -118,7 +119,9 @@ class TensorBoardStatsHandler(object):
         else:
             self._default_iteration_writer(engine, self._writer)
 
-    def _default_epoch_writer(self, engine: "ignite.engine.Engine", writer: SummaryWriter) -> None:
+    def _default_epoch_writer(
+        self, engine: "ignite.engine.Engine", writer: "torch.utils.tensorboard.SummaryWriter"
+    ) -> None:
         """
         Execute epoch level event write operation based on Ignite engine.state data.
         Default is to write the values from Ignite state.metrics dict.
@@ -134,7 +137,9 @@ class TensorBoardStatsHandler(object):
             writer.add_scalar(name, value, current_epoch)
         writer.flush()
 
-    def _default_iteration_writer(self, engine: "ignite.engine.Engine", writer: SummaryWriter) -> None:
+    def _default_iteration_writer(
+        self, engine: "ignite.engine.Engine", writer: "torch.utils.tensorboard.SummaryWriter"
+    ) -> None:
         """
         Execute iteration level event write operation based on Ignite engine.state data.
         Default is to write the loss value of current iteration.
@@ -195,7 +200,7 @@ class TensorBoardImageHandler(object):
 
     def __init__(
         self,
-        summary_writer: Optional[SummaryWriter] = None,
+        summary_writer: Optional["torch.utils.tensorboard.SummaryWriter"] = None,
         log_dir: str = "./runs",
         interval: int = 1,
         epoch_level: bool = True,

--- a/monai/handlers/tensorboard_handlers.py
+++ b/monai/handlers/tensorboard_handlers.py
@@ -9,8 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ignite.engine
+
 import warnings
-from typing import Callable, Optional
 
 import numpy as np
 import torch
@@ -19,7 +23,6 @@ from monai.utils import exact_version, optional_import, is_scalar
 from monai.visualize import plot_2d_or_3d_image
 
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
-Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 SummaryWriter, _ = optional_import("torch.utils.tensorboard", name="SummaryWriter")
 
 DEFAULT_TAG = "Loss"
@@ -48,10 +51,10 @@ class TensorBoardStatsHandler(object):
         output_transform: Callable = lambda x: x,
         global_epoch_transform: Callable = lambda x: x,
         tag_name: str = DEFAULT_TAG,
-    ):
+    ) -> None:
         """
         Args:
-            summary_writer (SummaryWriter): user can specify TensorBoard SummaryWriter,
+            summary_writer: user can specify TensorBoard SummaryWriter,
                 default to create a new writer.
             log_dir: if using default SummaryWriter, write logs to this directory, default is `./runs`.
             epoch_event_writer: customized callable TensorBoard writer for epoch level.
@@ -74,7 +77,7 @@ class TensorBoardStatsHandler(object):
         self.global_epoch_transform = global_epoch_transform
         self.tag_name = tag_name
 
-    def attach(self, engine: Engine):
+    def attach(self, engine: "ignite.engine.Engine") -> None:
         """
         Register a set of Ignite Event-Handlers to a specified Ignite engine.
 
@@ -87,7 +90,7 @@ class TensorBoardStatsHandler(object):
         if not engine.has_event_handler(self.epoch_completed, Events.EPOCH_COMPLETED):
             engine.add_event_handler(Events.EPOCH_COMPLETED, self.epoch_completed)
 
-    def epoch_completed(self, engine: Engine):
+    def epoch_completed(self, engine: "ignite.engine.Engine") -> None:
         """
         Handler for train or validation/evaluation epoch completed Event.
         Write epoch level events, default values are from Ignite state.metrics dict.
@@ -101,7 +104,7 @@ class TensorBoardStatsHandler(object):
         else:
             self._default_epoch_writer(engine, self._writer)
 
-    def iteration_completed(self, engine: Engine):
+    def iteration_completed(self, engine: "ignite.engine.Engine") -> None:
         """
         Handler for train or validation/evaluation iteration completed Event.
         Write iteration level events, default values are from Ignite state.logs dict.
@@ -115,14 +118,14 @@ class TensorBoardStatsHandler(object):
         else:
             self._default_iteration_writer(engine, self._writer)
 
-    def _default_epoch_writer(self, engine: Engine, writer: SummaryWriter):
+    def _default_epoch_writer(self, engine: "ignite.engine.Engine", writer: SummaryWriter) -> None:
         """
         Execute epoch level event write operation based on Ignite engine.state data.
         Default is to write the values from Ignite state.metrics dict.
 
         Args:
             engine: Ignite Engine, it can be a trainer, validator or evaluator.
-            writer (SummaryWriter): TensorBoard writer, created in TensorBoardHandler.
+            writer: TensorBoard writer, created in TensorBoardHandler.
 
         """
         current_epoch = self.global_epoch_transform(engine.state.epoch)
@@ -131,14 +134,14 @@ class TensorBoardStatsHandler(object):
             writer.add_scalar(name, value, current_epoch)
         writer.flush()
 
-    def _default_iteration_writer(self, engine: Engine, writer: SummaryWriter):
+    def _default_iteration_writer(self, engine: "ignite.engine.Engine", writer: SummaryWriter) -> None:
         """
         Execute iteration level event write operation based on Ignite engine.state data.
         Default is to write the loss value of current iteration.
 
         Args:
             engine: Ignite Engine, it can be a trainer, validator or evaluator.
-            writer (SummaryWriter): TensorBoard writer, created in TensorBoardHandler.
+            writer: TensorBoard writer, created in TensorBoardHandler.
 
         """
         loss = self.output_transform(engine.state.output)
@@ -202,10 +205,10 @@ class TensorBoardImageHandler(object):
         index: int = 0,
         max_channels: int = 1,
         max_frames: int = 64,
-    ):
+    ) -> None:
         """
         Args:
-            summary_writer (SummaryWriter): user can specify TensorBoard SummaryWriter,
+            summary_writer: user can specify TensorBoard SummaryWriter,
                 default to create a new writer.
             log_dir: if using default SummaryWriter, write logs to this directory, default is `./runs`.
             interval: plot content from engine.state every N epochs or every N iterations, default is 1.
@@ -231,13 +234,13 @@ class TensorBoardImageHandler(object):
         self.max_frames = max_frames
         self.max_channels = max_channels
 
-    def attach(self, engine) -> None:
+    def attach(self, engine: "ignite.engine.Engine") -> None:
         if self.epoch_level:
             engine.add_event_handler(Events.EPOCH_COMPLETED(every=self.interval), self)
         else:
             engine.add_event_handler(Events.ITERATION_COMPLETED(every=self.interval), self)
 
-    def __call__(self, engine: Engine):
+    def __call__(self, engine: "ignite.engine.Engine") -> None:
         step = self.global_iter_transform(engine.state.epoch if self.epoch_level else engine.state.iteration)
         show_images = self.batch_transform(engine.state.batch)[0]
         if torch.is_tensor(show_images):

--- a/monai/handlers/utils.py
+++ b/monai/handlers/utils.py
@@ -9,24 +9,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable, TYPE_CHECKING
 
-def stopping_fn_from_metric(metric_name):
+if TYPE_CHECKING:
+    import ignite.engine
+
+
+def stopping_fn_from_metric(metric_name: str) -> Callable:
     """
     Returns a stopping function for ignite.handlers.EarlyStopping using the given metric name.
     """
 
-    def stopping_fn(engine):
+    def stopping_fn(engine: "ignite.engine.Engine"):
         return engine.state.metrics[metric_name]
 
     return stopping_fn
 
 
-def stopping_fn_from_loss():
+def stopping_fn_from_loss() -> Callable:
     """
     Returns a stopping function for ignite.handlers.EarlyStopping using the loss value.
     """
 
-    def stopping_fn(engine):
+    def stopping_fn(engine: "ignite.engine.Engine"):
         return -engine.state.output
 
     return stopping_fn

--- a/monai/handlers/validation_handler.py
+++ b/monai/handlers/validation_handler.py
@@ -9,11 +9,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import ignite.engine
+
 from monai.engines import Evaluator
 from monai.utils import exact_version, optional_import
 
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
-Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
 class ValidationHandler:
@@ -23,10 +27,10 @@ class ValidationHandler:
 
     """
 
-    def __init__(self, validator: Evaluator, interval: int, epoch_level: bool = True) -> None:  # type: ignore
+    def __init__(self, validator: Evaluator, interval: int, epoch_level: bool = True) -> None:
         """
         Args:
-            validator (Evaluator): run the validator when trigger validation, suppose to be Evaluator.
+            validator: run the validator when trigger validation, suppose to be Evaluator.
             interval: do validation every N epochs or every N iterations during training.
             epoch_level: execute validation every N epochs or N iterations.
                 `True` is epoch level, `False` is iteration level.
@@ -35,17 +39,17 @@ class ValidationHandler:
             ValueError: validator must be Evaluator ignite engine.
 
         """
-        if not isinstance(validator, Evaluator):  # type: ignore
+        if not isinstance(validator, Evaluator):
             raise ValueError("validator must be Evaluator ignite engine.")
         self.validator = validator
         self.interval = interval
         self.epoch_level = epoch_level
 
-    def attach(self, engine: Engine):
+    def attach(self, engine: "ignite.engine.Engine") -> None:
         if self.epoch_level:
             engine.add_event_handler(Events.EPOCH_COMPLETED(every=self.interval), self)
         else:
             engine.add_event_handler(Events.ITERATION_COMPLETED(every=self.interval), self)
 
-    def __call__(self, engine: Engine):
+    def __call__(self, engine: "ignite.engine.Engine") -> None:
         self.validator.run(engine.state.epoch)

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+from typing import Optional, Union
 
 import warnings
 
@@ -61,7 +61,7 @@ class DiceMetric:
         self.logit_thresh = logit_thresh
         self.reduction: MetricReduction = MetricReduction(reduction)
 
-        self.not_nans = None  # keep track for valid elements in the batch
+        self.not_nans: Optional[torch.Tensor] = None  # keep track for valid elements in the batch
 
     def __call__(self, y_pred: torch.Tensor, y: torch.Tensor):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -128,19 +128,11 @@ ignore_errors = True
 # Always ignore any type issues in the monai/._version.py file
 ignore_errors = True
 
-[mypy-monai.handlers.*]
-# Always ignore any type issues in the monai/handlers files
-ignore_errors = True
-
-[mypy-monai.engines.*]
-# Always ignore any type issues in the monai/engines files
-ignore_errors = True
-
 [pytype]
 # NOTE: All relative paths are relative to the location of this file.
 # Space-separated list of files or directories to exclude.
 #  i.e. exclude = **/*_test.py **/test_*.py
-exclude = **/versioneer.py _version.py monai/handlers monai/engines
+exclude = **/versioneer.py _version.py
 # Space-separated list of files or directories to process.
 inputs = monai
 # Keep going past errors to analyze as many files as possible.


### PR DESCRIPTION
### Description

Iteration of #476

- remove unused imports
- reorder imports
- use 'if TYPE_CHECKING:' for optional imports
- add type hints
- fix type hints
- remove docstring type hints

optional_import does not enable correct type hinting
so 'if TYPE_CHECKING:' is used. The type annotation must
then be a forward reference i.e. it must be in quotes.

### Status

**Ready**

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated