### PR TITLE
1057 Add ignite handler for confusion matrix metric

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -34,6 +34,12 @@ ROC AUC metrics handler
     :members:
 
 
+Confusion Matrix metrics handler
+--------------------------------
+.. autoclass:: ConfusionMatrix
+    :members:
+
+
 Metric logger
 -------------
 .. autoclass:: MetricLogger

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -19,7 +19,7 @@ Metrics
 
 `Confusion Matrix`
 ------------------
-.. autofunction:: compute_confusion_metric
+.. autofunction:: compute_confusion_matrix
 
 `Hausdorff Distance`
 --------------------

--- a/monai/handlers/__init__.py
+++ b/monai/handlers/__init__.py
@@ -12,6 +12,7 @@
 from .checkpoint_loader import CheckpointLoader
 from .checkpoint_saver import CheckpointSaver
 from .classification_saver import ClassificationSaver
+from .confusion_matrix import ConfusionMatrix
 from .lr_schedule_handler import LrScheduleHandler
 from .mean_dice import MeanDice
 from .metric_logger import MetricLogger

--- a/monai/handlers/confusion_matrix.py
+++ b/monai/handlers/confusion_matrix.py
@@ -14,7 +14,7 @@ from typing import Callable, List, Optional, Sequence, Union
 import torch
 import torch.distributed as dist
 
-from monai.metrics import compute_roc_auc
+from monai.metrics import compute_confusion_matrix
 from monai.utils import Average, exact_version, optional_import
 from .utils import all_gather
 
@@ -22,18 +22,37 @@ Metric, _ = optional_import("ignite.metrics", "0.4.2", exact_version, "Metric")
 reinit__is_reduced, _ = optional_import("ignite.metrics.metric", "0.4.2", exact_version, "reinit__is_reduced")
 
 
-class ROCAUC(Metric):  # type: ignore[valid-type, misc]  # due to optional_import
+class ConfusionMatrix(Metric):  # type: ignore[valid-type, misc]  # due to optional_import
     """
-    Computes Area Under the Receiver Operating Characteristic Curve (ROC AUC).
-    accumulating predictions and the ground-truth during an epoch and applying `compute_roc_auc`.
+    Compute confusion matrix related metrics. This function supports to calculate all metrics
+    mentioned in: `Confusion matrix <https://en.wikipedia.org/wiki/Confusion_matrix>`_.
+    accumulating predictions and the ground-truth during an epoch and applying `compute_confusion_matrix`.
 
     Args:
         to_onehot_y: whether to convert `y` into the one-hot format. Defaults to False.
-        softmax: whether to add softmax function to `y_pred` before computation. Defaults to False.
-        other_act: callable function to replace `softmax` as activation layer if needed, Defaults to ``None``.
-            for example: `other_act = lambda x: torch.log_softmax(x)`.
-        average: {``"macro"``, ``"weighted"``, ``"micro"``, ``"none"``}
-            Type of averaging performed if not binary classification. Defaults to ``"macro"``.
+        activation: [``"sigmoid"``, ``"softmax"``]
+            Activation method, if specified, an activation function will be employed for `y_pred`.
+            Defaults to None.
+            The parameter can also be a callable function, for example:
+            ``activation = lambda x: torch.log_softmax(x)``.
+        bin_mode: [``"threshold"``, ``"mutually_exclusive"``]
+            Binarization method, if specified, a binarization manipulation will be employed
+            for `y_pred`.
+
+            - ``"threshold"``, a single threshold or a sequence of thresholds should be set.
+            - ``"mutually_exclusive"``, `y_pred` will be converted by a combination of `argmax` and `to_onehot`.
+        bin_threshold: the threshold for binarization, can be a single value or a sequence of
+            values that each one of the value represents a threshold for a class.
+        metric_name: [``"sensitivity"``, ``"specificity"``, ``"precision"``, ``"negative predictive value"``,
+            ``"miss rate"``, ``"fall out"``, ``"false discovery rate"``, ``"false omission rate"``,
+            ``"prevalence threshold"``, ``"threat score"``, ``"accuracy"``, ``"balanced accuracy"``,
+            ``"f1 score"``, ``"matthews correlation coefficient"``, ``"fowlkes mallows index"``,
+            ``"informedness"``, ``"markedness"``]
+            Some of the metrics have multiple aliases (as shown in the wikipedia page aforementioned),
+            and you can also input those names instead.
+        average: [``"macro"``, ``"weighted"``, ``"micro"``, ``"none"``]
+            Type of averaging performed if not binary classification.
+            Defaults to ``"macro"``.
 
             - ``"macro"``: calculate metrics for each label, and find their unweighted mean.
                 This does not take label imbalance into account.
@@ -42,33 +61,35 @@ class ROCAUC(Metric):  # type: ignore[valid-type, misc]  # due to optional_impor
             - ``"micro"``: calculate metrics globally by considering each element of the label
                 indicator matrix as a label.
             - ``"none"``: the scores for each class are returned.
-
+        zero_division: the value to return when there is a zero division, for example, when all
+            predictions and labels are negative. Defaults to 0.
         output_transform: a callable that is used to transform the
             :class:`~ignite.engine.Engine` `process_function` output into the
             form expected by the metric. This can be useful if, for example, you have a multi-output model and
             you want to compute the metric with respect to one of the outputs.
         device: device specification in case of distributed computation usage.
 
-    Note:
-        ROCAUC expects y to be comprised of 0's and 1's.
-        y_pred must either be probability estimates or confidence values.
-
     """
-
     def __init__(
         self,
         to_onehot_y: bool = False,
-        softmax: bool = False,
-        other_act: Optional[Callable] = None,
+        activation: Optional[Union[str, Callable]] = None,
+        bin_mode: Optional[str] = "threshold",
+        bin_threshold: Union[float, Sequence[float]] = 0.5,
+        metric_name: str = "hit_rate",
         average: Union[Average, str] = Average.MACRO,
+        zero_division: int = 0,
         output_transform: Callable = lambda x: x,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(output_transform, device=device)
         self.to_onehot_y = to_onehot_y
-        self.softmax = softmax
-        self.other_act = other_act
+        self.activation = activation
+        self.bin_mode = bin_mode
+        self.bin_threshold = bin_threshold
+        self.metric_name = metric_name
         self.average: Average = Average(average)
+        self.zero_division = zero_division
 
     @reinit__is_reduced
     def reset(self) -> None:
@@ -82,7 +103,7 @@ class ROCAUC(Metric):  # type: ignore[valid-type, misc]  # due to optional_impor
             output: sequence with contents [y_pred, y].
 
         Raises:
-            ValueError: When ``output`` length is not 2. ROCAUC metric can only support y_pred and y.
+            ValueError: When ``output`` length is not 2.
             ValueError: When ``y_pred`` dimension is not one of [1, 2].
             ValueError: When ``y`` dimension is not one of [1, 2].
 
@@ -107,11 +128,14 @@ class ROCAUC(Metric):  # type: ignore[valid-type, misc]  # due to optional_impor
             _target_tensor = all_gather(_target_tensor)
             self._is_reduced = True
 
-        return compute_roc_auc(
+        return compute_confusion_matrix(
             y_pred=_prediction_tensor,
             y=_target_tensor,
             to_onehot_y=self.to_onehot_y,
-            softmax=self.softmax,
-            other_act=self.other_act,
+            activation=self.activation,
+            bin_mode=self.bin_mode,
+            bin_threshold=self.bin_threshold,
+            metric_name=self.metric_name,
             average=self.average,
+            zero_division=self.zero_division,
         )

--- a/monai/handlers/confusion_matrix.py
+++ b/monai/handlers/confusion_matrix.py
@@ -16,6 +16,7 @@ import torch.distributed as dist
 
 from monai.metrics import compute_confusion_matrix
 from monai.utils import Average, exact_version, optional_import
+
 from .utils import all_gather
 
 Metric, _ = optional_import("ignite.metrics", "0.4.2", exact_version, "Metric")
@@ -70,6 +71,7 @@ class ConfusionMatrix(Metric):  # type: ignore[valid-type, misc]  # due to optio
         device: device specification in case of distributed computation usage.
 
     """
+
     def __init__(
         self,
         to_onehot_y: bool = False,

--- a/monai/handlers/roc_auc.py
+++ b/monai/handlers/roc_auc.py
@@ -16,6 +16,7 @@ import torch.distributed as dist
 
 from monai.metrics import compute_roc_auc
 from monai.utils import Average, exact_version, optional_import
+
 from .utils import all_gather
 
 Metric, _ = optional_import("ignite.metrics", "0.4.2", exact_version, "Metric")

--- a/monai/handlers/utils.py
+++ b/monai/handlers/utils.py
@@ -48,6 +48,8 @@ def all_gather(tensor):
     """
     All gather the data of tensor value in distributed data parallel.
     """
+    if not dist.is_available() or not dist.is_initialized():
+        raise RuntimeError("should not execute all_gather operation before torch.distributed is ready.")
     # create placeholder to collect the data from all processes
     output = [torch.zeros_like(tensor) for _ in range(dist.get_world_size())]
     dist.all_gather(output, tensor)

--- a/monai/handlers/utils.py
+++ b/monai/handlers/utils.py
@@ -10,8 +10,10 @@
 # limitations under the License.
 
 from typing import TYPE_CHECKING, Any, Callable
+
 import torch
 import torch.distributed as dist
+
 from monai.utils import exact_version, optional_import
 
 if TYPE_CHECKING:
@@ -40,6 +42,7 @@ def stopping_fn_from_loss() -> Callable[[Engine], Any]:
         return -engine.state.output
 
     return stopping_fn
+
 
 def all_gather(tensor):
     """

--- a/monai/handlers/utils.py
+++ b/monai/handlers/utils.py
@@ -10,7 +10,8 @@
 # limitations under the License.
 
 from typing import TYPE_CHECKING, Any, Callable
-
+import torch
+import torch.distributed as dist
 from monai.utils import exact_version, optional_import
 
 if TYPE_CHECKING:
@@ -39,3 +40,12 @@ def stopping_fn_from_loss() -> Callable[[Engine], Any]:
         return -engine.state.output
 
     return stopping_fn
+
+def all_gather(tensor):
+    """
+    All gather the data of tensor value in distributed data parallel.
+    """
+    # create placeholder to collect the data from all processes
+    output = [torch.zeros_like(tensor) for _ in range(dist.get_world_size())]
+    dist.all_gather(output, tensor)
+    return torch.cat(output, dim=0)

--- a/monai/metrics/__init__.py
+++ b/monai/metrics/__init__.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .confusion_matrix import compute_confusion_metric
+from .confusion_matrix import compute_confusion_matrix
 from .confusion_matrix_utils import *
 from .hausdorff_distance import compute_hausdorff_distance
 from .meandice import DiceMetric, compute_meandice

--- a/monai/metrics/confusion_matrix.py
+++ b/monai/metrics/confusion_matrix.py
@@ -19,7 +19,7 @@ from monai.networks import one_hot
 from monai.utils import Average
 
 
-def compute_confusion_metric(
+def compute_confusion_matrix(
     y_pred: torch.Tensor,
     y: torch.Tensor,
     to_onehot_y: bool = False,

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -93,6 +93,7 @@ def run_testsuit():
         "test_zoom_affine",
         "test_zoomd",
         "test_compute_occlusion_sensitivity",
+        "test_handler_confusion_matrix",
     ]
     assert sorted(exclude_cases) == sorted(set(exclude_cases)), f"Duplicated items in {exclude_cases}"
 

--- a/tests/test_compute_tnr.py
+++ b/tests/test_compute_tnr.py
@@ -16,7 +16,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.metrics import compute_confusion_metric
+from monai.metrics import compute_confusion_matrix
 
 metric_name = "true negative rate"
 # test the metric under 2 class classification task
@@ -135,14 +135,14 @@ for y_pred in [y_org, -y_org]:
 class TestComputeTnrClf(unittest.TestCase):
     @parameterized.expand(TEST_CASES_2_CLS_CLF + TEST_CASES_M_CLS_CLF + TEST_CASES_M_LABEL_CLF)
     def test_value(self, input_data, expected_value):
-        result = compute_confusion_metric(**input_data)
+        result = compute_confusion_matrix(**input_data)
         np.testing.assert_allclose(expected_value, result, rtol=1e-7)
 
 
 class TestComputeTnrSeg(unittest.TestCase):
     @parameterized.expand(TEST_CASES_2D_SEG + TEST_CASES_3D_SEG)
     def test_value(self, input_data, expected_value):
-        result = compute_confusion_metric(**input_data)
+        result = compute_confusion_matrix(**input_data)
         self.assertEqual(expected_value, result)
 
 

--- a/tests/test_compute_tpr.py
+++ b/tests/test_compute_tpr.py
@@ -16,7 +16,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.metrics import compute_confusion_metric
+from monai.metrics import compute_confusion_matrix
 
 metric_name = "true positive rate"
 # test the metric under 2 class classification task
@@ -135,14 +135,14 @@ for y_pred in [y_org, -y_org]:
 class TestComputeTprClf(unittest.TestCase):
     @parameterized.expand(TEST_CASES_2_CLS_CLF + TEST_CASES_M_CLS_CLF + TEST_CASES_M_LABEL_CLF)
     def test_value(self, input_data, expected_value):
-        result = compute_confusion_metric(**input_data)
+        result = compute_confusion_matrix(**input_data)
         np.testing.assert_allclose(expected_value, result, rtol=1e-7)
 
 
 class TestComputeTprSeg(unittest.TestCase):
     @parameterized.expand(TEST_CASES_2D_SEG + TEST_CASES_3D_SEG)
     def test_value(self, input_data, expected_value):
-        result = compute_confusion_metric(**input_data)
+        result = compute_confusion_matrix(**input_data)
         self.assertEqual(expected_value, result)
 
 

--- a/tests/test_handler_confusion_matrix.py
+++ b/tests/test_handler_confusion_matrix.py
@@ -1,0 +1,37 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import torch
+
+from monai.handlers import ConfusionMatrix
+
+
+class TestHandlerConfusionMatrix(unittest.TestCase):
+    def test_compute(self):
+        matrix_metric = ConfusionMatrix(to_onehot_y=True, activation="softmax")
+
+        y_pred = torch.Tensor([[0.1, 0.9], [0.3, 1.4]])
+        y = torch.Tensor([[0], [1]])
+        matrix_metric.update([y_pred, y])
+
+        y_pred = torch.Tensor([[0.2, 0.1], [0.1, 0.5]])
+        y = torch.Tensor([[0], [1]])
+        matrix_metric.update([y_pred, y])
+
+        value = matrix_metric.compute()
+        np.testing.assert_allclose(0.75, value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Partly fix #1057 

### Description
This PR implemented the ignite handler for confusion matrix metric and fixed typo in `compute_confusion_matrix()`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
