### PR TITLE
476 Type hint transforms/*/array.py __call__

### DIFF
--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 from monai.utils import ensure_tuple_size
 
 
-def one_hot(labels, num_classes: int, dtype: torch.dtype = torch.float, dim: int = 1):
+def one_hot(labels: torch.Tensor, num_classes: int, dtype: torch.dtype = torch.float, dim: int = 1):
     """
     For a tensor `labels` of dimensions B1[spatial_dims], return a tensor of dimensions `BN[spatial_dims]`
     for `num_classes` N number of classes.

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -62,7 +62,7 @@ class SpatialPad(Transform):
         else:
             return [(0, max(self.spatial_size[i] - data_shape[i], 0)) for i in range(len(self.spatial_size))]
 
-    def __call__(self, img, mode: Optional[Union[NumpyPadMode, str]] = None):
+    def __call__(self, img: np.ndarray, mode: Optional[Union[NumpyPadMode, str]] = None) -> np.ndarray:
         """
         Args:
             img: data to be transformed, assuming `img` is channel-first and
@@ -110,7 +110,7 @@ class BorderPad(Transform):
         self.spatial_border = spatial_border
         self.mode: NumpyPadMode = NumpyPadMode(mode)
 
-    def __call__(self, img, mode: Optional[Union[NumpyPadMode, str]] = None):
+    def __call__(self, img: np.ndarray, mode: Optional[Union[NumpyPadMode, str]] = None) -> np.ndarray:
         """
         Args:
             img: data to be transformed, assuming `img` is channel-first and
@@ -165,7 +165,7 @@ class DivisiblePad(Transform):
         self.k = k
         self.mode: NumpyPadMode = NumpyPadMode(mode)
 
-    def __call__(self, img, mode: Optional[Union[NumpyPadMode, str]] = None):
+    def __call__(self, img: np.ndarray, mode: Optional[Union[NumpyPadMode, str]] = None) -> np.ndarray:
         """
         Args:
             img: data to be transformed, assuming `img` is channel-first
@@ -224,7 +224,7 @@ class SpatialCrop(Transform):
         assert np.all(self.roi_end > 0), "all elements of roi_end must be positive."
         assert np.all(self.roi_end >= self.roi_start), "invalid roi range."
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`, assuming `img` is channel-first and
         slicing doesn't apply to the channel dim.
@@ -250,7 +250,7 @@ class CenterSpatialCrop(Transform):
     def __init__(self, roi_size: Union[Sequence[int], int]) -> None:
         self.roi_size = roi_size
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`, assuming `img` is channel-first and
         slicing doesn't apply to the channel dim.
@@ -292,12 +292,13 @@ class RandSpatialCrop(Randomizable, Transform):
             valid_size = get_valid_patch_size(img_size, self._size)
             self._slices = (slice(None),) + get_random_patch(img_size, valid_size, self.R)
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`, assuming `img` is channel-first and
         slicing doesn't apply to the channel dim.
         """
         self.randomize(img.shape[1:])
+        assert self._size is not None
         if self.random_center:
             return img[self._slices]
         else:
@@ -336,7 +337,7 @@ class RandSpatialCropSamples(Randomizable, Transform):
     def randomize(self, data: Optional[Any] = None) -> None:
         pass
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> List[np.ndarray]:
         """
         Apply the transform to `img`, assuming `img` is channel-first and
         cropping doesn't change the channel dim.
@@ -383,7 +384,7 @@ class CropForeground(Transform):
         self.channel_indexes = ensure_tuple(channel_indexes) if channel_indexes is not None else None
         self.margin = margin
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`, assuming `img` is channel-first and
         slicing doesn't change the channel dim.
@@ -451,7 +452,9 @@ class RandCropByPosNegLabel(Randomizable, Transform):
             label, self.spatial_size, self.num_samples, self.pos_ratio, image, self.image_threshold, self.R
         )
 
-    def __call__(self, img: np.ndarray, label: Optional[np.ndarray] = None, image: Optional[np.ndarray] = None):
+    def __call__(
+        self, img: np.ndarray, label: Optional[np.ndarray] = None, image: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
         """
         Args:
             img: input data to crop samples from based on the pos/neg ratio of `label` and `image`.

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -454,7 +454,7 @@ class RandCropByPosNegLabel(Randomizable, Transform):
 
     def __call__(
         self, img: np.ndarray, label: Optional[np.ndarray] = None, image: Optional[np.ndarray] = None,
-    ) -> np.ndarray:
+    ) -> List[np.ndarray]:
         """
         Args:
             img: input data to crop samples from based on the pos/neg ratio of `label` and `image`.

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -123,7 +123,7 @@ class ScaleIntensity(Transform):
             factor: factor scale by ``v = v * (1 + factor)``.
 
         Raises:
-            ValueError: if `minv` and `maxv` are None `factor` must be non None
+            ValueError: When `minv` and `maxv` are None and `factor` is not specified.
         """
         self.minv = minv
         self.maxv = maxv
@@ -138,7 +138,7 @@ class ScaleIntensity(Transform):
         elif self.factor is not None:
             return (img * (1 + self.factor)).astype(img.dtype)
         else:
-            raise ValueError("if `minv` and `maxv` are None `factor` must be non None")
+            raise ValueError("If `minv` and `maxv` are None `factor` must be non None.")
 
 
 class RandScaleIntensity(Randomizable, Transform):

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -44,11 +44,12 @@ class RandGaussianNoise(Randomizable, Transform):
         self._do_transform = self.R.random() < self.prob
         self._noise = self.R.normal(self.mean, self.R.uniform(0, self.std), size=im_shape)
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
         self.randomize(img.shape)
+        assert self._noise is not None
         return img + self._noise.astype(img.dtype) if self._do_transform else img
 
 
@@ -63,7 +64,7 @@ class ShiftIntensity(Transform):
     def __init__(self, offset: float) -> None:
         self.offset = offset
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -95,7 +96,7 @@ class RandShiftIntensity(Randomizable, Transform):
         self._offset = self.R.uniform(low=self.offsets[0], high=self.offsets[1])
         self._do_transform = self.R.random() < self.prob
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -120,19 +121,24 @@ class ScaleIntensity(Transform):
             minv: minimum value of output data.
             maxv: maximum value of output data.
             factor: factor scale by ``v = v * (1 + factor)``.
+
+        Raises:
+            ValueError: if `minv` and `maxv` are None `factor` must be non None
         """
         self.minv = minv
         self.maxv = maxv
         self.factor = factor
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
         if self.minv is not None and self.maxv is not None:
             return rescale_array(img, self.minv, self.maxv, img.dtype)
-        else:
+        elif self.factor is not None:
             return (img * (1 + self.factor)).astype(img.dtype)
+        else:
+            raise ValueError("if `minv` and `maxv` are None `factor` must be non None")
 
 
 class RandScaleIntensity(Randomizable, Transform):
@@ -162,7 +168,7 @@ class RandScaleIntensity(Randomizable, Transform):
         self.factor = self.R.uniform(low=self.factors[0], high=self.factors[1])
         self._do_transform = self.R.random() < self.prob
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -205,7 +211,7 @@ class NormalizeIntensity(Transform):
         self.nonzero = nonzero
         self.channel_wise = channel_wise
 
-    def _normalize(self, img):
+    def _normalize(self, img: np.ndarray):
         slices = (img != 0) if self.nonzero else np.ones(img.shape, dtype=np.bool_)
         if np.any(slices):
             if self.subtrahend is not None and self.divisor is not None:
@@ -214,7 +220,7 @@ class NormalizeIntensity(Transform):
                 img[slices] = (img[slices] - np.mean(img[slices])) / np.std(img[slices])
         return img
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`, assuming `img` is a channel-first array if `self.channel_wise` is True,
         """
@@ -244,7 +250,7 @@ class ThresholdIntensity(Transform):
         self.above = above
         self.cval = cval
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -271,7 +277,7 @@ class ScaleIntensityRange(Transform):
         self.b_max = b_max
         self.clip = clip
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -301,7 +307,7 @@ class AdjustContrast(Transform):
         assert isinstance(gamma, (int, float)), "gamma must be a float or int number."
         self.gamma = gamma
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -340,11 +346,12 @@ class RandAdjustContrast(Randomizable, Transform):
         self._do_transform = self.R.random_sample() < self.prob
         self.gamma_value = self.R.uniform(low=self.gamma[0], high=self.gamma[1])
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
         self.randomize()
+        assert self.gamma_value is not None
         if not self._do_transform:
             return img
         adjuster = AdjustContrast(self.gamma_value)
@@ -418,7 +425,7 @@ class ScaleIntensityRangePercentiles(Transform):
         self.clip = clip
         self.relative = relative
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -458,7 +465,7 @@ class MaskIntensity(Transform):
     def __init__(self, mask_data: np.ndarray):
         self.mask_data = mask_data
 
-    def __call__(self, img, mask_data: Optional[np.ndarray] = None):
+    def __call__(self, img: np.ndarray, mask_data: Optional[np.ndarray] = None) -> np.ndarray:
         mask_data_ = self.mask_data > 0 if mask_data is None else mask_data > 0
         if mask_data_.shape[0] != 1 and mask_data_.shape[0] != img.shape[0]:
             raise RuntimeError("mask data has more than 1 channel and do not match channels of input data.")

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -13,7 +13,7 @@ A collection of "vanilla" transforms for the model output tensors
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, List, Optional, Sequence, Union
 import warnings
 import numpy as np
 import torch
@@ -43,7 +43,9 @@ class SplitChannel(Transform):
         self.to_onehot = to_onehot
         self.num_classes = num_classes
 
-    def __call__(self, img: torch.Tensor, to_onehot: Optional[bool] = None, num_classes: Optional[int] = None):
+    def __call__(
+        self, img: torch.Tensor, to_onehot: Optional[bool] = None, num_classes: Optional[int] = None
+    ) -> List[torch.Tensor]:
         """
         Args:
             to_onehot: whether to convert the data to One-Hot format first.
@@ -89,7 +91,7 @@ class Activations(Transform):
         sigmoid: Optional[bool] = None,
         softmax: Optional[bool] = None,
         other: Optional[Callable] = None,
-    ):
+    ) -> torch.Tensor:
         """
         Args:
             sigmoid: whether to execute sigmoid function on model output before transform.
@@ -164,7 +166,7 @@ class AsDiscrete(Transform):
         n_classes: Optional[int] = None,
         threshold_values: Optional[bool] = None,
         logit_thresh: Optional[float] = None,
-    ):
+    ) -> torch.Tensor:
         """
         Args:
             argmax: whether to execute argmax function on input data before transform.
@@ -259,7 +261,7 @@ class KeepLargestConnectedComponent(Transform):
         self.independent = independent
         self.connectivity = connectivity
 
-    def __call__(self, img: torch.Tensor):
+    def __call__(self, img: torch.Tensor) -> torch.Tensor:
         """
         Args:
             img: shape must be (batch_size, C, spatial_dim1[, spatial_dim2, ...]).
@@ -319,7 +321,7 @@ class LabelToContour(Transform):
             raise NotImplementedError("currently, LabelToContour only supports Laplace kernel.")
         self.kernel_type = kernel_type
 
-    def __call__(self, img: torch.Tensor):
+    def __call__(self, img: torch.Tensor) -> torch.Tensor:
         """
         Args:
             img: torch tensor data to extract the contour, with shape: [batch_size, channels, height, width[, depth]]
@@ -375,7 +377,7 @@ class MeanEnsemble(Transform):
     def __init__(self, weights: Optional[Union[Sequence[float], torch.Tensor, np.ndarray]] = None):
         self.weights = torch.as_tensor(weights, dtype=torch.float) if weights is not None else None
 
-    def __call__(self, img: Union[Sequence[torch.Tensor], torch.Tensor]):
+    def __call__(self, img: Union[Sequence[torch.Tensor], torch.Tensor]) -> torch.Tensor:
         img_: torch.Tensor = torch.stack(img) if isinstance(img, (tuple, list)) else torch.as_tensor(img)
         if self.weights is not None:
             self.weights = self.weights.to(img_.device)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -13,7 +13,7 @@ A collection of "vanilla" transforms for spatial operations
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Callable, List, Optional, Sequence, Tuple, Union, Any
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 import warnings
 
@@ -268,7 +268,7 @@ class Flip(Transform):
     def __init__(self, spatial_axis: Optional[Union[Sequence[int], int]]) -> None:
         self.spatial_axis = spatial_axis
 
-    def __call__(self, img: np.ndarray):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Args:
             img: channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -309,7 +309,7 @@ class Resize(Transform):
 
     def __call__(
         self, img: np.ndarray, mode: Optional[Union[InterpolateMode, str]] = None, align_corners: Optional[bool] = None,
-    ):
+    ) -> np.ndarray:
         """
         Args:
             img: channel first array, must have shape: (num_channels, H[, W, ..., ]).
@@ -385,7 +385,7 @@ class Rotate(Transform):
         mode: Optional[Union[GridSampleMode, str]] = None,
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
         align_corners: Optional[bool] = None,
-    ):
+    ) -> np.ndarray:
         """
         Args:
             img: channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -474,7 +474,7 @@ class Zoom(Transform):
 
     def __call__(
         self, img: np.ndarray, mode: Optional[Union[InterpolateMode, str]] = None, align_corners: Optional[bool] = None,
-    ):
+    ) -> np.ndarray:
         """
         Args:
             img: channel first array, must have shape: (num_channels, H[, W, ..., ]).
@@ -525,7 +525,7 @@ class Rotate90(Transform):
         self.k = k
         self.spatial_axes = spatial_axes
 
-    def __call__(self, img: np.ndarray):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Args:
             img: channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -562,7 +562,7 @@ class RandRotate90(Randomizable, Transform):
         self._rand_k = self.R.randint(self.max_k) + 1
         self._do_transform = self.R.random() < self.prob
 
-    def __call__(self, img: np.ndarray):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Args:
             img: channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -643,7 +643,7 @@ class RandRotate(Randomizable, Transform):
         mode: Optional[Union[GridSampleMode, str]] = None,
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
         align_corners: Optional[bool] = None,
-    ):
+    ) -> np.ndarray:
         """
         Args:
             img: channel first array, must have shape 2D: (nchannels, H, W), or 3D: (nchannels, H, W, D).
@@ -688,7 +688,7 @@ class RandFlip(Randomizable, Transform):
     def randomize(self, data: Optional[Any] = None) -> None:
         self._do_transform = self.R.random_sample() < self.prob
 
-    def __call__(self, img: np.ndarray):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Args:
             img: channel first array, must have shape: (num_channels, H[, W, ..., ]),
@@ -751,7 +751,7 @@ class RandZoom(Randomizable, Transform):
 
     def __call__(
         self, img: np.ndarray, mode: Optional[Union[InterpolateMode, str]] = None, align_corners: Optional[bool] = None,
-    ):
+    ) -> np.ndarray:
         """
         Args:
             img: channel first array, must have shape 2D: (nchannels, H, W), or 3D: (nchannels, H, W, D).
@@ -816,7 +816,9 @@ class AffineGrid(Transform):
         self.as_tensor_output = as_tensor_output
         self.device = device
 
-    def __call__(self, spatial_size: Optional[Sequence[int]] = None, grid: Optional[np.ndarray] = None):
+    def __call__(
+        self, spatial_size: Optional[Sequence[int]] = None, grid: Optional[Union[np.ndarray, torch.Tensor]] = None
+    ) -> Union[np.ndarray, torch.Tensor]:
         """
         Args:
             spatial_size: output grid size.
@@ -917,7 +919,9 @@ class RandAffineGrid(Randomizable, Transform):
         if self.scale_range:
             self.scale_params = [self.R.uniform(-f, f) + 1.0 for f in self.scale_range if f is not None]
 
-    def __call__(self, spatial_size: Optional[Sequence[int]] = None, grid: Optional[np.ndarray] = None):
+    def __call__(
+        self, spatial_size: Optional[Sequence[int]] = None, grid: Optional[Union[np.ndarray, torch.Tensor]] = None
+    ) -> Union[np.ndarray, torch.Tensor]:
         """
         Returns:
             a 2D (3xHxW) or 3D (4xHxWxD) grid.
@@ -970,7 +974,7 @@ class RandDeformGrid(Randomizable, Transform):
         self.random_offset = self.R.normal(size=([len(grid_size)] + list(grid_size))).astype(np.float32)
         self.rand_mag = self.R.uniform(self.magnitude[0], self.magnitude[1])
 
-    def __call__(self, spatial_size: Sequence[int]):
+    def __call__(self, spatial_size: Sequence[int]) -> Union[np.ndarray, torch.Tensor]:
         """
         Args:
             spatial_size: spatial size of the grid.
@@ -1017,7 +1021,7 @@ class Resample(Transform):
         grid: Optional[Union[np.ndarray, torch.Tensor]] = None,
         mode: Optional[Union[GridSampleMode, str]] = None,
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
-    ):
+    ) -> Union[np.ndarray, torch.Tensor]:
         """
         Args:
             img: shape must be (num_channels, H, W[, D]).
@@ -1118,7 +1122,7 @@ class Affine(Transform):
         spatial_size: Optional[Union[Sequence[int], int]] = None,
         mode: Optional[Union[GridSampleMode, str]] = None,
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
-    ):
+    ) -> Union[np.ndarray, torch.Tensor]:
         """
         Args:
             img: shape must be (num_channels, H, W[, D]),
@@ -1231,7 +1235,7 @@ class RandAffine(Randomizable, Transform):
         spatial_size: Optional[Union[Sequence[int], int]] = None,
         mode: Optional[Union[GridSampleMode, str]] = None,
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
-    ):
+    ) -> Union[np.ndarray, torch.Tensor]:
         """
         Args:
             img: shape must be (num_channels, H, W[, D]),
@@ -1353,7 +1357,7 @@ class Rand2DElastic(Randomizable, Transform):
         spatial_size: Optional[Union[Tuple[int, int], int]] = None,
         mode: Optional[Union[GridSampleMode, str]] = None,
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
-    ):
+    ) -> Union[np.ndarray, torch.Tensor]:
         """
         Args:
             img: shape must be (num_channels, H, W),
@@ -1481,7 +1485,7 @@ class Rand3DElastic(Randomizable, Transform):
         spatial_size: Optional[Union[Tuple[int, int, int], int]] = None,
         mode: Optional[Union[GridSampleMode, str]] = None,
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
-    ):
+    ) -> Union[np.ndarray, torch.Tensor]:
         """
         Args:
             img: shape must be (num_channels, H, W, D),

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -13,7 +13,7 @@ A collection of "vanilla" transforms for utility functions
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Callable, Optional, Union, Sequence
+from typing import Callable, Optional, Sequence, TypeVar, Union
 
 import time
 import logging
@@ -24,6 +24,10 @@ import torch
 from monai.transforms.compose import Transform
 from monai.utils import ensure_tuple
 
+# Generic type which can represent either a numpy.ndarray or a torch.Tensor
+# Unlike Union can create a dependence between parameter(s) / return(s)
+NdarrayTensor = TypeVar("NdarrayTensor", np.ndarray, torch.Tensor)
+
 
 class Identity(Transform):
     """
@@ -33,7 +37,7 @@ class Identity(Transform):
 
     """
 
-    def __call__(self, img):
+    def __call__(self, img: Union[np.ndarray, torch.Tensor]) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -60,7 +64,7 @@ class AsChannelFirst(Transform):
         assert isinstance(channel_dim, int) and channel_dim >= -1, "invalid channel dimension."
         self.channel_dim = channel_dim
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -86,7 +90,7 @@ class AsChannelLast(Transform):
         assert isinstance(channel_dim, int) and channel_dim >= -1, "invalid channel dimension."
         self.channel_dim = channel_dim
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -107,7 +111,7 @@ class AddChannel(Transform):
     transforms.
     """
 
-    def __call__(self, img):
+    def __call__(self, img: NdarrayTensor) -> NdarrayTensor:
         """
         Apply the transform to `img`.
         """
@@ -128,7 +132,7 @@ class RepeatChannel(Transform):
         assert repeats > 0, "repeats count must be greater than 0."
         self.repeats = repeats
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`, assuming `img` is a "channel-first" array.
         """
@@ -148,7 +152,7 @@ class CastToType(Transform):
         """
         self.dtype = dtype
 
-    def __call__(self, img: Union[np.ndarray, torch.Tensor], dtype: Optional[Union[np.dtype, torch.dtype]] = None):
+    def __call__(self, img: NdarrayTensor, dtype: Optional[Union[np.dtype, torch.dtype]] = None) -> NdarrayTensor:
         """
         Apply the transform to `img`, assuming `img` is a numpy array or PyTorch Tensor.
         """
@@ -165,7 +169,7 @@ class ToTensor(Transform):
     Converts the input image to a tensor without applying any other transformations.
     """
 
-    def __call__(self, img):
+    def __call__(self, img: Union[np.ndarray, torch.Tensor]) -> torch.Tensor:
         """
         Apply the transform to `img` and make it contiguous.
         """
@@ -179,7 +183,7 @@ class ToNumpy(Transform):
     Converts the input Tensor data to numpy array.
     """
 
-    def __call__(self, img):
+    def __call__(self, img: Union[np.ndarray, torch.Tensor]) -> np.ndarray:
         """
         Apply the transform to `img` and make it contiguous.
         """
@@ -196,7 +200,7 @@ class Transpose(Transform):
     def __init__(self, indices) -> None:
         self.indices = indices
 
-    def __call__(self, img):
+    def __call__(self, img: np.ndarray) -> np.ndarray:
         """
         Apply the transform to `img`.
         """
@@ -222,7 +226,7 @@ class SqueezeDim(Transform):
             raise ValueError(f"Invalid channel dimension {dim}")
         self.dim = dim
 
-    def __call__(self, img: np.ndarray):
+    def __call__(self, img: NdarrayTensor) -> NdarrayTensor:
         """
         Args:
             img: numpy arrays with required dimension `dim` removed
@@ -278,13 +282,13 @@ class DataStats(Transform):
 
     def __call__(
         self,
-        img,
+        img: NdarrayTensor,
         prefix: Optional[str] = None,
         data_shape: Optional[bool] = None,
         value_range: Optional[bool] = None,
         data_value: Optional[bool] = None,
         additional_info=None,
-    ):
+    ) -> NdarrayTensor:
         """
         Apply the transform to `img`, optionally take arguments similar to the class constructor.
         """
@@ -332,7 +336,7 @@ class SimulateDelay(Transform):
         super().__init__()
         self.delay_time: float = delay_time
 
-    def __call__(self, img, delay_time: Optional[float] = None):
+    def __call__(self, img: NdarrayTensor, delay_time: Optional[float] = None) -> NdarrayTensor:
         """
         Args:
             img: data remain unchanged throughout this transform.
@@ -366,7 +370,7 @@ class Lambda(Transform):
             raise ValueError("func must be callable.")
         self.func = func
 
-    def __call__(self, img, func: Optional[Callable] = None):
+    def __call__(self, img: Union[np.ndarray, torch.Tensor], func: Optional[Callable] = None):
         """
         Apply `self.func` to `img`.
         """
@@ -404,8 +408,11 @@ class LabelToMask(Transform):
         self.merge_channels = merge_channels
 
     def __call__(
-        self, img, select_labels: Optional[Union[Sequence[int], int]] = None, merge_channels: Optional[bool] = None
-    ):
+        self,
+        img: np.ndarray,
+        select_labels: Optional[Union[Sequence[int], int]] = None,
+        merge_channels: Optional[bool] = None,
+    ) -> np.ndarray:
         if select_labels is None:
             select_labels = self.select_labels
         else:

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -152,7 +152,9 @@ class CastToType(Transform):
         """
         self.dtype = dtype
 
-    def __call__(self, img: NdarrayTensor, dtype: Optional[Union[np.dtype, torch.dtype]] = None) -> NdarrayTensor:
+    def __call__(
+        self, img: Union[np.ndarray, torch.Tensor], dtype: Optional[Union[np.dtype, torch.dtype]] = None
+    ) -> Union[np.ndarray, torch.Tensor]:
         """
         Apply the transform to `img`, assuming `img` is a numpy array or PyTorch Tensor.
         """

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -66,7 +66,7 @@ def zero_margins(img, margin) -> bool:
     return True
 
 
-def rescale_array(arr, minv=0.0, maxv=1.0, dtype: Optional[np.dtype] = np.float32):
+def rescale_array(arr: np.ndarray, minv=0.0, maxv=1.0, dtype: Optional[np.dtype] = np.float32) -> np.ndarray:
     """
     Rescale the values of numpy array `arr` to be from `minv` to `maxv`.
     """
@@ -284,7 +284,7 @@ def create_grid(
     spacing: Optional[Sequence[float]] = None,
     homogeneous: bool = True,
     dtype: np.dtype = float,
-):
+) -> np.ndarray:
     """
     compute a `spatial_size` mesh.
 


### PR DESCRIPTION
Iteration of #476

### Description
Add type hints to `__call__`.

- `-> Union[np.ndarray, torch.Tensor]` is because the output depends on `self.as_tensor_output`'s value
- `-> NdarrayTensor` is because the output depends on `img`'s data type

```python
# Generic type which can represent either a numpy.ndarray or a torch.Tensor
# Unlike Union can create a dependence between parameter(s) / return(s)
NdarrayTensor = TypeVar("NdarrayTensor", np.ndarray, torch.Tensor)
```

### Status
**Ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
