### PR TITLE
Remove test_smartcachedataset from min dependency tests

### DIFF
--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - master
-      # temp add for test
-      - remove-smartcache-test-from-min
 
 jobs:
   # caching of these jobs:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+      # temp add for test
+      - remove-smartcache-test-from-min
 
 jobs:
   # caching of these jobs:

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -74,6 +74,7 @@ def run_testsuit():
         "test_zoomd",
         "test_load_image",
         "test_load_imaged",
+        "test_smartcachedataset",
     ]
 
     files = glob.glob(os.path.join(os.path.dirname(__file__), "test_*.py"))


### PR DESCRIPTION
### Description
I forgot to remove it from min dependency tests as it depends on nibabel.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
