### PR TITLE
Resolve pytype: disable errors

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -89,13 +89,11 @@ class LoadNifti(Transform):
             if not compatible_meta:
                 for meta_key in header:
                     meta_datum = header[meta_key]
-                    # pytype: disable=attribute-error
                     if (
-                        type(meta_datum).__name__ == "ndarray"
+                        isinstance(meta_datum, np.ndarray)
                         and np_str_obj_array_pattern.search(meta_datum.dtype.str) is not None
                     ):
                         continue
-                    # pytype: enable=attribute-error
                     compatible_meta[meta_key] = meta_datum
             else:
                 assert np.allclose(


### PR DESCRIPTION
### Description

- Resolves 2 of the pytype disabled errors
  1. The second argument to ``isinstance`` must be a ``type``. Types came from their ``factory_function``.
  2. Use ``isinstance`` to check type.
- Convert 2 strings to f string

### Status

**Ready**

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
