### PR TITLE
[WIP] 476 Type hint ensure_tuple* and fall_back_tuple return

### DIFF
--- a/monai/data/grid_dataset.py
+++ b/monai/data/grid_dataset.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import math
-from typing import Dict, Sequence, Union
+from typing import Dict, Sequence, Tuple, Union
 
 import torch
 from torch.utils.data import Dataset, IterableDataset
@@ -52,7 +52,7 @@ class GridPatchDataset(IterableDataset):
 
         self.dataset = dataset
         self.patch_size = (None,) + tuple(patch_size)
-        self.start_pos = ensure_tuple(start_pos)
+        self.start_pos: Tuple[int, ...] = ensure_tuple(start_pos)
         self.mode: NumpyPadMode = NumpyPadMode(mode)
         self.pad_opts = pad_opts
 

--- a/monai/data/png_writer.py
+++ b/monai/data/png_writer.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -51,7 +51,7 @@ def write_png(
     if len(data.shape) == 3 and data.shape[2] == 1:  # PIL Image can't save image with 1 channel
         data = data.squeeze(2)
     if output_spatial_shape is not None:
-        output_spatial_shape_ = ensure_tuple_rep(output_spatial_shape, 2)
+        output_spatial_shape_: Tuple[int, ...] = ensure_tuple_rep(output_spatial_shape, 2)
         mode = InterpolateMode(mode)
         align_corners = None if mode in (InterpolateMode.NEAREST, InterpolateMode.AREA) else False
         xform = Resize(spatial_size=output_spatial_shape_, mode=mode, align_corners=align_corners)

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -68,10 +68,10 @@ def iter_patch_slices(dims: Sequence[int], patch_size: Union[Sequence[int], int]
     # ensure patchSize and startPos are the right length
     ndim = len(dims)
     patch_size_ = get_valid_patch_size(dims, patch_size)
-    start_pos = ensure_tuple_size(start_pos, ndim)
+    start_pos_: Tuple[int, ...] = ensure_tuple_size(start_pos, ndim)
 
     # collect the ranges to step over each dimension
-    ranges = tuple(starmap(range, zip(start_pos, dims, patch_size_)))
+    ranges = tuple(starmap(range, zip(start_pos_, dims, patch_size_)))
 
     # choose patches by applying product to the ranges
     for position in product(*ranges[::-1]):  # reverse ranges order to iterate in index order
@@ -100,42 +100,42 @@ def dense_patch_slices(
     if num_spatial_dims not in (2, 3):
         raise ValueError("image_size should have 2 or 3 elements")
     patch_size = get_valid_patch_size(image_size, patch_size)
-    scan_interval = ensure_tuple_size(scan_interval, num_spatial_dims)
+    scan_interval_: Tuple[int, ...] = ensure_tuple_size(scan_interval, num_spatial_dims)
 
     scan_num = list()
     for i in range(num_spatial_dims):
-        if scan_interval[i] == 0:
+        if scan_interval_[i] == 0:
             scan_num.append(1)
         else:
-            num = int(math.ceil(float(image_size[i]) / scan_interval[i]))
-            scan_dim = first(d for d in range(num) if d * scan_interval[i] + patch_size[i] >= image_size[i])
+            num = int(math.ceil(float(image_size[i]) / scan_interval_[i]))
+            scan_dim = first(d for d in range(num) if d * scan_interval_[i] + patch_size[i] >= image_size[i])
             scan_num.append(scan_dim + 1)
 
     slices: List[Tuple[slice, ...]] = []
     if num_spatial_dims == 3:
         for i in range(scan_num[0]):
-            start_i = i * scan_interval[0]
+            start_i = i * scan_interval_[0]
             start_i -= max(start_i + patch_size[0] - image_size[0], 0)
             slice_i = slice(start_i, start_i + patch_size[0])
 
             for j in range(scan_num[1]):
-                start_j = j * scan_interval[1]
+                start_j = j * scan_interval_[1]
                 start_j -= max(start_j + patch_size[1] - image_size[1], 0)
                 slice_j = slice(start_j, start_j + patch_size[1])
 
                 for k in range(0, scan_num[2]):
-                    start_k = k * scan_interval[2]
+                    start_k = k * scan_interval_[2]
                     start_k -= max(start_k + patch_size[2] - image_size[2], 0)
                     slice_k = slice(start_k, start_k + patch_size[2])
                     slices.append((slice_i, slice_j, slice_k))
     else:
         for i in range(scan_num[0]):
-            start_i = i * scan_interval[0]
+            start_i = i * scan_interval_[0]
             start_i -= max(start_i + patch_size[0] - image_size[0], 0)
             slice_i = slice(start_i, start_i + patch_size[0])
 
             for j in range(scan_num[1]):
-                start_j = j * scan_interval[1]
+                start_j = j * scan_interval_[1]
                 start_j -= max(start_j + patch_size[1] - image_size[1], 0)
                 slice_j = slice(start_j, start_j + patch_size[1])
                 slices.append((slice_i, slice_j))
@@ -172,13 +172,13 @@ def iter_patch(
     """
     # ensure patchSize and startPos are the right length
     patch_size_ = get_valid_patch_size(arr.shape, patch_size)
-    start_pos = ensure_tuple_size(start_pos, arr.ndim)
+    start_pos_: Tuple[int, ...] = ensure_tuple_size(start_pos, arr.ndim)
 
     # pad image by maximum values needed to ensure patches are taken from inside an image
     arrpad = np.pad(arr, tuple((p, p) for p in patch_size_), NumpyPadMode(mode).value, **pad_opts)
 
     # choose a start position in the padded image
-    start_pos_padded = tuple(s + p for s, p in zip(start_pos, patch_size_))
+    start_pos_padded = tuple(s + p for s, p in zip(start_pos_, patch_size_))
 
     # choose a size to iterate over which is smaller than the actual padded image to prevent producing
     # patches which are only in the padded regions
@@ -201,7 +201,7 @@ def get_valid_patch_size(image_size: Sequence[int], patch_size: Union[Sequence[i
     patch of the same dimensionality of `image_size` with that size in each dimension.
     """
     ndim = len(image_size)
-    patch_size_ = ensure_tuple_size(patch_size, ndim)
+    patch_size_: Tuple[int, ...] = ensure_tuple_size(patch_size, ndim)
 
     # ensure patch size dimensions are not larger than image dimension, if a dimension is None or 0 use whole dimension
     return tuple(min(ms, ps or ms) for ms, ps in zip(image_size, patch_size_))

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Tuple, Union
 
 import torch
 from torch.utils.data import DataLoader
@@ -224,8 +224,8 @@ class EnsembleEvaluator(Evaluator):
             val_handlers=val_handlers,
         )
 
-        self.networks = ensure_tuple(networks)
-        self.pred_keys = ensure_tuple(pred_keys)
+        self.networks: Tuple[torch.nn.Module, ...] = ensure_tuple(networks)
+        self.pred_keys: Tuple[str, ...] = ensure_tuple(pred_keys)
         self.inferer = inferer
 
     def _iteration(self, engine: Engine, batchdata: Union[Dict, Sequence]) -> Dict[str, torch.Tensor]:

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Tuple, Union
 
 import torch
 from torch.utils.data import DataLoader
@@ -133,7 +133,7 @@ class Workflow(IgniteEngine):  # type: ignore # incorrectly typed due to optiona
                         engine.state.best_metric_epoch = engine.state.epoch
 
         if handlers is not None:
-            handlers_ = ensure_tuple(handlers)
+            handlers_: Tuple = ensure_tuple(handlers)
             for handler in handlers_:
                 handler.attach(self)
 

--- a/monai/networks/blocks/upsample.py
+++ b/monai/networks/blocks/upsample.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -48,7 +48,7 @@ class UpSample(nn.Module):
             align_corners: set the align_corners parameter of `torch.nn.Upsample`. Defaults to True.
         """
         super().__init__()
-        scale_factor_ = ensure_tuple_rep(scale_factor, spatial_dims)
+        scale_factor_: Tuple[int, ...] = ensure_tuple_rep(scale_factor, spatial_dims)
         if not out_channels:
             out_channels = in_channels
         if not with_conv:

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, Union
+from typing import Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -77,9 +77,9 @@ class GaussianFilter(nn.Module):
         """
         super().__init__()
         self.spatial_dims = int(spatial_dims)
-        _sigma = ensure_tuple_rep(sigma, self.spatial_dims)
+        sigma_: Tuple[float, ...] = ensure_tuple_rep(sigma, self.spatial_dims)
         self.kernel = [
-            torch.nn.Parameter(torch.as_tensor(gaussian_1d(s, truncated), dtype=torch.float), False) for s in _sigma
+            torch.nn.Parameter(torch.as_tensor(gaussian_1d(s, truncated), dtype=torch.float), False) for s in sigma_
         ]
         self.padding = [same_padding(k.size()[0]) for k in self.kernel]
         self.conv_n = [F.conv1d, F.conv2d, F.conv3d][spatial_dims - 1]

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -65,7 +65,7 @@ class AffineTransform(nn.Module):
                 set to `True` if `theta` follows `scipy.ndimage` default "i, j, k" convention.
         """
         super().__init__()
-        self.spatial_size = ensure_tuple(spatial_size) if spatial_size is not None else None
+        self.spatial_size: Optional[Tuple[int, ...]] = ensure_tuple(spatial_size) if spatial_size is not None else None
         self.normalized = normalized
         self.mode: GridSampleMode = GridSampleMode(mode)
         self.padding_mode: GridSamplePadMode = GridSamplePadMode(padding_mode)

--- a/monai/networks/nets/generator.py
+++ b/monai/networks/nets/generator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -69,13 +69,16 @@ class Generator(nn.Module):
         """
         super().__init__()
 
+        self.in_channels: int
+        self.start_shape: List[int]
+
         self.in_channels, *self.start_shape = ensure_tuple(start_shape)
         self.dimensions = len(self.start_shape)
 
-        self.latent_shape = ensure_tuple(latent_shape)
-        self.channels = ensure_tuple(channels)
-        self.strides = ensure_tuple(strides)
-        self.kernel_size = ensure_tuple_rep(kernel_size, self.dimensions)
+        self.latent_shape: Tuple[int, ...] = ensure_tuple(latent_shape)
+        self.channels: Tuple[int, ...] = ensure_tuple(channels)
+        self.strides: Tuple[int, ...] = ensure_tuple(strides)
+        self.kernel_size: Tuple[int, ...] = ensure_tuple_rep(kernel_size, self.dimensions)
         self.num_res_units = num_res_units
         self.act = act
         self.norm = norm

--- a/monai/networks/nets/regressor.py
+++ b/monai/networks/nets/regressor.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -61,12 +61,16 @@ class Regressor(nn.Module):
         """
         super().__init__()
 
+        self.in_channels: int
+        self.in_shape: List[int]
+
         self.in_channels, *self.in_shape = ensure_tuple(in_shape)
         self.dimensions = len(self.in_shape)
-        self.channels = ensure_tuple(channels)
-        self.strides = ensure_tuple(strides)
-        self.out_shape = ensure_tuple(out_shape)
-        self.kernel_size = ensure_tuple_rep(kernel_size, self.dimensions)
+
+        self.channels: Tuple[int, ...] = ensure_tuple(channels)
+        self.strides: Tuple[int, ...] = ensure_tuple(strides)
+        self.out_shape: Tuple[int, ...] = ensure_tuple(out_shape)
+        self.kernel_size: Tuple[int, ...] = ensure_tuple_rep(kernel_size, self.dimensions)
         self.num_res_units = num_res_units
         self.act = act
         self.norm = norm

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -13,7 +13,7 @@ Utilities and types for defining networks, these depend on PyTorch.
 """
 
 import warnings
-from typing import Callable, Optional, Sequence
+from typing import Callable, Optional, Sequence, Tuple
 
 import torch
 import torch.nn as nn
@@ -35,7 +35,7 @@ def one_hot(labels: torch.Tensor, num_classes: int, dtype: torch.dtype = torch.f
 
     # if `dim` is bigger, add singelton dim at the end
     if labels.ndim < dim + 1:
-        shape = ensure_tuple_size(labels.shape, dim + 1, 1)
+        shape: Tuple[int, ...] = ensure_tuple_size(labels.shape, dim + 1, 1)
         labels = labels.reshape(*shape)
 
     sh = list(labels.shape)

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -203,7 +203,7 @@ class Compose(Randomizable):
     def __init__(self, transforms: Optional[Union[Sequence[Callable], Callable]] = None) -> None:
         if transforms is None:
             transforms = []
-        self.transforms = ensure_tuple(transforms)
+        self.transforms: Tuple[Callable, ...] = ensure_tuple(transforms)
         self.set_random_state(seed=get_seed())
 
     def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -125,7 +125,7 @@ class BorderPad(Transform):
             ValueError: unsupported length of spatial_border definition.
         """
         spatial_shape = img.shape[1:]
-        spatial_border = ensure_tuple(self.spatial_border)
+        spatial_border: Tuple[int, ...] = ensure_tuple(self.spatial_border)
         for b in spatial_border:
             if b < 0 or not isinstance(b, int):
                 raise ValueError("spatial_border must be int number and can not be less than 0.")
@@ -176,7 +176,7 @@ class DivisiblePad(Transform):
                 See also: https://numpy.org/doc/1.18/reference/generated/numpy.pad.html
         """
         spatial_shape = img.shape[1:]
-        k = fall_back_tuple(self.k, (1,) * len(spatial_shape))
+        k: Tuple[int, ...] = fall_back_tuple(self.k, (1,) * len(spatial_shape))
         new_size = []
         for k_d, dim in zip(k, spatial_shape):
             new_dim = int(np.ceil(dim / k_d) * k_d) if k_d > 0 else dim
@@ -281,7 +281,7 @@ class RandSpatialCrop(Randomizable, Transform):
         self.roi_size = roi_size
         self.random_center = random_center
         self.random_size = random_size
-        self._size: Optional[Sequence[int]] = None
+        self._size: Optional[Tuple[int, ...]] = None
         self._slices: Optional[Tuple[slice, ...]] = None
 
     def randomize(self, img_size: Sequence[int]) -> None:
@@ -381,7 +381,9 @@ class CropForeground(Transform):
             margin: add margin to all dims of the bounding box.
         """
         self.select_fn = select_fn
-        self.channel_indexes = ensure_tuple(channel_indexes) if channel_indexes is not None else None
+        self.channel_indexes: Optional[Tuple[int, ...]] = None if channel_indexes is None else ensure_tuple(
+            channel_indexes
+        )
         self.margin = margin
 
     def __call__(self, img: np.ndarray) -> np.ndarray:

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -58,7 +58,7 @@ class SpatialPadd(MapTransform):
 
         """
         super().__init__(keys)
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
+        self.mode: Tuple[Union[NumpyPadMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
         self.padder = SpatialPad(spatial_size, method)
 
     def __call__(self, data):
@@ -103,7 +103,7 @@ class BorderPadd(MapTransform):
 
         """
         super().__init__(keys)
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
+        self.mode: Tuple[Union[NumpyPadMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
         self.padder = BorderPad(spatial_border=spatial_border)
 
     def __call__(self, data):
@@ -139,7 +139,7 @@ class DivisiblePadd(MapTransform):
 
         """
         super().__init__(keys)
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
+        self.mode: Tuple[Union[NumpyPadMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
         self.padder = DivisiblePad(k=k)
 
     def __call__(self, data):
@@ -235,12 +235,12 @@ class RandSpatialCropd(Randomizable, MapTransform):
         self.random_center = random_center
         self.random_size = random_size
         self._slices: Optional[Tuple[slice, ...]] = None
-        self._size: Optional[Sequence[int]] = None
+        self._size: Optional[Tuple[int, ...]] = None
 
     def randomize(self, img_size: Sequence[int]) -> None:
         self._size = fall_back_tuple(self.roi_size, img_size)
         if self.random_size:
-            self._size = [self.R.randint(low=self._size[i], high=img_size[i] + 1) for i in range(len(img_size))]
+            self._size = tuple((self.R.randint(low=self._size[i], high=img_size[i] + 1) for i in range(len(img_size))))
         if self.random_center:
             valid_size = get_valid_patch_size(img_size, self._size)
             self._slices = (slice(None),) + get_random_patch(img_size, valid_size, self.R)
@@ -332,7 +332,9 @@ class CropForegroundd(MapTransform):
         super().__init__(keys)
         self.source_key = source_key
         self.select_fn = select_fn
-        self.channel_indexes = ensure_tuple(channel_indexes) if channel_indexes is not None else None
+        self.channel_indexes: Optional[Tuple[int, ...]] = None if channel_indexes is None else ensure_tuple(
+            channel_indexes
+        )
         self.margin = margin
 
     def __call__(self, data):

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -13,7 +13,7 @@ A collection of "vanilla" transforms for IO functions
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Optional
+from typing import Hashable, Optional, Tuple
 
 import numpy as np
 from torch.utils.data._utils.collate import np_str_obj_array_pattern
@@ -62,10 +62,10 @@ class LoadNifti(Transform):
         Args:
             filename (str, list, tuple, file): path file or file-like object or a list of files.
         """
-        filename = ensure_tuple(filename)
+        filename_: Tuple = ensure_tuple(filename)
         img_array = list()
         compatible_meta = dict()
-        for name in filename:
+        for name in filename_:
             img = nib.load(name)
             img = correct_nifti_header_if_necessary(img)
             header = dict(img.header)
@@ -130,10 +130,10 @@ class LoadPNG(Transform):
         Args:
             filename (str, list, tuple, file): path file or file-like object or a list of files.
         """
-        filename = ensure_tuple(filename)
+        filename_: Tuple = ensure_tuple(filename)
         img_array = list()
         compatible_meta = None
-        for name in filename:
+        for name in filename_:
             img = Image.open(name)
             data = np.asarray(img)
             if self.dtype:
@@ -187,9 +187,7 @@ class LoadNumpy(Transform):
         """
         self.data_only = data_only
         self.dtype = dtype
-        if npz_keys is not None:
-            npz_keys = ensure_tuple(npz_keys)
-        self.npz_keys = npz_keys
+        self.npz_keys: Optional[Tuple[Hashable, ...]] = None if npz_keys is None else ensure_tuple(npz_keys)
 
     def __call__(self, filename):
         """
@@ -200,7 +198,7 @@ class LoadNumpy(Transform):
             for name in filename:
                 if name.endswith(".npz"):
                     raise TypeError("can not load a list of npz file.")
-        filename = ensure_tuple(filename)
+        filename_: Tuple = ensure_tuple(filename)
         data_array = list()
         compatible_meta = None
 
@@ -218,7 +216,7 @@ class LoadNumpy(Transform):
                     ), "all the data in the list should have same shape."
             return compatible_meta
 
-        for name in filename:
+        for name in filename_:
             data = np.load(name, allow_pickle=True)
             if name.endswith(".npz"):
                 # load expected items from NPZ file

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -14,7 +14,7 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
 import warnings
-from typing import Callable, List, Optional, Sequence, Union
+from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -258,7 +258,7 @@ class KeepLargestConnectedComponent(Transform):
                 connectivity of ``input.ndim`` is used.
         """
         super().__init__()
-        self.applied_labels = ensure_tuple(applied_labels)
+        self.applied_labels: Tuple[int, ...] = ensure_tuple(applied_labels)
         self.independent = independent
         self.connectivity = connectivity
 

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -15,7 +15,7 @@ defined in :py:class:`monai.transforms.utility.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -67,8 +67,8 @@ class SplitChanneld(MapTransform):
         """
         super().__init__(keys)
         self.output_postfixes = output_postfixes
-        self.to_onehot = ensure_tuple_rep(to_onehot, len(self.keys))
-        self.num_classes = ensure_tuple_rep(num_classes, len(self.keys))
+        self.to_onehot: Tuple[bool, ...] = ensure_tuple_rep(to_onehot, len(self.keys))
+        self.num_classes: Tuple[int, ...] = ensure_tuple_rep(num_classes, len(self.keys))
         self.splitter = SplitChannel()
 
     def __call__(self, data):
@@ -108,9 +108,9 @@ class Activationsd(MapTransform):
 
         """
         super().__init__(keys)
-        self.sigmoid = ensure_tuple_rep(sigmoid, len(self.keys))
-        self.softmax = ensure_tuple_rep(softmax, len(self.keys))
-        self.other = ensure_tuple_rep(other, len(self.keys))
+        self.sigmoid: Tuple[bool, ...] = ensure_tuple_rep(sigmoid, len(self.keys))
+        self.softmax: Tuple[bool, ...] = ensure_tuple_rep(softmax, len(self.keys))
+        self.other: Tuple[Callable, ...] = ensure_tuple_rep(other, len(self.keys))
         self.converter = Activations()
 
     def __call__(self, data):
@@ -151,11 +151,11 @@ class AsDiscreted(MapTransform):
 
         """
         super().__init__(keys)
-        self.argmax = ensure_tuple_rep(argmax, len(self.keys))
-        self.to_onehot = ensure_tuple_rep(to_onehot, len(self.keys))
-        self.n_classes = ensure_tuple_rep(n_classes, len(self.keys))
-        self.threshold_values = ensure_tuple_rep(threshold_values, len(self.keys))
-        self.logit_thresh = ensure_tuple_rep(logit_thresh, len(self.keys))
+        self.argmax: Tuple[bool, ...] = ensure_tuple_rep(argmax, len(self.keys))
+        self.to_onehot: Tuple[bool, ...] = ensure_tuple_rep(to_onehot, len(self.keys))
+        self.n_classes: Tuple[int, ...] = ensure_tuple_rep(n_classes, len(self.keys))
+        self.threshold_values: Tuple[bool, ...] = ensure_tuple_rep(threshold_values, len(self.keys))
+        self.logit_thresh: Tuple[float, ...] = ensure_tuple_rep(logit_thresh, len(self.keys))
         self.converter = AsDiscrete()
 
     def __call__(self, data):

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -113,9 +113,9 @@ class Spacingd(MapTransform):
         """
         super().__init__(keys)
         self.spacing_transform = Spacing(pixdim, diagonal=diagonal)
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
-        self.dtype = ensure_tuple_rep(dtype, len(self.keys))
+        self.mode: Tuple[Union[GridSampleMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
+        self.padding_mode: Tuple[Union[GridSamplePadMode, str], ...] = ensure_tuple_rep(padding_mode, len(self.keys))
+        self.dtype: Tuple[np.dtype, ...] = ensure_tuple_rep(dtype, len(self.keys))
         if not isinstance(meta_key_postfix, str):
             raise ValueError("meta_key_postfix must be a string.")
         self.meta_key_postfix = meta_key_postfix
@@ -291,8 +291,8 @@ class Resized(MapTransform):
         align_corners: Union[Sequence[Optional[bool]], Optional[bool]] = None,
     ) -> None:
         super().__init__(keys)
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.align_corners = ensure_tuple_rep(align_corners, len(self.keys))
+        self.mode: Tuple[Union[InterpolateMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
+        self.align_corners: Tuple[Optional[bool], ...] = ensure_tuple_rep(align_corners, len(self.keys))
         self.resizer = Resize(spatial_size=spatial_size)
 
     def __call__(self, data):
@@ -374,8 +374,8 @@ class RandAffined(Randomizable, MapTransform):
             as_tensor_output=as_tensor_output,
             device=device,
         )
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
+        self.mode: Tuple[Union[GridSampleMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
+        self.padding_mode: Tuple[Union[GridSamplePadMode, str], ...] = ensure_tuple_rep(padding_mode, len(self.keys))
 
     def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         self.rand_affine.set_random_state(seed, state)
@@ -389,7 +389,7 @@ class RandAffined(Randomizable, MapTransform):
         d = dict(data)
         self.randomize()
 
-        sp_size = fall_back_tuple(self.rand_affine.spatial_size, data[self.keys[0]].shape[1:])
+        sp_size: Tuple[int, ...] = fall_back_tuple(self.rand_affine.spatial_size, data[self.keys[0]].shape[1:])
         if self.rand_affine.do_transform:
             grid = self.rand_affine.rand_affine_grid(spatial_size=sp_size)
         else:
@@ -476,8 +476,8 @@ class Rand2DElasticd(Randomizable, MapTransform):
             as_tensor_output=as_tensor_output,
             device=device,
         )
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
+        self.mode: Tuple[Union[GridSampleMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
+        self.padding_mode: Tuple[Union[GridSamplePadMode, str], ...] = ensure_tuple_rep(padding_mode, len(self.keys))
 
     def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         self.rand_2d_elastic.set_random_state(seed, state)
@@ -490,7 +490,7 @@ class Rand2DElasticd(Randomizable, MapTransform):
     def __call__(self, data):
         d = dict(data)
 
-        sp_size = fall_back_tuple(self.rand_2d_elastic.spatial_size, data[self.keys[0]].shape[1:])
+        sp_size: Tuple[int, ...] = fall_back_tuple(self.rand_2d_elastic.spatial_size, data[self.keys[0]].shape[1:])
         self.randomize(spatial_size=sp_size)
 
         if self.rand_2d_elastic.do_transform:
@@ -592,8 +592,8 @@ class Rand3DElasticd(Randomizable, MapTransform):
             as_tensor_output=as_tensor_output,
             device=device,
         )
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
+        self.mode: Tuple[Union[GridSampleMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
+        self.padding_mode: Tuple[Union[GridSamplePadMode, str], ...] = ensure_tuple_rep(padding_mode, len(self.keys))
 
     def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
         self.rand_3d_elastic.set_random_state(seed, state)
@@ -605,7 +605,7 @@ class Rand3DElasticd(Randomizable, MapTransform):
 
     def __call__(self, data):
         d = dict(data)
-        sp_size = fall_back_tuple(self.rand_3d_elastic.spatial_size, data[self.keys[0]].shape[1:])
+        sp_size: Tuple[int, ...] = fall_back_tuple(self.rand_3d_elastic.spatial_size, data[self.keys[0]].shape[1:])
 
         self.randomize(grid_size=sp_size)
         grid = create_grid(spatial_size=sp_size)
@@ -718,9 +718,9 @@ class Rotated(MapTransform):
         super().__init__(keys)
         self.rotator = Rotate(angle=angle, keep_size=keep_size)
 
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
-        self.align_corners = ensure_tuple_rep(align_corners, len(self.keys))
+        self.mode: Tuple[Union[GridSampleMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
+        self.padding_mode: Tuple[Union[GridSamplePadMode, str], ...] = ensure_tuple_rep(padding_mode, len(self.keys))
+        self.align_corners: Tuple[bool, ...] = ensure_tuple_rep(align_corners, len(self.keys))
 
     def __call__(self, data):
         d = dict(data)
@@ -774,21 +774,21 @@ class RandRotated(Randomizable, MapTransform):
         align_corners: Union[Sequence[bool], bool] = False,
     ) -> None:
         super().__init__(keys)
-        self.range_x = ensure_tuple(range_x)
+        self.range_x: Tuple[float, ...] = ensure_tuple(range_x)
         if len(self.range_x) == 1:
             self.range_x = tuple(sorted([-self.range_x[0], self.range_x[0]]))
-        self.range_y = ensure_tuple(range_y)
+        self.range_y: Tuple[float, ...] = ensure_tuple(range_y)
         if len(self.range_y) == 1:
             self.range_y = tuple(sorted([-self.range_y[0], self.range_y[0]]))
-        self.range_z = ensure_tuple(range_z)
+        self.range_z: Tuple[float, ...] = ensure_tuple(range_z)
         if len(self.range_z) == 1:
             self.range_z = tuple(sorted([-self.range_z[0], self.range_z[0]]))
 
         self.prob = prob
         self.keep_size = keep_size
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
-        self.align_corners = ensure_tuple_rep(align_corners, len(self.keys))
+        self.mode: Tuple[Union[GridSampleMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
+        self.padding_mode: Tuple[Union[GridSamplePadMode, str], ...] = ensure_tuple_rep(padding_mode, len(self.keys))
+        self.align_corners: Tuple[bool, ...] = ensure_tuple_rep(align_corners, len(self.keys))
 
         self._do_transform = False
         self.x = 0.0
@@ -845,8 +845,8 @@ class Zoomd(MapTransform):
         keep_size: bool = True,
     ) -> None:
         super().__init__(keys)
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.align_corners = ensure_tuple_rep(align_corners, len(self.keys))
+        self.mode: Tuple[Union[InterpolateMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
+        self.align_corners: Tuple[Optional[bool], ...] = ensure_tuple_rep(align_corners, len(self.keys))
         self.zoomer = Zoom(zoom=zoom, keep_size=keep_size)
 
     def __call__(self, data):
@@ -893,13 +893,13 @@ class RandZoomd(Randomizable, MapTransform):
         keep_size: bool = True,
     ) -> None:
         super().__init__(keys)
-        self.min_zoom = ensure_tuple(min_zoom)
-        self.max_zoom = ensure_tuple(max_zoom)
+        self.min_zoom: Tuple[float, ...] = ensure_tuple(min_zoom)
+        self.max_zoom: Tuple[float, ...] = ensure_tuple(max_zoom)
         assert len(self.min_zoom) == len(self.max_zoom), "min_zoom and max_zoom must have same length."
         self.prob = prob
 
-        self.mode = ensure_tuple_rep(mode, len(self.keys))
-        self.align_corners = ensure_tuple_rep(align_corners, len(self.keys))
+        self.mode: Tuple[Union[InterpolateMode, str], ...] = ensure_tuple_rep(mode, len(self.keys))
+        self.align_corners: Tuple[Optional[bool], ...] = ensure_tuple_rep(align_corners, len(self.keys))
         self.keep_size = keep_size
 
         self._do_transform = False

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -17,7 +17,7 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 
 import copy
 import logging
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Hashable, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -171,7 +171,7 @@ class CastToTyped(MapTransform):
 
         """
         MapTransform.__init__(self, keys)
-        self.dtype = ensure_tuple_rep(dtype, len(self.keys))
+        self.dtype: Tuple[np.dtype, ...] = ensure_tuple_rep(dtype, len(self.keys))
         self.converter = CastToType()
 
     def __call__(self, data):
@@ -300,11 +300,11 @@ class DataStatsd(MapTransform):
 
         """
         super().__init__(keys)
-        self.prefix = ensure_tuple_rep(prefix, len(self.keys))
-        self.data_shape = ensure_tuple_rep(data_shape, len(self.keys))
-        self.value_range = ensure_tuple_rep(value_range, len(self.keys))
-        self.data_value = ensure_tuple_rep(data_value, len(self.keys))
-        self.additional_info = ensure_tuple_rep(additional_info, len(self.keys))
+        self.prefix: Tuple[str, ...] = ensure_tuple_rep(prefix, len(self.keys))
+        self.data_shape: Tuple[bool, ...] = ensure_tuple_rep(data_shape, len(self.keys))
+        self.value_range: Tuple[bool, ...] = ensure_tuple_rep(value_range, len(self.keys))
+        self.data_value: Tuple[bool, ...] = ensure_tuple_rep(data_value, len(self.keys))
+        self.additional_info: Tuple[Callable, ...] = ensure_tuple_rep(additional_info, len(self.keys))
         self.logger_handler = logger_handler
         self.printer = DataStats(logger_handler=logger_handler)
 
@@ -337,7 +337,7 @@ class SimulateDelayd(MapTransform):
 
         """
         super().__init__(keys)
-        self.delay_time = ensure_tuple_rep(delay_time, len(self.keys))
+        self.delay_time: Tuple[float, ...] = ensure_tuple_rep(delay_time, len(self.keys))
         self.delayer = SimulateDelay()
 
     def __call__(self, data):
@@ -374,10 +374,9 @@ class CopyItemsd(MapTransform):
         if times < 1:
             raise ValueError("times must be greater than 0.")
         self.times = times
-        names = ensure_tuple(names)
-        if len(names) != (len(self.keys) * times):
+        self.names: Tuple[Hashable, ...] = ensure_tuple(names)
+        if len(self.names) != (len(self.keys) * self.times):
             raise ValueError("length of names does not match `len(keys) x times`.")
-        self.names = names
 
     def __call__(self, data):
         d = dict(data)
@@ -455,7 +454,7 @@ class Lambdad(MapTransform):
 
     def __init__(self, keys: KeysCollection, func: Union[Sequence[Callable], Callable]) -> None:
         super().__init__(keys)
-        self.func = ensure_tuple_rep(func, len(self.keys))
+        self.func: Tuple[Callable, ...] = ensure_tuple_rep(func, len(self.keys))
         self.lambd = Lambda()
 
     def __call__(self, data):

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -68,7 +68,7 @@ def ensure_tuple_size(tup, dim: int, pad_val=0) -> Tuple:
     return tuple(tup[:dim])
 
 
-def ensure_tuple_rep(tup: Any, dim: int):
+def ensure_tuple_rep(tup: Any, dim: int) -> Tuple:
     """
     Returns a copy of `tup` with `dim` values by either shortened or duplicated input.
 


### PR DESCRIPTION
Iteration of #476

### Description

The return of ensure_tuple, ensure_tuple_size, ensure_tuple_rep, and
fall_back_tuple cannot be generically typed as to create a dependance
between the parameter and return type.

The functions therefore return Tuple which loses information given by
the parameter type hint. This commit adds type hints to the variable
receiving the return to restore this information.

### Status
**Hold**

This solution is more of a patch job.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
