### PR TITLE
1021 cuda resampling 1

### DIFF
--- a/monai/csrc/resample/pushpull_cpu.cpp
+++ b/monai/csrc/resample/pushpull_cpu.cpp
@@ -627,8 +627,8 @@ MONAI_NAMESPACE_DEVICE { // cpu
     scalar_t y = grid_ptr_NXY[grid_sC];
 
     // Check if out-of-bound
-    if (!(extrapolate || inbounds(x, src_X, static_cast<scalar_t>(TINY)) ||
-          inbounds(y, src_Y, static_cast<scalar_t>(TINY)))) {
+    if (!(extrapolate || (inbounds(x, src_X, static_cast<scalar_t>(TINY)) &&
+          inbounds(y, src_Y, static_cast<scalar_t>(TINY))))) {
       if (do_pull || do_sgrad) {
         scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sZ + h * out_sY;
         for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC) {
@@ -676,8 +676,8 @@ MONAI_NAMESPACE_DEVICE { // cpu
     scalar_t z = grid_ptr_NXYZ[grid_sC * 2];
 
     // Check if out-of-bound
-    if (!(extrapolate || inbounds(x, src_X, static_cast<scalar_t>(TINY)) ||
-          inbounds(y, src_Y, static_cast<scalar_t>(TINY)) || inbounds(z, src_Z, static_cast<scalar_t>(TINY)))) {
+    if (!(extrapolate || (inbounds(x, src_X, static_cast<scalar_t>(TINY)) &&
+          inbounds(y, src_Y, static_cast<scalar_t>(TINY)) && inbounds(z, src_Z, static_cast<scalar_t>(TINY))))) {
       if (do_pull || do_sgrad) {
         scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
         for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC) {

--- a/monai/csrc/resample/pushpull_cuda.cu
+++ b/monai/csrc/resample/pushpull_cuda.cu
@@ -594,8 +594,8 @@ MONAI_NAMESPACE_DEVICE { // cuda
     scalar_t y = grid_ptr_NXY[grid_sC];
 
     // Check if out-of-bound
-    if (!(extrapolate || inbounds(x, src_X, static_cast<scalar_t>(TINY)) ||
-          inbounds(y, src_Y, static_cast<scalar_t>(TINY)))) {
+    if (!(extrapolate || (inbounds(x, src_X, static_cast<scalar_t>(TINY)) &&
+          inbounds(y, src_Y, static_cast<scalar_t>(TINY))))) {
       if (do_pull || do_sgrad) {
         scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sZ + h * out_sY;
         for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC) {
@@ -643,8 +643,8 @@ MONAI_NAMESPACE_DEVICE { // cuda
     scalar_t z = grid_ptr_NXYZ[grid_sC * 2];
 
     // Check if out-of-bound
-    if (!(extrapolate || inbounds(x, src_X, static_cast<scalar_t>(TINY)) ||
-          inbounds(y, src_Y, static_cast<scalar_t>(TINY)) || inbounds(z, src_Z, static_cast<scalar_t>(TINY)))) {
+    if (!(extrapolate || (inbounds(x, src_X, static_cast<scalar_t>(TINY)) &&
+          inbounds(y, src_Y, static_cast<scalar_t>(TINY)) && inbounds(z, src_Z, static_cast<scalar_t>(TINY))))) {
       if (do_pull || do_sgrad) {
         scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
         for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC) {

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -41,8 +41,10 @@ class _GridPull(torch.autograd.Function):
         grads = _C.grid_pull_backward(grad, *var, *opt)
         if ctx.needs_input_grad[0]:
             grad_input = grads[0]
-        if ctx.needs_input_grad[1]:
-            grad_grid = grads[1]
+            if ctx.needs_input_grad[1]:
+                grad_grid = grads[1]
+        elif ctx.needs_input_grad[1]:
+            grad_grid = grads[0]
         return grad_input, grad_grid, None, None, None
 
 
@@ -133,8 +135,10 @@ class _GridPush(torch.autograd.Function):
         grads = _C.grid_push_backward(grad, *var, *opt)
         if ctx.needs_input_grad[0]:
             grad_input = grads[0]
-        if ctx.needs_input_grad[1]:
-            grad_grid = grads[1]
+            if ctx.needs_input_grad[1]:
+                grad_grid = grads[1]
+        elif ctx.needs_input_grad[1]:
+            grad_grid = grads[0]
         return grad_input, grad_grid, None, None, None, None
 
 
@@ -328,8 +332,10 @@ class _GridGrad(torch.autograd.Function):
             grads = _C.grid_grad_backward(grad, *var, *opt)
             if ctx.needs_input_grad[0]:
                 grad_input = grads[0]
-            if ctx.needs_input_grad[1]:
-                grad_grid = grads[1]
+                if ctx.needs_input_grad[1]:
+                    grad_grid = grads[1]
+            elif ctx.needs_input_grad[1]:
+                grad_grid = grads[0]
         return grad_input, grad_grid, None, None, None
 
 


### PR DESCRIPTION
Fixes #1021 .

### Description
* Out-of-bounds checks not working when extrapolate = False.
* Backward pass not returning correct output.
* CPU implementation should use int64 offsets and the CUDA implementation int32.

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
