### PR TITLE
merge local isort/black commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ temp/
 
 # temporary testing data MedNIST
 tests/testing_data/MedNIST*
+tests/testing_data/*Hippocampus*

--- a/runtests.sh
+++ b/runtests.sh
@@ -48,7 +48,7 @@ function print_usage {
     echo "./runtests.sh --codeformat --coverage     # run full tests (${green}recommended before making pull requests${noColor})."
     echo "./runtests.sh --codeformat --nounittests  # run coding style and static type checking."
     echo "./runtests.sh --quick                     # run minimal unit tests, for quick verification during code developments."
-    echo "./runtests.sh --autofix --nounittests    # run automatic code formatting using \"isort\" and \"black\"."
+    echo "./runtests.sh --autofix --nounittests     # run automatic code formatting using \"isort\" and \"black\"."
     echo "./runtests.sh --clean                     # clean up temporary files and run \"python setup.py develop --uninstall\"."
     echo ""
     echo "Code style check options:"
@@ -101,14 +101,15 @@ function compile_cpp {
     fi
 }
 
-function clean_py() {
+function clean_py {
     # uninstall the development package
     echo "Uninstalling MONAI development files..."
     ${cmdPrefix}python setup.py -v develop --uninstall
 
-    # remove temporary files
-    echo "Removing temporary files..."
-    TO_CLEAN=${*:-'.'}
+    # remove temporary files (in the directory of this script)
+    TO_CLEAN="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    echo "Removing temporary files in ${TO_CLEAN}"
+
     find ${TO_CLEAN} -type f -name "*.py[co]" -delete
     find ${TO_CLEAN} -type f -name ".coverage" -delete
     find ${TO_CLEAN} -type d -name "__pycache__" -delete


### PR DESCRIPTION
part of https://github.com/Project-MONAI/MONAI/issues/776

Looks like the experimental isort + black doesn't cause any issues over the previous 2 weeks, this PR updates the runtests commands (so that autofix option corresponds to isort+black), and rolls out the isort + black autopipeline.

will update the formatter repo after this PR

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
