### PR TITLE
Add support to train not all iterations in workflows

### DIFF
--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -36,6 +36,7 @@ class Evaluator(Workflow):
     Args:
         device: an object representing the device on which to run.
         val_data_loader: Ignite engine use data_loader to run, must be torch.DataLoader.
+        epoch_length: number of iterations for one epoch, default to `len(val_data_loader)`.
         prepare_batch: function to parse image and label for current iteration.
         iteration_update: the callable function for every iteration, expect to accept `engine`
             and `batchdata` as input parameters. if not provided, use `self._iteration()` instead.
@@ -55,6 +56,7 @@ class Evaluator(Workflow):
         self,
         device: torch.device,
         val_data_loader: DataLoader,
+        epoch_length: Optional[int] = None,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
         post_transform: Optional[Transform] = None,
@@ -67,6 +69,7 @@ class Evaluator(Workflow):
             device=device,
             max_epochs=1,
             data_loader=val_data_loader,
+            epoch_length=epoch_length,
             prepare_batch=prepare_batch,
             iteration_update=iteration_update,
             post_transform=post_transform,
@@ -102,6 +105,7 @@ class SupervisedEvaluator(Evaluator):
         device: an object representing the device on which to run.
         val_data_loader: Ignite engine use data_loader to run, must be torch.DataLoader.
         network: use the network to run model forward.
+        epoch_length: number of iterations for one epoch, default to `len(val_data_loader)`.
         prepare_batch: function to parse image and label for current iteration.
         iteration_update: the callable function for every iteration, expect to accept `engine`
             and `batchdata` as input parameters. if not provided, use `self._iteration()` instead.
@@ -123,6 +127,7 @@ class SupervisedEvaluator(Evaluator):
         device: torch.device,
         val_data_loader: DataLoader,
         network: torch.nn.Module,
+        epoch_length: Optional[int] = None,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
         inferer: Inferer = SimpleInferer(),
@@ -135,6 +140,7 @@ class SupervisedEvaluator(Evaluator):
         super().__init__(
             device=device,
             val_data_loader=val_data_loader,
+            epoch_length=epoch_length,
             prepare_batch=prepare_batch,
             iteration_update=iteration_update,
             post_transform=post_transform,
@@ -190,6 +196,7 @@ class EnsembleEvaluator(Evaluator):
     Args:
         device: an object representing the device on which to run.
         val_data_loader: Ignite engine use data_loader to run, must be torch.DataLoader.
+        epoch_length: number of iterations for one epoch, default to `len(val_data_loader)`.
         networks: use the networks to run model forward in order.
         pred_keys: the keys to store every prediction data.
             the length must exactly match the number of networks.
@@ -215,6 +222,7 @@ class EnsembleEvaluator(Evaluator):
         val_data_loader: DataLoader,
         networks: Sequence[torch.nn.Module],
         pred_keys: Sequence[str],
+        epoch_length: Optional[int] = None,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
         inferer: Inferer = SimpleInferer(),
@@ -227,6 +235,7 @@ class EnsembleEvaluator(Evaluator):
         super().__init__(
             device=device,
             val_data_loader=val_data_loader,
+            epoch_length=epoch_length,
             prepare_batch=prepare_batch,
             iteration_update=iteration_update,
             post_transform=post_transform,

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -60,6 +60,7 @@ class SupervisedTrainer(Trainer):
         network: to train with this network.
         optimizer: the optimizer associated to the network.
         loss_function: the loss function associated to the optimizer.
+        epoch_length: number of iterations for one epoch, default to `len(train_data_loader)`.
         prepare_batch: function to parse image and label for current iteration.
         iteration_update: the callable function for every iteration, expect to accept `engine`
             and `batchdata` as input parameters. if not provided, use `self._iteration()` instead.
@@ -84,6 +85,7 @@ class SupervisedTrainer(Trainer):
         network: torch.nn.Module,
         optimizer: Optimizer,
         loss_function: Callable,
+        epoch_length: Optional[int] = None,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
         inferer: Inferer = SimpleInferer(),
@@ -98,6 +100,7 @@ class SupervisedTrainer(Trainer):
             device=device,
             max_epochs=max_epochs,
             data_loader=train_data_loader,
+            epoch_length=epoch_length,
             prepare_batch=prepare_batch,
             iteration_update=iteration_update,
             post_transform=post_transform,
@@ -173,6 +176,7 @@ class GanTrainer(Trainer):
         d_network: discriminator (D) network architecture.
         d_optimizer: D optimizer function.
         d_loss_function: D loss function for optimizer.
+        epoch_length: number of iterations for one epoch, default to `len(train_data_loader)`.
         g_inferer: inference method to execute G model forward. Defaults to ``SimpleInferer()``.
         d_inferer: inference method to execute D model forward. Defaults to ``SimpleInferer()``.
         d_train_steps: number of times to update D with real data minibatch. Defaults to ``1``.
@@ -206,6 +210,7 @@ class GanTrainer(Trainer):
         d_network: torch.nn.Module,
         d_optimizer: Optimizer,
         d_loss_function: Callable,
+        epoch_length: Optional[int] = None,
         g_inferer: Inferer = SimpleInferer(),
         d_inferer: Inferer = SimpleInferer(),
         d_train_steps: int = 1,
@@ -224,6 +229,7 @@ class GanTrainer(Trainer):
             device=device,
             max_epochs=max_epochs,
             data_loader=train_data_loader,
+            epoch_length=epoch_length,
             prepare_batch=d_prepare_batch,
             iteration_update=iteration_update,
             key_metric=key_train_metric,

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -44,6 +44,7 @@ class Workflow(IgniteEngine):  # type: ignore[valid-type, misc] # due to optiona
         device: an object representing the device on which to run.
         max_epochs: the total epoch number for engine to run, validator and evaluator have only 1 epoch.
         data_loader: Ignite engine use data_loader to run, must be torch.DataLoader.
+        epoch_length: number of iterations for one epoch, default to `len(data_loader)`.
         prepare_batch: function to parse image and label for every iteration.
         iteration_update: the callable function for every iteration, expect to accept `engine`
             and `batchdata` as input parameters. if not provided, use `self._iteration()` instead.
@@ -70,6 +71,7 @@ class Workflow(IgniteEngine):  # type: ignore[valid-type, misc] # due to optiona
         device: torch.device,
         max_epochs: int,
         data_loader: DataLoader,
+        epoch_length: Optional[int] = None,
         prepare_batch: Callable = default_prepare_batch,
         iteration_update: Optional[Callable] = None,
         post_transform: Optional[Callable] = None,
@@ -99,7 +101,7 @@ class Workflow(IgniteEngine):  # type: ignore[valid-type, misc] # due to optiona
             iteration=0,
             epoch=0,
             max_epochs=max_epochs,
-            epoch_length=len(data_loader),
+            epoch_length=len(data_loader) if epoch_length is None else epoch_length,
             output=None,
             batch=None,
             metrics={},


### PR DESCRIPTION
Signed-off-by: Nic Ma <nma@nvidia.com>

### Description
This PR added support to only train/evaluate several iterations of a very big dataset or iterable dataset.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
