### PR TITLE
Restore docker version for integration tests

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   cron-gpu:
     container:
-      image: nvcr.io/nvidia/pytorch:20.08-py3
+      image: nvcr.io/nvidia/pytorch:20.03-py3
       options: "--gpus all"
     runs-on: [self-hosted, linux, x64]
     strategy:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+      # add for test
+      - restore-integration-docker
 
 jobs:
   # caching of these jobs:
@@ -13,7 +15,7 @@ jobs:
   #   - os-latest-pip (shared)
   coverage-py3:
     container:
-      image: nvcr.io/nvidia/pytorch:20.08-py3
+      image: nvcr.io/nvidia/pytorch:20.03-py3
       options: --gpus all
     runs-on: [self-hosted, linux, x64]
     steps:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - master
-      # add for test
-      - restore-integration-docker
 
 jobs:
   # caching of these jobs:


### PR DESCRIPTION
### Description
As we can't build C++ with torch 1.4 in PyTorch docker 20.08, restore back to 20.03.
Will overall discuss CI plan soon.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
