### PR TITLE
392 Subpixel convolutional layer

### DIFF
--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -84,6 +84,8 @@ Blocks
 ~~~~~~~~~~~~
 .. autoclass:: UpSample
     :members:
+.. autoclass:: SubpixelUpsample
+    :members:
 
 
 Layers

--- a/monai/networks/blocks/__init__.py
+++ b/monai/networks/blocks/__init__.py
@@ -21,4 +21,4 @@ from .squeeze_and_excitation import (
     SEResNetBottleneck,
     SEResNeXtBottleneck,
 )
-from .upsample import UpSample
+from .upsample import SubpixelUpsample, UpSample

--- a/monai/networks/blocks/upsample.py
+++ b/monai/networks/blocks/upsample.py
@@ -81,7 +81,7 @@ class SubpixelUpsample(nn.Module):
     Secondly, a pixel shuffle manipulation is utilized to aggregates the feature maps from
     low resolution space and build the super resolution space.
     The first part of the module is not fixed, a sequential layers can be used to replace the
-    default single layer. 
+    default single layer.
     The idea comes from:
     https://arxiv.org/abs/1609.05158
     The pixel shuffle mechanism refers to:

--- a/monai/networks/blocks/upsample.py
+++ b/monai/networks/blocks/upsample.py
@@ -71,3 +71,64 @@ class UpSample(nn.Module):
             x: Tensor in shape (batch, channel, spatial_1[, spatial_2, ...).
         """
         return torch.as_tensor(self.upsample(x))
+
+
+class SubpixelUpsample(nn.Module):
+    """
+    Upsample via using a subpixel CNN. This module supports 1D, 2D and 3D input images.
+    The module is consisted with two parts. First of all, a convolutional layer is employed
+    to increase the number of channels into: ``in_channels * (scale_factor ** spatial_dims)``.
+    Secondly, a pixel shuffle manipulation is utilized to aggregates the feature maps from
+    low resolution space and build the super resolution space.
+    The first part of the module is not fixed, a sequential layers can be used to replace a
+    single layer. 
+    The idea comes from:
+    https://arxiv.org/abs/1609.05158
+    The pixel shuffle mechanism refers to:
+    https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/PixelShuffle.cpp
+    and:
+    https://github.com/pytorch/pytorch/pull/6340/files
+    """
+
+    def __init__(self, spatial_dims: int, in_channels: int, scale_factor: int = 2,) -> None:
+        """
+        Args:
+            spatial_dims: number of spatial dimensions of the input image.
+            in_channels: number of channels of the input image.
+            scale_factor: multiplier for spatial size. Defaults to 2.
+        """
+        super().__init__()
+        conv_out_channels = in_channels * (scale_factor ** spatial_dims)
+        self.spatial_dims = spatial_dims
+        self.scale_factor = scale_factor
+        self.conv = Conv[Conv.CONV, spatial_dims](
+            in_channels=in_channels, out_channels=conv_out_channels, kernel_size=3, stride=1, padding=1,
+        )
+
+    def pixelshuffle(self, x: torch.Tensor) -> torch.Tensor:
+
+        dim, factor = self.spatial_dims, self.scale_factor
+        input_size = list(x.size())
+        batch_size, channels = input_size[:2]
+        assert (
+            channels % (factor ** dim) == 0
+        ), "PixelShuffle expects input channel to be divisible by (scale_factor ** spatial_dims)."
+        org_channels = channels // (factor ** dim)
+        output_size = [batch_size, org_channels] + [dim * factor for dim in input_size[2:]]
+
+        indices = list(range(2, 2 + 2 * dim))
+        indices_factor, indices_dim = indices[:dim], indices[dim:]
+        indices = [j for i in zip(indices_dim, indices_factor) for j in i]
+
+        x = x.reshape(batch_size, org_channels, *([factor] * dim + input_size[2:]))
+        x = x.permute([0, 1] + indices).reshape(output_size)
+        return x
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: Tensor in shape (batch, channel, spatial_1[, spatial_2, ...).
+        """
+        x = self.conv(x)
+        x = self.pixelshuffle(x)
+        return torch.as_tensor(x)

--- a/tests/test_subpixel_upsample.py
+++ b/tests/test_subpixel_upsample.py
@@ -1,0 +1,54 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from parameterized import parameterized
+
+from monai.networks.blocks import SubpixelUpsample
+
+TEST_CASE_SUBPIXEL = []
+for inch in range(1, 5):
+    for dim in range(1, 4):
+        for factor in range(1, 3):
+            test_case = [
+                {"spatial_dims": dim, "in_channels": inch, "scale_factor": factor},
+                torch.randn(2, inch, *([8] * dim)),
+                (2, inch, *([8 * factor] * dim)),
+            ]
+            TEST_CASE_SUBPIXEL.append(test_case)
+TEST_CASE_SUBPIXEL_2D_EXTRA = [
+    {"spatial_dims": 2, "in_channels": 2, "scale_factor": 3},
+    torch.randn(2, 2, 8, 4),  # different size for H and W
+    (2, 2, 24, 12),
+]
+TEST_CASE_SUBPIXEL_3D_EXTRA = [
+    {"spatial_dims": 3, "in_channels": 1, "scale_factor": 2},
+    torch.randn(2, 1, 16, 8, 4),  # different size for H, W and D
+    (2, 1, 32, 16, 8),
+]
+TEST_CASE_SUBPIXEL.append(TEST_CASE_SUBPIXEL_2D_EXTRA)
+TEST_CASE_SUBPIXEL.append(TEST_CASE_SUBPIXEL_3D_EXTRA)
+
+
+class TestSUBPIXEL(unittest.TestCase):
+    @parameterized.expand(TEST_CASE_SUBPIXEL)
+    def test_subpixel_shape(self, input_param, input_data, expected_shape):
+        net = SubpixelUpsample(**input_param)
+        net.eval()
+        with torch.no_grad():
+            result = net.forward(input_data)
+            self.assertEqual(result.shape, expected_shape)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subpixel_upsample.py
+++ b/tests/test_subpixel_upsample.py
@@ -12,9 +12,11 @@
 import unittest
 
 import torch
+import torch.nn as nn
 from parameterized import parameterized
 
 from monai.networks.blocks import SubpixelUpsample
+from monai.networks.layers.factories import Conv
 
 TEST_CASE_SUBPIXEL = []
 for inch in range(1, 5):
@@ -36,8 +38,20 @@ TEST_CASE_SUBPIXEL_3D_EXTRA = [
     torch.randn(2, 1, 16, 8, 4),  # different size for H, W and D
     (2, 1, 32, 16, 8),
 ]
+
+conv_block = nn.Sequential(
+    Conv[Conv.CONV, 3](1, 4, kernel_size=1), Conv[Conv.CONV, 3](4, 8, kernel_size=3, stride=1, padding=1,),
+)
+
+TEST_CASE_SUBPIXEL_CONV_BLOCK_EXTRA = [
+    {"spatial_dims": 3, "in_channels": 1, "scale_factor": 2, "conv_block": conv_block},
+    torch.randn(2, 1, 16, 8, 4),  # different size for H, W and D
+    (2, 1, 32, 16, 8),
+]
+
 TEST_CASE_SUBPIXEL.append(TEST_CASE_SUBPIXEL_2D_EXTRA)
 TEST_CASE_SUBPIXEL.append(TEST_CASE_SUBPIXEL_3D_EXTRA)
+TEST_CASE_SUBPIXEL.append(TEST_CASE_SUBPIXEL_CONV_BLOCK_EXTRA)
 
 
 class TestSUBPIXEL(unittest.TestCase):


### PR DESCRIPTION
Implements #392 .

### Description
This implementation supports 1d, 2d and 3d inputs. The size of each dimension can be different. The implemented module is consisted with:

1. A convolutional layer, to produce a suitable number of channels for feature maps.
2. pixel shuffle, to aggregates the feature maps from low resolution space and build the super resolution space.

The pixel shuffle is modified from: [https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/PixelShuffle.cpp](url) and add 1D, 3D supports to meet MONAI's requirements.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
