### PR TITLE
1017 Add Novograd optimizer

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ exclude_patterns = [
     "visualize",
     "utils",
     "inferers",
+    "optimizers",
 ]
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,6 +57,7 @@ Technical documentation is available at `docs.monai.io <https://docs.monai.io>`_
    losses
    networks
    metrics
+   optimizers
    data
    engines
    inferers

--- a/docs/source/optimizers.rst
+++ b/docs/source/optimizers.rst
@@ -1,0 +1,12 @@
+:github_url: https://github.com/Project-MONAI/MONAI
+
+.. _optimizers:
+
+Optimizers
+==========
+.. currentmodule:: monai.optimizers
+
+`Novograd`
+----------
+.. autoclass:: Novograd
+    :members:

--- a/monai/README.md
+++ b/monai/README.md
@@ -20,6 +20,8 @@
 
 * **networks**: contains network definitions, component definitions, and Pytorch specific utilities.
 
+* **optimizers**: classes defining optimizers.
+
 * **transforms**: defines data transforms for preprocessing and postprocessing.
 
 * **utils**: generic utilities intended to be implemented in pure Python or using Numpy,

--- a/monai/optimizers/__init__.py
+++ b/monai/optimizers/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .novograd import Novograd

--- a/monai/optimizers/novograd.py
+++ b/monai/optimizers/novograd.py
@@ -1,0 +1,134 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Iterable, Optional, Tuple
+
+import torch
+from torch.optim import Optimizer
+
+
+class Novograd(Optimizer):
+    """
+    Novograd based on `Stochastic Gradient Methods with Layer-wise Adaptive Moments for Training of Deep Networks
+    <https://arxiv.org/pdf/1905.11286.pdf>`_.
+    The code is adapted from the implementations in `Jasper for PyTorch
+    <https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/SpeechRecognition/Jasper/optimizers.py>`_,
+    and `OpenSeq2Seq <https://github.com/NVIDIA/OpenSeq2Seq/blob/master/open_seq2seq/optimizers/novograd.py>`_.
+
+    Args:
+        params: iterable of parameters to optimize or dicts defining parameter groups.
+        lr: learning rate. Defaults to 1e-3.
+        betas: coefficients used for computing running averages of gradient and its square. Defaults to (0.9, 0.98).
+        eps: term added to the denominator to improve numerical stability. Defaults to 1e-8.
+        weight_decay: weight decay (L2 penalty). Defaults to 0.
+        grad_averaging: gradient averaging. Defaults to ``False``.
+        amsgrad: whether to use the AMSGrad variant of this algorithm from the paper
+            `On the Convergence of Adam and Beyond <https://arxiv.org/pdf/1904.09237.pdf>`_. Defaults to ``False``.
+    """
+
+    def __init__(
+        self,
+        params: Iterable,
+        lr: float = 1e-3,
+        betas: Tuple[float, float] = (0.9, 0.98),
+        eps: float = 1e-8,
+        weight_decay: float = 0,
+        grad_averaging: bool = False,
+        amsgrad: bool = False,
+    ):
+        if not 0.0 <= lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if not 0.0 <= eps:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+        defaults = dict(
+            lr=lr,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+            grad_averaging=grad_averaging,
+            amsgrad=amsgrad,
+        )
+
+        super(Novograd, self).__init__(params, defaults)
+
+    def __setstate__(self, state):
+        super(Novograd, self).__setstate__(state)
+        for group in self.param_groups:
+            group.setdefault("amsgrad", False)
+
+    def step(self, closure: Optional[Callable] = None):
+        """Performs a single optimization step.
+
+        Arguments:
+            closure: A closure that reevaluates the model and returns the loss. Defaults to ``None``.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                grad = p.grad.data
+                if grad.is_sparse:
+                    raise RuntimeError("Sparse gradients are not supported.")
+                amsgrad = group["amsgrad"]
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state["step"] = 0
+                    # Exponential moving average of gradient values
+                    state["exp_avg"] = torch.zeros_like(p.data)
+                    # Exponential moving average of squared gradient values
+                    state["exp_avg_sq"] = torch.zeros([]).to(state["exp_avg"].device)
+                    if amsgrad:
+                        # Maintains max of all exp. moving avg. of sq. grad. values
+                        state["max_exp_avg_sq"] = torch.zeros([]).to(state["exp_avg"].device)
+
+                exp_avg, exp_avg_sq = state["exp_avg"], state["exp_avg_sq"]
+                if amsgrad:
+                    max_exp_avg_sq = state["max_exp_avg_sq"]
+                beta1, beta2 = group["betas"]
+
+                state["step"] += 1
+
+                norm = torch.sum(torch.pow(grad, 2))
+
+                if exp_avg_sq == 0:
+                    exp_avg_sq.copy_(norm)
+                else:
+                    exp_avg_sq.mul_(beta2).add_(norm, alpha=1 - beta2)
+
+                if amsgrad:
+                    # Maintains the maximum of all 2nd moment running avg. till now
+                    torch.max(max_exp_avg_sq, exp_avg_sq, out=max_exp_avg_sq)
+                    # Use the max. for normalizing running avg. of gradient
+                    denom = max_exp_avg_sq.sqrt().add_(group["eps"])
+                else:
+                    denom = exp_avg_sq.sqrt().add_(group["eps"])
+
+                grad.div_(denom)
+                if group["weight_decay"] != 0:
+                    grad.add_(p.data, alpha=group["weight_decay"])
+                if group["grad_averaging"]:
+                    grad.mul_(1 - beta1)
+                exp_avg.mul_(beta1).add_(grad)
+
+                p.data.add_(exp_avg, alpha=-group["lr"])
+
+        return loss

--- a/monai/optimizers/novograd.py
+++ b/monai/optimizers/novograd.py
@@ -52,6 +52,8 @@ class Novograd(Optimizer):
             raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
         if not 0.0 <= betas[1] < 1.0:
             raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+        if not 0.0 <= weight_decay:
+            raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
         defaults = dict(
             lr=lr,
             betas=betas,

--- a/tests/test_optim_novograd.py
+++ b/tests/test_optim_novograd.py
@@ -1,0 +1,114 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from torch.autograd import Variable
+
+from monai.optimizers import Novograd
+
+
+def build_test_cases(data):
+    [weight, bias, input] = data
+    weight = Variable(weight, requires_grad=True)
+    bias = Variable(bias, requires_grad=True)
+    input = Variable(input)
+
+    default_params = {"lr": 1e-3, "amsgrad": False, "grad_averaging": False, "weight_decay": 0}
+
+    test_case_same_param = [{"params": [weight, bias]}]
+    test_case_diff_param = [
+        {"params": [weight]},
+        {"params": [bias], "lr": 1e-2, "amsgrad": True, "grad_averaging": True, "weight_decay": 0.1},
+    ]
+
+    test_cases = []
+    test_cases.append([test_case_same_param, default_params, weight, bias, input])
+    test_cases.append([test_case_diff_param, default_params, weight, bias, input])
+    return test_cases
+
+
+TEST_CASES_ALL = build_test_cases(  # normal parameters
+    [
+        torch.randn(10, 5),
+        torch.randn(10),
+        torch.randn(5),
+    ]
+)
+
+TEST_CASES_ALL += build_test_cases(  # non-contiguous parameters
+    [
+        torch.randn(10, 5, 2)[..., 0],
+        torch.randn(10, 2)[..., 0],
+        torch.randn(5),
+    ]
+)
+
+if torch.cuda.is_available():
+    TEST_CASES_ALL += build_test_cases(  # gpu parameters
+        [
+            torch.randn(10, 5).cuda(),
+            torch.randn(10).cuda(),
+            torch.randn(5).cuda(),
+        ]
+    )
+if torch.cuda.device_count() > 1:
+    TEST_CASES_ALL += build_test_cases(  # multi-gpu parameters
+        [
+            torch.randn(10, 5).cuda(0),
+            torch.randn(10).cuda(1),
+            torch.randn(5).cuda(0),
+        ]
+    )
+
+
+class TestNovograd(unittest.TestCase):
+    """
+    This class takes `Pytorch's test_optim function
+    <https://github.com/pytorch/pytorch/blob/master/test/test_optim.py>`_ for reference.
+    """
+
+    @parameterized.expand(TEST_CASES_ALL)
+    def test_step(self, specify_param, default_param, weight, bias, input):
+        optimizer = Novograd(specify_param, **default_param)
+
+        def fn():
+            optimizer.zero_grad()
+            y = weight.mv(input)
+            if y.is_cuda and bias.is_cuda and y.get_device() != bias.get_device():
+                y = y.cuda(bias.get_device())
+            loss = (y + bias).pow(2).sum()
+            loss.backward()
+            return loss
+
+        initial_value = fn().item()
+        for _ in range(100):
+            optimizer.step(fn)
+        self.assertLess(fn().item(), initial_value)
+
+    def test_ill_arg(self):
+        param = {"params": [Variable(torch.randn(10), requires_grad=True)]}
+        with self.assertRaisesRegex(ValueError, "Invalid learning rate: -1"):
+            Novograd(param, lr=-1)
+        with self.assertRaisesRegex(ValueError, "Invalid epsilon value: -1"):
+            Novograd(param, eps=-1)
+        with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
+            Novograd(param, betas=(1.0, 0.98))
+        with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 1: -1"):
+            Novograd(param, betas=(0.9, -1))
+        with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
+            Novograd(param, weight_decay=-1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: yiheng-wang-nv <vennw@nvidia.com>

Implement #1017 .

### Description
Novograd optimizer is added during this PR. The code takes [Jasper for PyTorch](https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/SpeechRecognition/Jasper/optimizers.py) and [OpenSeq2Seq](https://github.com/NVIDIA/OpenSeq2Seq/blob/master/open_seq2seq/optimizers/novograd.py) for reference, and I also refer to [pytorch's test_optim method](https://github.com/pytorch/pytorch/blob/master/test/test_optim.py) for the unittest.

Except for the unittest that tests the step function, I also manually use Novograd to replace Adam in `examples/notebooks/automatic_mixed_precision.ipynb` and tested the performance locally. The optimizer works well as described bellow:

- Average time consuming for Novograd (with and without amp) is much less than Adam.
- The convergence speed for Novograd is faster than Adam. `betas[1]` and `lr` are different from Adam as suggested in the [paper](https://arxiv.org/pdf/1905.11286.pdf) (Here I use `betas[1]=0.98` and `lr = 5e-4` for Novograd).
- The performance is similar as Adam without any parameters adjustment.

Updates: please see the images I uploaded bellow.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
