### PR TITLE
MultiCUDA CI

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -100,6 +100,7 @@ jobs:
           - "PT16+CUDA101"
           - "PT15+CUDA102"
           - "PT16+CUDA102"
+          - "PT16+CUDA110"
         include:
           - environment: PT15+CUDA101
             pytorch: "torch==1.5.0+cu101 torchvision==0.6.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html"
@@ -113,6 +114,10 @@ jobs:
           - environment: PT16+CUDA102
             pytorch: "torch torchvision"
             base: "nvcr.io/nvidia/cuda:10.2-devel-ubuntu18.04"
+          - environment: PT16+CUDA110
+            # we explicitly set pytorch to -h to avoid pip install error
+            pytorch: "-h"
+            base: "nvcr.io/nvidia/pytorch:20.07-py3"
     container:
       image: ${{ matrix.base }}
       options: --gpus all
@@ -121,6 +126,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: apt install
       run: |
+        if [ ${{ matrix.environment }} != "PT16+CUDA110" ]; then \
         PYVER=3.6 PYSFX=3 DISTUTILS=python3-distutils && \
         apt-get update && apt-get install -y --no-install-recommends \
           curl \
@@ -150,7 +156,7 @@ jobs:
         ln -s /usr/bin/python$PYVER /usr/bin/python`echo $PYVER | cut -c1-1` &&
         curl -O https://bootstrap.pypa.io/get-pip.py && \
         python get-pip.py && \
-        rm get-pip.py
+        rm get-pip.py ; fi 
     - name: Install dependencies
       run: |
         which python


### PR DESCRIPTION
Fixes #918  918

### Description
Just add one item so the public release of CUDA11 w/ Pytorch 1.6 container image is used in CI environment.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
