### PR TITLE
pip install, CI/CD enhancements

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -35,7 +35,7 @@ jobs:
         echo $CUDA_VISIBLE_DEVICES
         python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
         python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
-        ./runtests.sh --coverage
+        BUILD_MONAI=1 ./runtests.sh --coverage
         coverage xml
     - name: Upload coverage
       uses: codecov/codecov-action@v1
@@ -58,7 +58,7 @@ jobs:
         python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
         python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
         ngc --version
-        ./runtests.sh --coverage --pytype
+        BUILD_MONAI=1 ./runtests.sh --coverage --pytype
         coverage xml
     - name: Upload coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -84,14 +84,64 @@ jobs:
         cat "requirements-dev.txt"
         python -m pip install -r requirements-dev.txt
         python -m pip list
-        SKIP_MONAI_BUILD=1 python setup.py develop
+        python setup.py develop
         python setup.py develop --uninstall
-        python setup.py develop  # compile the cpp extensions
+        BUILD_MONAI=1 python setup.py develop  # compile the cpp extensions
       shell: bash
     - name: Run quick tests (CPU ${{ runner.os }})
       run: |
         python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
         python -m unittest -v
+      env:
+        QUICKTEST: True
+
+  min-dep-py3:  # min dependencies installed
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macOS-latest, ubuntu-latest]
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Prepare pip wheel
+      run: |
+        which python
+        python -m pip install --upgrade pip wheel
+    - name: cache weekly timestamp
+      id: pip-cache
+      run: |
+        echo "::set-output name=datew::$(date '+%Y-%V')"
+        echo "::set-output name=dir::$(pip cache dir)"
+      shell: bash
+    - name: cache for pip
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ matrix.os }}-latest-pip-${{ steps.pip-cache.outputs.datew }}
+    - if: runner.os == 'windows'
+      name: Install torch cpu from pytorch.org (Windows only)
+      run: |
+        python -m pip install torch==1.4 -f https://download.pytorch.org/whl/cpu/torch_stable.html
+    - name: Install the dependencies
+      run: |
+        # min. requirements for windows instances
+        python -m pip install torch==1.4
+        python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); print(txt); f=open('requirements-dev.txt', 'w'); f.writelines(txt[1:5]); f.close()"
+        cat "requirements-dev.txt"
+        python -m pip install -r requirements-dev.txt
+        python -m pip list
+        BUILD_MONAI=0 python setup.py develop  # no compile of extensions
+      shell: bash
+    - name: Run quick tests (CPU ${{ runner.os }})
+      run: |
+        python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
+        python -m tests.min_tests
       env:
         QUICKTEST: True
 
@@ -170,11 +220,11 @@ jobs:
       run: |
         python -m pip list
         nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        export CUDA_VISIBLE_DEVICES=$(coverage run -m tests.utils)
         echo $CUDA_VISIBLE_DEVICES
         python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
         python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
-        ./runtests.sh --quick
+        BUILD_MONAI=1 ./runtests.sh --quick
         if [ ${{ matrix.environment }} == "PT16+CUDA110" ]; then
           # test the clang-format tool downloading once
           coverage run -m tests.clang_format_utils
@@ -274,4 +324,7 @@ jobs:
     - name: Make html
       run: |
         cd docs/
-        make html
+        make clean
+        make html 2>&1 | tee tmp_log
+        if [[ $(grep -c "^WARNING:" tmp_log) != 0 ]]; then echo "found warnings"; exit 1; fi
+      shell: bash

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - default-to-no-build
 
 jobs:
   # caching of these jobs:
@@ -43,7 +44,7 @@ jobs:
         echo $CUDA_VISIBLE_DEVICES
         python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
         python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
-        ./runtests.sh --coverage
+        BUILD_MONAI=1 ./runtests.sh --coverage
         coverage xml
     - name: Upload coverage
       uses: codecov/codecov-action@v1
@@ -83,7 +84,7 @@ jobs:
       run: |
         python -m pip list
         python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
-        ./runtests.sh --quick
+        BUILD_MONAI=1 ./runtests.sh --quick
         coverage xml
     - name: Upload coverage
       uses: codecov/codecov-action@v1
@@ -91,57 +92,7 @@ jobs:
         fail_ci_if_error: false
         file: ./coverage.xml
 
-  min-dep-py3:  # min dependencies installed
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest, macOS-latest, ubuntu-latest]
-    timeout-minutes: 20
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
-    - name: Prepare pip wheel
-      run: |
-        which python
-        python -m pip install --upgrade pip wheel
-    - name: cache weekly timestamp
-      id: pip-cache
-      run: |
-        echo "::set-output name=datew::$(date '+%Y-%V')"
-        echo "::set-output name=dir::$(pip cache dir)"
-      shell: bash
-    - name: cache for pip
-      uses: actions/cache@v2
-      id: cache
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ matrix.os }}-latest-pip-${{ steps.pip-cache.outputs.datew }}
-    - if: runner.os == 'windows'
-      name: Install torch cpu from pytorch.org (Windows only)
-      run: |
-        python -m pip install torch==1.4 -f https://download.pytorch.org/whl/cpu/torch_stable.html
-    - name: Install the dependencies
-      run: |
-        # min. requirements for windows instances
-        python -m pip install torch==1.4
-        python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); print(txt); f=open('requirements-dev.txt', 'w'); f.writelines(txt[1:5]); f.close()"
-        cat "requirements-dev.txt"
-        python -m pip install -r requirements-dev.txt
-        python -m pip list
-        SKIP_MONAI_BUILD=1 python setup.py develop  # no compile of extensions
-      shell: bash
-    - name: Run quick tests (CPU ${{ runner.os }})
-      run: |
-        python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
-        python -m tests.min_tests
-      env:
-        QUICKTEST: True
-
-  install:
+  install:  # pip install from github url
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python 3.7
@@ -158,14 +109,19 @@ jobs:
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
-    - name: Install the default branch
+    - name: Install the default branch no build
       run: |
-        pip install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
-    - name: Import
-      run: |
+        BUILD_MONAI=0 pip install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
         python -c 'import monai; monai.config.print_config()'
-    - name: Uninstall
+        cd $(python -c 'import monai; import os; print(os.path.dirname(monai.__file__))')
+        ls .
+        pip uninstall -y monai
+    - name: Install the default branch with build
       run: |
+        BUILD_MONAI=1 pip install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
+        python -c 'import monai; monai.config.print_config()'
+        cd $(python -c 'import monai; import os; print(os.path.dirname(monai.__file__))')
+        ls .
         pip uninstall -y monai
 
   docker:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - default-to-no-build
 
 jobs:
   # caching of these jobs:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,3 @@ include monai/_version.py
 
 include README.md
 include LICENSE
-
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -40,6 +40,10 @@ for the latest features:
 ```bash
 pip install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
 ```
+or, to build with MONAI Cpp/CUDA extensions:
+```bash
+BUILD_MONAI=1 pip install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
+```
 this command will download and install the current master branch of [MONAI from
 GitHub](https://github.com/Project-MONAI/MONAI).
 
@@ -55,17 +59,25 @@ You can install it by running:
 ```bash
 cd MONAI/
 python setup.py develop
-
-# For MacOS:
-# CC=clang CXX=clang++ python setup.py develop
-
-# To install without build
-# SKIP_MONAI_BUILD=1 python setup.py develop
-
-# To uninstall the package please run:
-python setup.py develop --uninstall
 ```
-or simply adding the root directory of the cloned source code (e.g., ``/workspace/Documents/MONAI``) to your ``$PYTHONPATH``
+or, to build with MONAI Cpp/CUDA extensions:
+```bash
+cd MONAI/
+BUILD_MONAI=1 python setup.py develop
+# for MacOS
+BUILD_MONAI=1 CC=clang CXX=clang++ python setup.py develop
+```
+
+To uninstall the package please run:
+```bash
+cd MONAI/
+python setup.py develop --uninstall
+
+# to further clean up the MONAI/ folder (Bash script)
+./runtests.sh --clean
+```
+
+Alternatively, simply adding the root directory of the cloned source code (e.g., ``/workspace/Documents/MONAI``) to your ``$PYTHONPATH``
 and the codebase is ready to use (without the additional features of MONAI C++/CUDA extensions).
 
 

--- a/monai/__init__.py
+++ b/monai/__init__.py
@@ -13,7 +13,9 @@ import os
 import sys
 
 from ._version import get_versions
-from .utils.module import load_submodules
+
+PY_REQUIRED_MAJOR = 3
+PY_REQUIRED_MINOR = 6
 
 __version__ = get_versions()["version"]
 del get_versions
@@ -21,6 +23,15 @@ del get_versions
 __copyright__ = "(c) 2020 MONAI Consortium"
 
 __basedir__ = os.path.dirname(__file__)
+
+if not (sys.version_info.major == PY_REQUIRED_MAJOR and sys.version_info.minor >= PY_REQUIRED_MINOR):
+    raise RuntimeError(
+        "MONAI requires Python {}.{} or higher. But the current Python is: {}".format(
+            PY_REQUIRED_MAJOR, PY_REQUIRED_MINOR, sys.version
+        ),
+    )
+
+from .utils.module import load_submodules  # noqa: E402
 
 # handlers_* have some external decorators the users may not have installed
 # *.so files and folder "_C" may not exist when the cpp extensions are not compiled

--- a/runtests.sh
+++ b/runtests.sh
@@ -95,6 +95,11 @@ function print_usage {
     exit 1
 }
 
+function check_import {
+    echo "PYTHON: $(which python)"
+    ${cmdPrefix}python -c "import monai"
+}
+
 function print_version {
     ${cmdPrefix}python -c 'import monai; monai.config.print_config()'
 }
@@ -251,7 +256,7 @@ cd "$homedir"
 
 # python path
 export PYTHONPATH="$homedir:$PYTHONPATH"
-echo "$PYTHONPATH"
+echo "PYTHONPATH: $PYTHONPATH"
 
 # by default do nothing
 cmdPrefix=""
@@ -263,7 +268,10 @@ then
     # commands are echoed instead of ran
     cmdPrefix="dryrun "
     function dryrun { echo "    " "$@"; }
+else
+    check_import
 fi
+
 
 if [ $doCleanup = true ]
 then

--- a/runtests.sh
+++ b/runtests.sh
@@ -106,6 +106,8 @@ function install_deps {
 
 function compile_cpp {
     echo "Compiling and installing MONAI cpp extensions..."
+    # depends on setup.py behaviour for building
+    # currently setup.py uses environment variables: BUILD_MONAI and FORCE_CUDA
     ${cmdPrefix}python setup.py -v develop --uninstall
     if [[ "$OSTYPE" == "darwin"* ]];
     then  # clang for mac os
@@ -138,6 +140,7 @@ function clean_py {
 
     find ${TO_CLEAN} -type f -name "*.py[co]" -delete
     find ${TO_CLEAN} -type f -name ".coverage" -delete
+    find ${TO_CLEAN} -type f -name "*.so" -delete
     find ${TO_CLEAN} -type d -name "__pycache__" -delete
 
     find ${TO_CLEAN} -depth -type d -name ".eggs" -exec rm -r "{}" +

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,_version.py
 known_first_party = monai
 profile = black
 line_length = 120
-skip = .git, .eggs, venv, versioneer.py, _version.py, conf.py
+skip = .git, .eggs, venv, versioneer.py, _version.py, conf.py, monai/__init__.py
 skip_glob = *.pyi
 
 [versioneer]

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -47,6 +47,7 @@ def run_testsuit():
         "test_load_png",
         "test_load_pngd",
         "test_load_spacing_orientation",
+        "test_mednistdataset",
         "test_nifti_dataset",
         "test_nifti_header_revise",
         "test_nifti_rw",


### PR DESCRIPTION
### Description
Several enhancements to finalise v0.3 installation commands
- Default to no build, so that the following commands will be simple python scripts installations:
  - `pip install ...`
  - `python setup.py develop`
- Check flag to build, so that the following will build cpp/cuda extensions:
  - `BUILD_MONAI=1 pip install ...`
  - `BUILD_MONAI=1 python setup.py develop`
- installation guide updated to reflect the changes
- Move min-dep tests to run on every pull request
- Add additional tests for `pip install git+https://github.com/Project-MONAI/MONAI#egg=MONAI`
- Fix warnings in MANIFEST.in
- Documentation tests now check warnings
- `./runtests.sh --clean` now also removes any binary builds
- Add python version checks and improves error msg for https://github.com/Project-MONAI/MONAI/issues/1036, https://github.com/Project-MONAI/MONAI/issues/977

### Status
**WIP**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
