### PR TITLE
enable Gaussian noise for Torch

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -162,7 +162,7 @@ jobs:
             pytorch: "torch==1.5.0 torchvision==0.6.0"
             base: "nvcr.io/nvidia/cuda:10.2-devel-ubuntu18.04"
           - environment: PT16+CUDA102
-            pytorch: "torch torchvision"
+            pytorch: "torch==1.6.0 torchvision==0.7.0"
             base: "nvcr.io/nvidia/cuda:10.2-devel-ubuntu18.04"
           - environment: PT16+CUDA110
             # we explicitly set pytorch to -h to avoid pip install error

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -19,6 +19,7 @@ from collections.abc import Iterable
 from typing import Any, Dict, Hashable, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
+import torch
 
 from monai.config import KeysCollection
 from monai.transforms.compose import MapTransform, Randomizable
@@ -34,7 +35,7 @@ from monai.transforms.intensity.array import (
     ShiftIntensity,
     ThresholdIntensity,
 )
-from monai.utils import ensure_tuple_size
+from monai.utils import dtype_torch_to_numpy, ensure_tuple_size
 
 
 class RandGaussianNoised(Randomizable, MapTransform):
@@ -73,7 +74,8 @@ class RandGaussianNoised(Randomizable, MapTransform):
         if not self._do_transform:
             return d
         for key in self.keys:
-            d[key] = d[key] + self._noise.astype(d[key].dtype)
+            dtype = dtype_torch_to_numpy(d[key].dtype) if isinstance(d[key], torch.Tensor) else d[key].dtype
+            d[key] = d[key] + self._noise.astype(dtype)
         return d
 
 

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -260,3 +260,29 @@ def list_to_dict(items):
                 except ValueError:
                     d[key] = value
     return d
+
+
+_torch_to_np_dtype = {
+    torch.bool: np.bool,
+    torch.uint8: np.uint8,
+    torch.int8: np.int8,
+    torch.int16: np.int16,
+    torch.int32: np.int32,
+    torch.int64: np.int64,
+    torch.float16: np.float16,
+    torch.float32: np.float32,
+    torch.float64: np.float64,
+    torch.complex64: np.complex64,
+    torch.complex128: np.complex128,
+}
+_np_to_torch_dtype = {value: key for key, value in _torch_to_np_dtype.items()}
+
+
+def dtype_torch_to_numpy(dtype):
+    """Convert a torch dtype to its numpy equivalent."""
+    return _torch_to_np_dtype[dtype]
+
+
+def dtype_numpy_to_torch(dtype):
+    """Convert a numpy dtype to its torch equivalent."""
+    return _np_to_torch_dtype[dtype]

--- a/tests/test_rand_gaussian_noise.py
+++ b/tests/test_rand_gaussian_noise.py
@@ -15,10 +15,23 @@ import numpy as np
 from parameterized import parameterized
 
 from monai.transforms import RandGaussianNoise
-from tests.utils import NumpyImageTestCase2D
+from tests.utils import NumpyImageTestCase2D, TorchImageTestCase2D
 
 
 class TestRandGaussianNoise(NumpyImageTestCase2D):
+    @parameterized.expand([("test_zero_mean", 0, 0.1), ("test_non_zero_mean", 1, 0.5)])
+    def test_correct_results(self, _, mean, std):
+        seed = 0
+        gaussian_fn = RandGaussianNoise(prob=1.0, mean=mean, std=std)
+        gaussian_fn.set_random_state(seed)
+        noised = gaussian_fn(self.imt)
+        np.random.seed(seed)
+        np.random.random()
+        expected = self.imt + np.random.normal(mean, np.random.uniform(0, std), size=self.imt.shape)
+        np.testing.assert_allclose(expected, noised, atol=1e-5)
+
+
+class TestRandGaussianNoiseTorch(TorchImageTestCase2D):
     @parameterized.expand([("test_zero_mean", 0, 0.1), ("test_non_zero_mean", 1, 0.5)])
     def test_correct_results(self, _, mean, std):
         seed = 0

--- a/tests/test_rand_gaussian_noised.py
+++ b/tests/test_rand_gaussian_noised.py
@@ -15,13 +15,31 @@ import numpy as np
 from parameterized import parameterized
 
 from monai.transforms import RandGaussianNoised
-from tests.utils import NumpyImageTestCase2D
+from tests.utils import NumpyImageTestCase2D, TorchImageTestCase2D
 
+TEST_CASE_0 = ["test_zero_mean", ["img"], 0, 0.1]
+TEST_CASE_1 = ["test_non_zero_mean", ["img"], 1, 0.5]
+TEST_CASES = [TEST_CASE_0, TEST_CASE_1]
 
-class TestRandGaussianNoised(NumpyImageTestCase2D):
-    @parameterized.expand([("test_zero_mean", ["img"], 0, 0.1), ("test_non_zero_mean", ["img"], 1, 0.5)])
+seed = 0
+
+# Test with numpy
+class TestRandGaussianNoisedNumpy(NumpyImageTestCase2D):
+    @parameterized.expand(TEST_CASES)
     def test_correct_results(self, _, keys, mean, std):
-        seed = 0
+        gaussian_fn = RandGaussianNoised(keys=keys, prob=1.0, mean=mean, std=std)
+        gaussian_fn.set_random_state(seed)
+        noised = gaussian_fn({"img": self.imt})
+        np.random.seed(seed)
+        np.random.random()
+        expected = self.imt + np.random.normal(mean, np.random.uniform(0, std), size=self.imt.shape)
+        np.testing.assert_allclose(expected, noised["img"], atol=1e-5, rtol=1e-5)
+
+
+# Test with torch
+class TestRandGaussianNoisedTorch(TorchImageTestCase2D):
+    @parameterized.expand(TEST_CASES)
+    def test_correct_results(self, _, keys, mean, std):
         gaussian_fn = RandGaussianNoised(keys=keys, prob=1.0, mean=mean, std=std)
         gaussian_fn.set_random_state(seed)
         noised = gaussian_fn({"img": self.imt})


### PR DESCRIPTION
### Description
Previously, you couldn't use Gaussian noise with `torch.Tensor` because of the differences in `dtype` between numpy and torch. Created a small converter function for switching `dtype` between numpy and torch (and vice versa).

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
