### PR TITLE
fixes cron tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ temp/
 *.bak
 *.swp
 .DS_Store
+
+# temporary testing data MedNIST
+tests/testing_data/MedNIST*

--- a/tests/test_integration_classification_2d.py
+++ b/tests/test_integration_classification_2d.py
@@ -13,7 +13,6 @@ import os
 import shutil
 import subprocess
 import tarfile
-import tempfile
 import unittest
 
 import numpy as np
@@ -152,11 +151,12 @@ def run_inference_test(root_dir, test_x, test_y, device=torch.device("cuda:0")):
 class IntegrationClassification2D(unittest.TestCase):
     def setUp(self):
         set_determinism(seed=0)
-        self.data_dir = tempfile.mkdtemp()
+        self.data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "testing_data")
 
         # download
-        subprocess.call(["wget", "-nv", "-P", self.data_dir, TEST_DATA_URL])
         dataset_file = os.path.join(self.data_dir, "MedNIST.tar.gz")
+        if not os.path.exists(dataset_file):
+            subprocess.call(["wget", "-nv", "-P", self.data_dir, TEST_DATA_URL])
         assert os.path.exists(dataset_file)
 
         # extract tarfile
@@ -197,7 +197,7 @@ class IntegrationClassification2D(unittest.TestCase):
 
     def tearDown(self):
         set_determinism(seed=None)
-        shutil.rmtree(self.data_dir)
+        shutil.rmtree(os.path.join(self.data_dir, "MedNIST"))
 
     @skip_if_quick
     def test_training(self):


### PR DESCRIPTION
partly fixes the cron tests

### Description
the current tests fail because the remote data file access is unstable
this PR will
- skip the mednistdataset test if the downloading fails
- reuse the downloaded files in two tests, instead of repeating the download

known issue and won't be fixed by this pr:
- if the downloading is too slow (> 6 hours) the ci will still fail

https://github.com/Project-MONAI/MONAI/actions/runs/177446167

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] In-line docstrings updated.
