### PR TITLE
1117 Add TorchScript compatible test

### DIFF
--- a/monai/networks/nets/ahnet.py
+++ b/monai/networks/nets/ahnet.py
@@ -227,9 +227,9 @@ class Pseudo3DLayer(nn.Module):
         x = self.relu4(x)
         new_features = self.conv4(x)
 
-        self.dropout_prob = 0  # Dropout will make trouble!
+        self.dropout_prob = 0.0  # Dropout will make trouble!
         # since we use the train mode for inference
-        if self.dropout_prob > 0:
+        if self.dropout_prob > 0.0:
             new_features = F.dropout(new_features, p=self.dropout_prob, training=self.training)
         return torch.cat([inx, new_features], 1)
 

--- a/monai/networks/nets/ahnet.py
+++ b/monai/networks/nets/ahnet.py
@@ -299,28 +299,27 @@ class PSP(nn.Module):
             x16 = self.up16(self.proj16(self.pool16(x)))
             x8 = self.up8(self.proj8(self.pool8(x)))
         else:
-            interpolate_size = tuple(x.size()[2:])
             x64 = F.interpolate(
                 self.proj64(self.pool64(x)),
-                size=interpolate_size,
+                scale_factor=(64, 64, 1)[-self.spatial_dims:],
                 mode=self.upsample_mode,
                 align_corners=True,
             )
             x32 = F.interpolate(
                 self.proj32(self.pool32(x)),
-                size=interpolate_size,
+                scale_factor=(32, 32, 1)[-self.spatial_dims:],
                 mode=self.upsample_mode,
                 align_corners=True,
             )
             x16 = F.interpolate(
                 self.proj16(self.pool16(x)),
-                size=interpolate_size,
+                scale_factor=(16, 16, 1)[-self.spatial_dims:],
                 mode=self.upsample_mode,
                 align_corners=True,
             )
             x8 = F.interpolate(
                 self.proj8(self.pool8(x)),
-                size=interpolate_size,
+                scale_factor=(8, 8, 1)[-self.spatial_dims:],
                 mode=self.upsample_mode,
                 align_corners=True,
             )

--- a/monai/networks/nets/ahnet.py
+++ b/monai/networks/nets/ahnet.py
@@ -299,7 +299,7 @@ class PSP(nn.Module):
             x16 = self.up16(self.proj16(self.pool16(x)))
             x8 = self.up8(self.proj8(self.pool8(x)))
         else:
-            interpolate_size = tuple(x.size()[2:])
+            interpolate_size = x.shape[2:]
             x64 = F.interpolate(
                 self.proj64(self.pool64(x)),
                 size=interpolate_size,
@@ -350,8 +350,6 @@ class AHNet(nn.Module):
         model = monai.networks.nets.AHNet(out_channels=2, upsample_mode='transpose')
         model2d = monai.networks.blocks.FCN()
         model.copy_from(model2d)
-
-    Note that as this network contains dynamic parameters, it can't support ``torch.jit.script`` export.
 
     Args:
         layers: number of residual blocks for 4 layers of the network (layer1...layer4). Defaults to ``(3, 4, 6, 3)``.

--- a/monai/networks/nets/ahnet.py
+++ b/monai/networks/nets/ahnet.py
@@ -299,27 +299,28 @@ class PSP(nn.Module):
             x16 = self.up16(self.proj16(self.pool16(x)))
             x8 = self.up8(self.proj8(self.pool8(x)))
         else:
+            interpolate_size = tuple(x.size()[2:])
             x64 = F.interpolate(
                 self.proj64(self.pool64(x)),
-                scale_factor=(64, 64, 1)[-self.spatial_dims:],
+                size=interpolate_size,
                 mode=self.upsample_mode,
                 align_corners=True,
             )
             x32 = F.interpolate(
                 self.proj32(self.pool32(x)),
-                scale_factor=(32, 32, 1)[-self.spatial_dims:],
+                size=interpolate_size,
                 mode=self.upsample_mode,
                 align_corners=True,
             )
             x16 = F.interpolate(
                 self.proj16(self.pool16(x)),
-                scale_factor=(16, 16, 1)[-self.spatial_dims:],
+                size=interpolate_size,
                 mode=self.upsample_mode,
                 align_corners=True,
             )
             x8 = F.interpolate(
                 self.proj8(self.pool8(x)),
-                scale_factor=(8, 8, 1)[-self.spatial_dims:],
+                size=interpolate_size,
                 mode=self.upsample_mode,
                 align_corners=True,
             )
@@ -349,6 +350,8 @@ class AHNet(nn.Module):
         model = monai.networks.nets.AHNet(out_channels=2, upsample_mode='transpose')
         model2d = monai.networks.blocks.FCN()
         model.copy_from(model2d)
+
+    Note that as this network contains dynamic parameters, it can't support ``torch.jit.script`` export.
 
     Args:
         layers: number of residual blocks for 4 layers of the network (layer1...layer4). Defaults to ``(3, 4, 6, 3)``.

--- a/monai/networks/nets/dynunet.py
+++ b/monai/networks/nets/dynunet.py
@@ -37,8 +37,6 @@ class DynUNet(nn.Module):
     Therefore, pleasure ensure that the length of input sequences (``kernel_size`` and ``strides``)
     is no less than 3 in order to have at least one downsample upsample blocks.
 
-    Note that as this network contains dynamic parameters, it can't support ``torch.jit.script`` export.
-
     Args:
         spatial_dims: number of spatial dimensions.
         in_channels: number of input channels.

--- a/monai/networks/nets/dynunet.py
+++ b/monai/networks/nets/dynunet.py
@@ -37,6 +37,8 @@ class DynUNet(nn.Module):
     Therefore, pleasure ensure that the length of input sequences (``kernel_size`` and ``strides``)
     is no less than 3 in order to have at least one downsample upsample blocks.
 
+    Note that as this network contains dynamic parameters, it can't support ``torch.jit.script`` export.
+
     Args:
         spatial_dims: number of spatial dimensions.
         in_channels: number of input channels.

--- a/tests/test_ahnet.py
+++ b/tests/test_ahnet.py
@@ -16,7 +16,7 @@ from parameterized import parameterized
 
 from monai.networks.blocks import FCN, MCFCN
 from monai.networks.nets import AHNet
-from tests.utils import skip_if_quick
+from tests.utils import skip_if_quick, test_script_save
 
 TEST_CASE_FCN_1 = [
     {"out_channels": 3, "upsample_mode": "transpose"},
@@ -138,6 +138,12 @@ class TestAHNET(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(input_data)
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        net = AHNet(spatial_dims=3, out_channels=2)
+        test_data = torch.randn(1, 1, 128, 128, 64)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
 
 
 class TestAHNETWithPretrain(unittest.TestCase):

--- a/tests/test_ahnet.py
+++ b/tests/test_ahnet.py
@@ -16,7 +16,7 @@ from parameterized import parameterized
 
 from monai.networks.blocks import FCN, MCFCN
 from monai.networks.nets import AHNet
-from tests.utils import skip_if_quick
+from tests.utils import skip_if_quick, test_script_save
 
 TEST_CASE_FCN_1 = [
     {"out_channels": 3, "upsample_mode": "transpose"},
@@ -138,6 +138,12 @@ class TestAHNET(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(input_data)
             self.assertEqual(result.shape, expected_shape)
+
+    def test_ahnet_script(self):
+        net = AHNet(in_channels=2)
+        test_data = torch.randn(2, 2, 128, 128, 64)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
 
 
 class TestAHNETWithPretrain(unittest.TestCase):

--- a/tests/test_ahnet.py
+++ b/tests/test_ahnet.py
@@ -16,7 +16,7 @@ from parameterized import parameterized
 
 from monai.networks.blocks import FCN, MCFCN
 from monai.networks.nets import AHNet
-from tests.utils import skip_if_quick, test_script_save
+from tests.utils import skip_if_quick
 
 TEST_CASE_FCN_1 = [
     {"out_channels": 3, "upsample_mode": "transpose"},
@@ -138,12 +138,6 @@ class TestAHNET(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(input_data)
             self.assertEqual(result.shape, expected_shape)
-
-    def test_ahnet_script(self):
-        net = AHNet(in_channels=2)
-        test_data = torch.randn(2, 2, 128, 128, 64)
-        out_orig, out_reloaded = test_script_save(net, test_data)
-        assert torch.allclose(out_orig, out_reloaded)
 
 
 class TestAHNETWithPretrain(unittest.TestCase):

--- a/tests/test_discriminator.py
+++ b/tests/test_discriminator.py
@@ -13,8 +13,9 @@ import unittest
 
 import torch
 from parameterized import parameterized
-from tests.utils import test_script_save
+
 from monai.networks.nets import Discriminator
+from tests.utils import test_script_save
 
 TEST_CASE_0 = [
     {"in_shape": (1, 64, 64), "channels": (2, 4, 8), "strides": (2, 2, 2), "num_res_units": 0},

--- a/tests/test_discriminator.py
+++ b/tests/test_discriminator.py
@@ -13,7 +13,7 @@ import unittest
 
 import torch
 from parameterized import parameterized
-
+from tests.utils import test_script_save
 from monai.networks.nets import Discriminator
 
 TEST_CASE_0 = [
@@ -45,6 +45,12 @@ class TestDiscriminator(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(input_data)
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        net = Discriminator(in_shape=(1, 64, 64), channels=(2, 4), strides=(2, 2), num_res_units=0)
+        test_data = torch.rand(16, 1, 64, 64)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
 
 
 if __name__ == "__main__":

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -13,7 +13,7 @@ import unittest
 
 import torch
 from parameterized import parameterized
-
+from tests.utils import test_script_save
 from monai.networks.nets import Generator
 
 TEST_CASE_0 = [
@@ -45,6 +45,12 @@ class TestGenerator(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(input_data)
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        net = Generator(latent_shape=(64,), start_shape=(8, 8, 8), channels=(8, 1), strides=(2, 2), num_res_units=2)
+        test_data = torch.rand(16, 64)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
 
 
 if __name__ == "__main__":

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -13,8 +13,9 @@ import unittest
 
 import torch
 from parameterized import parameterized
-from tests.utils import test_script_save
+
 from monai.networks.nets import Generator
+from tests.utils import test_script_save
 
 TEST_CASE_0 = [
     {"latent_shape": (64,), "start_shape": (8, 8, 8), "channels": (8, 4, 1), "strides": (2, 2, 2), "num_res_units": 0},

--- a/tests/test_unet.py
+++ b/tests/test_unet.py
@@ -13,9 +13,10 @@ import unittest
 
 import torch
 from parameterized import parameterized
-from tests.utils import test_script_save
+
 from monai.networks.layers import Act, Norm
 from monai.networks.nets import UNet
+from tests.utils import test_script_save
 
 TEST_CASE_0 = [  # single channel 2D, batch 16, no residual
     {

--- a/tests/test_unet.py
+++ b/tests/test_unet.py
@@ -13,7 +13,7 @@ import unittest
 
 import torch
 from parameterized import parameterized
-
+from tests.utils import test_script_save
 from monai.networks.layers import Act, Norm
 from monai.networks.nets import UNet
 
@@ -122,6 +122,12 @@ class TestUNET(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(input_data)
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        net = UNet(dimensions=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2), num_res_units=0)
+        test_data = torch.randn(16, 1, 32, 32)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
 
 
 if __name__ == "__main__":

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -13,8 +13,9 @@ import unittest
 
 import torch
 from parameterized import parameterized
-from tests.utils import test_script_save
+
 from monai.networks.nets import VNet
+from tests.utils import test_script_save
 
 TEST_CASE_VNET_2D_1 = [
     {"spatial_dims": 2, "in_channels": 4, "out_channels": 1, "act": "elu", "dropout_dim": 1},

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -13,7 +13,7 @@ import unittest
 
 import torch
 from parameterized import parameterized
-
+from tests.utils import test_script_save
 from monai.networks.nets import VNet
 
 TEST_CASE_VNET_2D_1 = [
@@ -65,3 +65,9 @@ class TestVNet(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(input_data)
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        net = VNet(spatial_dims=3, in_channels=1, out_channels=3, dropout_dim=3)
+        test_data = torch.randn(1, 1, 32, 32, 32)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ import os
 import tempfile
 import unittest
 from subprocess import PIPE, Popen
-
+from io import BytesIO
 import numpy as np
 import torch
 
@@ -95,6 +95,13 @@ def expect_failure_if_no_gpu(test):
         return unittest.expectedFailure(test)
     else:
         return test
+
+def test_script_save(net, *inputs):
+    scripted = torch.jit.script(net)
+    buffer = scripted.save_to_buffer()
+    reloaded_net = torch.jit.load(BytesIO(buffer))
+
+    return net(*inputs), reloaded_net(*inputs)
 
 
 def query_memory(n=2):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -96,12 +96,17 @@ def expect_failure_if_no_gpu(test):
     else:
         return test
 
-def test_script_save(net, *inputs):
+def test_script_save(net, inputs):
     scripted = torch.jit.script(net)
     buffer = scripted.save_to_buffer()
     reloaded_net = torch.jit.load(BytesIO(buffer))
+    net.eval()
+    reloaded_net.eval()
+    with torch.no_grad():
+        result1 = net.forward(inputs)
+        result2 = reloaded_net.forward(inputs)
 
-    return net(*inputs), reloaded_net(*inputs)
+    return result1, result2
 
 
 def query_memory(n=2):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,8 +12,9 @@
 import os
 import tempfile
 import unittest
-from subprocess import PIPE, Popen
 from io import BytesIO
+from subprocess import PIPE, Popen
+
 import numpy as np
 import torch
 
@@ -96,6 +97,7 @@ def expect_failure_if_no_gpu(test):
     else:
         return test
 
+
 def test_script_save(net, inputs):
     scripted = torch.jit.script(net)
     buffer = scripted.save_to_buffer()
@@ -103,8 +105,8 @@ def test_script_save(net, inputs):
     net.eval()
     reloaded_net.eval()
     with torch.no_grad():
-        result1 = net.forward(inputs)
-        result2 = reloaded_net.forward(inputs)
+        result1 = net(inputs)
+        result2 = reloaded_net(inputs)
 
     return result1, result2
 


### PR DESCRIPTION
Fixes #1117 .

### Description
This PR added TorchScript tests for several networks, other networks contain some logic that can't support `torch.jit.script` and not easy to fix.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
