### PR TITLE
FIX only use gdown if present

### DIFF
--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -116,7 +116,6 @@ def download_url(url: str, filepath: str, md5_value: Optional[str] = None) -> No
             elif file_size == -1:
                 raise Exception("Error getting Content-Length from server: %s" % url)
     else:
-        print("using urlretrieve")
         os.makedirs(os.path.dirname(filepath), exist_ok=True)
 
         def _process_hook(blocknum: int, blocksize: int, totalsize: int):

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -79,7 +79,7 @@ def download_url(url: str, filepath: str, md5_value: Optional[str] = None) -> No
 
     if url.startswith("https://drive.google.com"):
         if not has_gdown:
-            raise RuntimeError(f"To download files from Google Drive, please install the gdown dependency.")
+            raise RuntimeError("To download files from Google Drive, please install the gdown dependency.")
         os.makedirs(os.path.dirname(filepath), exist_ok=True)
         gdown.download(url, filepath, quiet=False)
         if not os.path.exists(filepath):

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -77,7 +77,7 @@ def download_url(url: str, filepath: str, md5_value: Optional[str] = None) -> No
         print(f"file {filepath} exists, skip downloading.")
         return
 
-    if url.startswith("https://drive.google.com"):
+    if url.startswith("https://drive.google.com") and has_gdown:
         os.makedirs(os.path.dirname(filepath), exist_ok=True)
         gdown.download(url, filepath, quiet=False)
         if not os.path.exists(filepath):

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -77,7 +77,9 @@ def download_url(url: str, filepath: str, md5_value: Optional[str] = None) -> No
         print(f"file {filepath} exists, skip downloading.")
         return
 
-    if url.startswith("https://drive.google.com") and has_gdown:
+    if url.startswith("https://drive.google.com"):
+        if not has_gdown:
+            raise RuntimeError(f"To download files from Google Drive, please install the gdown dependency.")
         os.makedirs(os.path.dirname(filepath), exist_ok=True)
         gdown.download(url, filepath, quiet=False)
         if not os.path.exists(filepath):
@@ -114,6 +116,7 @@ def download_url(url: str, filepath: str, md5_value: Optional[str] = None) -> No
             elif file_size == -1:
                 raise Exception("Error getting Content-Length from server: %s" % url)
     else:
+        print("using urlretrieve")
         os.makedirs(os.path.dirname(filepath), exist_ok=True)
 
         def _process_hook(blocknum: int, blocksize: int, totalsize: int):


### PR DESCRIPTION
Fixes #
Bug mentioned indirectly in https://github.com/Project-MONAI/MONAI/issues/935

### Description
`gdown` should be optional dependency, but beforehand was hard dependency if downloading a file from google drive.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).