### PR TITLE
476 Add type hints to monai/inferers/

### DIFF
--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -9,8 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Sequence, Union
+
 from abc import ABC, abstractmethod
-from typing import Union
 
 import torch
 
@@ -30,7 +31,7 @@ class Inferer(ABC):
         Run inference on `inputs` with the `network` model.
 
         Args:
-            inputs (torch.tensor): input of the model inference.
+            inputs: input of the model inference.
             network (Network): model for inference.
 
         Raises:
@@ -53,7 +54,7 @@ class SimpleInferer(Inferer):
         """Unified callable function API of Inferers.
 
         Args:
-            inputs (torch.tensor): model input data for inference.
+            inputs: model input data for inference.
             network (Network): target model to execute inference.
 
         """
@@ -66,7 +67,7 @@ class SlidingWindowInferer(Inferer):
     with `sw_batch_size` windows for every model.forward().
 
     Args:
-        roi_size (list, tuple): the window size to execute SlidingWindow evaluation.
+        roi_size: the window size to execute SlidingWindow evaluation.
             If it has non-positive components, the corresponding `inputs` size will be used.
             if the components of the `roi_size` are non-positive values, the transform will use the
             corresponding components of img size. For example, `roi_size=(32, -1)` will be adapted
@@ -86,8 +87,12 @@ class SlidingWindowInferer(Inferer):
     """
 
     def __init__(
-        self, roi_size, sw_batch_size: int = 1, overlap: float = 0.25, mode: Union[BlendMode, str] = BlendMode.CONSTANT
-    ):
+        self,
+        roi_size: Union[Sequence[int], int],
+        sw_batch_size: int = 1,
+        overlap: float = 0.25,
+        mode: Union[BlendMode, str] = BlendMode.CONSTANT,
+    ) -> None:
         Inferer.__init__(self)
         self.roi_size = roi_size
         self.sw_batch_size = sw_batch_size
@@ -99,7 +104,7 @@ class SlidingWindowInferer(Inferer):
         Unified callable function API of Inferers.
 
         Args:
-            inputs (torch.tensor): model input data for inference.
+            inputs: model input data for inference.
             network (Network): target model to execute inference.
 
         """

--- a/monai/inferers/utils.py
+++ b/monai/inferers/utils.py
@@ -9,23 +9,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Union
+from typing import Callable, Sequence, Union
 
 import torch
 import torch.nn.functional as F
+
 from monai.data.utils import compute_importance_map, dense_patch_slices, get_valid_patch_size
 from monai.utils import BlendMode, PytorchPadMode, fall_back_tuple
 
 
 def sliding_window_inference(
     inputs: torch.Tensor,
-    roi_size,
+    roi_size: Union[Sequence[int], int],
     sw_batch_size: int,
     predictor: Callable,
     overlap: float = 0.25,
     mode: Union[BlendMode, str] = BlendMode.CONSTANT,
     padding_mode: Union[PytorchPadMode, str] = PytorchPadMode.CONSTANT,
-    cval=0,
+    cval: float = 0.0,
 ):
     """
     Sliding window inference on `inputs` with `predictor`.
@@ -35,7 +36,7 @@ def sliding_window_inference(
 
     Args:
         inputs: input image to be processed (assuming NCHW[D])
-        roi_size (list, tuple): the spatial window size for inferences.
+        roi_size: the spatial window size for inferences.
             When its components have None or non-positives, the corresponding inputs dimension will be used.
             if the components of the `roi_size` are non-positive values, the transform will use the
             corresponding components of img size. For example, `roi_size=(32, -1)` will be adapted


### PR DESCRIPTION
### Description

Iteration of #476

- reorder imports
- add type hints
- remove docstring type hints

### Status

**Ready**

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docstrings/Documentation updated