### PR TITLE
1115 Add pretrained weights support for AHNet

### DIFF
--- a/monai/networks/nets/ahnet.py
+++ b/monai/networks/nets/ahnet.py
@@ -365,6 +365,7 @@ class AHNet(nn.Module):
             - ``"bilinear"``, uses bilinear interpolate.
             - ``"trilinear"``, uses trilinear interpolate.
         pretrained: whether to load pretrained weights from ResNet50 to initialize convolution layers, default to False.
+        progress: If True, displays a progress bar of the download of pretrained weights to stderr.
     """
 
     def __init__(
@@ -375,6 +376,7 @@ class AHNet(nn.Module):
         out_channels: int = 1,
         upsample_mode: str = "transpose",
         pretrained: bool = False,
+        progress: bool = True,
     ):
         self.inplanes = 64
         super(AHNet, self).__init__()
@@ -462,7 +464,7 @@ class AHNet(nn.Module):
                 m.bias.data.zero_()
 
         if pretrained:
-            net2d = FCN(pretrained=True)
+            net2d = FCN(pretrained=True, progress=progress)
             self.copy_from(net2d)
 
     def _make_layer(

--- a/monai/networks/nets/ahnet.py
+++ b/monai/networks/nets/ahnet.py
@@ -16,8 +16,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from monai.networks.layers.factories import Act, Conv, Norm, Pool
 from monai.networks.blocks import FCN
+from monai.networks.layers.factories import Act, Conv, Norm, Pool
 
 
 class Bottleneck3x3x1(nn.Module):

--- a/monai/networks/nets/ahnet.py
+++ b/monai/networks/nets/ahnet.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from monai.networks.layers.factories import Act, Conv, Norm, Pool
+from monai.networks.blocks import FCN
 
 
 class Bottleneck3x3x1(nn.Module):
@@ -363,6 +364,7 @@ class AHNet(nn.Module):
             - ``"transpose"``, uses transposed convolution layers.
             - ``"bilinear"``, uses bilinear interpolate.
             - ``"trilinear"``, uses trilinear interpolate.
+        pretrained: whether to load pretrained weights from ResNet50 to initialize convolution layers, default to False.
     """
 
     def __init__(
@@ -372,6 +374,7 @@ class AHNet(nn.Module):
         in_channels: int = 1,
         out_channels: int = 1,
         upsample_mode: str = "transpose",
+        pretrained: bool = False,
     ):
         self.inplanes = 64
         super(AHNet, self).__init__()
@@ -457,6 +460,10 @@ class AHNet(nn.Module):
             elif isinstance(m, norm_type):
                 m.weight.data.fill_(1)
                 m.bias.data.zero_()
+
+        if pretrained:
+            net2d = FCN(pretrained=True)
+            self.copy_from(net2d)
 
     def _make_layer(
         self,

--- a/tests/test_ahnet.py
+++ b/tests/test_ahnet.py
@@ -93,7 +93,7 @@ TEST_CASE_AHNET_3D_WITH_PRETRAIN_2 = [
     {"out_channels": 1, "upsample_mode": "bilinear"},
 ]
 TEST_CASE_AHNET_3D_WITH_PRETRAIN_3 = [
-    {"spatial_dims": 3, "upsample_mode": "transpose", "in_channels": 2, "out_channels": 3, "progress": True},
+    {"spatial_dims": 3, "upsample_mode": "transpose", "in_channels": 2, "out_channels": 3},
     torch.randn(2, 2, 128, 128, 64),
     (2, 3, 128, 128, 64),
     {"out_channels": 1, "upsample_mode": "bilinear"},
@@ -159,7 +159,14 @@ class TestAHNETWithPretrain(unittest.TestCase):
             self.assertEqual(result.shape, expected_shape)
 
     def test_initialize_pretrained(self):
-        net = AHNet(spatial_dims=3, upsample_mode="transpose", in_channels=2, out_channels=3, pretrained=True)
+        net = AHNet(
+            spatial_dims=3,
+            upsample_mode="transpose",
+            in_channels=2,
+            out_channels=3,
+            pretrained=True,
+            progress=True,
+        )
         input_data = torch.randn(2, 2, 128, 128, 64)
         with torch.no_grad():
             result = net.forward(input_data)

--- a/tests/test_ahnet.py
+++ b/tests/test_ahnet.py
@@ -158,6 +158,13 @@ class TestAHNETWithPretrain(unittest.TestCase):
             result = net.forward(input_data)
             self.assertEqual(result.shape, expected_shape)
 
+    def test_initialize_pretrained(self):
+        net = AHNet(spatial_dims=3, upsample_mode="transpose", in_channels=2, out_channels=3, pretrained=True)
+        input_data = torch.randn(2, 2, 128, 128, 64)
+        with torch.no_grad():
+            result = net.forward(input_data)
+            self.assertEqual(result.shape, (2, 3, 128, 128, 64))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ahnet.py
+++ b/tests/test_ahnet.py
@@ -93,7 +93,7 @@ TEST_CASE_AHNET_3D_WITH_PRETRAIN_2 = [
     {"out_channels": 1, "upsample_mode": "bilinear"},
 ]
 TEST_CASE_AHNET_3D_WITH_PRETRAIN_3 = [
-    {"spatial_dims": 3, "upsample_mode": "transpose", "in_channels": 2, "out_channels": 3},
+    {"spatial_dims": 3, "upsample_mode": "transpose", "in_channels": 2, "out_channels": 3, "progress": True},
     torch.randn(2, 2, 128, 128, 64),
     (2, 3, 128, 128, 64),
     {"out_channels": 1, "upsample_mode": "bilinear"},


### PR DESCRIPTION
Fixes #1115 .

### Description
This PR added `pretrained` parameter to `AHNet`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
