### PR TITLE
Disable model grad in occlusion sensitivity

### DIFF
--- a/monai/metrics/occlusion_sensitivity.py
+++ b/monai/metrics/occlusion_sensitivity.py
@@ -73,7 +73,9 @@ def _append_to_sensitivity_im(model, batch_images, batch_ids, sensitivity_im):
     a given label. Append to previous evaluations."""
     batch_images = torch.cat(batch_images, dim=0)
     batch_ids = torch.LongTensor(batch_ids).unsqueeze(1).to(sensitivity_im.device)
-    scores = model(batch_images).detach().gather(1, batch_ids)
+    model.eval()
+    with torch.no_grad():
+        scores = model(batch_images).detach().gather(1, batch_ids)
     return torch.cat((sensitivity_im, scores))
 
 
@@ -136,7 +138,9 @@ def compute_occlusion_sensitivity(
     b_box_min, b_box_max = _check_input_bounding_box(b_box, im_shape)
 
     # Get baseline probability
-    baseline = model(image).detach()[0, label].item()
+    model.eval()
+    with torch.no_grad():
+        baseline = model(image).detach()[0, label].item()
 
     # Create some lists
     batch_images = []


### PR DESCRIPTION
### Description
This PR added the missing logic to disable model grad for occlusion sensitivity metric.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
