### PR TITLE
476 Reconfigure mypy and pytype

### DIFF
--- a/monai/apps/datasets.py
+++ b/monai/apps/datasets.py
@@ -11,7 +11,7 @@
 
 import os
 import sys
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from monai.apps.utils import download_and_extract
 from monai.data import CacheDataset, load_decathalon_datalist
@@ -87,7 +87,7 @@ class MedNISTDataset(Randomizable, CacheDataset):
     def randomize(self, data: Optional[Any] = None) -> None:
         self.rann = self.R.random()
 
-    def _generate_data_list(self, dataset_dir: str):
+    def _generate_data_list(self, dataset_dir: str) -> List[Dict]:
         """
         Raises:
             ValueError: When ``section`` is not one of ["training", "validation", "test"].
@@ -246,7 +246,7 @@ class DecathlonDataset(Randomizable, CacheDataset):
     def randomize(self, data: Optional[Any] = None) -> None:
         self.rann = self.R.random()
 
-    def _generate_data_list(self, dataset_dir: str):
+    def _generate_data_list(self, dataset_dir: str) -> List[Dict]:
         section = "training" if self.section in ["training", "validation"] else "test"
         datalist = load_decathalon_datalist(os.path.join(dataset_dir, "dataset.json"), True, section)
         if section == "test":

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -84,7 +84,7 @@ def download_url(url: str, filepath: str, md5_value: Optional[str] = None) -> No
             )
     else:
 
-        def _process_hook(blocknum, blocksize, totalsize):
+        def _process_hook(blocknum: int, blocksize: int, totalsize: int):
             progress_bar(blocknum * blocksize, totalsize, f"Downloading {filepath.split('/')[-1]}:")
 
         try:

--- a/monai/data/dataloader.py
+++ b/monai/data/dataloader.py
@@ -64,7 +64,7 @@ class DataLoader(_TorchDataLoader):
         timeout: float = 0.0,
         multiprocessing_context: Optional[Callable] = None,
     ) -> None:
-        super().__init__(  # type: ignore # No overload variant matches argument types
+        super().__init__(  # type: ignore[call-overload]
             dataset=dataset,
             batch_size=batch_size,
             shuffle=shuffle,

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -172,9 +172,9 @@ class PersistentDataset(Dataset):
             cache is ONLY dependant on the input filename paths.
         """
         if item_transformed.get("cached", False) is False:
-            hashfile: Optional[Path] = None
+            hashfile = None
             if self.cache_dir is not None:
-                cache_dir_path: Path = Path(self.cache_dir)
+                cache_dir_path = Path(self.cache_dir)
                 if cache_dir_path.is_dir():
                     # TODO: Find way to hash transforms content as part of the cache
                     data_item_md5 = hashlib.md5(
@@ -192,7 +192,7 @@ class PersistentDataset(Dataset):
                     # NOTE: Writing to ".temp_write_cache" and then using a nearly atomic rename operation
                     #       to make the cache more robust to manual killing of parent process
                     #       which may leave partially written cache files in an incomplete state
-                    temp_hash_file: Path = hashfile.with_suffix(".temp_write_cache")
+                    temp_hash_file = hashfile.with_suffix(".temp_write_cache")
                     torch.save(item_transformed, temp_hash_file)
                     temp_hash_file.rename(hashfile)
 
@@ -289,7 +289,7 @@ class CacheDataset(Dataset):
             item = apply_transform(_transform, item)
         return item
 
-    def _load_cache_item_thread(self, args: Tuple) -> None:
+    def _load_cache_item_thread(self, args: Tuple[int, Any, Sequence[Callable]]) -> None:
         """
         Args:
             args: tuple with contents (i, item, transforms).

--- a/monai/data/decathalon_datalist.py
+++ b/monai/data/decathalon_datalist.py
@@ -11,10 +11,20 @@
 
 import json
 import os
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, overload
 
 
-def _compute_path(base_dir: str, element: Union[List[str], str]):
+@overload
+def _compute_path(base_dir: str, element: str) -> str:
+    ...
+
+
+@overload
+def _compute_path(base_dir: str, element: List[str]) -> List[str]:
+    ...
+
+
+def _compute_path(base_dir, element):
     """
     Args:
         base_dir: the base directory of the dataset.
@@ -36,7 +46,7 @@ def _compute_path(base_dir: str, element: Union[List[str], str]):
         raise TypeError(f"element must be one of (str, list) but is {type(element).__name__}.")
 
 
-def _append_paths(base_dir: str, is_segmentation: bool, items: List[Dict]):
+def _append_paths(base_dir: str, is_segmentation: bool, items: List[Dict]) -> List[Dict]:
     """
     Args:
         base_dir: the base directory of the dataset.
@@ -63,7 +73,7 @@ def load_decathalon_datalist(
     is_segmentation: bool = True,
     data_list_key: str = "training",
     base_dir: Optional[str] = None,
-):
+) -> List[Dict]:
     """Load image/label paths of decathalon challenge from JSON file
 
     Json file is similar to what you get from http://medicaldecathlon.com/

--- a/monai/data/nifti_writer.py
+++ b/monai/data/nifti_writer.py
@@ -128,26 +128,26 @@ def write_nifti(
         while len(output_spatial_shape_) < 3:
             output_spatial_shape_ = output_spatial_shape_ + [1]
         spatial_shape, channel_shape = data.shape[:3], data.shape[3:]
-        data_ = data.reshape(list(spatial_shape) + [-1])
-        data_ = np.moveaxis(data_, -1, 0)  # channel first for pytorch
-        data_ = affine_xform(
-            torch.as_tensor(np.ascontiguousarray(data_).astype(dtype)).unsqueeze(0),
+        data = data.reshape(list(spatial_shape) + [-1])
+        data = np.moveaxis(data, -1, 0)  # channel first for pytorch
+        data = affine_xform(
+            torch.as_tensor(np.ascontiguousarray(data).astype(dtype)).unsqueeze(0),
             torch.as_tensor(np.ascontiguousarray(transform).astype(dtype)),
             spatial_size=output_spatial_shape_[:3],
         )
-        data_ = data_.squeeze(0).detach().cpu().numpy()
-        data_ = np.moveaxis(data_, 0, -1)  # channel last for nifti
-        data_ = data_.reshape(list(data_.shape[:3]) + list(channel_shape))
+        data = data.squeeze(0).detach().cpu().numpy()
+        data = np.moveaxis(data, 0, -1)  # channel last for nifti
+        data = data.reshape(list(data.shape[:3]) + list(channel_shape))
     else:  # single channel image, need to expand to have batch and channel
         while len(output_spatial_shape_) < len(data.shape):
             output_spatial_shape_ = output_spatial_shape_ + [1]
-        data_ = affine_xform(
+        data = affine_xform(
             torch.as_tensor(np.ascontiguousarray(data).astype(dtype)[None, None]),
             torch.as_tensor(np.ascontiguousarray(transform).astype(dtype)),
             spatial_size=output_spatial_shape_[: len(data.shape)],
         )
-        data_ = data_.squeeze(0).squeeze(0).detach().cpu().numpy()
+        data = data.squeeze(0).squeeze(0).detach().cpu().numpy()
 
-    results_img = nib.Nifti1Image(data_.astype(np.float32), to_affine_nd(3, target_affine))
+    results_img = nib.Nifti1Image(data.astype(np.float32), to_affine_nd(3, target_affine))
     nib.save(results_img, file_name)
     return

--- a/monai/data/synthetic.py
+++ b/monai/data/synthetic.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -27,7 +27,7 @@ def create_test_image_2d(
     num_seg_classes: int = 5,
     channel_dim: Optional[int] = None,
     random_state: Optional[np.random.RandomState] = None,
-):
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     Return a noisy 2D image with `num_objs` circles and a 2D mask image. The maximum radius of the circles is given as
     `rad_max`. The mask will have `num_seg_classes` number of classes for segmentations labeled sequentially from 1, plus a
@@ -69,10 +69,12 @@ def create_test_image_2d(
 
     if channel_dim is not None:
         assert isinstance(channel_dim, int) and channel_dim in (-1, 0, 2), "invalid channel dim."
-        noisyimage, labels = (
-            noisyimage[None],
-            labels[None] if channel_dim == 0 else (noisyimage[..., None], labels[..., None]),
-        )
+        if channel_dim == 0:
+            noisyimage = noisyimage[None]
+            labels = labels[None]
+        else:
+            noisyimage = noisyimage[..., None]
+            labels = labels[..., None]
 
     return noisyimage, labels
 
@@ -87,7 +89,7 @@ def create_test_image_3d(
     num_seg_classes: int = 5,
     channel_dim: Optional[int] = None,
     random_state: Optional[np.random.RandomState] = None,
-):
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     Return a noisy 3D image and segmentation.
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -322,21 +322,21 @@ def zoom_affine(affine: np.ndarray, scale: Sequence[float], diagonal: bool = Tru
     affine = np.array(affine, dtype=float, copy=True)
     if len(affine) != len(affine[0]):
         raise ValueError(f"affine must be n x n, got {len(affine)} x {len(affine[0])}.")
-    scale = np.array(scale, dtype=float, copy=True)
-    if np.any(scale <= 0):
+    scale_np = np.array(scale, dtype=float, copy=True)
+    if np.any(scale_np <= 0):
         raise ValueError("scale must contain only positive numbers.")
     d = len(affine) - 1
-    if len(scale) < d:  # defaults based on affine
+    if len(scale_np) < d:  # defaults based on affine
         norm = np.sqrt(np.sum(np.square(affine), 0))[:-1]
-        scale = np.append(scale, norm[len(scale) :])
-    scale = scale[:d]
-    scale[scale == 0] = 1.0
+        scale_np = np.append(scale_np, norm[len(scale_np) :])
+    scale_np = scale_np[:d]
+    scale_np[scale_np == 0] = 1.0
     if diagonal:
-        return np.diag(np.append(scale, [1.0]))
+        return np.diag(np.append(scale_np, [1.0]))
     rzs = affine[:-1, :-1]  # rotation zoom scale
     zs = np.linalg.cholesky(rzs.T @ rzs).T
     rotation = rzs @ np.linalg.inv(zs)
-    s = np.sign(np.diag(zs)) * np.abs(scale)
+    s = np.sign(np.diag(zs)) * np.abs(scale_np)
     # construct new affine with rotation and zoom
     new_affine = np.eye(len(affine))
     new_affine[:-1, :-1] = rotation @ np.diag(s)
@@ -406,19 +406,19 @@ def to_affine_nd(r: Union[np.ndarray, int], affine: np.ndarray) -> np.ndarray:
         an (r+1) x (r+1) matrix
 
     """
-    affine = np.array(affine, dtype=np.float64)
-    if affine.ndim != 2:
-        raise ValueError(f"affine must have 2 dimensions, got {affine.ndim}.")
+    affine_np = np.array(affine, dtype=np.float64)
+    if affine_np.ndim != 2:
+        raise ValueError(f"affine must have 2 dimensions, got {affine_np.ndim}.")
     new_affine = np.array(r, dtype=np.float64, copy=True)
     if new_affine.ndim == 0:
         sr = new_affine.astype(int)
         if not np.isfinite(sr) or sr < 0:
             raise ValueError(f"r must be positive, got {sr}.")
         new_affine = np.eye(sr + 1, dtype=np.float64)
-    d = max(min(len(new_affine) - 1, len(affine) - 1), 1)
-    new_affine[:d, :d] = affine[:d, :d]
+    d = max(min(len(new_affine) - 1, len(affine_np) - 1), 1)
+    new_affine[:d, :d] = affine_np[:d, :d]
     if d > 1:
-        new_affine[:d, -1] = affine[:d, -1]
+        new_affine[:d, -1] = affine_np[:d, -1]
     return new_affine
 
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -13,7 +13,7 @@ import math
 import os
 import warnings
 from itertools import product, starmap
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, Generator, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -50,7 +50,9 @@ def get_random_patch(
     return tuple(slice(mc, mc + ps) for mc, ps in zip(min_corner, patch_size))
 
 
-def iter_patch_slices(dims: Sequence[int], patch_size: Union[Sequence[int], int], start_pos: Sequence[int] = ()):
+def iter_patch_slices(
+    dims: Sequence[int], patch_size: Union[Sequence[int], int], start_pos: Sequence[int] = ()
+) -> Generator[Tuple[slice, ...], None, None]:
     """
     Yield successive tuples of slices defining patches of size `patch_size` from an array of dimensions `dims`. The
     iteration starts from position `start_pos` in the array, or starting at the origin if this isn't provided. Each
@@ -149,7 +151,7 @@ def iter_patch(
     copy_back: bool = True,
     mode: Union[NumpyPadMode, str] = NumpyPadMode.WRAP,
     **pad_opts: Dict,
-):
+) -> Generator[np.ndarray, None, None]:
     """
     Yield successive patches from `arr` of size `patch_size`. The iteration can start from position `start_pos` in `arr`
     but drawing from a padded array extended by the `patch_size` in each dimension (so these coordinates can be negative
@@ -193,7 +195,7 @@ def iter_patch(
         arr[...] = arrpad[slices]
 
 
-def get_valid_patch_size(image_size: Sequence[int], patch_size: Union[Sequence[int], int]):
+def get_valid_patch_size(image_size: Sequence[int], patch_size: Union[Sequence[int], int]) -> Tuple[int, ...]:
     """
     Given an image of dimensions `image_size`, return a patch size tuple taking the dimension from `patch_size` if this is
     not 0/None. Otherwise, or if `patch_size` is shorter than `image_size`, the dimension from `image_size` is taken. This ensures
@@ -292,7 +294,7 @@ def rectify_header_sform_qform(img_nii):
     return img_nii
 
 
-def zoom_affine(affine, scale: Sequence[float], diagonal: bool = True):
+def zoom_affine(affine: np.ndarray, scale: Sequence[float], diagonal: bool = True) -> np.ndarray:
     """
     To make column norm of `affine` the same as `scale`.  If diagonal is False,
     returns an affine that combines orthogonal rotation and the new scale.
@@ -320,28 +322,30 @@ def zoom_affine(affine, scale: Sequence[float], diagonal: bool = True):
     affine = np.array(affine, dtype=float, copy=True)
     if len(affine) != len(affine[0]):
         raise ValueError(f"affine must be n x n, got {len(affine)} x {len(affine[0])}.")
-    scale_ = np.array(scale, dtype=float, copy=True)
-    if np.any(scale_ <= 0):
+    scale = np.array(scale, dtype=float, copy=True)
+    if np.any(scale <= 0):
         raise ValueError("scale must contain only positive numbers.")
     d = len(affine) - 1
-    if len(scale_) < d:  # defaults based on affine
+    if len(scale) < d:  # defaults based on affine
         norm = np.sqrt(np.sum(np.square(affine), 0))[:-1]
-        scale_ = np.append(scale_, norm[len(scale_) :])
-    scale_ = scale_[:d]
-    scale_[scale_ == 0] = 1.0
+        scale = np.append(scale, norm[len(scale) :])
+    scale = scale[:d]
+    scale[scale == 0] = 1.0
     if diagonal:
-        return np.diag(np.append(scale_, [1.0]))
+        return np.diag(np.append(scale, [1.0]))
     rzs = affine[:-1, :-1]  # rotation zoom scale
     zs = np.linalg.cholesky(rzs.T @ rzs).T
     rotation = rzs @ np.linalg.inv(zs)
-    s = np.sign(np.diag(zs)) * np.abs(scale_)
+    s = np.sign(np.diag(zs)) * np.abs(scale)
     # construct new affine with rotation and zoom
     new_affine = np.eye(len(affine))
     new_affine[:-1, :-1] = rotation @ np.diag(s)
     return new_affine
 
 
-def compute_shape_offset(spatial_shape, in_affine, out_affine):
+def compute_shape_offset(
+    spatial_shape: np.ndarray, in_affine: np.ndarray, out_affine: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     Given input and output affine, compute appropriate shapes
     in the output space based on the input array's shape.
@@ -375,7 +379,7 @@ def compute_shape_offset(spatial_shape, in_affine, out_affine):
     return out_shape.astype(int), offset
 
 
-def to_affine_nd(r, affine):
+def to_affine_nd(r: Union[np.ndarray, int], affine: np.ndarray) -> np.ndarray:
     """
     Using elements from affine, to create a new affine matrix by
     assigning the rotation/zoom/scaling matrix and the translation vector.
@@ -402,19 +406,19 @@ def to_affine_nd(r, affine):
         an (r+1) x (r+1) matrix
 
     """
-    affine_ = np.array(affine, dtype=np.float64)
-    if affine_.ndim != 2:
-        raise ValueError(f"affine must have 2 dimensions, got {affine_.ndim}.")
+    affine = np.array(affine, dtype=np.float64)
+    if affine.ndim != 2:
+        raise ValueError(f"affine must have 2 dimensions, got {affine.ndim}.")
     new_affine = np.array(r, dtype=np.float64, copy=True)
     if new_affine.ndim == 0:
         sr = new_affine.astype(int)
         if not np.isfinite(sr) or sr < 0:
             raise ValueError(f"r must be positive, got {sr}.")
         new_affine = np.eye(sr + 1, dtype=np.float64)
-    d = max(min(len(new_affine) - 1, len(affine_) - 1), 1)
-    new_affine[:d, :d] = affine_[:d, :d]
+    d = max(min(len(new_affine) - 1, len(affine) - 1), 1)
+    new_affine[:d, :d] = affine[:d, :d]
     if d > 1:
-        new_affine[:d, -1] = affine_[:d, -1]
+        new_affine[:d, -1] = affine[:d, -1]
     return new_affine
 
 
@@ -460,7 +464,7 @@ def compute_importance_map(
     mode: Union[BlendMode, str] = BlendMode.CONSTANT,
     sigma_scale: float = 0.125,
     device: Optional[torch.device] = None,
-):
+) -> torch.Tensor:
     """Get importance map for different weight modes.
 
     Args:

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence
 
 import torch
 from torch.utils.data import DataLoader
@@ -131,7 +131,7 @@ class SupervisedEvaluator(Evaluator):
         additional_metrics: Optional[Dict[str, Metric]] = None,
         val_handlers: Optional[Sequence] = None,
         amp: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             device=device,
             val_data_loader=val_data_loader,
@@ -147,7 +147,7 @@ class SupervisedEvaluator(Evaluator):
         self.network = network
         self.inferer = inferer
 
-    def _iteration(self, engine: Engine, batchdata: Union[Dict, Sequence]) -> Dict[str, torch.Tensor]:
+    def _iteration(self, engine: Engine, batchdata: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         """
         callback function for the Supervised Evaluation processing logic of 1 iteration in Ignite Engine.
         Return below items in a dictionary:
@@ -223,7 +223,7 @@ class EnsembleEvaluator(Evaluator):
         additional_metrics: Optional[Dict[str, Metric]] = None,
         val_handlers: Optional[Sequence] = None,
         amp: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             device=device,
             val_data_loader=val_data_loader,
@@ -240,7 +240,7 @@ class EnsembleEvaluator(Evaluator):
         self.pred_keys = ensure_tuple(pred_keys)
         self.inferer = inferer
 
-    def _iteration(self, engine: Engine, batchdata: Union[Dict, Sequence]) -> Dict[str, torch.Tensor]:
+    def _iteration(self, engine: Engine, batchdata: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         """
         callback function for the Supervised Evaluation processing logic of 1 iteration in Ignite Engine.
         Return below items in a dictionary:
@@ -267,7 +267,7 @@ class EnsembleEvaluator(Evaluator):
             targets = targets.to(engine.state.device)
 
         # execute forward computation
-        predictions: Dict[str, torch.Tensor] = {Keys.IMAGE: inputs, Keys.LABEL: targets}
+        predictions = {Keys.IMAGE: inputs, Keys.LABEL: targets}
         for idx, network in enumerate(self.networks):
             network.eval()
             with torch.no_grad():

--- a/monai/engines/multi_gpu_supervised_trainer.py
+++ b/monai/engines/multi_gpu_supervised_trainer.py
@@ -9,9 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Tuple
 
 import torch
+import torch.nn
 from torch.optim.optimizer import Optimizer
 
 from monai.engines.utils import get_devices_spec
@@ -21,16 +22,20 @@ create_supervised_trainer, _ = optional_import("ignite.engine", "0.3.0", exact_v
 create_supervised_evaluator, _ = optional_import("ignite.engine", "0.3.0", exact_version, "create_supervised_evaluator")
 _prepare_batch, _ = optional_import("ignite.engine", "0.3.0", exact_version, "_prepare_batch")
 if TYPE_CHECKING:
+    from ignite.engine import Engine
     from ignite.metrics import Metric
 else:
+    Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
     Metric, _ = optional_import("ignite.metrics", "0.3.0", exact_version, "Metric")
 
 
-def _default_transform(_x, _y, _y_pred, loss):
+def _default_transform(_x: torch.Tensor, _y: torch.Tensor, _y_pred: torch.Tensor, loss: torch.Tensor) -> float:
     return loss.item()
 
 
-def _default_eval_transform(x, y, y_pred):
+def _default_eval_transform(
+    x: torch.Tensor, y: torch.Tensor, y_pred: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
     return y_pred, y
 
 
@@ -42,7 +47,7 @@ def create_multigpu_supervised_trainer(
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,
     output_transform: Callable = _default_transform,
-):
+) -> Engine:
     """
     Derived from `create_supervised_trainer` in Ignite.
 
@@ -86,7 +91,7 @@ def create_multigpu_supervised_evaluator(
     non_blocking: bool = False,
     prepare_batch: Callable = _prepare_batch,
     output_transform: Callable = _default_eval_transform,
-):
+) -> Engine:
     """
     Derived from `create_supervised_evaluator` in Ignite.
 

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence
 
 import torch
 from torch.optim.optimizer import Optimizer
@@ -94,7 +94,7 @@ class SupervisedTrainer(Trainer):
         additional_metrics: Optional[Dict[str, Metric]] = None,
         train_handlers: Optional[Sequence] = None,
         amp: bool = False,
-    ):
+    ) -> None:
         # set up Ignite engine and environments
         super().__init__(
             device=device,
@@ -114,7 +114,7 @@ class SupervisedTrainer(Trainer):
         self.loss_function = loss_function
         self.inferer = inferer
 
-    def _iteration(self, engine: Engine, batchdata: Union[Dict, Sequence]) -> Dict[str, torch.Tensor]:
+    def _iteration(self, engine: Engine, batchdata: Dict[str, torch.Tensor]):
         """
         Callback function for the Supervised Training processing logic of 1 iteration in Ignite Engine.
         Return below items in a dictionary:

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import torch
 
@@ -62,7 +62,7 @@ def get_devices_spec(devices: Optional[Sequence[torch.device]] = None) -> List[t
     return devices
 
 
-def default_prepare_batch(batchdata: Dict[str, Any]) -> Tuple[Any, Any]:
+def default_prepare_batch(batchdata: Dict[str, torch.Tensor]) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     assert isinstance(batchdata, dict), "default prepare_batch expects dictionary input data."
     return (
         (batchdata[CommonKeys.IMAGE], batchdata[CommonKeys.LABEL])

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence
 
 import torch
 from torch.utils.data import DataLoader
@@ -29,7 +29,7 @@ else:
     Metric, _ = optional_import("ignite.metrics", "0.3.0", exact_version, "Metric")
 
 
-class Workflow(IgniteEngine):  # type: ignore # incorrectly typed due to optional_import
+class Workflow(IgniteEngine):  # type: ignore[valid-type, misc] # due to optional_import
     """
     Workflow defines the core work process inheriting from Ignite engine.
     All trainer, validator and evaluator share this same workflow as base class,
@@ -108,7 +108,7 @@ class Workflow(IgniteEngine):  # type: ignore # incorrectly typed due to optiona
         if post_transform is not None:
 
             @self.on(Events.ITERATION_COMPLETED)
-            def run_post_transform(engine: Engine):
+            def run_post_transform(engine: Engine) -> None:
                 assert post_transform is not None
                 engine.state.output = apply_transform(post_transform, engine.state.output)
 
@@ -128,7 +128,7 @@ class Workflow(IgniteEngine):  # type: ignore # incorrectly typed due to optiona
                 metric.attach(self, name)
 
             @self.on(Events.EPOCH_COMPLETED)
-            def _compare_metrics(engine: Engine):
+            def _compare_metrics(engine: Engine) -> None:
                 if engine.state.key_metric_name is not None:
                     current_val_metric = engine.state.metrics[engine.state.key_metric_name]
                     if current_val_metric > engine.state.best_metric:
@@ -149,7 +149,7 @@ class Workflow(IgniteEngine):  # type: ignore # incorrectly typed due to optiona
         """
         super().run(data=self.data_loader, epoch_length=len(self.data_loader))
 
-    def _iteration(self, engine: Engine, batchdata: Union[Dict, Sequence]):
+    def _iteration(self, engine: Engine, batchdata: Dict[str, torch.Tensor]):
         """
         Abstract callback function for the processing logic of 1 iteration in Ignite Engine.
         Need subclass to implement different logics, like SupervisedTrainer/Evaluator, GANTrainer, etc.

--- a/monai/handlers/checkpoint_loader.py
+++ b/monai/handlers/checkpoint_loader.py
@@ -19,9 +19,10 @@ from monai.utils import exact_version, optional_import
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
 Checkpoint, _ = optional_import("ignite.handlers", "0.3.0", exact_version, "Checkpoint")
 if TYPE_CHECKING:
-    from ignite.engine import Engine
+    from ignite.engine import Engine, RemovableEventHandle
 else:
     Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
+    RemovableEventHandle, _ = optional_import("ignite.engine", "0.3.0", exact_version, "RemovableEventHandle")
 
 
 class CheckpointLoader:
@@ -53,7 +54,7 @@ class CheckpointLoader:
 
         self._name = name
 
-    def attach(self, engine: Engine):
+    def attach(self, engine: Engine) -> RemovableEventHandle:
         """
         Args:
             engine: Ignite Engine, it can be a trainer, validator or evaluator.

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 from monai.utils import exact_version, optional_import
 
@@ -64,7 +64,7 @@ class CheckpointSaver:
     def __init__(
         self,
         save_dir: str,
-        save_dict: Dict[str, Any],
+        save_dict: Dict,
         name: Optional[str] = None,
         file_prefix: str = "",
         save_final: bool = False,

--- a/monai/handlers/classification_saver.py
+++ b/monai/handlers/classification_saver.py
@@ -55,7 +55,7 @@ class ClassificationSaver:
         self.batch_transform = batch_transform
         self.output_transform = output_transform
 
-        self.logger = None if name is None else logging.getLogger(name)
+        self.logger = logging.getLogger(name)
         self._name = name
 
     def attach(self, engine: Engine) -> None:

--- a/monai/handlers/lr_schedule_handler.py
+++ b/monai/handlers/lr_schedule_handler.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import logging
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from torch.optim.lr_scheduler import ReduceLROnPlateau, _LRScheduler
 
@@ -34,7 +34,7 @@ class LrScheduleHandler:
         print_lr: bool = True,
         name: Optional[str] = None,
         epoch_level: bool = True,
-        step_transform: Callable = lambda engine: (),
+        step_transform: Callable[[Engine], Any] = lambda engine: (),
     ) -> None:
         """
         Args:
@@ -81,6 +81,4 @@ class LrScheduleHandler:
         args = ensure_tuple(self.step_transform(engine))
         self.lr_scheduler.step(*args)
         if self.print_lr:
-            self.logger.info(
-                f"Current learning rate: {self.lr_scheduler._last_lr[0]}"  # type: ignore # Module has no attribute
-            )
+            self.logger.info(f"Current learning rate: {self.lr_scheduler._last_lr[0]}")  # type: ignore[union-attr]

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -22,7 +22,7 @@ reinit__is_reduced, _ = optional_import("ignite.metrics.metric", "0.3.0", exact_
 sync_all_reduce, _ = optional_import("ignite.metrics.metric", "0.3.0", exact_version, "sync_all_reduce")
 
 
-class MeanDice(Metric):  # type: ignore # incorrectly typed due to optional_import
+class MeanDice(Metric):  # type: ignore[valid-type, misc] # due to optional_import
     """
     Computes Dice score metric from full size Tensor and collects average over batch, class-channels, iterations.
     """
@@ -67,12 +67,12 @@ class MeanDice(Metric):  # type: ignore # incorrectly typed due to optional_impo
             logit_thresh=logit_thresh,
             reduction=MetricReduction.MEAN,
         )
-        self._sum = 0
+        self._sum = 0.0
         self._num_examples = 0
 
     @reinit__is_reduced
     def reset(self) -> None:
-        self._sum = 0
+        self._sum = 0.0
         self._num_examples = 0
 
     @reinit__is_reduced

--- a/monai/handlers/metric_logger.py
+++ b/monai/handlers/metric_logger.py
@@ -10,25 +10,26 @@
 # limitations under the License.
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, DefaultDict, List
 
 from monai.utils import exact_version, optional_import
 
 Events, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Events")
 if TYPE_CHECKING:
-    from ignite.engine import Engine
+    from ignite.engine import Engine, RemovableEventHandle
 else:
     Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
+    RemovableEventHandle, _ = optional_import("ignite.engine", "0.3.0", exact_version, "RemovableEventHandle")
 
 
 class MetricLogger:
     def __init__(self, loss_transform: Callable = lambda x: x, metric_transform: Callable = lambda x: x) -> None:
         self.loss_transform = loss_transform
         self.metric_transform = metric_transform
-        self.loss: list = []
-        self.metrics: defaultdict = defaultdict(list)
+        self.loss: List = []
+        self.metrics: DefaultDict = defaultdict(list)
 
-    def attach(self, engine: Engine):
+    def attach(self, engine: Engine) -> RemovableEventHandle:
         """
         Args:
             engine: Ignite Engine, it can be a trainer, validator or evaluator.

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -19,7 +19,7 @@ from monai.utils import Average, exact_version, optional_import
 Metric, _ = optional_import("ignite.metrics", "0.3.0", exact_version, "Metric")
 
 
-class ROCAUC(Metric):  # type: ignore # incorrectly typed due to optional_import
+class ROCAUC(Metric):  # type: ignore[valid-type, misc]  # due to optional_import
     """
     Computes Area Under the Receiver Operating Characteristic Curve (ROC AUC).
     accumulating predictions and the ground-truth during an epoch and applying `compute_roc_auc`.

--- a/monai/handlers/stats_handler.py
+++ b/monai/handlers/stats_handler.py
@@ -11,7 +11,7 @@
 
 import logging
 import warnings
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import torch
 
@@ -42,8 +42,8 @@ class StatsHandler(object):
 
     def __init__(
         self,
-        epoch_print_logger: Optional[Callable] = None,
-        iteration_print_logger: Optional[Callable] = None,
+        epoch_print_logger: Optional[Callable[[Engine], Any]] = None,
+        iteration_print_logger: Optional[Callable[[Engine], Any]] = None,
         output_transform: Callable = lambda x: x,
         global_epoch_transform: Callable = lambda x: x,
         name: Optional[str] = None,

--- a/monai/handlers/tensorboard_handlers.py
+++ b/monai/handlers/tensorboard_handlers.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import warnings
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import numpy as np
 import torch
@@ -47,8 +47,8 @@ class TensorBoardStatsHandler(object):
         self,
         summary_writer: Optional[SummaryWriter] = None,
         log_dir: str = "./runs",
-        epoch_event_writer: Optional[Callable] = None,
-        iteration_event_writer: Optional[Callable] = None,
+        epoch_event_writer: Optional[Callable[[Engine, SummaryWriter], Any]] = None,
+        iteration_event_writer: Optional[Callable[[Engine, SummaryWriter], Any]] = None,
         output_transform: Callable = lambda x: x,
         global_epoch_transform: Callable = lambda x: x,
         tag_name: str = DEFAULT_TAG,

--- a/monai/handlers/utils.py
+++ b/monai/handlers/utils.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from monai.utils import exact_version, optional_import
 
@@ -19,7 +19,7 @@ else:
     Engine, _ = optional_import("ignite.engine", "0.3.0", exact_version, "Engine")
 
 
-def stopping_fn_from_metric(metric_name: str) -> Callable:
+def stopping_fn_from_metric(metric_name: str) -> Callable[[Engine], Any]:
     """
     Returns a stopping function for ignite.handlers.EarlyStopping using the given metric name.
     """
@@ -30,7 +30,7 @@ def stopping_fn_from_metric(metric_name: str) -> Callable:
     return stopping_fn
 
 
-def stopping_fn_from_loss() -> Callable:
+def stopping_fn_from_loss() -> Callable[[Engine], Any]:
     """
     Returns a stopping function for ignite.handlers.EarlyStopping using the loss value.
     """

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -98,7 +98,7 @@ class SlidingWindowInferer(Inferer):
         self.overlap = overlap
         self.mode: BlendMode = BlendMode(mode)
 
-    def __call__(self, inputs: torch.Tensor, network: torch.nn.Module):
+    def __call__(self, inputs: torch.Tensor, network: torch.nn.Module) -> torch.Tensor:
         """
         Unified callable function API of Inferers.
 

--- a/monai/inferers/utils.py
+++ b/monai/inferers/utils.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Sequence, Union
+from typing import Callable, Sequence, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -22,7 +22,7 @@ def sliding_window_inference(
     inputs: torch.Tensor,
     roi_size: Union[Sequence[int], int],
     sw_batch_size: int,
-    predictor: Callable,
+    predictor: Callable[[torch.Tensor], torch.Tensor],
     overlap: float = 0.25,
     mode: Union[BlendMode, str] = BlendMode.CONSTANT,
     padding_mode: Union[PytorchPadMode, str] = PytorchPadMode.CONSTANT,
@@ -153,7 +153,9 @@ def sliding_window_inference(
     ]  # 2D
 
 
-def _get_scan_interval(image_size: Sequence[int], roi_size: Sequence[int], num_spatial_dims: int, overlap: float):
+def _get_scan_interval(
+    image_size: Sequence[int], roi_size: Sequence[int], num_spatial_dims: int, overlap: float
+) -> Tuple[int, ...]:
     assert len(image_size) == num_spatial_dims, "image coord different from spatial dims."
     assert len(roi_size) == num_spatial_dims, "roi coord different from spatial dims."
 

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -72,7 +72,7 @@ class DiceMetric:
 
         self.not_nans: Optional[torch.Tensor] = None  # keep track for valid elements in the batch
 
-    def __call__(self, y_pred: torch.Tensor, y: torch.Tensor):
+    def __call__(self, y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         """
         Args:
             y_pred: input data to compute, typical segmentation model output.
@@ -153,7 +153,7 @@ def compute_meandice(
     sigmoid: bool = False,
     other_act: Optional[Callable] = None,
     logit_thresh: float = 0.5,
-):
+) -> torch.Tensor:
     """Computes Dice score metric from full size Tensor and collects average.
 
     Args:

--- a/monai/metrics/rocauc.py
+++ b/monai/metrics/rocauc.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import warnings
-from typing import Callable, Optional, Union, cast
+from typing import Callable, List, Optional, Union, cast
 
 import numpy as np
 import torch
@@ -19,7 +19,7 @@ from monai.networks import one_hot
 from monai.utils import Average
 
 
-def _calculate(y: torch.Tensor, y_pred: torch.Tensor):
+def _calculate(y: torch.Tensor, y_pred: torch.Tensor) -> float:
     assert y.ndimension() == y_pred.ndimension() == 1 and len(y) == len(
         y_pred
     ), "y and y_pred must be 1 dimension data with same length."
@@ -59,7 +59,7 @@ def compute_roc_auc(
     softmax: bool = False,
     other_act: Optional[Callable] = None,
     average: Union[Average, str] = Average.MACRO,
-):
+) -> Union[np.ndarray, List[float], float]:
     """Computes Area Under the Receiver Operating Characteristic Curve (ROC AUC). Referring to:
     `sklearn.metrics.roc_auc_score <https://scikit-learn.org/stable/modules/generated/
     sklearn.metrics.roc_auc_score.html#sklearn.metrics.roc_auc_score>`_.

--- a/monai/networks/blocks/aspp.py
+++ b/monai/networks/blocks/aspp.py
@@ -90,7 +90,7 @@ class SimpleASPP(nn.Module):
             norm=norm_type,
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: in shape (batch, channel, spatial_1[, spatial_2, ...]).

--- a/monai/networks/blocks/aspp.py
+++ b/monai/networks/blocks/aspp.py
@@ -90,7 +90,7 @@ class SimpleASPP(nn.Module):
             norm=norm_type,
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor):
         """
         Args:
             x: in shape (batch, channel, spatial_1[, spatial_2, ...]).

--- a/monai/networks/blocks/convolutions.py
+++ b/monai/networks/blocks/convolutions.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -61,9 +61,9 @@ class Convolution(nn.Sequential):
         out_channels: int,
         strides: int = 1,
         kernel_size: Union[Sequence[int], int] = 3,
-        act: Optional[Union[tuple, str]] = Act.PRELU,
-        norm: Union[tuple, str] = Norm.INSTANCE,
-        dropout: Optional[Union[int, float, tuple, str]] = None,
+        act: Optional[Union[Tuple, str]] = Act.PRELU,
+        norm: Union[Tuple, str] = Norm.INSTANCE,
+        dropout: Optional[Union[Tuple, str, float]] = None,
         dilation: Union[Sequence[int], int] = 1,
         groups: int = 1,
         bias: bool = True,

--- a/monai/networks/blocks/squeeze_and_excitation.py
+++ b/monai/networks/blocks/squeeze_and_excitation.py
@@ -73,8 +73,8 @@ class ChannelSELayer(nn.Module):
             x: in shape (batch, in_channels, spatial_1[, spatial_2, ...]).
         """
         b, c = x.shape[:2]
-        y = self.avg_pool(x).view(b, c)
-        y: torch.Tensor = self.fc(y).view([b, c] + [1] * (x.ndimension() - 2))
+        y: torch.Tensor = self.avg_pool(x).view(b, c)
+        y = self.fc(y).view([b, c] + [1] * (x.ndimension() - 2))
         return x * y
 
 
@@ -205,7 +205,7 @@ class SEBlock(nn.Module):
             act_final, act_final_args = split_args(acti_type_final)
             self.act = Act[act_final](**act_final_args)
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: in shape (batch, in_channels, spatial_1[, spatial_2, ...]).

--- a/monai/networks/blocks/squeeze_and_excitation.py
+++ b/monai/networks/blocks/squeeze_and_excitation.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import math
-from typing import Any, Dict, Optional, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -30,8 +30,8 @@ class ChannelSELayer(nn.Module):
         spatial_dims: int,
         in_channels: int,
         r: int = 2,
-        acti_type_1: Union[str, tuple] = ("relu", {"inplace": True}),
-        acti_type_2: Union[str, tuple] = "sigmoid",
+        acti_type_1: Union[Tuple[str, Dict], str] = ("relu", {"inplace": True}),
+        acti_type_2: Union[Tuple[str, Dict], str] = "sigmoid",
     ) -> None:
         """
         Args:
@@ -67,14 +67,14 @@ class ChannelSELayer(nn.Module):
             Act[act_2](**act_2_args),
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: in shape (batch, in_channels, spatial_1[, spatial_2, ...]).
         """
         b, c = x.shape[:2]
         y = self.avg_pool(x).view(b, c)
-        y = self.fc(y).view([b, c] + [1] * (x.ndimension() - 2))
+        y: torch.Tensor = self.fc(y).view([b, c] + [1] * (x.ndimension() - 2))
         return x * y
 
 
@@ -89,7 +89,12 @@ class ResidualSELayer(ChannelSELayer):
     """
 
     def __init__(
-        self, spatial_dims: int, in_channels: int, r: int = 2, acti_type_1="leakyrelu", acti_type_2="relu"
+        self,
+        spatial_dims: int,
+        in_channels: int,
+        r: int = 2,
+        acti_type_1: Union[Tuple[str, Dict], str] = "leakyrelu",
+        acti_type_2: Union[Tuple[str, Dict], str] = "relu",
     ) -> None:
         """
         Args:
@@ -108,7 +113,7 @@ class ResidualSELayer(ChannelSELayer):
             spatial_dims=spatial_dims, in_channels=in_channels, r=r, acti_type_1=acti_type_1, acti_type_2=acti_type_2
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Args:
             x: in shape (batch, in_channels, spatial_1[, spatial_2, ...]).
@@ -135,15 +140,15 @@ class SEBlock(nn.Module):
         n_chns_1: int,
         n_chns_2: int,
         n_chns_3: int,
-        conv_param_1: Optional[Dict[str, Any]] = None,
-        conv_param_2: Optional[Dict[str, Any]] = None,
-        conv_param_3: Optional[Dict[str, Any]] = None,
+        conv_param_1: Optional[Dict] = None,
+        conv_param_2: Optional[Dict] = None,
+        conv_param_3: Optional[Dict] = None,
         project: Optional[Convolution] = None,
         r: int = 2,
-        acti_type_1: Union[str, tuple] = "relu",
-        acti_type_2: Union[str, tuple] = "sigmoid",
-        acti_type_final: Optional[Union[str, tuple]] = "relu",
-    ):
+        acti_type_1: Union[Tuple[str, Dict], str] = "relu",
+        acti_type_2: Union[Tuple[str, Dict], str] = "sigmoid",
+        acti_type_final: Optional[Union[Tuple[str, Dict], str]] = "relu",
+    ) -> None:
         """
         Args:
             spatial_dims: number of spatial dimensions, could be 1, 2, or 3.
@@ -200,7 +205,7 @@ class SEBlock(nn.Module):
             act_final, act_final_args = split_args(acti_type_final)
             self.act = Act[act_final](**act_final_args)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor):
         """
         Args:
             x: in shape (batch, in_channels, spatial_1[, spatial_2, ...]).

--- a/monai/networks/layers/convutils.py
+++ b/monai/networks/layers/convutils.py
@@ -9,14 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, Union
+from typing import Sequence, Tuple, Union
 
 import numpy as np
 
 __all__ = ["same_padding", "calculate_out_shape", "gaussian_1d"]
 
 
-def same_padding(kernel_size: Union[Sequence[int], int], dilation: Union[Sequence[int], int] = 1):
+def same_padding(
+    kernel_size: Union[Sequence[int], int], dilation: Union[Sequence[int], int] = 1
+) -> Union[Tuple[int, ...], int]:
     """
     Return the padding value needed to ensure a convolution using the given kernel size produces an output of the same
     shape as the input for a stride of 1, otherwise ensure a shape of the input divided by the stride rounded down.
@@ -26,34 +28,40 @@ def same_padding(kernel_size: Union[Sequence[int], int], dilation: Union[Sequenc
 
     """
 
-    kernel_size_ = np.atleast_1d(kernel_size)
-    dilation_ = np.atleast_1d(dilation)
+    kernel_size = np.atleast_1d(kernel_size)
+    dilation = np.atleast_1d(dilation)
 
-    if np.any((kernel_size_ - 1) * dilation_ % 2 == 1):
-        raise NotImplementedError(
-            f"Same padding not available for kernel_size={kernel_size_} and dilation={dilation_}."
-        )
+    if np.any((kernel_size - 1) * dilation % 2 == 1):
+        raise NotImplementedError(f"Same padding not available for kernel_size={kernel_size} and dilation={dilation}.")
 
-    padding = (kernel_size_ - 1) / 2 * dilation_
+    padding = (kernel_size - 1) / 2 * dilation
     padding = tuple(int(p) for p in padding)
 
-    return tuple(padding) if len(padding) > 1 else padding[0]
+    return padding if len(padding) > 1 else padding[0]
 
 
-def calculate_out_shape(in_shape, kernel_size, stride, padding):
+def calculate_out_shape(
+    in_shape: Union[Sequence[int], int],
+    kernel_size: Union[Sequence[int], int],
+    stride: Union[Sequence[int], int],
+    padding: Union[Sequence[int], int],
+) -> Union[Tuple[int, ...], int]:
     """
     Calculate the output tensor shape when applying a convolution to a tensor of shape `inShape` with kernel size
     `kernel_size`, stride value `stride`, and input padding value `padding`. All arguments can be scalars or multiple
     values, return value is a scalar if all inputs are scalars.
     """
     in_shape = np.atleast_1d(in_shape)
+    kernel_size = np.atleast_1d(kernel_size)
+    stride = np.atleast_1d(stride)
+    padding = np.atleast_1d(padding)
     out_shape = ((in_shape - kernel_size + padding + padding) // stride) + 1
     out_shape = tuple(int(s) for s in out_shape)
 
-    return tuple(out_shape) if len(out_shape) > 1 else out_shape[0]
+    return out_shape if len(out_shape) > 1 else out_shape[0]
 
 
-def gaussian_1d(sigma, truncated=4.0):
+def gaussian_1d(sigma: float, truncated: float = 4.0) -> np.ndarray:
     """
     one dimensional gaussian kernel.
 

--- a/monai/networks/layers/convutils.py
+++ b/monai/networks/layers/convutils.py
@@ -28,14 +28,16 @@ def same_padding(
 
     """
 
-    kernel_size = np.atleast_1d(kernel_size)
-    dilation = np.atleast_1d(dilation)
+    kernel_size_np = np.atleast_1d(kernel_size)
+    dilation_np = np.atleast_1d(dilation)
 
-    if np.any((kernel_size - 1) * dilation % 2 == 1):
-        raise NotImplementedError(f"Same padding not available for kernel_size={kernel_size} and dilation={dilation}.")
+    if np.any((kernel_size_np - 1) * dilation % 2 == 1):
+        raise NotImplementedError(
+            f"Same padding not available for kernel_size={kernel_size_np} and dilation={dilation_np}."
+        )
 
-    padding = (kernel_size - 1) / 2 * dilation
-    padding = tuple(int(p) for p in padding)
+    padding_np = (kernel_size_np - 1) / 2 * dilation_np
+    padding = tuple(int(p) for p in padding_np)
 
     return padding if len(padding) > 1 else padding[0]
 
@@ -51,12 +53,13 @@ def calculate_out_shape(
     `kernel_size`, stride value `stride`, and input padding value `padding`. All arguments can be scalars or multiple
     values, return value is a scalar if all inputs are scalars.
     """
-    in_shape = np.atleast_1d(in_shape)
-    kernel_size = np.atleast_1d(kernel_size)
-    stride = np.atleast_1d(stride)
-    padding = np.atleast_1d(padding)
-    out_shape = ((in_shape - kernel_size + padding + padding) // stride) + 1
-    out_shape = tuple(int(s) for s in out_shape)
+    in_shape_np = np.atleast_1d(in_shape)
+    kernel_size_np = np.atleast_1d(kernel_size)
+    stride_np = np.atleast_1d(stride)
+    padding_np = np.atleast_1d(padding)
+
+    out_shape_np = ((in_shape_np - kernel_size_np + padding_np + padding_np) // stride_np) + 1
+    out_shape = tuple(int(s) for s in out_shape_np)
 
     return out_shape if len(out_shape) > 1 else out_shape[0]
 

--- a/monai/networks/layers/factories.py
+++ b/monai/networks/layers/factories.py
@@ -60,7 +60,7 @@ can be parameterized with the factory name and the arguments to pass to the crea
     layer = use_factory( (fact.TEST, kwargs) )
 """
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Tuple, Type, Union
 
 import torch.nn as nn
 
@@ -77,14 +77,14 @@ class LayerFactory:
         self.factories: Dict[str, Callable] = {}
 
     @property
-    def names(self):
+    def names(self) -> Tuple[str, ...]:
         """
         Produces all factory names.
         """
 
         return tuple(self.factories)
 
-    def add_factory_callable(self, name: str, func: Callable):
+    def add_factory_callable(self, name: str, func: Callable) -> None:
         """
         Add the factory function to this object under the given name.
         """
@@ -97,12 +97,12 @@ class LayerFactory:
             + ".\nPlease see :py:class:`monai.networks.layers.split_args` for additional args parsing."
         )
 
-    def factory_function(self, name: str):
+    def factory_function(self, name: str) -> Callable:
         """
         Decorator for adding a factory function with the given name.
         """
 
-        def _add(func: Callable):
+        def _add(func: Callable) -> Callable:
             self.add_factory_callable(name, func)
             return func
 
@@ -198,20 +198,20 @@ Pool = LayerFactory()
 
 
 @Dropout.factory_function("dropout")
-def dropout_factory(dim: int):
-    types = [nn.Dropout, nn.Dropout2d, nn.Dropout3d]
+def dropout_factory(dim: int) -> Type[Union[nn.Dropout, nn.Dropout2d, nn.Dropout3d]]:
+    types = (nn.Dropout, nn.Dropout2d, nn.Dropout3d)
     return types[dim - 1]
 
 
 @Norm.factory_function("instance")
-def instance_factory(dim: int):
-    types = [nn.InstanceNorm1d, nn.InstanceNorm2d, nn.InstanceNorm3d]
+def instance_factory(dim: int) -> Type[Union[nn.InstanceNorm1d, nn.InstanceNorm2d, nn.InstanceNorm3d]]:
+    types = (nn.InstanceNorm1d, nn.InstanceNorm2d, nn.InstanceNorm3d)
     return types[dim - 1]
 
 
 @Norm.factory_function("batch")
-def batch_factory(dim: int):
-    types = [nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d]
+def batch_factory(dim: int) -> Type[Union[nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d]]:
+    types = (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)
     return types[dim - 1]
 
 
@@ -229,36 +229,40 @@ Act.add_factory_callable("logsoftmax", lambda: nn.modules.LogSoftmax)
 
 
 @Conv.factory_function("conv")
-def conv_factory(dim: int):
-    types = [nn.Conv1d, nn.Conv2d, nn.Conv3d]
+def conv_factory(dim: int) -> Type[Union[nn.Conv1d, nn.Conv2d, nn.Conv3d]]:
+    types = (nn.Conv1d, nn.Conv2d, nn.Conv3d)
     return types[dim - 1]
 
 
 @Conv.factory_function("convtrans")
-def convtrans_factory(dim: int):
-    types = [nn.ConvTranspose1d, nn.ConvTranspose2d, nn.ConvTranspose3d]
+def convtrans_factory(dim: int) -> Type[Union[nn.ConvTranspose1d, nn.ConvTranspose2d, nn.ConvTranspose3d]]:
+    types = (nn.ConvTranspose1d, nn.ConvTranspose2d, nn.ConvTranspose3d)
     return types[dim - 1]
 
 
 @Pool.factory_function("max")
-def maxpooling_factory(dim: int):
-    types = [nn.MaxPool1d, nn.MaxPool2d, nn.MaxPool3d]
+def maxpooling_factory(dim: int) -> Type[Union[nn.MaxPool1d, nn.MaxPool2d, nn.MaxPool3d]]:
+    types = (nn.MaxPool1d, nn.MaxPool2d, nn.MaxPool3d)
     return types[dim - 1]
 
 
 @Pool.factory_function("adaptivemax")
-def adaptive_maxpooling_factory(dim: int):
-    types = [nn.AdaptiveMaxPool1d, nn.AdaptiveMaxPool2d, nn.AdaptiveMaxPool3d]
+def adaptive_maxpooling_factory(
+    dim: int,
+) -> Type[Union[nn.AdaptiveMaxPool1d, nn.AdaptiveMaxPool2d, nn.AdaptiveMaxPool3d]]:
+    types = (nn.AdaptiveMaxPool1d, nn.AdaptiveMaxPool2d, nn.AdaptiveMaxPool3d)
     return types[dim - 1]
 
 
 @Pool.factory_function("avg")
-def avgpooling_factory(dim: int):
-    types = [nn.AvgPool1d, nn.AvgPool2d, nn.AvgPool3d]
+def avgpooling_factory(dim: int) -> Type[Union[nn.AvgPool1d, nn.AvgPool2d, nn.AvgPool3d]]:
+    types = (nn.AvgPool1d, nn.AvgPool2d, nn.AvgPool3d)
     return types[dim - 1]
 
 
 @Pool.factory_function("adaptiveavg")
-def adaptive_avgpooling_factory(dim: int):
-    types = [nn.AdaptiveAvgPool1d, nn.AdaptiveAvgPool2d, nn.AdaptiveAvgPool3d]
+def adaptive_avgpooling_factory(
+    dim: int,
+) -> Type[Union[nn.AdaptiveAvgPool1d, nn.AdaptiveAvgPool2d, nn.AdaptiveAvgPool3d]]:
+    types = (nn.AdaptiveAvgPool1d, nn.AdaptiveAvgPool2d, nn.AdaptiveAvgPool3d)
     return types[dim - 1]

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import math
-from typing import Sequence, Union
+from typing import Sequence, Union, cast
 
 import torch
 import torch.nn.functional as F
@@ -54,7 +54,7 @@ class Reshape(nn.Module):
     Reshapes input tensors to the given shape (minus batch dimension), retaining original batch size.
     """
 
-    def __init__(self, *shape) -> None:
+    def __init__(self, *shape: int) -> None:
         """
         Given a shape list/tuple `shape` of integers (s0, s1, ... , sn), this layer will reshape input tensors of
         shape (batch, s0 * s1 * ... * sn) to shape (batch, s0, s1, ... , sn).
@@ -86,7 +86,7 @@ class GaussianFilter(nn.Module):
         self.kernel = [
             torch.nn.Parameter(torch.as_tensor(gaussian_1d(s, truncated), dtype=torch.float), False) for s in _sigma
         ]
-        self.padding = [same_padding(k.size()[0]) for k in self.kernel]
+        self.padding = [cast(int, (same_padding(k.size()[0]))) for k in self.kernel]
         self.conv_n = [F.conv1d, F.conv2d, F.conv3d][spatial_dims - 1]
         for idx, param in enumerate(self.kernel):
             self.register_parameter(f"kernel_{idx}", param)

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -72,7 +72,9 @@ class AffineTransform(nn.Module):
         self.align_corners = align_corners
         self.reverse_indexing = reverse_indexing
 
-    def forward(self, src, theta, spatial_size: Optional[Union[Sequence[int], int]] = None):
+    def forward(
+        self, src: torch.Tensor, theta: torch.Tensor, spatial_size: Optional[Union[Sequence[int], int]] = None
+    ) -> torch.Tensor:
         """
         ``theta`` must be an affine transformation matrix with shape
         3x3 or Nx3x3 or Nx2x3 or 2x3 for spatial 2D transforms,
@@ -100,9 +102,9 @@ class AffineTransform(nn.Module):
         # validate `theta`
         if not torch.is_tensor(theta):
             raise TypeError(f"theta must be torch.Tensor but is {type(theta).__name__}.")
-        if theta.ndim not in (2, 3):
+        if theta.dim() not in (2, 3):
             raise ValueError(f"theta must be Nxdxd or dxd, got {theta.shape}.")
-        if theta.ndim == 2:
+        if theta.dim() == 2:
             theta = theta[None]  # adds a batch dim.
         theta = theta.clone()  # no in-place change of theta
         theta_shape = tuple(theta.shape[1:])
@@ -117,7 +119,7 @@ class AffineTransform(nn.Module):
         # validate `src`
         if not torch.is_tensor(src):
             raise TypeError(f"src must be torch.Tensor but is {type(src).__name__}.")
-        sr = src.ndim - 2  # input spatial rank
+        sr = src.dim() - 2  # input spatial rank
         if sr not in (2, 3):
             raise ValueError(f"Unsupported src dimension: {sr}, available options are [2, 3].")
 

--- a/monai/networks/nets/classifier.py
+++ b/monai/networks/nets/classifier.py
@@ -136,5 +136,5 @@ class Critic(Classifier):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.net(x)
         x = self.final(x)
-        x: torch.Tensor = x.mean(1)
+        x = x.mean(1)
         return x.view((x.shape[0], -1))

--- a/monai/networks/nets/classifier.py
+++ b/monai/networks/nets/classifier.py
@@ -130,11 +130,11 @@ class Critic(Classifier):
         """
         super().__init__(in_shape, 1, channels, strides, kernel_size, num_res_units, act, norm, dropout, bias, None)
 
-    def _get_final_layer(self, in_shape):
+    def _get_final_layer(self, in_shape: Sequence[int]):
         return nn.Flatten()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.net(x)
         x = self.final(x)
-        x = x.mean(1)
+        x: torch.Tensor = x.mean(1)
         return x.view((x.shape[0], -1))

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -186,7 +186,7 @@ class DenseNet(nn.Module):
             elif isinstance(m, nn.Linear):
                 nn.init.constant_(torch.as_tensor(m.bias), 0)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor):
         x = self.features(x)
         x = self.class_layers(x)
         return x

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -186,7 +186,7 @@ class DenseNet(nn.Module):
             elif isinstance(m, nn.Linear):
                 nn.init.constant_(torch.as_tensor(m.bias), 0)
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.features(x)
         x = self.class_layers(x)
         return x

--- a/monai/networks/nets/generator.py
+++ b/monai/networks/nets/generator.py
@@ -139,7 +139,7 @@ class Generator(nn.Module):
 
         return layer
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.flatten(x)
         x = self.linear(x)
         x = self.reshape(x)

--- a/monai/networks/nets/generator.py
+++ b/monai/networks/nets/generator.py
@@ -96,7 +96,9 @@ class Generator(nn.Module):
             self.conv.add_module("layer_%i" % i, layer)
             echannel = c
 
-    def _get_layer(self, in_channels: int, out_channels: int, strides: int, is_last: bool):
+    def _get_layer(
+        self, in_channels: int, out_channels: int, strides: int, is_last: bool
+    ) -> Union[Convolution, nn.Sequential]:
         """
         Returns a layer accepting inputs with `in_channels` number of channels and producing outputs of `out_channels`
         number of channels. The `strides` indicates upsampling factor, ie. transpose convolutional stride. If `is_last`
@@ -137,7 +139,7 @@ class Generator(nn.Module):
 
         return layer
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor):
         x = self.flatten(x)
         x = self.linear(x)
         x = self.reshape(x)

--- a/monai/networks/nets/highresnet.py
+++ b/monai/networks/nets/highresnet.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Dict, Optional, Sequence, Union
 
 import torch
 import torch.nn as nn
@@ -190,7 +190,7 @@ class HighResNet(nn.Module):
         norm_type: Union[Normalisation, str] = Normalisation.BATCH,
         acti_type: Union[Activation, str] = Activation.RELU,
         dropout_prob: Optional[float] = None,
-        layer_params: Sequence[Dict[str, Any]] = DEFAULT_LAYER_PARAMS_3D,
+        layer_params: Sequence[Dict] = DEFAULT_LAYER_PARAMS_3D,
     ) -> None:
 
         super(HighResNet, self).__init__()

--- a/monai/networks/nets/regressor.py
+++ b/monai/networks/nets/regressor.py
@@ -135,7 +135,7 @@ class Regressor(nn.Module):
         linear = nn.Linear(int(np.product(in_shape)), int(np.product(self.out_shape)))
         return nn.Sequential(nn.Flatten(), linear)
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.net(x)
         x = self.final(x)
         x = self.reshape(x)

--- a/monai/networks/nets/regressor.py
+++ b/monai/networks/nets/regressor.py
@@ -41,7 +41,7 @@ class Regressor(nn.Module):
         norm=Norm.INSTANCE,
         dropout: Optional[float] = None,
         bias: bool = True,
-    ):
+    ) -> None:
         """
         Construct the regressor network with the number of layers defined by `channels` and `strides`. Inputs are
         first passed through the convolutional layers in the forward pass, the output from this is then pass
@@ -90,7 +90,9 @@ class Regressor(nn.Module):
 
         self.final = self._get_final_layer((echannel,) + self.final_size)
 
-    def _get_layer(self, in_channels: int, out_channels: int, strides: int, is_last: bool):
+    def _get_layer(
+        self, in_channels: int, out_channels: int, strides: int, is_last: bool
+    ) -> Union[ResidualUnit, Convolution]:
         """
         Returns a layer accepting inputs with `in_channels` number of channels and producing outputs of `out_channels`
         number of channels. The `strides` indicates downsampling factor, ie. convolutional stride. If `is_last`
@@ -129,11 +131,11 @@ class Regressor(nn.Module):
 
         return layer
 
-    def _get_final_layer(self, in_shape):
+    def _get_final_layer(self, in_shape: Sequence[int]):
         linear = nn.Linear(int(np.product(in_shape)), int(np.product(self.out_shape)))
         return nn.Sequential(nn.Flatten(), linear)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor):
         x = self.net(x)
         x = self.final(x)
         x = self.reshape(x)

--- a/monai/networks/nets/senet.py
+++ b/monai/networks/nets/senet.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from collections import OrderedDict
-from typing import List, Optional, Type, Union
+from typing import Any, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.nn as nn
@@ -28,37 +28,37 @@ class SENet(nn.Module):
 
     Args:
         spatial_dims: spatial dimension of the input data.
-        in_ch (int): channel number of the input data.
-        block (SEBlock): SEBlock class.
+        in_ch: channel number of the input data.
+        block: SEBlock class.
             for SENet154: SEBottleneck
             for SE-ResNet models: SEResNetBottleneck
             for SE-ResNeXt models:  SEResNeXtBottleneck
-        layers (list): number of residual blocks for 4 layers of the network (layer1...layer4).
-        groups (int): number of groups for the 3x3 convolution in each bottleneck block.
+        layers: number of residual blocks for 4 layers of the network (layer1...layer4).
+        groups: number of groups for the 3x3 convolution in each bottleneck block.
             for SENet154: 64
             for SE-ResNet models: 1
             for SE-ResNeXt models:  32
-        reduction (int): reduction ratio for Squeeze-and-Excitation modules.
+        reduction: reduction ratio for Squeeze-and-Excitation modules.
             for all models: 16
-        dropout_p (float or None): drop probability for the Dropout layer.
+        dropout_p: drop probability for the Dropout layer.
             if `None` the Dropout layer is not used.
             for SENet154: 0.2
             for SE-ResNet models: None
             for SE-ResNeXt models: None
-        inplanes (int):  number of input channels for layer1.
+        inplanes:  number of input channels for layer1.
             for SENet154: 128
             for SE-ResNet models: 64
             for SE-ResNeXt models: 64
-        input_3x3 (bool): If `True`, use three 3x3 convolutions instead of
+        downsample_kernel_size: kernel size for downsampling convolutions in layer2, layer3 and layer4.
+            for SENet154: 3
+            for SE-ResNet models: 1
+            for SE-ResNeXt models: 1
+        input_3x3: If `True`, use three 3x3 convolutions instead of
             a single 7x7 convolution in layer0.
             - For SENet154: True
             - For SE-ResNet models: False
             - For SE-ResNeXt models: False
-        downsample_kernel_size (int): kernel size for downsampling convolutions in layer2, layer3 and layer4.
-            for SENet154: 3
-            for SE-ResNet models: 1
-            for SE-ResNeXt models: 1
-        num_classes (int): number of outputs in `last_linear` layer.
+        num_classes: number of outputs in `last_linear` layer.
             for all models: 1000
 
     """
@@ -92,7 +92,8 @@ class SENet(nn.Module):
         self.inplanes = inplanes
         self.spatial_dims = spatial_dims
 
-        layer0_modules: Optional[List] = None
+        layer0_modules: List[Tuple[str, Any]]
+
         if input_3x3:
             layer0_modules = [
                 (
@@ -216,7 +217,7 @@ class SENet(nn.Module):
 
         return nn.Sequential(*layers)
 
-    def features(self, x):
+    def features(self, x: torch.Tensor):
         x = self.layer0(x)
         x = self.layer1(x)
         x = self.layer2(x)
@@ -224,7 +225,7 @@ class SENet(nn.Module):
         x = self.layer4(x)
         return x
 
-    def logits(self, x):
+    def logits(self, x: torch.Tensor):
         x = self.adaptive_avg_pool(x)
         if self.dropout is not None:
             x = self.dropout(x)
@@ -232,13 +233,13 @@ class SENet(nn.Module):
         x = self.last_linear(x)
         return x
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor):
         x = self.features(x)
         x = self.logits(x)
         return x
 
 
-def senet154(spatial_dims, in_ch, num_classes):
+def senet154(spatial_dims: int, in_ch: int, num_classes: int) -> SENet:
     model = SENet(
         spatial_dims=spatial_dims,
         in_ch=in_ch,
@@ -252,7 +253,7 @@ def senet154(spatial_dims, in_ch, num_classes):
     return model
 
 
-def se_resnet50(spatial_dims, in_ch, num_classes):
+def se_resnet50(spatial_dims: int, in_ch: int, num_classes: int) -> SENet:
     model = SENet(
         spatial_dims=spatial_dims,
         in_ch=in_ch,
@@ -269,7 +270,7 @@ def se_resnet50(spatial_dims, in_ch, num_classes):
     return model
 
 
-def se_resnet101(spatial_dims, in_ch, num_classes):
+def se_resnet101(spatial_dims: int, in_ch: int, num_classes: int) -> SENet:
     model = SENet(
         spatial_dims=spatial_dims,
         in_ch=in_ch,
@@ -286,7 +287,7 @@ def se_resnet101(spatial_dims, in_ch, num_classes):
     return model
 
 
-def se_resnet152(spatial_dims, in_ch, num_classes):
+def se_resnet152(spatial_dims: int, in_ch: int, num_classes: int) -> SENet:
     model = SENet(
         spatial_dims=spatial_dims,
         in_ch=in_ch,
@@ -303,7 +304,7 @@ def se_resnet152(spatial_dims, in_ch, num_classes):
     return model
 
 
-def se_resnext50_32x4d(spatial_dims, in_ch, num_classes):
+def se_resnext50_32x4d(spatial_dims: int, in_ch: int, num_classes: int) -> SENet:
     model = SENet(
         spatial_dims=spatial_dims,
         in_ch=in_ch,
@@ -320,7 +321,7 @@ def se_resnext50_32x4d(spatial_dims, in_ch, num_classes):
     return model
 
 
-def se_resnext101_32x4d(spatial_dims, in_ch, num_classes):
+def se_resnext101_32x4d(spatial_dims: int, in_ch: int, num_classes: int) -> SENet:
     model = SENet(
         spatial_dims=spatial_dims,
         in_ch=in_ch,

--- a/monai/networks/nets/senet.py
+++ b/monai/networks/nets/senet.py
@@ -233,7 +233,7 @@ class SENet(nn.Module):
         x = self.last_linear(x)
         return x
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.features(x)
         x = self.logits(x)
         return x

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -183,7 +183,7 @@ class UNet(nn.Module):
 
         return conv
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.model(x)
         return x
 

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -65,7 +65,9 @@ class UNet(nn.Module):
         self.norm = norm
         self.dropout = dropout
 
-        def _create_block(inc: int, outc: int, channels: Sequence[int], strides: Sequence[int], is_top: bool):
+        def _create_block(
+            inc: int, outc: int, channels: Sequence[int], strides: Sequence[int], is_top: bool
+        ) -> nn.Sequential:
             """
             Builds the UNet structure from the bottom up by recursing down to the bottom block, then creating sequential
             blocks containing the downsample path, a skip connection around the previous block, and the upsample path.
@@ -79,6 +81,8 @@ class UNet(nn.Module):
             """
             c = channels[0]
             s = strides[0]
+
+            subblock: Union[nn.Sequential, ResidualUnit, Convolution]
 
             if len(channels) > 2:
                 subblock = _create_block(c, c, channels[1:], strides[1:], False)  # continue recursion down
@@ -95,7 +99,9 @@ class UNet(nn.Module):
 
         self.model = _create_block(in_channels, out_channels, self.channels, self.strides, True)
 
-    def _get_down_layer(self, in_channels: int, out_channels: int, strides: int, is_top: bool):
+    def _get_down_layer(
+        self, in_channels: int, out_channels: int, strides: int, is_top: bool
+    ) -> Union[ResidualUnit, Convolution]:
         """
         Args:
             in_channels: number of input channels.
@@ -127,7 +133,7 @@ class UNet(nn.Module):
                 dropout=self.dropout,
             )
 
-    def _get_bottom_layer(self, in_channels: int, out_channels: int):
+    def _get_bottom_layer(self, in_channels: int, out_channels: int) -> Union[ResidualUnit, Convolution]:
         """
         Args:
             in_channels: number of input channels.
@@ -135,7 +141,9 @@ class UNet(nn.Module):
         """
         return self._get_down_layer(in_channels, out_channels, 1, False)
 
-    def _get_up_layer(self, in_channels: int, out_channels: int, strides: int, is_top: bool):
+    def _get_up_layer(
+        self, in_channels: int, out_channels: int, strides: int, is_top: bool
+    ) -> Union[Convolution, nn.Sequential]:
         """
         Args:
             in_channels: number of input channels.
@@ -143,6 +151,8 @@ class UNet(nn.Module):
             strides: convolution stride.
             is_top: True if this is the top block.
         """
+        conv: Union[Convolution, nn.Sequential]
+
         conv = Convolution(
             self.dimensions,
             in_channels,
@@ -169,11 +179,11 @@ class UNet(nn.Module):
                 dropout=self.dropout,
                 last_conv_only=is_top,
             )
-            return nn.Sequential(conv, ru)
-        else:
-            return conv
+            conv = nn.Sequential(conv, ru)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return conv
+
+    def forward(self, x: torch.Tensor):
         x = self.model(x)
         return x
 

--- a/monai/transforms/adaptors.py
+++ b/monai/transforms/adaptors.py
@@ -122,6 +122,8 @@ Outputs:
 
 """
 
+from typing import Callable
+
 from monai.utils import export as _monai_export
 
 
@@ -240,7 +242,7 @@ def to_kwargs(fn):
 
 
 class FunctionSignature:
-    def __init__(self, function) -> None:
+    def __init__(self, function: Callable) -> None:
         import inspect
 
         sfn = inspect.signature(function)
@@ -257,9 +259,9 @@ class FunctionSignature:
                 self.non_var_parameters.add(p.name)
                 self.defaults[p.name] = p.default is not p.empty
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = "<class 'FunctionSignature': found_args={}, found_kwargs={}, defaults={}"
         return s.format(self.found_args, self.found_kwargs, self.defaults)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__repr__()

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -91,7 +91,9 @@ class Randomizable(ABC):
 
     R: np.random.RandomState = np.random.RandomState()
 
-    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
+    def set_random_state(
+        self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None
+    ) -> "Randomizable":
         """
         Set the random state locally, to control the randomness, the derived
         classes should use :py:attr:`self.R` instead of `np.random` to introduce random
@@ -206,11 +208,12 @@ class Compose(Randomizable):
         self.transforms = ensure_tuple(transforms)
         self.set_random_state(seed=get_seed())
 
-    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None):
+    def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None) -> "Compose":
         for _transform in self.transforms:
             if not isinstance(_transform, Randomizable):
                 continue
             _transform.set_random_state(seed, state)
+        return self
 
     def randomize(self, data: Optional[Any] = None) -> None:
         for _transform in self.transforms:
@@ -256,7 +259,7 @@ class MapTransform(Transform):
     """
 
     def __init__(self, keys: KeysCollection) -> None:
-        self.keys: Tuple[Any, ...] = ensure_tuple(keys)
+        self.keys: Tuple[Hashable, ...] = ensure_tuple(keys)
         if not self.keys:
             raise ValueError("keys must be non empty.")
         for key in self.keys:

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -51,7 +51,7 @@ class SpatialPad(Transform):
         self.method: Method = Method(method)
         self.mode: NumpyPadMode = NumpyPadMode(mode)
 
-    def _determine_data_pad_width(self, data_shape: Sequence[int]):
+    def _determine_data_pad_width(self, data_shape: Sequence[int]) -> List[Tuple[int, int]]:
         self.spatial_size = fall_back_tuple(self.spatial_size, data_shape)
         if self.method == Method.SYMMETRIC:
             pad_width = list()
@@ -448,7 +448,7 @@ class RandCropByPosNegLabel(Randomizable, Transform):
         image: Optional[np.ndarray] = None,
         image_threshold: float = 0.0,
     ) -> None:
-        self.spatial_size = spatial_size
+        self.spatial_size = ensure_tuple(spatial_size)
         self.label = label
         if pos < 0 or neg < 0:
             raise ValueError(f"pos and neg must be nonnegative, got pos={pos} neg={neg}.")
@@ -458,7 +458,7 @@ class RandCropByPosNegLabel(Randomizable, Transform):
         self.num_samples = num_samples
         self.image = image
         self.image_threshold = image_threshold
-        self.centers = None
+        self.centers: Optional[List[List[np.ndarray]]] = None
 
     def randomize(self, label: np.ndarray, image: Optional[np.ndarray] = None) -> None:
         self.spatial_size = fall_back_tuple(self.spatial_size, default=label.shape[1:])

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -79,7 +79,7 @@ class RandShiftIntensity(Randomizable, Transform):
     Randomly shift intensity with randomly picked offset.
     """
 
-    def __init__(self, offsets: Union[Tuple[float, float], float], prob: float = 0.1):
+    def __init__(self, offsets: Union[Tuple[float, float], float], prob: float = 0.1) -> None:
         """
         Args:
             offsets: offset range to randomly shift.
@@ -215,7 +215,7 @@ class NormalizeIntensity(Transform):
         self.nonzero = nonzero
         self.channel_wise = channel_wise
 
-    def _normalize(self, img: np.ndarray):
+    def _normalize(self, img: np.ndarray) -> np.ndarray:
         slices = (img != 0) if self.nonzero else np.ones(img.shape, dtype=np.bool_)
         if np.any(slices):
             if self.subtrahend is not None and self.divisor is not None:
@@ -466,7 +466,7 @@ class MaskIntensity(Transform):
 
     """
 
-    def __init__(self, mask_data: np.ndarray):
+    def __init__(self, mask_data: np.ndarray) -> None:
         self.mask_data = mask_data
 
     def __call__(self, img: np.ndarray, mask_data: Optional[np.ndarray] = None) -> np.ndarray:

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -13,7 +13,8 @@ A collection of "vanilla" transforms for IO functions
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from typing import Optional
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Union
 
 import numpy as np
 from torch.utils.data._utils.collate import np_str_obj_array_pattern
@@ -57,14 +58,14 @@ class LoadNifti(Transform):
         self.image_only = image_only
         self.dtype = dtype
 
-    def __call__(self, filename):
+    def __call__(self, filename: Union[Sequence[Union[Path, str]], Path, str]):
         """
         Args:
-            filename (str, list, tuple, file): path file or file-like object or a list of files.
+            filename: path file or file-like object or a list of files.
         """
         filename = ensure_tuple(filename)
         img_array = list()
-        compatible_meta = dict()
+        compatible_meta: Dict = dict()
         for name in filename:
             img = nib.load(name)
             img = correct_nifti_header_if_necessary(img)
@@ -125,10 +126,10 @@ class LoadPNG(Transform):
         self.image_only = image_only
         self.dtype = dtype
 
-    def __call__(self, filename):
+    def __call__(self, filename: Union[Sequence[Union[Path, str]], Path, str]):
         """
         Args:
-            filename (str, list, tuple, file): path file or file-like object or a list of files.
+            filename: path file or file-like object or a list of files.
         """
         filename = ensure_tuple(filename)
         img_array = list()
@@ -191,10 +192,10 @@ class LoadNumpy(Transform):
             npz_keys = ensure_tuple(npz_keys)
         self.npz_keys = npz_keys
 
-    def __call__(self, filename):
+    def __call__(self, filename: Union[Sequence[Union[Path, str]], Path, str]):
         """
         Args:
-            filename (str, list, tuple, file): path file or file-like object or a list of files.
+            filename: path file or file-like object or a list of files.
 
         Raises:
             ValueError: When ``filename`` is a sequence and contains a "npz" file extension.
@@ -205,7 +206,7 @@ class LoadNumpy(Transform):
                 if name.endswith(".npz"):
                     raise ValueError("Cannot load a sequence of npz files.")
         filename = ensure_tuple(filename)
-        data_array = list()
+        data_array: List = list()
         compatible_meta = None
 
         def _save_data_meta(data_array, name, data, compatible_meta):

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -389,11 +389,11 @@ class MeanEnsemble(Transform):
 
     """
 
-    def __init__(self, weights: Optional[Union[Sequence[float], torch.Tensor, np.ndarray]] = None):
+    def __init__(self, weights: Optional[Union[Sequence[float], torch.Tensor, np.ndarray]] = None) -> None:
         self.weights = torch.as_tensor(weights, dtype=torch.float) if weights is not None else None
 
     def __call__(self, img: Union[Sequence[torch.Tensor], torch.Tensor]) -> torch.Tensor:
-        img_: torch.Tensor = torch.stack(img) if isinstance(img, (tuple, list)) else torch.as_tensor(img)
+        img_ = torch.stack(img) if isinstance(img, (tuple, list)) else torch.as_tensor(img)
         if self.weights is not None:
             self.weights = self.weights.to(img_.device)
             shape = tuple(self.weights.shape)
@@ -426,11 +426,11 @@ class VoteEnsemble(Transform):
 
     """
 
-    def __init__(self, num_classes: Optional[int] = None):
+    def __init__(self, num_classes: Optional[int] = None) -> None:
         self.num_classes = num_classes
 
-    def __call__(self, img: Union[Sequence[torch.Tensor], torch.Tensor]):
-        img_: torch.Tensor = torch.stack(img) if isinstance(img, (tuple, list)) else torch.as_tensor(img)
+    def __call__(self, img: Union[Sequence[torch.Tensor], torch.Tensor]) -> torch.Tensor:
+        img_ = torch.stack(img) if isinstance(img, (tuple, list)) else torch.as_tensor(img)
         if self.num_classes is not None:
             has_ch_dim = True
             if img_.ndimension() > 2 and img_.shape[2] > 1:

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -205,8 +205,8 @@ class Transpose(Transform):
     Transposes the input image based on the given `indices` dimension ordering.
     """
 
-    def __init__(self, indices) -> None:
-        self.indices = indices
+    def __init__(self, indices: Optional[Sequence[int]]) -> None:
+        self.indices = None if indices is None else tuple(indices)
 
     def __call__(self, img: np.ndarray) -> np.ndarray:
         """
@@ -295,7 +295,7 @@ class DataStats(Transform):
         data_shape: Optional[bool] = None,
         value_range: Optional[bool] = None,
         data_value: Optional[bool] = None,
-        additional_info=None,
+        additional_info: Optional[Callable] = None,
     ) -> NdarrayTensor:
         """
         Apply the transform to `img`, optionally take arguments similar to the class constructor.
@@ -423,7 +423,9 @@ class LabelToMask(Transform):
 
     """
 
-    def __init__(self, select_labels: Union[Sequence[int], int], merge_channels: bool = False):
+    def __init__(
+        self, select_labels: Union[Sequence[int], int], merge_channels: bool = False,
+    ) -> None:  # pytype: disable=annotation-type-mismatch # pytype bug with bool
         self.select_labels = ensure_tuple(select_labels)
         self.merge_channels = merge_channels
 

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -17,7 +17,7 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 
 import copy
 import logging
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Dict, Hashable, Mapping, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -57,7 +57,7 @@ class Identityd(MapTransform):
         super().__init__(keys)
         self.identity = Identity()
 
-    def __call__(self, data):
+    def __call__(self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]) -> Dict[Hashable, np.ndarray]:
         d = dict(data)
         for key in self.keys:
             d[key] = self.identity(d[key])
@@ -79,7 +79,7 @@ class AsChannelFirstd(MapTransform):
         super().__init__(keys)
         self.converter = AsChannelFirst(channel_dim=channel_dim)
 
-    def __call__(self, data):
+    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
         d = dict(data)
         for key in self.keys:
             d[key] = self.converter(d[key])
@@ -101,7 +101,7 @@ class AsChannelLastd(MapTransform):
         super().__init__(keys)
         self.converter = AsChannelLast(channel_dim=channel_dim)
 
-    def __call__(self, data):
+    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
         d = dict(data)
         for key in self.keys:
             d[key] = self.converter(d[key])
@@ -122,7 +122,9 @@ class AddChanneld(MapTransform):
         super().__init__(keys)
         self.adder = AddChannel()
 
-    def __call__(self, data):
+    def __call__(
+        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]
+    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor]]:
         d = dict(data)
         for key in self.keys:
             d[key] = self.adder(d[key])
@@ -144,7 +146,7 @@ class RepeatChanneld(MapTransform):
         super().__init__(keys)
         self.repeater = RepeatChannel(repeats)
 
-    def __call__(self, data):
+    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
         d = dict(data)
         for key in self.keys:
             d[key] = self.repeater(d[key])
@@ -160,7 +162,7 @@ class CastToTyped(MapTransform):
         self,
         keys: KeysCollection,
         dtype: Union[Sequence[Union[np.dtype, torch.dtype]], np.dtype, torch.dtype] = np.float32,
-    ):
+    ) -> None:
         """
         Args:
             keys: keys of the corresponding items to be transformed.
@@ -174,7 +176,9 @@ class CastToTyped(MapTransform):
         self.dtype = ensure_tuple_rep(dtype, len(self.keys))
         self.converter = CastToType()
 
-    def __call__(self, data):
+    def __call__(
+        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]
+    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor]]:
         d = dict(data)
         for idx, key in enumerate(self.keys):
             d[key] = self.converter(d[key], dtype=self.dtype[idx])
@@ -196,7 +200,7 @@ class ToTensord(MapTransform):
         super().__init__(keys)
         self.converter = ToTensor()
 
-    def __call__(self, data):
+    def __call__(self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]) -> Dict[Hashable, torch.Tensor]:
         d = dict(data)
         for key in self.keys:
             d[key] = self.converter(d[key])
@@ -217,7 +221,7 @@ class ToNumpyd(MapTransform):
         super().__init__(keys)
         self.converter = ToNumpy()
 
-    def __call__(self, data):
+    def __call__(self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]) -> Dict[Hashable, np.ndarray]:
         d = dict(data)
         for key in self.keys:
             d[key] = self.converter(d[key])
@@ -257,7 +261,9 @@ class SqueezeDimd(MapTransform):
         super().__init__(keys)
         self.converter = SqueezeDim(dim=dim)
 
-    def __call__(self, data):
+    def __call__(
+        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]
+    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor]]:
         d = dict(data)
         for key in self.keys:
             d[key] = self.converter(d[key])
@@ -308,7 +314,9 @@ class DataStatsd(MapTransform):
         self.logger_handler = logger_handler
         self.printer = DataStats(logger_handler=logger_handler)
 
-    def __call__(self, data):
+    def __call__(
+        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]
+    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor]]:
         d = dict(data)
         for idx, key in enumerate(self.keys):
             d[key] = self.printer(
@@ -327,7 +335,7 @@ class SimulateDelayd(MapTransform):
     Dictionary-based wrapper of :py:class:monai.transforms.utility.array.SimulateDelay.
     """
 
-    def __init__(self, keys: KeysCollection, delay_time: Union[Sequence[float], float] = 0.0):
+    def __init__(self, keys: KeysCollection, delay_time: Union[Sequence[float], float] = 0.0) -> None:
         """
         Args:
             keys: keys of the corresponding items to be transformed.
@@ -340,7 +348,9 @@ class SimulateDelayd(MapTransform):
         self.delay_time = ensure_tuple_rep(delay_time, len(self.keys))
         self.delayer = SimulateDelay()
 
-    def __call__(self, data):
+    def __call__(
+        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]
+    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor]]:
         d = dict(data)
         for idx, key in enumerate(self.keys):
             d[key] = self.delayer(d[key], delay_time=self.delay_time[idx])
@@ -354,7 +364,7 @@ class CopyItemsd(MapTransform):
 
     """
 
-    def __init__(self, keys: KeysCollection, times: int, names: KeysCollection):
+    def __init__(self, keys: KeysCollection, times: int, names: KeysCollection) -> None:
         """
         Args:
             keys: keys of the corresponding items to be transformed.
@@ -496,12 +506,12 @@ class LabelToMaskd(MapTransform):
     """
 
     def __init__(
-        self, keys: KeysCollection, select_labels: Union[Sequence[int], int], merge_channels: bool = False
-    ) -> None:
+        self, keys: KeysCollection, select_labels: Union[Sequence[int], int], merge_channels: bool = False,
+    ) -> None:  # pytype: disable=annotation-type-mismatch # pytype bug with bool
         super().__init__(keys)
         self.converter = LabelToMask(select_labels, merge_channels)
 
-    def __call__(self, data):
+    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
         d = dict(data)
         for key in self.keys:
             d[key] = self.converter(d[key])

--- a/monai/utils/decorators.py
+++ b/monai/utils/decorators.py
@@ -37,7 +37,7 @@ class RestartGenerator:
     used to create an iterator which can start iteration over the given generator multiple times.
     """
 
-    def __init__(self, create_gen):
+    def __init__(self, create_gen) -> None:
         self.create_gen = create_gen
 
     def __iter__(self):
@@ -51,7 +51,7 @@ class MethodReplacer(object):
 
     replace_list_name = "__replacemethods__"
 
-    def __init__(self, meth):
+    def __init__(self, meth) -> None:
         self.meth = meth
 
     def replace_method(self, meth):

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections.abc
 import itertools
 import random
-from collections.abc import Iterable
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -43,14 +43,14 @@ def first(iterable, default=None):
     return default
 
 
-def issequenceiterable(obj) -> bool:
+def issequenceiterable(obj: Any) -> bool:
     """
     Determine if the object is an iterable sequence and is not a string.
     """
-    return isinstance(obj, Iterable) and not isinstance(obj, str)
+    return isinstance(obj, collections.abc.Iterable) and not isinstance(obj, str)
 
 
-def ensure_tuple(vals: Any) -> Tuple:
+def ensure_tuple(vals: Any) -> Tuple[Any, ...]:
     """
     Returns a tuple of `vals`.
     """
@@ -60,7 +60,7 @@ def ensure_tuple(vals: Any) -> Tuple:
     return tuple(vals)
 
 
-def ensure_tuple_size(tup, dim: int, pad_val=0) -> Tuple:
+def ensure_tuple_size(tup: Any, dim: int, pad_val: Any = 0) -> Tuple[Any, ...]:
     """
     Returns a copy of `tup` with `dim` values by either shortened or padded with `pad_val` as necessary.
     """
@@ -68,7 +68,7 @@ def ensure_tuple_size(tup, dim: int, pad_val=0) -> Tuple:
     return tuple(tup[:dim])
 
 
-def ensure_tuple_rep(tup: Any, dim: int):
+def ensure_tuple_rep(tup: Any, dim: int) -> Tuple[Any, ...]:
     """
     Returns a copy of `tup` with `dim` values by either shortened or duplicated input.
 
@@ -99,7 +99,7 @@ def ensure_tuple_rep(tup: Any, dim: int):
     raise ValueError(f"Sequence must have length {dim}, got {len(tup)}.")
 
 
-def fall_back_tuple(user_provided: Any, default: Sequence, func: Callable = lambda x: x and x > 0) -> Tuple:
+def fall_back_tuple(user_provided: Any, default: Sequence, func: Callable = lambda x: x and x > 0) -> Tuple[Any, ...]:
     """
     Refine `user_provided` according to the `default`, and returns as a validated tuple.
 
@@ -143,19 +143,19 @@ def fall_back_tuple(user_provided: Any, default: Sequence, func: Callable = lamb
     )
 
 
-def is_scalar_tensor(val) -> bool:
+def is_scalar_tensor(val: Any) -> bool:
     if torch.is_tensor(val) and val.ndim == 0:
         return True
     return False
 
 
-def is_scalar(val) -> bool:
+def is_scalar(val: Any) -> bool:
     if torch.is_tensor(val) and val.ndim == 0:
         return True
     return bool(np.isscalar(val))
 
 
-def progress_bar(index: int, count: int, desc: str = None, bar_len: int = 30, newline: bool = False) -> None:
+def progress_bar(index: int, count: int, desc: Optional[str] = None, bar_len: int = 30, newline: bool = False) -> None:
     """print a progress bar to track some time consuming task.
 
     Args:
@@ -174,13 +174,13 @@ def progress_bar(index: int, count: int, desc: str = None, bar_len: int = 30, ne
         print("")
 
 
-def get_seed():
+def get_seed() -> Optional[int]:
     return _seed
 
 
 def set_determinism(
     seed: Optional[int] = np.iinfo(np.int32).max,
-    additional_settings: Optional[Union[Sequence[Callable], Callable]] = None,
+    additional_settings: Optional[Union[Sequence[Callable[[int], Any]], Callable[[int], Any]]] = None,
 ) -> None:
     """
     Set random seed for modules to enable or disable deterministic training.

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -88,7 +88,7 @@ def exact_version(the_module, version_str: str = "") -> bool:
 def optional_import(
     module: str,
     version: str = "",
-    version_checker: Callable = min_version,
+    version_checker: Callable[..., bool] = min_version,
     name: str = "",
     descriptor: str = OPTIONAL_IMPORT_MSG_FMT,
     version_args=None,

--- a/monai/visualize/img2tensorboard.py
+++ b/monai/visualize/img2tensorboard.py
@@ -21,11 +21,11 @@ PIL, _ = optional_import("PIL")
 GifImage, _ = optional_import("PIL.GifImagePlugin", name="Image")
 
 if TYPE_CHECKING:
-    from torch.utils.tensorboard import SummaryWriter
     from tensorboard.compat.proto.summary_pb2 import Summary
+    from torch.utils.tensorboard import SummaryWriter
 else:
-    SummaryWriter, _ = optional_import("torch.utils.tensorboard", name="SummaryWriter")
     Summary, _ = optional_import("tensorboard.compat.proto.summary_pb2", name="Summary")
+    SummaryWriter, _ = optional_import("torch.utils.tensorboard", name="SummaryWriter")
 
 
 def _image3_animated_gif(tag: str, image: Union[np.ndarray, torch.Tensor], scale_factor: float = 1.0) -> Summary:

--- a/monai/visualize/img2tensorboard.py
+++ b/monai/visualize/img2tensorboard.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Dict, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -19,14 +19,16 @@ from monai.utils import optional_import
 
 PIL, _ = optional_import("PIL")
 GifImage, _ = optional_import("PIL.GifImagePlugin", name="Image")
-summary_pb2, _ = optional_import("tensorboard.compat.proto.summary_pb2")
+
 if TYPE_CHECKING:
     from torch.utils.tensorboard import SummaryWriter
+    from tensorboard.compat.proto.summary_pb2 import Summary
 else:
     SummaryWriter, _ = optional_import("torch.utils.tensorboard", name="SummaryWriter")
+    Summary, _ = optional_import("tensorboard.compat.proto.summary_pb2", name="Summary")
 
 
-def _image3_animated_gif(tag: str, image: Union[np.ndarray, torch.Tensor], scale_factor: float = 1.0):
+def _image3_animated_gif(tag: str, image: Union[np.ndarray, torch.Tensor], scale_factor: float = 1.0) -> Summary:
     """Function to actually create the animated gif.
 
     Args:
@@ -47,9 +49,9 @@ def _image3_animated_gif(tag: str, image: Union[np.ndarray, torch.Tensor], scale
         for b_data in PIL.GifImagePlugin.getdata(i):
             img_str += b_data
     img_str += b"\x3B"
-    summary_image_str = summary_pb2.Summary.Image(height=10, width=10, colorspace=1, encoded_image_string=img_str)
-    image_summary = summary_pb2.Summary.Value(tag=tag, image=summary_image_str)
-    return summary_pb2.Summary(value=[image_summary])
+    summary_image_str = Summary.Image(height=10, width=10, colorspace=1, encoded_image_string=img_str)
+    image_summary = Summary.Value(tag=tag, image=summary_image_str)
+    return Summary(value=[image_summary])
 
 
 def make_animated_gif_summary(
@@ -58,9 +60,9 @@ def make_animated_gif_summary(
     max_out: int = 3,
     animation_axes: Sequence[int] = (3,),
     image_axes: Sequence[int] = (1, 2),
-    other_indices=None,
+    other_indices: Optional[Dict] = None,
     scale_factor: float = 1.0,
-):
+) -> Summary:
     """Creates an animated gif out of an image tensor in 'CHWD' format and returns Summary.
 
     Args:

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,8 +79,6 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 # Shows a warning when returning a value with type Any from a function declared with a non-Any return type.
 warn_return_any = True
-# Allows variables to be redefined with an arbitrary type, as long as the redefinition is in the same block and nesting level as the original definition.
-allow_redefinition = True
 # Prohibit equality checks, identity checks, and container checks between non-overlapping types.
 strict_equality = True
 # Shows column numbers in error messages.

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,57 +69,42 @@ tag_prefix =
 parentdir_prefix =
 
 [mypy]
-# --- Temporary disabling to allow smaller PRs
-# Subsequent fixes necessary to make this tool pass are not yet
-# merged into the master branch, but requested as separate
-# commits.  Can not enable until all outstanding typehint
-# PR's are approved
-## Temporarily disable all mypy warnings
-# --ignore_errors = True
-# ^^^^^^ Temporary disabling to allow smaller PRs
-
-
-# do not follow imports (except for ones found in typeshed)
-follow_imports=normal
-
-# suppress errors about unsatisfied imports
-# The pytorch-ignite package is not type hinted and generates
-# hundreds of failures that are not the priority to address
-# at the monment.  Eventually ignore_missing_imports=False
-# should be used add consistent typing information to
-# those parts of the MONAI package that depend on ignite.
-ignore_missing_imports=True
-# Temporarily ignore all site packages too
-# --no_site_packages=True
-
-# allow returning Any as a consequence of the options above
-warn_return_any=True
-
-# ensure all execution paths are returning
-warn_no_return=True
-
-# lint-style cleanliness for typing needs to be disabled; returns more errors
-# than the full run.
-warn_redundant_casts=True
-warn_unused_ignores=True
+# Suppresses error messages about imports that cannot be resolved.
+ignore_missing_imports = True
+# Changes the treatment of arguments with a default value of None by not implicitly making their type Optional.
+no_implicit_optional = True
+# Warns about casting an expression to its inferred type.
+warn_redundant_casts = True
+# Warns about unneeded # type: ignore comments.
+warn_unused_ignores = True
+# Shows a warning when returning a value with type Any from a function declared with a non-Any return type.
+warn_return_any = True
+# Allows variables to be redefined with an arbitrary type, as long as the redefinition is in the same block and nesting level as the original definition.
+allow_redefinition = True
+# Prohibit equality checks, identity checks, and container checks between non-overlapping types.
+strict_equality = True
+# Shows column numbers in error messages.
+show_column_numbers = True
+# Shows error codes in error messages.
+show_error_codes = True
+# Use visually nicer output in error messages: use soft word wrap, show source code snippets, and show error location markers.
+pretty = False
 
 [mypy-versioneer]
-# Always ignore any type issues in the versioneer.py file
+# Ignores all non-fatal errors.
 ignore_errors = True
 
 [mypy-monai._version]
-# Always ignore any type issues in the monai/._version.py file
+# Ignores all non-fatal errors.
 ignore_errors = True
 
 [mypy-monai.eggs]
-# Always ignore any type issues in the monai/.eggs file
+# Ignores all non-fatal errors.
 ignore_errors = True
 
 [pytype]
-# NOTE: All relative paths are relative to the location of this file.
 # Space-separated list of files or directories to exclude.
-#  i.e. exclude = **/*_test.py **/test_*.py
-exclude = **/versioneer.py _version.py .eggs
+exclude = versioneer.py _version.py
 # Space-separated list of files or directories to process.
 inputs = monai
 # Keep going past errors to analyze as many files as possible.
@@ -130,21 +115,17 @@ jobs = 8
 output = .pytype
 # Paths to source code directories, separated by ':'.
 pythonpath = .
-# Python version (major.minor) of the target code.
-# Do not set this! The python environment used for
-#   evaluating the `pytype` process spawns a separate
-#   subprocess for inspecting the code with the
-#   `python{python_version}` executable which must
-#   be configured to support testing MONAI.  Leaving
-#   this unset uses the parent python version to
-#   to spawn the testing environment the same as
-#   the calling envirionment
-# python_version = 3.X
-# Experimental: Check variable values against their annotations.
+# Check attribute values against their annotations.
+check_attribute_types = True
+# Check container mutations against their annotations.
+check_container_types = True
+# Check parameter defaults and assignments against their annotations.
+check_parameter_types = True
+# Check variable values against their annotations.
 check_variable_types = True
 # Comma or space separated list of error names to ignore.
 disable = pyi-error
-# Report errors
+# Report errors.
 report_errors = True
 # Experimental: Infer precise return types even for invalid function calls.
 precise_return = True


### PR DESCRIPTION
Iteration of #476

### Description

**Reconfigure mypy and pytype**

- Enable as many checks as possible

**Resolve errors, Add and Update type hints**

- Update type: ignore to specify error
- Update type hints to specify contents
- Add type hints to parameters
- Add type hints to returns
- Remove unnecessary type hints
- Remove incorrect type hints
- Rename internal variables (redefinition)
- Resolve errors as a result of the above

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] In-line docstrings updated.
