### PR TITLE
Reenable checks and fix errors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,6 +95,7 @@ autoclass_content = "both"
 add_module_names = True
 autosectionlabel_prefix_document = True
 napoleon_use_param = True
+set_type_checking_flag = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/monai/apps/datasets.py
+++ b/monai/apps/datasets.py
@@ -89,7 +89,7 @@ class MedNISTDataset(Randomizable, CacheDataset):
         self.rann = self.R.random()
 
     def _generate_data_list(self, dataset_dir: str):
-        class_names = sorted([x for x in os.listdir(dataset_dir) if os.path.isdir(os.path.join(dataset_dir, x))])
+        class_names = sorted((x for x in os.listdir(dataset_dir) if os.path.isdir(os.path.join(dataset_dir, x))))
         num_class = len(class_names)
         image_files = [
             [

--- a/monai/apps/datasets.py
+++ b/monai/apps/datasets.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
+from typing import Any, Callable
 
 import os
 import sys

--- a/monai/apps/datasets.py
+++ b/monai/apps/datasets.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable
+from typing import Callable
 
 import os
 import sys

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -116,4 +116,4 @@ def get_torch_version_tuple():
     Returns:
         tuple of ints represents the pytorch major/minor version.
     """
-    return tuple([int(x) for x in torch.__version__.split(".")[:2]])
+    return tuple((int(x) for x in torch.__version__.split(".")[:2]))

--- a/monai/data/csv_saver.py
+++ b/monai/data/csv_saver.py
@@ -77,6 +77,7 @@ class CSVSaver:
         self._data_index += 1
         if torch.is_tensor(data):
             data = data.detach().cpu().numpy()
+        assert isinstance(data, np.ndarray)
         self._cache_dict[save_key] = data.astype(np.float32)
 
     def save_batch(self, batch_data: Union[torch.Tensor, np.ndarray], meta_data: Optional[dict] = None) -> None:

--- a/monai/data/dataloader.py
+++ b/monai/data/dataloader.py
@@ -63,7 +63,7 @@ class DataLoader(_TorchDataLoader):
         timeout: float = 0.0,
         multiprocessing_context: Optional[Callable] = None,
     ) -> None:
-        super().__init__(
+        super().__init__(  # type: ignore # No overload variant matches argument types
             dataset=dataset,
             batch_size=batch_size,
             shuffle=shuffle,

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -331,7 +331,7 @@ class ZipDataset(Dataset):
         super().__init__(list(datasets), transform=transform)
 
     def __len__(self) -> int:
-        return min([len(dataset) for dataset in self.data])
+        return min((len(dataset) for dataset in self.data))
 
     def __getitem__(self, index: int):
         def to_list(x):

--- a/monai/data/synthetic.py
+++ b/monai/data/synthetic.py
@@ -38,7 +38,7 @@ def create_test_image_2d(
     image = np.zeros((width, height))
     rs = np.random if random_state is None else random_state
 
-    for i in range(num_objs):
+    for _ in range(num_objs):
         x = rs.randint(rad_max, width - rad_max)
         y = rs.randint(rad_max, height - rad_max)
         rad = rs.randint(5, rad_max)
@@ -85,7 +85,7 @@ def create_test_image_3d(
     image = np.zeros((width, height, depth))
     rs = np.random if random_state is None else random_state
 
-    for i in range(num_objs):
+    for _ in range(num_objs):
         x = rs.randint(rad_max, width - rad_max)
         y = rs.randint(rad_max, height - rad_max)
         z = rs.randint(rad_max, depth - rad_max)

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -452,7 +452,7 @@ def compute_importance_map(
     patch_size,
     mode: Union[BlendMode, str] = BlendMode.CONSTANT,
     sigma_scale: float = 0.125,
-    device: Optional[Union[torch.device, str]] = None,
+    device: Optional[torch.device] = None,
 ):
     """Get importance map for different weight modes.
 

--- a/monai/engines/multi_gpu_supervised_trainer.py
+++ b/monai/engines/multi_gpu_supervised_trainer.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     import ignite.metrics
 
 import torch
+from torch.optim.optimizer import Optimizer
 
 from monai.utils import exact_version, optional_import
 from monai.engines.utils import get_devices_spec
@@ -34,7 +35,7 @@ def _default_eval_transform(x, y, y_pred):
 
 def create_multigpu_supervised_trainer(
     net: torch.nn.Module,
-    optimizer: torch.optim.Optimizer,
+    optimizer: Optimizer,
     loss_fn,
     devices=None,
     non_blocking: bool = False,

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     import ignite.metrics
 
 import torch
+from torch.optim.optimizer import Optimizer
 from torch.utils.data import DataLoader
 
 from monai.inferers import Inferer, SimpleInferer
@@ -78,7 +79,7 @@ class SupervisedTrainer(Trainer):
         max_epochs: int,
         train_data_loader: DataLoader,
         network,
-        optimizer: torch.optim.Optimizer,
+        optimizer: Optimizer,
         loss_function,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 import torch
 from torch.utils.data import DataLoader
 
-from monai.transforms import apply_transform, Transform
+from monai.transforms import apply_transform
 from monai.utils import exact_version, optional_import, ensure_tuple
 from monai.engines.utils import default_prepare_batch
 

--- a/monai/handlers/lr_schedule_handler.py
+++ b/monai/handlers/lr_schedule_handler.py
@@ -9,14 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional, TYPE_CHECKING
+from typing import Callable, Optional, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import ignite.engine
 
-import torch
-
 import logging
+
+from torch.optim.lr_scheduler import _LRScheduler, ReduceLROnPlateau
 
 from monai.utils import ensure_tuple, exact_version, optional_import
 
@@ -30,7 +30,7 @@ class LrScheduleHandler:
 
     def __init__(
         self,
-        lr_scheduler: torch.optim.lr_scheduler,
+        lr_scheduler: Union[_LRScheduler, ReduceLROnPlateau],
         print_lr: bool = True,
         name: Optional[str] = None,
         epoch_level: bool = True,
@@ -73,4 +73,6 @@ class LrScheduleHandler:
         args = ensure_tuple(self.step_transform(engine))
         self.lr_scheduler.step(*args)
         if self.print_lr:
-            self.logger.info(f"Current learning rate: {self.lr_scheduler._last_lr[0]}")
+            self.logger.info(
+                f"Current learning rate: {self.lr_scheduler._last_lr[0]}"  # type: ignore # Module has no attribute
+            )

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence
 
 import torch
 
@@ -72,13 +72,13 @@ class MeanDice(Metric):  # type: ignore # incorrectly typed due to optional_impo
         self._num_examples = 0
 
     @reinit__is_reduced
-    def update(self, output: Sequence[Union[torch.Tensor, dict]]) -> None:
+    def update(self, output: Sequence[torch.Tensor]) -> None:
         if not len(output) == 2:
             raise ValueError("MeanDice metric can only support y_pred and y.")
         y_pred, y = output
         score = self.dice(y_pred, y)
         assert self.dice.not_nans is not None
-        not_nans = self.dice.not_nans.item()
+        not_nans = int(self.dice.not_nans.item())
 
         # add all items in current batch
         self._sum += score.item() * not_nans

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -63,8 +63,8 @@ class ROCAUC(Metric):  # type: ignore # incorrectly typed due to optional_import
         self.average: Average = Average(average)
 
     def reset(self) -> None:
-        self._predictions: List[float] = []
-        self._targets: List[float] = []
+        self._predictions: List[torch.Tensor] = []
+        self._targets: List[torch.Tensor] = []
 
     def update(self, output: Sequence[torch.Tensor]) -> None:
         y_pred, y = output

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -66,7 +66,7 @@ class DiceLoss(_Loss):
             ValueError: sigmoid=True and softmax=True are not compatible.
 
         """
-        super().__init__(reduction=LossReduction(reduction))
+        super().__init__(reduction=LossReduction(reduction).value)
 
         if sigmoid and softmax:
             raise ValueError("sigmoid=True and softmax=True are not compatible.")
@@ -133,11 +133,11 @@ class DiceLoss(_Loss):
 
         f = 1.0 - (2.0 * intersection + smooth) / (denominator + smooth)
 
-        if self.reduction == LossReduction.MEAN:
+        if self.reduction == LossReduction.MEAN.value:
             f = torch.mean(f)  # the batch and channel average
-        elif self.reduction == LossReduction.SUM:
+        elif self.reduction == LossReduction.SUM.value:
             f = torch.sum(f)  # sum over the batch and channel dims
-        elif self.reduction == LossReduction.NONE:
+        elif self.reduction == LossReduction.NONE.value:
             pass  # returns [N, n_classes] losses
         else:
             raise ValueError(f"reduction={self.reduction} is invalid.")
@@ -219,7 +219,7 @@ class GeneralizedDiceLoss(_Loss):
             ValueError: sigmoid=True and softmax=True are not compatible.
 
         """
-        super().__init__(reduction=LossReduction(reduction))
+        super().__init__(reduction=LossReduction(reduction).value)
 
         self.include_background = include_background
         self.to_onehot_y = to_onehot_y
@@ -286,11 +286,11 @@ class GeneralizedDiceLoss(_Loss):
 
         f = 1.0 - (2.0 * (intersection * w).sum(1) + smooth) / ((denominator * w).sum(1) + smooth)
 
-        if self.reduction == LossReduction.MEAN:
+        if self.reduction == LossReduction.MEAN.value:
             f = torch.mean(f)  # the batch and channel average
-        elif self.reduction == LossReduction.SUM:
+        elif self.reduction == LossReduction.SUM.value:
             f = torch.sum(f)  # sum over the batch and channel dims
-        elif self.reduction == LossReduction.NONE:
+        elif self.reduction == LossReduction.NONE.value:
             pass  # returns [N, n_classes] losses
         else:
             raise ValueError(f"reduction={self.reduction} is invalid.")

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -57,7 +57,7 @@ class FocalLoss(_WeightedLoss):
                 fl(pred, grnd)
 
         """
-        super(FocalLoss, self).__init__(weight=weight, reduction=LossReduction(reduction))
+        super(FocalLoss, self).__init__(weight=weight, reduction=LossReduction(reduction).value)
         self.gamma = gamma
         self.weight: Optional[torch.Tensor]
 
@@ -129,10 +129,10 @@ class FocalLoss(_WeightedLoss):
         else:
             loss = torch.mean(-weight * t * logpt, dim=-1)  # N,C
 
-        if self.reduction == LossReduction.SUM:
+        if self.reduction == LossReduction.SUM.value:
             return loss.sum()
-        if self.reduction == LossReduction.NONE:
+        if self.reduction == LossReduction.NONE.value:
             return loss
-        if self.reduction == LossReduction.MEAN:
+        if self.reduction == LossReduction.MEAN.value:
             return loss.mean()
         raise ValueError(f"reduction={self.reduction} is invalid.")

--- a/monai/losses/tversky.py
+++ b/monai/losses/tversky.py
@@ -63,7 +63,7 @@ class TverskyLoss(_Loss):
 
         """
 
-        super().__init__(reduction=LossReduction(reduction))
+        super().__init__(reduction=LossReduction(reduction).value)
         self.include_background = include_background
         self.to_onehot_y = to_onehot_y
 
@@ -125,10 +125,10 @@ class TverskyLoss(_Loss):
 
         score = 1.0 - numerator / denominator
 
-        if self.reduction == LossReduction.SUM:
+        if self.reduction == LossReduction.SUM.value:
             return score.sum()  # sum over the batch and channel dims
-        if self.reduction == LossReduction.NONE:
+        if self.reduction == LossReduction.NONE.value:
             return score  # returns [N, n_classes] losses
-        if self.reduction == LossReduction.MEAN:
+        if self.reduction == LossReduction.MEAN.value:
             return score.mean()
         raise ValueError(f"reduction={self.reduction} is invalid.")

--- a/monai/metrics/rocauc.py
+++ b/monai/metrics/rocauc.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+from typing import cast, Union
 
 import warnings
 
@@ -34,7 +34,7 @@ def _calculate(y: torch.Tensor, y_pred: torch.Tensor):
     nneg = auc = tmp_pos = tmp_neg = 0.0
 
     for i in range(n):
-        y_i = y[i]
+        y_i = cast(float, y[i])
         if i + 1 < n and y_pred[i] == y_pred[i + 1]:
             tmp_pos += y_i
             tmp_neg += 1 - y_i

--- a/monai/metrics/rocauc.py
+++ b/monai/metrics/rocauc.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union
+from typing import Union
 
 import warnings
 

--- a/monai/networks/blocks/aspp.py
+++ b/monai/networks/blocks/aspp.py
@@ -9,8 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, Tuple
-
 import torch
 import torch.nn as nn
 

--- a/monai/networks/blocks/convolutions.py
+++ b/monai/networks/blocks/convolutions.py
@@ -9,8 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Union
-
 import numpy as np
 import torch.nn as nn
 

--- a/monai/networks/blocks/upsample.py
+++ b/monai/networks/blocks/upsample.py
@@ -48,7 +48,7 @@ class UpSample(nn.Module):
             align_corners: set the align_corners parameter of `torch.nn.Upsample`. Defaults to True.
         """
         super().__init__()
-        scale_factor = ensure_tuple_rep(scale_factor, spatial_dims)
+        scale_factor_ = ensure_tuple_rep(scale_factor, spatial_dims)
         if not out_channels:
             out_channels = in_channels
         if not with_conv:
@@ -58,11 +58,11 @@ class UpSample(nn.Module):
                 mode = linear_mode[spatial_dims - 1]
             self.upsample = nn.Sequential(
                 Conv[Conv.CONV, spatial_dims](in_channels=in_channels, out_channels=out_channels, kernel_size=1),
-                nn.Upsample(scale_factor=scale_factor, mode=mode.value, align_corners=align_corners),
+                nn.Upsample(scale_factor=scale_factor_, mode=mode.value, align_corners=align_corners),
             )
         else:
             self.upsample = Conv[Conv.CONVTRANS, spatial_dims](
-                in_channels=in_channels, out_channels=out_channels, kernel_size=scale_factor, stride=scale_factor
+                in_channels=in_channels, out_channels=out_channels, kernel_size=scale_factor_, stride=scale_factor_
             )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/monai/networks/layers/factories.py
+++ b/monai/networks/layers/factories.py
@@ -204,8 +204,8 @@ Act.add_factory_callable("celu", lambda: nn.modules.CELU)
 Act.add_factory_callable("gelu", lambda: nn.modules.GELU)
 Act.add_factory_callable("sigmoid", lambda: nn.modules.Sigmoid)
 Act.add_factory_callable("tanh", lambda: nn.modules.Tanh)
-Act.add_factory_callable("softmax", lambda: nn.modules.SoftMax)
-Act.add_factory_callable("logsoftmax", lambda: nn.modules.LogSoftMax)
+Act.add_factory_callable("softmax", lambda: nn.modules.Softmax)
+Act.add_factory_callable("logsoftmax", lambda: nn.modules.LogSoftmax)
 
 
 @Conv.factory_function("conv")

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -147,7 +147,7 @@ class AffineTransform(nn.Module):
                 )
             )
 
-        grid = nn.functional.affine_grid(theta=theta[:, :sr], size=dst_size, align_corners=self.align_corners)
+        grid = nn.functional.affine_grid(theta=theta[:, :sr], size=list(dst_size), align_corners=self.align_corners)
         dst = nn.functional.grid_sample(
             input=src.contiguous(),
             grid=grid,

--- a/monai/networks/nets/classifier.py
+++ b/monai/networks/nets/classifier.py
@@ -9,12 +9,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Union
 
 import torch.nn as nn
 from monai.networks.layers.factories import Norm, Act, split_args
 from monai.networks.nets.regressor import Regressor
-from monai.utils import ensure_tuple
 
 
 class Classifier(Regressor):

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from collections import OrderedDict
-from typing import Callable, Sequence, Tuple
+from typing import Callable, Sequence
 
 import torch
 import torch.nn as nn

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -144,7 +144,7 @@ class DenseNet(nn.Module):
                 [
                     ("relu", nn.ReLU(inplace=True)),
                     ("norm", avg_pool_type(1)),
-                    ("flatten", nn.Flatten(1)),
+                    ("flatten", nn.Flatten(1)),  # type: ignore # Module has no attribute
                     ("class", nn.Linear(in_channels, out_channels)),
                 ]
             )

--- a/monai/networks/nets/generator.py
+++ b/monai/networks/nets/generator.py
@@ -81,7 +81,7 @@ class Generator(nn.Module):
         self.dropout = dropout
         self.bias = bias
 
-        self.flatten = nn.Flatten()
+        self.flatten = nn.Flatten()  # type: ignore # Module has no attribute
         self.linear = nn.Linear(int(np.prod(self.latent_shape)), int(np.prod(start_shape)))
         self.reshape = Reshape(*start_shape)
         self.conv = nn.Sequential()
@@ -101,6 +101,8 @@ class Generator(nn.Module):
         number of channels. The `strides` indicates upsampling factor, ie. transpose convolutional stride. If `is_last`
         is True this is the final layer and is not expected to include activation and normalization layers.
         """
+
+        layer: Union[Convolution, nn.Sequential]
 
         layer = Convolution(
             in_channels=in_channels,

--- a/monai/networks/nets/generator.py
+++ b/monai/networks/nets/generator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Union
 
 import numpy as np
 import torch.nn as nn

--- a/monai/networks/nets/regressor.py
+++ b/monai/networks/nets/regressor.py
@@ -96,6 +96,8 @@ class Regressor(nn.Module):
         is True this is the final layer and is not expected to include activation and normalization layers.
         """
 
+        layer: Union[ResidualUnit, Convolution]
+
         if self.num_res_units > 0:
             layer = ResidualUnit(
                 subunits=self.num_res_units,

--- a/monai/networks/nets/regressor.py
+++ b/monai/networks/nets/regressor.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Union
 
 import numpy as np
 import torch.nn as nn

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -9,8 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
-
 import torch.nn as nn
 
 from monai.networks.blocks.convolutions import Convolution, ResidualUnit

--- a/monai/transforms/adaptors.py
+++ b/monai/transforms/adaptors.py
@@ -158,7 +158,7 @@ def adaptor(function, outputs, inputs=None):
         else:
             # no **kwargs
             # select only items from the method signature
-            dinputs = dict((k, v) for k, v in ditems.items() if k in sig.non_var_parameters)
+            dinputs = {k: v for k, v in ditems.items() if k in sig.non_var_parameters}
             must_be_types_or_none("inputs", inputs, (str, list, tuple, dict))
             if inputs is None:
                 pass
@@ -167,7 +167,7 @@ def adaptor(function, outputs, inputs=None):
                     raise ValueError("if 'inputs' is a string, function may only have a single non-variadic parameter")
                 dinputs = {inputs: ditems[inputs]}
             elif isinstance(inputs, (list, tuple)):
-                dinputs = dict((k, dinputs[k]) for k in inputs)
+                dinputs = {k: dinputs[k] for k in inputs}
             else:
                 # dict
                 dinputs = map_only_names(ditems, inputs)
@@ -192,7 +192,7 @@ def adaptor(function, outputs, inputs=None):
             if len(ret) != len(outputs):
                 raise ValueError("'outputs' must have the same length as the number of elements that were returned")
 
-            ret = dict((k, v) for k, v in zip(op, ret))
+            ret = {k: v for k, v in zip(op, ret)}
         else:
             must_be_types("outputs", op, (str, list, tuple))
             if isinstance(op, (list, tuple)):

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -284,7 +284,7 @@ class RandSpatialCrop(Randomizable, Transform):
         self._size: Optional[Sequence[int]] = None
         self._slices: Optional[Tuple[slice, ...]] = None
 
-    def randomize(self, img_size) -> None:  # type: ignore # see issue #495
+    def randomize(self, img_size) -> None:  # type: ignore # see issue #729
         self._size = fall_back_tuple(self.roi_size, img_size)
         if self.random_size:
             self._size = tuple((self.R.randint(low=self._size[i], high=img_size[i] + 1) for i in range(len(img_size))))
@@ -445,7 +445,7 @@ class RandCropByPosNegLabel(Randomizable, Transform):
         self.image_threshold = image_threshold
         self.centers = None
 
-    def randomize(self, label, image) -> None:  # type: ignore # see issue #495
+    def randomize(self, label, image) -> None:  # type: ignore # see issue #729
         self.spatial_size = fall_back_tuple(self.spatial_size, default=label.shape[1:])
         self.centers = generate_pos_neg_label_crop_centers(
             label, self.spatial_size, self.num_samples, self.pos_ratio, image, self.image_threshold, self.R

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -21,7 +21,7 @@ from monai.config import IndexSelection
 from monai.data.utils import get_random_patch, get_valid_patch_size
 from monai.transforms.compose import Randomizable, Transform
 from monai.transforms.utils import generate_pos_neg_label_crop_centers, generate_spatial_bounding_box
-from monai.utils import ensure_tuple, ensure_tuple_rep, fall_back_tuple, NumpyPadMode, Method
+from monai.utils import ensure_tuple, fall_back_tuple, NumpyPadMode, Method
 
 
 class SpatialPad(Transform):

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -287,7 +287,7 @@ class RandSpatialCrop(Randomizable, Transform):
     def randomize(self, img_size) -> None:  # type: ignore # see issue #495
         self._size = fall_back_tuple(self.roi_size, img_size)
         if self.random_size:
-            self._size = tuple([self.R.randint(low=self._size[i], high=img_size[i] + 1) for i in range(len(img_size))])
+            self._size = tuple((self.R.randint(low=self._size[i], high=img_size[i] + 1) for i in range(len(img_size))))
         if self.random_center:
             valid_size = get_valid_patch_size(img_size, self._size)
             self._slices = (slice(None),) + get_random_patch(img_size, valid_size, self.R)

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -235,7 +235,7 @@ class RandSpatialCropd(Randomizable, MapTransform):
         self._slices: Optional[Tuple[slice, ...]] = None
         self._size: Optional[Sequence[int]] = None
 
-    def randomize(self, img_size) -> None:  # type: ignore # see issue #495
+    def randomize(self, img_size) -> None:  # type: ignore # see issue #729
         self._size = fall_back_tuple(self.roi_size, img_size)
         if self.random_size:
             self._size = [self.R.randint(low=self._size[i], high=img_size[i] + 1) for i in range(len(img_size))]
@@ -397,7 +397,7 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
         self.image_threshold = image_threshold
         self.centers = None
 
-    def randomize(self, label, image) -> None:  # type: ignore # see issue #495
+    def randomize(self, label, image) -> None:  # type: ignore # see issue #729
         self.spatial_size = fall_back_tuple(self.spatial_size, default=label.shape[1:])
         self.centers = generate_pos_neg_label_crop_centers(
             label, self.spatial_size, self.num_samples, self.pos_ratio, image, self.image_threshold, self.R

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -40,7 +40,7 @@ class RandGaussianNoise(Randomizable, Transform):
         self._do_transform = False
         self._noise = None
 
-    def randomize(self, im_shape) -> None:  # type: ignore # see issue #495
+    def randomize(self, im_shape) -> None:  # type: ignore # see issue #729
         self._do_transform = self.R.random() < self.prob
         self._noise = self.R.normal(self.mean, self.R.uniform(0, self.std), size=im_shape)
 

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -56,7 +56,7 @@ class RandGaussianNoised(Randomizable, MapTransform):
         self._do_transform = False
         self._noise = None
 
-    def randomize(self, im_shape) -> None:  # type: ignore # see issue #495
+    def randomize(self, im_shape) -> None:  # type: ignore # see issue #729
         self._do_transform = self.R.random() < self.prob
         self._noise = self.R.normal(self.mean, self.R.uniform(0, self.std), size=im_shape)
 

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -344,5 +344,5 @@ class LabelToContour(Transform):
         else:
             raise RuntimeError("the dimensions of img should be 4 or 5.")
 
-        torch.clamp_(contour_img, min=0.0, max=1.0)
+        contour_img.clamp_(min=0.0, max=1.0)
         return contour_img

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -1039,7 +1039,7 @@ class Resample(Transform):
         for i, dim in enumerate(img.shape[1:]):
             grid[i] = 2.0 * grid[i] / (dim - 1.0)
         grid = grid[:-1] / grid[-1:]
-        index_ordering: List[int] = [x for x in range(img.ndim - 2, -1, -1)]
+        index_ordering: List[int] = list(range(img.ndim - 2, -1, -1))
         grid = grid[index_ordering]
         grid = grid.permute(list(range(grid.ndim))[1:] + [0])
         out = torch.nn.functional.grid_sample(

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -13,7 +13,7 @@ A collection of "vanilla" transforms for spatial operations
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Iterable, List, Optional, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import warnings
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -1342,7 +1342,7 @@ class Rand2DElastic(Randomizable, Transform):
         super().set_random_state(seed, state)
         return self
 
-    def randomize(self, spatial_size) -> None:  # type: ignore # see issue #495
+    def randomize(self, spatial_size) -> None:  # type: ignore # see issue #729
         self.do_transform = self.R.rand() < self.prob
         self.deform_grid.randomize(spatial_size)
         self.rand_affine_grid.randomize()
@@ -1467,7 +1467,7 @@ class Rand3DElastic(Randomizable, Transform):
         super().set_random_state(seed, state)
         return self
 
-    def randomize(self, grid_size) -> None:  # type: ignore # see issue #495
+    def randomize(self, grid_size) -> None:  # type: ignore # see issue #729
         self.do_transform = self.R.rand() < self.prob
         if self.do_transform:
             self.rand_offset = self.R.uniform(-1.0, 1.0, [3] + list(grid_size)).astype(np.float32)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -13,7 +13,7 @@ A collection of "vanilla" transforms for spatial operations
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 import warnings
 
@@ -46,6 +46,8 @@ from monai.utils import (
 )
 
 nib, _ = optional_import("nibabel")
+
+_torch_interp: Callable
 
 if get_torch_version_tuple() >= (1, 5):
     # additional argument since torch 1.5 (to avoid warnings)

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -484,7 +484,7 @@ class Rand2DElasticd(Randomizable, MapTransform):
         super().set_random_state(seed, state)
         return self
 
-    def randomize(self, spatial_size) -> None:  # type: ignore # see issue #495
+    def randomize(self, spatial_size) -> None:  # type: ignore # see issue #729
         self.rand_2d_elastic.randomize(spatial_size)
 
     def __call__(self, data):
@@ -600,7 +600,7 @@ class Rand3DElasticd(Randomizable, MapTransform):
         super().set_random_state(seed, state)
         return self
 
-    def randomize(self, grid_size) -> None:  # type: ignore # see issue #495
+    def randomize(self, grid_size) -> None:  # type: ignore # see issue #729
         self.rand_3d_elastic.randomize(grid_size)
 
     def __call__(self, data):

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -15,7 +15,7 @@ defined in :py:class:`monai.transforms.spatial.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
-from typing import Iterable, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -248,7 +248,7 @@ def generate_pos_neg_label_crop_centers(
         center = np.unravel_index(indices_to_use[random_int], label.shape)
         center = center[1:]
         # shift center to range of valid centers
-        center_ori = [c for c in center]
+        center_ori = list(center)
         centers.append(_correct_centers(center_ori, valid_start, valid_end))
 
     return centers

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -197,9 +197,9 @@ def set_determinism(
     """
     if seed is None:
         # cast to 32 bit seed for CUDA
-        seed_ = torch.default_generator.seed() % (np.iinfo(np.int32).max + 1)
-        if not torch.cuda._is_in_bad_fork():
-            torch.cuda.manual_seed_all(seed_)
+        seed_ = torch.default_generator.seed() % (np.iinfo(np.int32).max + 1)  # type: ignore # Module has no attribute
+        if not torch.cuda._is_in_bad_fork():  # type: ignore # Module has no attribute
+            torch.cuda.manual_seed_all(seed_)  # type: ignore # Module has no attribute
     else:
         torch.manual_seed(seed)
 
@@ -214,7 +214,7 @@ def set_determinism(
             func(seed)
 
     if seed is not None:
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.deterministic = True  # type: ignore # Module has no attribute
+        torch.backends.cudnn.benchmark = False  # type: ignore # Module has no attribute
     else:
-        torch.backends.cudnn.deterministic = False
+        torch.backends.cudnn.deterministic = False  # type: ignore # Module has no attribute

--- a/research/lamp-automated-model-parallelism/data_utils.py
+++ b/research/lamp-automated-model-parallelism/data_utils.py
@@ -53,7 +53,7 @@ def load_data_and_mask(data, mask_data):
     img = np.load(data)  # z y x
     img = pad_xform(img[None])[0]
     item = dict(image=img, label=[])
-    for idx, maskfnm in enumerate(mask_data):
+    for maskfnm in mask_data:
         if maskfnm is None:
             ms = np.zeros(img.shape, np.uint8)
         else:

--- a/research/lamp-automated-model-parallelism/unet_pipe.py
+++ b/research/lamp-automated-model-parallelism/unet_pipe.py
@@ -112,7 +112,7 @@ class UNetPipe(nn.Sequential):
         """
         super(UNetPipe, self).__init__()
         n_enc_filter: List[int] = [n_feat]
-        for i in range(1, depth + 1):
+        for _ in range(depth):
             n_enc_filter.append(min(n_enc_filter[-1] * 2, 1024))
         namespaces = [Namespace() for _ in range(depth)]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,8 +45,6 @@ ignore =
     E203,E305,E402,E501,E721,E741,F403,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,
     # this ignore is from flake8-bugbear; please fix!
     B008, # see issue #727
-    # these ignores are from flake8-comprehensions; please fix!
-    C400,C401,C402,C403,C404,C405,C407,C411,C413,C414,C415,C416,
     # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
     N812
     # suppress flake8-mypy failures occuring when MYPYPATH=${src_dir}/monai/monai

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,15 +47,6 @@ ignore =
     B008, # see issue #727
     # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
     N812
-    # suppress flake8-mypy failures occuring when MYPYPATH=${src_dir}/monai/monai
-    T499
-# --- Temporary disabling to allow smaller PRs
-# Subsequent fixes necessary to make this tool pass are not yet
-# merged into the master branch, but requested as separate
-# commits.  Can not enable until all outstanding typehint
-# PR's are approved
-    T484
-# ^^^^^^^^^ Temporary disabling to allow smaller PRs
 per-file-ignores = __init__.py: F401
 exclude = *.pyi,.git,monai/_version.py,versioneer.py,venv, _version.py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,8 @@ max-line-length = 120
 # E501 is not flexible enough, we're using B950 instead
 ignore =
     E203,E305,E402,E501,E721,E741,F403,F405,F821,F841,F999,W503,W504,C408,E302,W291,E303,
-    # these ignores are from flake8-bugbear; please fix!
-    B007,B008,
+    # this ignore is from flake8-bugbear; please fix!
+    B008, # see issue #727
     # these ignores are from flake8-comprehensions; please fix!
     C400,C401,C402,C403,C404,C405,C407,C411,C413,C414,C415,C416,
     # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,9 +55,6 @@ ignore =
 # commits.  Can not enable until all outstanding typehint
 # PR's are approved
     T484
-# Unused imports may be used later, disable warning while we
-# separate many PR's
-    F401
 # ^^^^^^^^^ Temporary disabling to allow smaller PRs
 per-file-ignores = __init__.py: F401
 exclude = *.pyi,.git,monai/_version.py,versioneer.py,venv, _version.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,20 +91,7 @@ warn_no_return=True
 # lint-style cleanliness for typing needs to be disabled; returns more errors
 # than the full run.
 warn_redundant_casts=True
-warn_unused_ignores=False
-
-
-[mypy-torch.*]
-# --- Temporary disabling to allow smaller PRs
-# Subsequent fixes necessary to make this tool pass are not yet
-# merged into the master branch, but requested as separate
-# commits.  Can not enable until all outstanding typehint
-# PR's are approved
-## Temporarily disable all mypy warnings
-ignore_errors = True
-# ^^^^^^ Temporary disabling to allow smaller PRs
-follow_imports = skip
-follow_imports_for_stubs = True
+warn_unused_ignores=True
 
 [mypy-versioneer]
 # Always ignore any type issues in the versioneer.py file

--- a/tests/test_concat_itemsd.py
+++ b/tests/test_concat_itemsd.py
@@ -10,8 +10,6 @@
 # limitations under the License.
 
 import unittest
-import time
-import sys
 import torch
 import numpy as np
 from monai.transforms import ConcatItemsd

--- a/tests/test_copy_itemsd.py
+++ b/tests/test_copy_itemsd.py
@@ -10,8 +10,6 @@
 # limitations under the License.
 
 import unittest
-import time
-import sys
 import torch
 import numpy as np
 from parameterized import parameterized

--- a/tests/test_download_and_extract.py
+++ b/tests/test_download_and_extract.py
@@ -12,7 +12,6 @@
 import unittest
 import os
 import shutil
-import numpy as np
 import tempfile
 from monai.apps import download_and_extract, download_url, extractall
 from tests.utils import skip_if_quick

--- a/tests/test_integration_classification_2d.py
+++ b/tests/test_integration_classification_2d.py
@@ -172,7 +172,7 @@ class IntegrationClassification2D(unittest.TestCase):
             for class_name in class_names
         ]
         image_file_list, image_classes = [], []
-        for i, class_name in enumerate(class_names):
+        for i, _ in enumerate(class_names):
             image_file_list.extend(image_files[i])
             image_classes.extend([i] * len(image_files[i]))
 

--- a/tests/test_integration_classification_2d.py
+++ b/tests/test_integration_classification_2d.py
@@ -166,7 +166,7 @@ class IntegrationClassification2D(unittest.TestCase):
 
         # find image files and labels
         data_dir = os.path.join(self.data_dir, "MedNIST")
-        class_names = sorted([x for x in os.listdir(data_dir) if os.path.isdir(os.path.join(data_dir, x))])
+        class_names = sorted((x for x in os.listdir(data_dir) if os.path.isdir(os.path.join(data_dir, x))))
         image_files = [
             [os.path.join(data_dir, class_name, x) for x in sorted(os.listdir(os.path.join(data_dir, class_name)))]
             for class_name in class_names

--- a/tests/test_nifti_dataset.py
+++ b/tests/test_nifti_dataset.py
@@ -54,7 +54,7 @@ class TestNiftiDataset(unittest.TestCase):
 
         # loading no meta, int
         dataset = NiftiDataset(full_names, dtype=np.float16)
-        for d, ref in zip(dataset, ref_data):
+        for d, _ in zip(dataset, ref_data):
             self.assertEqual(d.dtype, np.float16)
 
         # loading with meta, no transform

--- a/tests/test_simulatedelayd.py
+++ b/tests/test_simulatedelayd.py
@@ -15,7 +15,6 @@ import numpy as np
 from parameterized import parameterized
 from monai.transforms.utility.dictionary import SimulateDelayd
 from tests.utils import NumpyImageTestCase2D
-from monai.config import KeysCollection
 
 
 class TestSimulateDelay(NumpyImageTestCase2D):


### PR DESCRIPTION
### Description

Fix currently ignored errors and reenable corresponding checks

- `autodoc-typehints`: enable flag (TYPE_CHECKING imports)
- `flake8-bugbear`: reenable checks and fix errors
- `flake8-comprehensions`: reenable checks and fix errors
- `flake8 unused imports`: reenable checks and fix errors
- `flake8-mypy`: remove checks (no longer using)
- `mypy-torch`: reenable checks and fix errors

### Status

**Ready**

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
