### PR TITLE
runtests.sh optionally set path to python

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -175,7 +175,7 @@ function print_style_fail_msg() {
 }
 
 function is_pip_installed() {
-	return $($PY_EXE -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader(sys.argv[1]) else 1)" $1)
+	return $(${PY_EXE} -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader(sys.argv[1]) else 1)" $1)
 }
 
 if [ -z "$1" ]
@@ -326,9 +326,9 @@ then
 
     if [ $doIsortFix = true ]
     then
-        ${cmdPrefix}$PY_EXE -m isort "$(pwd)"
+        ${cmdPrefix}${PY_EXE} -m isort "$(pwd)"
     else
-        ${cmdPrefix}$PY_EXE -m isort --check "$(pwd)"
+        ${cmdPrefix}${PY_EXE} -m isort --check "$(pwd)"
     fi
 
     isort_status=$?
@@ -358,13 +358,13 @@ then
     then
         install_deps
     fi
-    ${cmdPrefix}$PY_EXE -m black --version
+    ${cmdPrefix}${PY_EXE} -m black --version
 
     if [ $doBlackFix = true ]
     then
-        ${cmdPrefix}$PY_EXE -m black "$(pwd)"
+        ${cmdPrefix}${PY_EXE} -m black "$(pwd)"
     else
-        ${cmdPrefix}$PY_EXE -m black --check "$(pwd)"
+        ${cmdPrefix}${PY_EXE} -m black --check "$(pwd)"
     fi
 
     black_status=$?
@@ -389,9 +389,9 @@ then
 	then
         install_deps
     fi
-    ${cmdPrefix}$PY_EXE -m flake8 --version
+    ${cmdPrefix}${PY_EXE} -m flake8 --version
 
-    ${cmdPrefix}$PY_EXE -m flake8 "$(pwd)" --count --statistics
+    ${cmdPrefix}${PY_EXE} -m flake8 "$(pwd)" --count --statistics
 
     flake8_status=$?
     if [ ${flake8_status} -ne 0 ]
@@ -415,9 +415,9 @@ then
     then
         install_deps
     fi
-    ${cmdPrefix}$PY_EXE -m pytype --version
+    ${cmdPrefix}${PY_EXE} -m pytype --version
 
-    ${cmdPrefix}$PY_EXE -m pytype -j ${NUM_PARALLEL} --python-version="$(${PY_EXE} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
+    ${cmdPrefix}${PY_EXE} -m pytype -j ${NUM_PARALLEL} --python-version="$(${PY_EXE} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
 
     pytype_status=$?
     if [ ${pytype_status} -ne 0 ]
@@ -441,13 +441,13 @@ then
     then
         install_deps
     fi
-    ${cmdPrefix}$PY_EXE -m mypy --version
+    ${cmdPrefix}${PY_EXE} -m mypy --version
 
     if [ $doDryRun = true ]
     then
-        ${cmdPrefix}MYPYPATH="$(pwd)"/monai $PY_EXE -m mypy "$(pwd)"
+        ${cmdPrefix}MYPYPATH="$(pwd)"/monai ${PY_EXE} -m mypy "$(pwd)"
     else
-        MYPYPATH="$(pwd)"/monai $PY_EXE -m mypy "$(pwd)" # cmdPrefix does not work with MYPYPATH
+        MYPYPATH="$(pwd)"/monai ${PY_EXE} -m mypy "$(pwd)" # cmdPrefix does not work with MYPYPATH
     fi
 
     mypy_status=$?
@@ -478,8 +478,8 @@ fi
 if [ $doCoverage = true ]
 then
     echo "${separator}${blue}coverage${noColor}"
-    cmd="coverage run -a --source ."
-    ${cmdPrefix}coverage erase
+    cmd="${PY_EXE} -m coverage run -a --source ."
+    ${cmdPrefix}${PY_EXE} -m coverage erase
 fi
 
 # # download test data if needed
@@ -518,5 +518,5 @@ fi
 if [ $doCoverage = true ]
 then
     echo "${separator}${blue}coverage${noColor}"
-    ${cmdPrefix}coverage report --skip-covered -m
+    ${cmdPrefix}${PY_EXE} -m coverage report --skip-covered -m
 fi

--- a/runtests.sh
+++ b/runtests.sh
@@ -51,6 +51,8 @@ doCleanup=false
 
 NUM_PARALLEL=1
 
+PY_EXE=${MONAI_PY_EXE:-$(which python)}
+
 function print_usage {
     echo "runtests.sh [--codeformat] [--autofix] [--black] [--isort] [--flake8] [--clangformat] [--pytype] [--mypy]"
     echo "            [--nounittests] [--coverage] [--quick] [--net] [--dryrun] [-j number] [--clean] [--help] [--version]"
@@ -62,7 +64,7 @@ function print_usage {
     echo "./runtests.sh --codeformat --nounittests  # run coding style and static type checking."
     echo "./runtests.sh --quick                     # run minimal unit tests, for quick verification during code developments."
     echo "./runtests.sh --autofix --nounittests     # run automatic code formatting using \"isort\" and \"black\"."
-    echo "./runtests.sh --clean                     # clean up temporary files and run \"python setup.py develop --uninstall\"."
+    echo "./runtests.sh --clean                     # clean up temporary files and run \"${PY_EXE} setup.py develop --uninstall\"."
     echo ""
     echo "Code style check options:"
     echo "    --black           : perform \"black\" code format checks"
@@ -92,39 +94,40 @@ function print_usage {
     echo "${separator}For bug reports, questions, and discussions, please file an issue at:"
     echo "    https://github.com/Project-MONAI/MONAI/issues/new/choose"
     echo ""
+    echo "To choose an alternative python executable, set the environmental variable, \"MONAI_PY_EXE\"."
     exit 1
 }
 
 function check_import {
-    echo "PYTHON: $(which python)"
-    ${cmdPrefix}python -c "import monai"
+    echo "python: ${PY_EXE}"
+    ${cmdPrefix}${PY_EXE} -c "import monai"
 }
 
 function print_version {
-    ${cmdPrefix}python -c 'import monai; monai.config.print_config()'
+    ${cmdPrefix}${PY_EXE} -c 'import monai; monai.config.print_config()'
 }
 
 function install_deps {
     echo "Pip installing MONAI development dependencies and compile MONAI cpp extensions..."
-    ${cmdPrefix}python -m pip install -r requirements-dev.txt
+    ${cmdPrefix}${PY_EXE} -m pip install -r requirements-dev.txt
 }
 
 function compile_cpp {
     echo "Compiling and installing MONAI cpp extensions..."
     # depends on setup.py behaviour for building
     # currently setup.py uses environment variables: BUILD_MONAI and FORCE_CUDA
-    ${cmdPrefix}python setup.py -v develop --uninstall
+    ${cmdPrefix}${PY_EXE} setup.py -v develop --uninstall
     if [[ "$OSTYPE" == "darwin"* ]];
     then  # clang for mac os
-        CC=clang CXX=clang++ ${cmdPrefix}python setup.py -v develop
+        CC=clang CXX=clang++ ${cmdPrefix}${PY_EXE} setup.py -v develop
     else
-        ${cmdPrefix}python setup.py -v develop
+        ${cmdPrefix}${PY_EXE} setup.py -v develop
     fi
 }
 
 function clang_format {
     echo "Running clang-format..."
-    ${cmdPrefix}python -m tests.clang_format_utils
+    ${cmdPrefix}${PY_EXE} -m tests.clang_format_utils
     clang_format_tool='.clang-format-bin/clang-format'
     # Verify .
     if ! type -p "$clang_format_tool" >/dev/null; then
@@ -137,7 +140,7 @@ function clang_format {
 function clean_py {
     # uninstall the development package
     echo "Uninstalling MONAI development files..."
-    ${cmdPrefix}python setup.py -v develop --uninstall
+    ${cmdPrefix}${PY_EXE} setup.py -v develop --uninstall
 
     # remove temporary files (in the directory of this script)
     TO_CLEAN="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -158,7 +161,7 @@ function clean_py {
 }
 
 function torch_validate {
-    ${cmdPrefix}python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
+    ${cmdPrefix}${PY_EXE} -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
 }
 
 function print_error_msg() {
@@ -169,6 +172,10 @@ function print_error_msg() {
 function print_style_fail_msg() {
     echo "${red}Check failed!${noColor}"
     echo "Please run auto style fixes: ${green}./runtests.sh --autofix --nounittests${noColor}"
+}
+
+function is_pip_installed() {
+	return $($PY_EXE -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader(sys.argv[1]) else 1)" $1)
 }
 
 if [ -z "$1" ]
@@ -311,7 +318,7 @@ then
     fi
 
     # ensure that the necessary packages for code format testing are installed
-    if [[ ! -f "$(which isort)" ]]
+    if ! is_pip_installed isort
     then
         install_deps
     fi
@@ -319,9 +326,9 @@ then
 
     if [ $doIsortFix = true ]
     then
-        ${cmdPrefix}isort "$(pwd)"
+        ${cmdPrefix}$PY_EXE -m isort "$(pwd)"
     else
-        ${cmdPrefix}isort --check "$(pwd)"
+        ${cmdPrefix}$PY_EXE -m isort --check "$(pwd)"
     fi
 
     isort_status=$?
@@ -347,17 +354,17 @@ then
     fi
 
     # ensure that the necessary packages for code format testing are installed
-    if [[ ! -f "$(which black)" ]]
+    if ! is_pip_installed black
     then
         install_deps
     fi
-    ${cmdPrefix}black --version
+    ${cmdPrefix}$PY_EXE -m black --version
 
     if [ $doBlackFix = true ]
     then
-        ${cmdPrefix}black "$(pwd)"
+        ${cmdPrefix}$PY_EXE -m black "$(pwd)"
     else
-        ${cmdPrefix}black --check "$(pwd)"
+        ${cmdPrefix}$PY_EXE -m black --check "$(pwd)"
     fi
 
     black_status=$?
@@ -378,13 +385,13 @@ then
     echo "${separator}${blue}flake8${noColor}"
 
     # ensure that the necessary packages for code format testing are installed
-    if [[ ! -f "$(which flake8)" ]]
-    then
+    if ! is_pip_installed flake8
+	then
         install_deps
     fi
-    ${cmdPrefix}flake8 --version
+    ${cmdPrefix}$PY_EXE -m flake8 --version
 
-    ${cmdPrefix}flake8 "$(pwd)" --count --statistics
+    ${cmdPrefix}$PY_EXE -m flake8 "$(pwd)" --count --statistics
 
     flake8_status=$?
     if [ ${flake8_status} -ne 0 ]
@@ -404,13 +411,13 @@ then
     echo "${separator}${blue}pytype${noColor}"
 
     # ensure that the necessary packages for code format testing are installed
-    if [[ ! -f "$(which pytype)" ]]
+    if ! is_pip_installed pytype
     then
         install_deps
     fi
-    ${cmdPrefix}pytype --version
+    ${cmdPrefix}$PY_EXE -m pytype --version
 
-    ${cmdPrefix}pytype -j ${NUM_PARALLEL} --python-version="$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
+    ${cmdPrefix}$PY_EXE -m pytype -j ${NUM_PARALLEL} --python-version="$(${PY_EXE} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
 
     pytype_status=$?
     if [ ${pytype_status} -ne 0 ]
@@ -430,17 +437,17 @@ then
     echo "${separator}${blue}mypy${noColor}"
 
     # ensure that the necessary packages for code format testing are installed
-    if [[ ! -f "$(which mypy)" ]]
+    if ! is_pip_installed mypy
     then
         install_deps
     fi
-    ${cmdPrefix}mypy --version
+    ${cmdPrefix}$PY_EXE -m mypy --version
 
     if [ $doDryRun = true ]
     then
-        ${cmdPrefix}MYPYPATH="$(pwd)"/monai mypy "$(pwd)"
+        ${cmdPrefix}MYPYPATH="$(pwd)"/monai $PY_EXE -m mypy "$(pwd)"
     else
-        MYPYPATH="$(pwd)"/monai mypy "$(pwd)" # cmdPrefix does not work with MYPYPATH
+        MYPYPATH="$(pwd)"/monai $PY_EXE -m mypy "$(pwd)" # cmdPrefix does not work with MYPYPATH
     fi
 
     mypy_status=$?
@@ -456,7 +463,7 @@ fi
 
 
 # testing command to run
-cmd="python3"
+cmd="${PY_EXE}"
 
 # When running --quick, require doCoverage as well and set QUICKTEST environmental
 # variable to disable slow unit tests from running.


### PR DESCRIPTION
Fixes #1036.

### Description
option to set environmental variable `MONAI_PY_EXE` to set the python executable. If this environmental variable is not, then `$(which python)` is used as before, ensuring backwards compatibility. Future python calls then use `$PY_EXE`.

pip-installed packages are now run with e.g., `$PY_EXE -m flake8` instead of just `flake8`, in case they are not added to `PATH`. For example:

```
> $PY_EXE -m pip install -r requirements-dev.txt
> flake8
zsh: command not found: flake8
> $PY_EXE -m flake8
[command runs successfully]
```

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
