### PR TITLE
606 reduce sliding window memory footprint

### DIFF
--- a/docs/source/inferers.rst
+++ b/docs/source/inferers.rst
@@ -17,13 +17,16 @@ Inferers
 .. currentmodule:: monai.inferers
 .. autoclass:: Inferer
     :members:
+    :special-members: __call__
 
 `SimpleInferer`
 ~~~~~~~~~~~~~~~
 .. autoclass:: SimpleInferer
     :members:
+    :special-members: __call__
 
 `SlidingWindowInferer`
 ~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: SlidingWindowInferer
     :members:
+    :special-members: __call__

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Sequence, Union
+from typing import Callable, Sequence, Union
 
 import torch
 
@@ -114,13 +114,14 @@ class SlidingWindowInferer(Inferer):
         self.padding_mode = padding_mode
         self.cval = cval
 
-    def __call__(self, inputs: torch.Tensor, network: torch.nn.Module) -> torch.Tensor:
+    def __call__(self, inputs: torch.Tensor, network: Callable[[torch.Tensor], torch.Tensor]) -> torch.Tensor:
         """
         Unified callable function API of Inferers.
 
         Args:
             inputs: model input data for inference.
             network: target model to execute inference.
+                supports callables such as ``lambda x: torch_model(x, additional_config)``
 
         """
         return sliding_window_inference(

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -25,7 +25,7 @@ class Inferer(ABC):
     """
 
     @abstractmethod
-    def __call__(self, inputs: torch.Tensor, network: torch.nn.Module):
+    def __call__(self, inputs: torch.Tensor, network: Callable[[torch.Tensor], torch.Tensor]):
         """
         Run inference on `inputs` with the `network` model.
 
@@ -49,13 +49,13 @@ class SimpleInferer(Inferer):
     def __init__(self) -> None:
         Inferer.__init__(self)
 
-    def __call__(self, inputs: torch.Tensor, network: torch.nn.Module):
+    def __call__(self, inputs: torch.Tensor, network: Callable[[torch.Tensor], torch.Tensor]):
         """Unified callable function API of Inferers.
 
         Args:
             inputs: model input data for inference.
             network: target model to execute inference.
-
+                supports callables such as ``lambda x: my_torch_model(x, additional_config)``
         """
         return network(inputs)
 
@@ -116,12 +116,11 @@ class SlidingWindowInferer(Inferer):
 
     def __call__(self, inputs: torch.Tensor, network: Callable[[torch.Tensor], torch.Tensor]) -> torch.Tensor:
         """
-        Unified callable function API of Inferers.
 
         Args:
             inputs: model input data for inference.
             network: target model to execute inference.
-                supports callables such as ``lambda x: torch_model(x, additional_config)``
+                supports callables such as ``lambda x: my_torch_model(x, additional_config)``
 
         """
         return sliding_window_inference(

--- a/tests/test_gaussian_filter.py
+++ b/tests/test_gaussian_filter.py
@@ -66,7 +66,7 @@ class GaussianFilterBackprop(unittest.TestCase):
         for s in range(1000):
             optimizer.zero_grad()
             pred = trainable(base)
-            loss = torch.square(pred - target).mean()
+            loss = torch.pow(pred - target, 2).mean()
             loss.backward()
             if (s + 1) % 50 == 0:
                 var = list(trainable.parameters())[0]

--- a/tests/test_sliding_window_inference.py
+++ b/tests/test_sliding_window_inference.py
@@ -17,65 +17,56 @@ from parameterized import parameterized
 
 from monai.inferers import SlidingWindowInferer, sliding_window_inference
 
-TEST_CASE_0 = [(1, 3, 16, 15, 7), (4, -1, 7), 3, 0.25, "constant", torch.device("cpu:0")]  # 3D small roi
-
-TEST_CASE_1 = [(1, 3, 16, 15, 7), (4, 10, 7), 3, 0.25, "constant", torch.device("cpu:0")]  # 3D small roi
-
-TEST_CASE_2 = [(1, 3, 16, 15, 7), (20, 22, 23), 10, 0.25, "constant", torch.device("cpu:0")]  # 3D large roi
-
-TEST_CASE_3 = [(1, 3, 15, 7), (2, 6), 1000, 0.25, "constant", torch.device("cpu:0")]  # 2D small roi, large batch
-
-TEST_CASE_4 = [(1, 3, 16, 7), (80, 50), 7, 0.25, "constant", torch.device("cpu:0")]  # 2D large roi
-
-TEST_CASE_5 = [(1, 3, 16, 15, 7), (20, 22, 23), 10, 0.5, "constant", torch.device("cpu:0")]  # 3D large overlap
-
-TEST_CASE_6 = [(1, 3, 16, 7), (80, 50), 7, 0.5, "gaussian", torch.device("cpu:0")]  # 2D large overlap, gaussian
-
-TEST_CASE_7 = [(1, 3, 16, 15, 7), (4, 10, 7), 3, 0.25, "gaussian", torch.device("cpu:0")]  # 3D small roi, gaussian
-
-TEST_CASE_8 = [
-    (1, 3, 16, 15, 7),
-    (4, 10, 7),
-    3,
-    0.25,
-    "gaussian",
-    torch.device("cuda:0"),
-]  # test inference on gpu if availabe
-
-TEST_CASE_9 = [(1, 3, 16, 15, 7), (4, 1, 7), 3, 0.25, "constant", torch.device("cpu:0")]  # 3D small roi
+TEST_CASES = [
+    [(1, 3, 16, 15, 7), (4, -1, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi
+    [(2, 3, 16, 15, 7), (4, -1, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi
+    [(3, 3, 16, 15, 7), (4, -1, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi
+    [(2, 3, 16, 15, 7), (4, -1, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi
+    [(1, 3, 16, 15, 7), (4, 10, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi
+    [(1, 3, 16, 15, 7), (20, 22, 23), 10, 0.25, "constant", torch.device("cpu:0")],  # 3D large roi
+    [(2, 3, 15, 7), (2, 6), 1000, 0.25, "constant", torch.device("cpu:0")],  # 2D small roi, large batch
+    [(1, 3, 16, 7), (80, 50), 7, 0.25, "constant", torch.device("cpu:0")],  # 2D large roi
+    [(1, 3, 16, 15, 7), (20, 22, 23), 10, 0.5, "constant", torch.device("cpu:0")],  # 3D large overlap
+    [(1, 3, 16, 7), (80, 50), 7, 0.5, "gaussian", torch.device("cpu:0")],  # 2D large overlap, gaussian
+    [(1, 3, 16, 15, 7), (4, 10, 7), 3, 0.25, "gaussian", torch.device("cpu:0")],  # 3D small roi, gaussian
+    [(3, 3, 16, 15, 7), (4, 10, 7), 3, 0.25, "gaussian", torch.device("cpu:0")],  # 3D small roi, gaussian
+    [
+        (1, 3, 16, 15, 7),
+        (4, 10, 7),
+        3,
+        0.25,
+        "gaussian",
+        torch.device("cuda:0"),
+    ],  # test inference on gpu if availabe
+    [(1, 3, 16, 15, 7), (4, 1, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi
+    [(5, 3, 16, 15, 7), (4, 1, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi
+]
 
 
 class TestSlidingWindowInference(unittest.TestCase):
-    @parameterized.expand(
-        [
-            TEST_CASE_0,
-            TEST_CASE_1,
-            TEST_CASE_2,
-            TEST_CASE_3,
-            TEST_CASE_4,
-            TEST_CASE_5,
-            TEST_CASE_6,
-            TEST_CASE_7,
-            TEST_CASE_8,
-            TEST_CASE_9,
-        ]
-    )
+    @parameterized.expand(TEST_CASES)
     def test_sliding_window_default(self, image_shape, roi_shape, sw_batch_size, overlap, mode, device):
-        inputs = torch.ones(*image_shape)
+        n_total = np.prod(image_shape)
+        if mode == "constant":
+            inputs = torch.arange(n_total, dtype=torch.float).reshape(*image_shape)
+        else:
+            inputs = torch.ones(*image_shape, dtype=torch.float)
         if device.type == "cuda" and not torch.cuda.is_available():
             device = torch.device("cpu:0")
 
         def compute(data):
             return data + 1
 
+        if mode == "constant":
+            expected_val = np.arange(n_total, dtype=np.float32).reshape(*image_shape) + 1.0
+        else:
+            expected_val = np.ones(image_shape, dtype=np.float32) + 1.0
         result = sliding_window_inference(inputs.to(device), roi_shape, sw_batch_size, compute, overlap, mode=mode)
         np.testing.assert_string_equal(device.type, result.device.type)
-        expected_val = np.ones(image_shape, dtype=np.float32) + 1
         np.testing.assert_allclose(result.cpu().numpy(), expected_val)
 
         result = SlidingWindowInferer(roi_shape, sw_batch_size, overlap, mode)(inputs.to(device), compute)
         np.testing.assert_string_equal(device.type, result.device.type)
-        expected_val = np.ones(image_shape, dtype=np.float32) + 1
         np.testing.assert_allclose(result.cpu().numpy(), expected_val)
 
     def test_default_device(self):

--- a/tests/test_sliding_window_inference.py
+++ b/tests/test_sliding_window_inference.py
@@ -18,6 +18,8 @@ from parameterized import parameterized
 from monai.inferers import SlidingWindowInferer, sliding_window_inference
 
 TEST_CASES = [
+    [(2, 3, 16), (4,), 3, 0.25, "constant", torch.device("cpu:0")],  # 1D small roi
+    [(2, 3, 16, 15, 7, 9), 4, 3, 0.25, "constant", torch.device("cpu:0")],  # 4D small roi
     [(1, 3, 16, 15, 7), (4, -1, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi
     [(2, 3, 16, 15, 7), (4, -1, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi
     [(3, 3, 16, 15, 7), (4, -1, 7), 3, 0.25, "constant", torch.device("cpu:0")],  # 3D small roi


### PR DESCRIPTION
addresses the issue raised in the comment https://github.com/Project-MONAI/MONAI/issues/606#issuecomment-709802874,
this PR
- largely reduces the sliding window memory footprint because `slice_batches `, `output_rois` are not allocated
- uses more generic indexing convention
- adds support for input batch_size > 1

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.