### PR TITLE
476 Add and update type hints

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -333,7 +333,7 @@ class ZipDataset(Dataset):
     def __init__(self, datasets: Sequence, transform: Optional[Callable] = None) -> None:
         """
         Args:
-            datasets (list or tuple): list of datasets to zip together.
+            datasets: list of datasets to zip together.
             transform: a callable data transform operates on the zipped item from `datasets`.
         """
         super().__init__(list(datasets), transform=transform)

--- a/monai/data/nifti_reader.py
+++ b/monai/data/nifti_reader.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional, Sequence, Union, Any
+from typing import Callable, Optional, Sequence, Any
 
 import numpy as np
 from torch.utils.data import Dataset
@@ -28,7 +28,7 @@ class NiftiDataset(Dataset, Randomizable):
         self,
         image_files: Sequence[str],
         seg_files: Optional[Sequence[str]] = None,
-        labels: Optional[Sequence[Union[int, float]]] = None,
+        labels: Optional[Sequence[float]] = None,
         as_closest_canonical: bool = False,
         transform: Optional[Callable] = None,
         seg_transform: Optional[Callable] = None,
@@ -42,7 +42,7 @@ class NiftiDataset(Dataset, Randomizable):
         Args:
             image_files: list of image filenames
             seg_files: if in segmentation task, list of segmentation filenames
-            labels (list or array): if in classification task, list of classification labels
+            labels: if in classification task, list of classification labels
             as_closest_canonical: if True, load the image as closest to canonical orientation
             transform: transform to apply to image arrays
             seg_transform: transform to apply to segmentation arrays

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -59,7 +59,7 @@ class Evaluator(Workflow):
         post_transform: Optional[Transform] = None,
         key_val_metric: Optional[Dict[str, Metric]] = None,
         additional_metrics: Optional[Dict[str, Metric]] = None,
-        val_handlers: Optional[Sequence[Metric]] = None,
+        val_handlers: Optional[Sequence] = None,
     ) -> None:
         super().__init__(
             device=device,
@@ -126,7 +126,7 @@ class SupervisedEvaluator(Evaluator):
         post_transform: Optional[Transform] = None,
         key_val_metric: Optional[Dict[str, Metric]] = None,
         additional_metrics: Optional[Dict[str, Metric]] = None,
-        val_handlers: Optional[Sequence[Metric]] = None,
+        val_handlers: Optional[Sequence] = None,
     ):
         super().__init__(
             device=device,

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -59,7 +59,7 @@ class Evaluator(Workflow):
         post_transform: Optional[Transform] = None,
         key_val_metric: Optional[Dict[str, Metric]] = None,
         additional_metrics: Optional[Dict[str, Metric]] = None,
-        val_handlers: Optional[Sequence] = None,
+        val_handlers: Optional[Sequence[Metric]] = None,
     ) -> None:
         super().__init__(
             device=device,
@@ -88,7 +88,7 @@ class Evaluator(Workflow):
         self.state.iteration = 0
         super().run()
 
-    def get_validation_stats(self) -> Dict[str, Union[int, float]]:
+    def get_validation_stats(self) -> Dict[str, float]:
         return {"best_validation_metric": self.state.best_metric, "best_validation_epoch": self.state.best_metric_epoch}
 
 
@@ -126,7 +126,7 @@ class SupervisedEvaluator(Evaluator):
         post_transform: Optional[Transform] = None,
         key_val_metric: Optional[Dict[str, Metric]] = None,
         additional_metrics: Optional[Dict[str, Metric]] = None,
-        val_handlers: Optional[Sequence] = None,
+        val_handlers: Optional[Sequence[Metric]] = None,
     ):
         super().__init__(
             device=device,

--- a/monai/engines/multi_gpu_supervised_trainer.py
+++ b/monai/engines/multi_gpu_supervised_trainer.py
@@ -37,7 +37,7 @@ def _default_eval_transform(x, y, y_pred):
 def create_multigpu_supervised_trainer(
     net: torch.nn.Module,
     optimizer: Optimizer,
-    loss_fn: torch.nn.modules.loss._Loss,
+    loss_fn: Callable,
     devices: Optional[Sequence[torch.device]] = None,
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,

--- a/monai/engines/multi_gpu_supervised_trainer.py
+++ b/monai/engines/multi_gpu_supervised_trainer.py
@@ -37,7 +37,7 @@ def _default_eval_transform(x, y, y_pred):
 def create_multigpu_supervised_trainer(
     net: torch.nn.Module,
     optimizer: Optimizer,
-    loss_fn: Callable,
+    loss_fn: torch.nn.modules.loss._Loss,
     devices: Optional[Sequence[torch.device]] = None,
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -84,7 +84,7 @@ class SupervisedTrainer(Trainer):
         train_data_loader: DataLoader,
         network: torch.nn.Module,
         optimizer: Optimizer,
-        loss_function: torch.nn.modules.loss._Loss,
+        loss_function: Callable,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
         inferer: Inferer = SimpleInferer(),
@@ -92,7 +92,7 @@ class SupervisedTrainer(Trainer):
         post_transform: Optional[Transform] = None,
         key_train_metric: Optional[Dict[str, Metric]] = None,
         additional_metrics: Optional[Dict[str, Metric]] = None,
-        train_handlers: Optional[Sequence[Metric]] = None,
+        train_handlers: Optional[Sequence] = None,
     ):
         # set up Ignite engine and environments
         super().__init__(

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -46,7 +46,7 @@ class Trainer(Workflow):
             self.state.iteration = 0  # to avoid creating new State instance in ignite Engine.run
         super().run()
 
-    def get_train_stats(self) -> Dict[str, Union[int, float]]:
+    def get_train_stats(self) -> Dict[str, float]:
         return {"total_epochs": self.state.max_epochs, "total_iterations": self.state.epoch_length}
 
 
@@ -84,7 +84,7 @@ class SupervisedTrainer(Trainer):
         train_data_loader: DataLoader,
         network: torch.nn.Module,
         optimizer: Optimizer,
-        loss_function: Callable,
+        loss_function: torch.nn.modules.loss._Loss,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
         inferer: Inferer = SimpleInferer(),
@@ -92,7 +92,7 @@ class SupervisedTrainer(Trainer):
         post_transform: Optional[Transform] = None,
         key_train_metric: Optional[Dict[str, Metric]] = None,
         additional_metrics: Optional[Dict[str, Metric]] = None,
-        train_handlers: Optional[Sequence] = None,
+        train_handlers: Optional[Sequence[Metric]] = None,
     ):
         # set up Ignite engine and environments
         super().__init__(

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -9,7 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, Dict, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
 import torch
 
 
@@ -30,7 +31,7 @@ class CommonKeys:
     LOSS = "loss"
 
 
-def get_devices_spec(devices: Optional[Sequence[torch.device]] = None):
+def get_devices_spec(devices: Optional[Sequence[torch.device]] = None) -> List[torch.device]:
     """
     Get a valid specification for one or more devices. If `devices` is None get devices for all CUDA devices available.
     If `devices` is and zero-length structure a single CPU compute device is returned. In any other cases `devices` is
@@ -55,10 +56,13 @@ def get_devices_spec(devices: Optional[Sequence[torch.device]] = None):
     elif len(devices) == 0:
         devices = [torch.device("cpu")]
 
+    else:
+        devices = list(devices)
+
     return devices
 
 
-def default_prepare_batch(batchdata: Dict):
+def default_prepare_batch(batchdata: Dict[str, Any]) -> Tuple[Any, Any]:
     assert isinstance(batchdata, dict), "default prepare_batch expects dictionary input data."
     return (
         (batchdata[CommonKeys.IMAGE], batchdata[CommonKeys.LABEL])

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -69,7 +69,7 @@ class Workflow(IgniteEngine):  # type: ignore # incorrectly typed due to optiona
         post_transform: Optional[Callable] = None,
         key_metric: Optional[Dict[str, Metric]] = None,
         additional_metrics: Optional[Dict[str, Metric]] = None,
-        handlers: Optional[Sequence] = None,
+        handlers: Optional[Sequence[Metric]] = None,
     ) -> None:
         if iteration_update is not None:
             super().__init__(iteration_update)
@@ -133,8 +133,8 @@ class Workflow(IgniteEngine):  # type: ignore # incorrectly typed due to optiona
                         engine.state.best_metric_epoch = engine.state.epoch
 
         if handlers is not None:
-            handlers = ensure_tuple(handlers)
-            for handler in handlers:
+            handlers_ = ensure_tuple(handlers)
+            for handler in handlers_:
                 handler.attach(self)
 
     def run(self) -> None:

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -69,7 +69,7 @@ class Workflow(IgniteEngine):  # type: ignore # incorrectly typed due to optiona
         post_transform: Optional[Callable] = None,
         key_metric: Optional[Dict[str, Metric]] = None,
         additional_metrics: Optional[Dict[str, Metric]] = None,
-        handlers: Optional[Sequence[Metric]] = None,
+        handlers: Optional[Sequence] = None,
     ) -> None:
         if iteration_update is not None:
             super().__init__(iteration_update)

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -26,13 +26,13 @@ class Inferer(ABC):
     """
 
     @abstractmethod
-    def __call__(self, inputs: torch.Tensor, network):
+    def __call__(self, inputs: torch.Tensor, network: torch.nn.Module):
         """
         Run inference on `inputs` with the `network` model.
 
         Args:
             inputs: input of the model inference.
-            network (Network): model for inference.
+            network: model for inference.
 
         Raises:
             NotImplementedError: subclass will implement the operations.
@@ -50,12 +50,12 @@ class SimpleInferer(Inferer):
     def __init__(self) -> None:
         Inferer.__init__(self)
 
-    def __call__(self, inputs: torch.Tensor, network):
+    def __call__(self, inputs: torch.Tensor, network: torch.nn.Module):
         """Unified callable function API of Inferers.
 
         Args:
             inputs: model input data for inference.
-            network (Network): target model to execute inference.
+            network: target model to execute inference.
 
         """
         return network(inputs)
@@ -99,13 +99,13 @@ class SlidingWindowInferer(Inferer):
         self.overlap = overlap
         self.mode: BlendMode = BlendMode(mode)
 
-    def __call__(self, inputs: torch.Tensor, network):
+    def __call__(self, inputs: torch.Tensor, network: torch.nn.Module):
         """
         Unified callable function API of Inferers.
 
         Args:
             inputs: model input data for inference.
-            network (Network): target model to execute inference.
+            network: target model to execute inference.
 
         """
         return sliding_window_inference(inputs, self.roi_size, self.sw_batch_size, network, self.overlap, self.mode)

--- a/monai/inferers/utils.py
+++ b/monai/inferers/utils.py
@@ -152,7 +152,7 @@ def sliding_window_inference(
     ]  # 2D
 
 
-def _get_scan_interval(image_size, roi_size, num_spatial_dims: int, overlap: float):
+def _get_scan_interval(image_size: Sequence[int], roi_size: Sequence[int], num_spatial_dims: int, overlap: float):
     assert len(image_size) == num_spatial_dims, "image coord different from spatial dims."
     assert len(roi_size) == num_spatial_dims, "roi coord different from spatial dims."
 

--- a/monai/networks/blocks/aspp.py
+++ b/monai/networks/blocks/aspp.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Sequence
+
 import torch
 import torch.nn as nn
 
@@ -33,8 +35,8 @@ class SimpleASPP(nn.Module):
         spatial_dims: int,
         in_channels: int,
         conv_out_channels: int,
-        kernel_sizes=(1, 3, 3, 3),
-        dilations=(1, 2, 4, 6),
+        kernel_sizes: Sequence[int] = (1, 3, 3, 3),
+        dilations: Sequence[int] = (1, 2, 4, 6),
         norm_type=Norm.BATCH,
         acti_type=Act.LEAKYRELU,
     ) -> None:

--- a/monai/networks/blocks/convolutions.py
+++ b/monai/networks/blocks/convolutions.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Sequence, Union
+
 import numpy as np
 import torch.nn as nn
 
@@ -55,12 +57,12 @@ class Convolution(nn.Sequential):
         dimensions: int,
         in_channels: int,
         out_channels: int,
-        strides=1,
-        kernel_size=3,
+        strides: int = 1,
+        kernel_size: Union[Sequence[int], int] = 3,
         act=Act.PRELU,
         norm=Norm.INSTANCE,
         dropout=None,
-        dilation=1,
+        dilation: Union[Sequence[int], int] = 1,
         bias: bool = True,
         conv_only: bool = False,
         is_transposed: bool = False,
@@ -125,13 +127,13 @@ class ResidualUnit(nn.Module):
         dimensions: int,
         in_channels: int,
         out_channels: int,
-        strides=1,
-        kernel_size=3,
+        strides: int = 1,
+        kernel_size: Union[Sequence[int], int] = 3,
         subunits: int = 2,
         act=Act.PRELU,
         norm=Norm.INSTANCE,
         dropout=None,
-        dilation=1,
+        dilation: Union[Sequence[int], int] = 1,
         bias: bool = True,
         last_conv_only: bool = False,
     ) -> None:

--- a/monai/networks/blocks/squeeze_and_excitation.py
+++ b/monai/networks/blocks/squeeze_and_excitation.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import torch
 import torch.nn as nn
@@ -134,9 +134,9 @@ class SEBlock(nn.Module):
         n_chns_1: int,
         n_chns_2: int,
         n_chns_3: int,
-        conv_param_1: Optional[Dict] = None,
-        conv_param_2: Optional[Dict] = None,
-        conv_param_3: Optional[Dict] = None,
+        conv_param_1: Optional[Dict[str, Any]] = None,
+        conv_param_2: Optional[Dict[str, Any]] = None,
+        conv_param_3: Optional[Dict[str, Any]] = None,
         r: int = 2,
         acti_type_1="relu",
         acti_type_2="sigmoid",

--- a/monai/networks/layers/convutils.py
+++ b/monai/networks/layers/convutils.py
@@ -9,12 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Sequence, Union
+
 import numpy as np
 
 __all__ = ["same_padding", "calculate_out_shape", "gaussian_1d"]
 
 
-def same_padding(kernel_size, dilation=1):
+def same_padding(kernel_size: Union[Sequence[int], int], dilation: Union[Sequence[int], int] = 1):
     """
     Return the padding value needed to ensure a convolution using the given kernel size produces an output of the same
     shape as the input for a stride of 1, otherwise ensure a shape of the input divided by the stride rounded down.
@@ -24,13 +26,13 @@ def same_padding(kernel_size, dilation=1):
 
     """
 
-    kernel_size = np.atleast_1d(kernel_size)
-    dilation = np.atleast_1d(dilation)
+    kernel_size_ = np.atleast_1d(kernel_size)
+    dilation_ = np.atleast_1d(dilation)
 
-    if np.any((kernel_size - 1) * dilation % 2 == 1):
-        raise NotImplementedError(f"Same padding not available for k={kernel_size} and d={dilation}.")
+    if np.any((kernel_size_ - 1) * dilation_ % 2 == 1):
+        raise NotImplementedError(f"Same padding not available for k={kernel_size_} and d={dilation_}.")
 
-    padding = (kernel_size - 1) / 2 * dilation
+    padding = (kernel_size_ - 1) / 2 * dilation_
     padding = tuple(int(p) for p in padding)
 
     return tuple(padding) if len(padding) > 1 else padding[0]

--- a/monai/networks/nets/generator.py
+++ b/monai/networks/nets/generator.py
@@ -95,7 +95,7 @@ class Generator(nn.Module):
             self.conv.add_module("layer_%i" % i, layer)
             echannel = c
 
-    def _get_layer(self, in_channels: int, out_channels: int, strides, is_last: bool):
+    def _get_layer(self, in_channels: int, out_channels: int, strides: int, is_last: bool):
         """
         Returns a layer accepting inputs with `in_channels` number of channels and producing outputs of `out_channels`
         number of channels. The `strides` indicates upsampling factor, ie. transpose convolutional stride. If `is_last`

--- a/monai/networks/nets/highresnet.py
+++ b/monai/networks/nets/highresnet.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
 import torch.nn as nn
 import torch.nn.functional as F
@@ -79,7 +79,7 @@ class HighResBlock(nn.Module):
         in_channels: int,
         out_channels: int,
         kernels: Sequence[int] = (3, 3),
-        dilation=1,
+        dilation: Union[Sequence[int], int] = 1,
         norm_type: Union[Normalisation, str] = Normalisation.INSTANCE,
         acti_type: Union[Activation, str] = Activation.RELU,
         channel_matching: Union[ChannelMatching, str] = ChannelMatching.PAD,
@@ -162,7 +162,7 @@ class HighResNet(nn.Module):
             Non-linear activation using ReLU or PReLU. Defaults to ``"relu"``.
         dropout_prob: probability of the feature map to be zeroed
             (only applies to the penultimate conv layer).
-        layer_params (a list of dictionaries): specifying key parameters of each layer/block.
+        layer_params: specifying key parameters of each layer/block.
     """
 
     def __init__(
@@ -173,7 +173,7 @@ class HighResNet(nn.Module):
         norm_type: Union[Normalisation, str] = Normalisation.BATCH,
         acti_type: Union[Activation, str] = Activation.RELU,
         dropout_prob: Optional[float] = None,
-        layer_params=DEFAULT_LAYER_PARAMS_3D,
+        layer_params: Sequence[Dict[str, Any]] = DEFAULT_LAYER_PARAMS_3D,
     ) -> None:
 
         super(HighResNet, self).__init__()

--- a/monai/networks/nets/regressor.py
+++ b/monai/networks/nets/regressor.py
@@ -89,7 +89,7 @@ class Regressor(nn.Module):
 
         self.final = self._get_final_layer((echannel,) + self.final_size)
 
-    def _get_layer(self, in_channels: int, out_channels: int, strides, is_last: bool):
+    def _get_layer(self, in_channels: int, out_channels: int, strides: int, is_last: bool):
         """
         Returns a layer accepting inputs with `in_channels` number of channels and producing outputs of `out_channels`
         number of channels. The `strides` indicates downsampling factor, ie. convolutional stride. If `is_last`

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Sequence, Union
+
 import torch.nn as nn
 
 from monai.networks.blocks.convolutions import Convolution, ResidualUnit
@@ -22,14 +24,14 @@ from monai.utils import export, alias
 class UNet(nn.Module):
     def __init__(
         self,
-        dimensions,
+        dimensions: int,
         in_channels: int,
         out_channels: int,
-        channels,
-        strides,
-        kernel_size=3,
-        up_kernel_size=3,
-        num_res_units=0,
+        channels: Sequence[int],
+        strides: Sequence[int],
+        kernel_size: Union[Sequence[int], int] = 3,
+        up_kernel_size: Union[Sequence[int], int] = 3,
+        num_res_units: int = 0,
         act=Act.PRELU,
         norm=Norm.INSTANCE,
         dropout=0,
@@ -48,7 +50,7 @@ class UNet(nn.Module):
         self.norm = norm
         self.dropout = dropout
 
-        def _create_block(inc: int, outc: int, channels, strides, is_top: bool):
+        def _create_block(inc: int, outc: int, channels: Sequence[int], strides: Sequence[int], is_top: bool):
             """
             Builds the UNet structure from the bottom up by recursing down to the bottom block, then creating sequential
             blocks containing the downsample path, a skip connection around the previous block, and the upsample path.
@@ -71,7 +73,7 @@ class UNet(nn.Module):
 
         self.model = _create_block(in_channels, out_channels, self.channels, self.strides, True)
 
-    def _get_down_layer(self, in_channels: int, out_channels: int, strides, is_top: bool):
+    def _get_down_layer(self, in_channels: int, out_channels: int, strides: int, is_top: bool):
         if self.num_res_units > 0:
             return ResidualUnit(
                 self.dimensions,
@@ -92,7 +94,7 @@ class UNet(nn.Module):
     def _get_bottom_layer(self, in_channels: int, out_channels: int):
         return self._get_down_layer(in_channels, out_channels, 1, False)
 
-    def _get_up_layer(self, in_channels: int, out_channels: int, strides, is_top: bool):
+    def _get_up_layer(self, in_channels: int, out_channels: int, strides: int, is_top: bool):
         conv = Convolution(
             self.dimensions,
             in_channels,

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -12,6 +12,8 @@
 Utilities and types for defining networks, these depend on PyTorch.
 """
 
+from typing import Callable, Optional, Sequence
+
 import warnings
 import torch
 import torch.nn as nn
@@ -60,7 +62,7 @@ def predict_segmentation(logits: torch.Tensor, mutually_exclusive: bool = False,
     logits has shape `BCHW[D]`.
 
     Args:
-        logits (Tensor): raw data of model output.
+        logits: raw data of model output.
         mutually_exclusive: if True, `logits` will be converted into a binary matrix using
             a combination of argmax, which is suitable for multi-classes task. Defaults to False.
         threshold: thresholding the prediction values if multi-labels task.
@@ -74,16 +76,21 @@ def predict_segmentation(logits: torch.Tensor, mutually_exclusive: bool = False,
         return logits.argmax(1, keepdim=True)
 
 
-def normalize_transform(shape, device=None, dtype=None, align_corners: bool = False):
+def normalize_transform(
+    shape: Sequence[int],
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None,
+    align_corners: bool = False,
+):
     """
     Compute an affine matrix according to the input shape.
     The transform normalizes the homogeneous image coordinates to the
     range of `[-1, 1]`.
 
     Args:
-        shape (sequence of int): input spatial shape
-        device (torch device): device on which the returned affine will be allocated.
-        dtype (torch dtype): data type of the returned affine
+        shape: input spatial shape
+        device: device on which the returned affine will be allocated.
+        dtype: data type of the returned affine
         align_corners: if True, consider -1 and 1 to refer to the centers of the
             corner pixels rather than the image corners.
             See also: https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.grid_sample
@@ -104,15 +111,15 @@ def normalize_transform(shape, device=None, dtype=None, align_corners: bool = Fa
     return norm
 
 
-def to_norm_affine(affine, src_size, dst_size, align_corners: bool = False):
+def to_norm_affine(affine: torch.Tensor, src_size: Sequence[int], dst_size: Sequence[int], align_corners: bool = False):
     """
     Given ``affine`` defined for coordinates in the pixel space, compute the corresponding affine
     for the normalized coordinates.
 
     Args:
-        affine (torch Tensor): Nxdxd batched square matrix
-        src_size (sequence of int): source image spatial shape
-        dst_size (sequence of int): target image spatial shape
+        affine: Nxdxd batched square matrix
+        src_size: source image spatial shape
+        dst_size: target image spatial shape
         align_corners: if True, consider -1 and 1 to refer to the centers of the
             corner pixels rather than the image corners.
             See also: https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.grid_sample
@@ -139,7 +146,7 @@ def to_norm_affine(affine, src_size, dst_size, align_corners: bool = False):
     return new_affine
 
 
-def normal_init(m, std=0.02, normal_func=torch.nn.init.normal_):
+def normal_init(m, std=0.02, normal_func: Callable = torch.nn.init.normal_) -> None:
     """
     Initialize the weight and bias tensors of `m' and its submodules to values from a normal distribution with a
     stddev of `std'. Weight tensors of convolution and linear modules are initialized with a mean of 0, batch

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -12,7 +12,7 @@
 A collection of generic interfaces for MONAI transforms.
 """
 
-from typing import Any, Hashable, Optional, Tuple
+from typing import Any, Callable, Hashable, Optional, Sequence, Tuple, Union
 
 from abc import ABC, abstractmethod
 import warnings
@@ -201,7 +201,7 @@ class Compose(Randomizable):
         them are called on the labels.
     """
 
-    def __init__(self, transforms=None) -> None:
+    def __init__(self, transforms: Optional[Union[Sequence[Callable], Callable]] = None) -> None:
         if transforms is None:
             transforms = []
         self.transforms = ensure_tuple(transforms)

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -51,7 +51,7 @@ class SpatialPad(Transform):
         self.method: Method = Method(method)
         self.mode: NumpyPadMode = NumpyPadMode(mode)
 
-    def _determine_data_pad_width(self, data_shape):
+    def _determine_data_pad_width(self, data_shape: Sequence[int]):
         self.spatial_size = fall_back_tuple(self.spatial_size, data_shape)
         if self.method == Method.SYMMETRIC:
             pad_width = list()

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -384,7 +384,7 @@ class Rotate(Transform):
         img: np.ndarray,
         mode: Optional[Union[GridSampleMode, str]] = None,
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
-        align_corners=None,
+        align_corners: Optional[bool] = None,
     ):
         """
         Args:
@@ -397,7 +397,7 @@ class Rotate(Transform):
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
                 align_corners: Defaults to ``self.align_corners``.
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
-            align_corners (bool): Defaults to ``self.align_corners``.
+            align_corners: Defaults to ``self.align_corners``.
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
 
         Raises:
@@ -642,7 +642,7 @@ class RandRotate(Randomizable, Transform):
         img: np.ndarray,
         mode: Optional[Union[GridSampleMode, str]] = None,
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
-        align_corners=None,
+        align_corners: Optional[bool] = None,
     ):
         """
         Args:
@@ -653,7 +653,7 @@ class RandRotate(Randomizable, Transform):
             padding_mode: {``"zeros"``, ``"border"``, ``"reflection"``}
                 Padding mode for outside grid values. Defaults to ``self.padding_mode``.
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
-            align_corners (bool): Defaults to ``self.align_corners``.
+            align_corners: Defaults to ``self.align_corners``.
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
         """
         self.randomize()

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -277,7 +277,7 @@ class Resized(MapTransform):
             The interpolation mode. Defaults to ``"area"``.
             See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
             It also can be a sequence of string, each element corresponds to a key in ``keys``.
-        align_corners (bool, None or sequence of bool or None): This only has an effect when mode is
+        align_corners: This only has an effect when mode is
             'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
             See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
             It also can be a sequence of bool or None, each element corresponds to a key in ``keys``.
@@ -288,7 +288,7 @@ class Resized(MapTransform):
         keys: KeysCollection,
         spatial_size: Union[Sequence[int], int],
         mode: InterpolateModeSequence = InterpolateMode.AREA,
-        align_corners=None,
+        align_corners: Union[Sequence[Optional[bool]], Optional[bool]] = None,
     ) -> None:
         super().__init__(keys)
         self.mode = ensure_tuple_rep(mode, len(self.keys))
@@ -829,7 +829,7 @@ class Zoomd(MapTransform):
             The interpolation mode. Defaults to ``"area"``.
             See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
             It also can be a sequence of string, each element corresponds to a key in ``keys``.
-        align_corners (bool, None or sequence of bool or None): This only has an effect when mode is
+        align_corners: This only has an effect when mode is
             'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
             See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
             It also can be a sequence of bool or None, each element corresponds to a key in ``keys``.
@@ -841,7 +841,7 @@ class Zoomd(MapTransform):
         keys: KeysCollection,
         zoom: Union[Sequence[float], float],
         mode: InterpolateModeSequence = InterpolateMode.AREA,
-        align_corners=None,
+        align_corners: Union[Sequence[Optional[bool]], Optional[bool]] = None,
         keep_size: bool = True,
     ) -> None:
         super().__init__(keys)
@@ -875,7 +875,7 @@ class RandZoomd(Randomizable, MapTransform):
             The interpolation mode. Defaults to ``"area"``.
             See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
             It also can be a sequence of string, each element corresponds to a key in ``keys``.
-        align_corners (bool, None or sequence of bool or None): This only has an effect when mode is
+        align_corners: This only has an effect when mode is
             'linear', 'bilinear', 'bicubic' or 'trilinear'. Default: None.
             See also: https://pytorch.org/docs/stable/nn.functional.html#interpolate
             It also can be a sequence of bool or None, each element corresponds to a key in ``keys``.
@@ -889,7 +889,7 @@ class RandZoomd(Randomizable, MapTransform):
         min_zoom: Union[Sequence[float], float] = 0.9,
         max_zoom: Union[Sequence[float], float] = 1.1,
         mode: InterpolateModeSequence = InterpolateMode.AREA,
-        align_corners=None,
+        align_corners: Union[Sequence[Optional[bool]], Optional[bool]] = None,
         keep_size: bool = True,
     ) -> None:
         super().__init__(keys)

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -303,7 +303,7 @@ def create_grid(
 
 
 def create_control_grid(
-    spatial_shape: Sequence[int], spacing: Sequence[float], homogeneous: bool = True, dtype: Optional[np.dtype] = float
+    spatial_shape: Sequence[int], spacing: Sequence[float], homogeneous: bool = True, dtype: np.dtype = float
 ):
     """
     control grid with two additional point in each direction


### PR DESCRIPTION
### Description
Another iteration of adding missing type hints.

Type hint updates
- [`Union[int, float] ≡ float`](https://www.python.org/dev/peps/pep-0484/#the-numeric-tower)
- ~~`val_handlers: Optional[Sequence[Metric]]`, previously `Optional[Sequence]`~~
- ~~`loss_fn: torch.nn.modules.loss._Loss`, previously `Callable`~~
- `dtype: np.dtype`, previously `Optional[np.dtype]`
  - to match underlying function call


### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
