### PR TITLE
fixes ci tests

### DIFF
--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - fixes-ci-tests
 
 jobs:
   # caching of these jobs:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - fixes-ci-tests
 
 jobs:
   # caching of these jobs:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - fixes-ci-tests
 
 jobs:
   # caching of these jobs:
@@ -124,11 +125,10 @@ jobs:
       name: Install torch cpu from pytorch.org (Windows only)
       run: |
         python -m pip install torch==1.4 -f https://download.pytorch.org/whl/cpu/torch_stable.html
-        python -m pip install torchvision==0.5.0
     - name: Install the dependencies
       run: |
         # min. requirements for windows instances
-        python -m pip install torch==1.4 torchvision==0.5.0
+        python -m pip install torch==1.4
         python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); print(txt); f=open('requirements-dev.txt', 'w'); f.writelines(txt[1:5]); f.close()"
         cat "requirements-dev.txt"
         python -m pip install -r requirements-dev.txt

--- a/monai/csrc/lltm/lltm.h
+++ b/monai/csrc/lltm/lltm.h
@@ -85,8 +85,8 @@ std::vector<torch::Tensor> lltm_backward(
     torch::Tensor candidate_cell,
     torch::Tensor X,
     torch::Tensor gate_weights,
-    torch::Tensor weights){
-  if(X.is_cuda()) {
+    torch::Tensor weights) {
+  if (X.is_cuda()) {
 #ifdef WITH_CUDA
     CHECK_CONTIGUOUS_CUDA(grad_h);
     CHECK_CONTIGUOUS_CUDA(grad_cell);
@@ -99,27 +99,11 @@ std::vector<torch::Tensor> lltm_backward(
     CHECK_CONTIGUOUS_CUDA(weights);
 
     return lltm_cuda_backward(
-        grad_h,
-        grad_cell,
-        new_cell,
-        input_gate,
-        output_gate,
-        candidate_cell,
-        X,
-        gate_weights,
-        weights);
+        grad_h, grad_cell, new_cell, input_gate, output_gate, candidate_cell, X, gate_weights, weights);
 #else
     AT_ERROR("Not compiled with GPU support.");
 #endif
   }
   return lltm_cpu_backward(
-      grad_h,
-      grad_cell,
-      new_cell,
-      input_gate,
-      output_gate,
-      candidate_cell,
-      X,
-      gate_weights,
-      weights);
+      grad_h, grad_cell, new_cell, input_gate, output_gate, candidate_cell, X, gate_weights, weights);
 }

--- a/monai/csrc/lltm/lltm.h
+++ b/monai/csrc/lltm/lltm.h
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 #pragma once
+
 #include <torch/extension.h>
 #include <vector>
 #include "utils/common_utils.h"

--- a/monai/csrc/lltm/lltm_cpu.cpp
+++ b/monai/csrc/lltm/lltm_cpu.cpp
@@ -50,13 +50,7 @@ std::vector<torch::Tensor> lltm_cpu_forward(
   auto new_cell = old_cell + candidate_cell * input_gate;
   auto new_h = torch::tanh(new_cell) * output_gate;
 
-  return {new_h,
-          new_cell,
-          input_gate,
-          output_gate,
-          candidate_cell,
-          X,
-          gate_weights};
+  return {new_h, new_cell, input_gate, output_gate, candidate_cell, X, gate_weights};
 }
 
 std::vector<torch::Tensor> lltm_cpu_backward(
@@ -82,8 +76,7 @@ std::vector<torch::Tensor> lltm_cpu_backward(
   d_output_gate *= d_sigmoid(gates[1]);
   d_candidate_cell *= d_elu(gates[2]);
 
-  auto d_gates =
-      torch::cat({d_input_gate, d_output_gate, d_candidate_cell}, /*dim=*/1);
+  auto d_gates = torch::cat({d_input_gate, d_output_gate, d_candidate_cell}, /*dim=*/1);
 
   auto d_weights = d_gates.t().mm(X);
   auto d_bias = d_gates.sum(/*dim=*/0, /*keepdim=*/true);

--- a/monai/csrc/utils/common_utils.h
+++ b/monai/csrc/utils/common_utils.h
@@ -15,8 +15,7 @@ limitations under the License.
 #include <torch/extension.h>
 
 #define CHECK_CUDA(x) TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor.")
-#define CHECK_CONTIGUOUS(x) \
-  TORCH_CHECK(x.is_contiguous(), #x " must be contiguous.")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous.")
 #define CHECK_CONTIGUOUS_CUDA(x) \
   CHECK_CUDA(x);                 \
   CHECK_CONTIGUOUS(x)

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -160,7 +160,7 @@ class ITKReader(ImageReader):
         img_array_ = np.stack(img_array, axis=0) if len(img_array) > 1 else img_array[0]
         return img_array_, compatible_meta
 
-    def _get_meta_dict(self, img: Image) -> Dict:
+    def _get_meta_dict(self, img) -> Dict:
         """
         Get all the meta data of the image and convert to dict type.
 
@@ -180,7 +180,7 @@ class ITKReader(ImageReader):
         meta_dict["direction"] = itk.array_from_matrix(img.GetDirection())
         return meta_dict
 
-    def _get_affine(self, img: Image) -> np.ndarray:
+    def _get_affine(self, img) -> np.ndarray:
         """
         Get or construct the affine matrix of the image, it can be used to correct
         spacing, orientation or execute spatial transforms.
@@ -201,7 +201,7 @@ class ITKReader(ImageReader):
         affine[(slice(-1), -1)] = origin
         return affine
 
-    def _get_spatial_shape(self, img: Image) -> Sequence:
+    def _get_spatial_shape(self, img) -> Sequence:
         """
         Get the spatial shape of image data, it doesn't contain the channel dim.
 
@@ -211,7 +211,7 @@ class ITKReader(ImageReader):
         """
         return list(itk.size(img))
 
-    def _get_array_data(self, img: Image) -> np.ndarray:
+    def _get_array_data(self, img) -> np.ndarray:
         """
         Get the raw array data of the image, converted to Numpy array.
 
@@ -309,7 +309,7 @@ class NibabelReader(ImageReader):
         img_array_ = np.stack(img_array, axis=0) if len(img_array) > 1 else img_array[0]
         return img_array_, compatible_meta
 
-    def _get_meta_dict(self, img: Nifti1Image) -> Dict:
+    def _get_meta_dict(self, img) -> Dict:
         """
         Get the all the meta data of the image and convert to dict type.
 
@@ -319,7 +319,7 @@ class NibabelReader(ImageReader):
         """
         return dict(img.header)
 
-    def _get_affine(self, img: Nifti1Image) -> np.ndarray:
+    def _get_affine(self, img) -> np.ndarray:
         """
         Get the affine matrix of the image, it can be used to correct
         spacing, orientation or execute spatial transforms.
@@ -330,7 +330,7 @@ class NibabelReader(ImageReader):
         """
         return img.affine
 
-    def _get_spatial_shape(self, img: Nifti1Image) -> Sequence:
+    def _get_spatial_shape(self, img) -> Sequence:
         """
         Get the spatial shape of image data, it doesn't contain the channel dim.
 
@@ -342,7 +342,7 @@ class NibabelReader(ImageReader):
         spatial_rank = min(ndim, 3)
         return list(img.header["dim"][1 : spatial_rank + 1])
 
-    def _get_array_data(self, img: Nifti1Image) -> np.ndarray:
+    def _get_array_data(self, img) -> np.ndarray:
         """
         Get the raw array data of the image, converted to Numpy array.
 
@@ -521,7 +521,7 @@ class PILReader(ImageReader):
         img_array_ = np.stack(img_array, axis=0) if len(img_array) > 1 else img_array[0]
         return img_array_, compatible_meta
 
-    def _get_meta_dict(self, img: PILImage.Image) -> Dict:
+    def _get_meta_dict(self, img) -> Dict:
         """
         Get the all the meta data of the image and convert to dict type.
         Args:
@@ -536,7 +536,7 @@ class PILReader(ImageReader):
         meta["info"] = img.info
         return meta
 
-    def _get_spatial_shape(self, img: PILImage.Image) -> Sequence:
+    def _get_spatial_shape(self, img) -> Sequence:
         """
         Get the spatial shape of image data, it doesn't contain the channel dim.
         Args:

--- a/tests/clang_format_utils.py
+++ b/tests/clang_format_utils.py
@@ -61,7 +61,8 @@ def get_and_check_clang_format():
             PLATFORM_TO_CF_URL[HOST_PLATFORM], CLANG_FORMAT_PATH, PLATFORM_TO_HASH[HOST_PLATFORM], hash_type="sha1"
         )
     except Exception as e:
-        print(f"Download {CLANG_FORMAT_PATH} failed: {e}.")
+        print(f"Download {CLANG_FORMAT_PATH} failed: {e}")
+        print(f"Please remove {CLANG_FORMAT_PATH} and retry.")
         return False
 
     # Make sure the binary is executable.

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -55,6 +55,7 @@ def run_testsuit():
         "test_orientationd",
         "test_parallel_execution",
         "test_persistentdataset",
+        "test_pil_reader",
         "test_plot_2d_or_3d_image",
         "test_png_rw",
         "test_png_saver",

--- a/tests/test_decathlondataset.py
+++ b/tests/test_decathlondataset.py
@@ -51,7 +51,7 @@ class TestDecathlonDataset(unittest.TestCase):
             print(str(e))
             if isinstance(e, RuntimeError):
                 # FIXME: skip MD5 check as current downloading method may fail
-                self.assertTrue(str(e).startswith("MD5 check"))
+                self.assertTrue(str(e).startswith("md5 check"))
             return  # skipping this test due the network connection errors
 
         _test_dataset(data)

--- a/tests/test_download_and_extract.py
+++ b/tests/test_download_and_extract.py
@@ -32,7 +32,7 @@ class TestDownloadAndExtract(unittest.TestCase):
             print(str(e))
             if isinstance(e, RuntimeError):
                 # FIXME: skip MD5 check as current downloading method may fail
-                self.assertTrue(str(e).startswith("MD5 check"))
+                self.assertTrue(str(e).startswith("md5 check"))
             return  # skipping this test due the network connection errors
 
         wrong_md5 = "0"
@@ -42,13 +42,13 @@ class TestDownloadAndExtract(unittest.TestCase):
             print(str(e))
             if isinstance(e, RuntimeError):
                 # FIXME: skip MD5 check as current downloading method may fail
-                self.assertTrue(str(e).startswith("MD5 check"))
+                self.assertTrue(str(e).startswith("md5 check"))
             return  # skipping this test due the network connection errors
 
         try:
             extractall(filepath, output_dir, wrong_md5)
         except RuntimeError as e:
-            self.assertTrue(str(e).startswith("MD5 check"))
+            self.assertTrue(str(e).startswith("md5 check"))
 
 
 if __name__ == "__main__":

--- a/tests/test_mednistdataset.py
+++ b/tests/test_mednistdataset.py
@@ -45,7 +45,7 @@ class TestMedNISTDataset(unittest.TestCase):
             print(str(e))
             if isinstance(e, RuntimeError):
                 # FIXME: skip MD5 check as current downloading method may fail
-                self.assertTrue(str(e).startswith("MD5 check"))
+                self.assertTrue(str(e).startswith("md5 check"))
             return  # skipping this test due the network connection errors
 
         _test_dataset(data)


### PR DESCRIPTION
- fixes a ci error of md5 assertion
- update minimal dependencies CI to not include torchvision
- exclude test_pil_reader in min. dep CI
- fixes monai/data/image_reader.py importing issue
- tested clangformat in /black
- fixes build warnings:
  - `/__w/MONAI/MONAI/monai/csrc/lltm/lltm_cuda.cu:131:43: warning: ‘at::DeprecatedTypeProperties& at::Tensor::type() const’ is deprecated: Tensor.type() is deprecated. Instead use Tensor.options(), which in many cases (e.g. in a constructor) is a drop-in replacement. If you were using data from type(), that is now available from Tensor itself, so instead of tensor.type().scalar_type(), use tensor.scalar_type() instead and instead of tensor.type().backend() use tensor.device(). [-Wdeprecated-declarations]`
  - `/__w/MONAI/MONAI/monai/csrc/lltm/lltm_cuda.cu:131:440: warning: ‘at::GenericPackedTensorAccessor<T, N, PtrTraits, index_t> at::Tensor::packed_accessor() const & [with T = double; long unsigned int N = 2; PtrTraits = at::RestrictPtrTraits; index_t = long unsigned int]’ is deprecated: packed_accessor is deprecated, use packed_accessor32 or packed_accessor64 instead [-Wdeprecated-declarations]`
### Status
**ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.