### PR TITLE
Test timing

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -492,7 +492,7 @@ if [ $doUnitTests = true ]
 then
     echo "${separator}${blue}unittests${noColor}"
     torch_validate
-    ${cmdPrefix}${cmd} -m unittest -v
+    ${cmdPrefix}${cmd} ./tests/runner.py
 fi
 
 # network training/inference/eval tests

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -15,6 +15,7 @@ import unittest
 
 results: dict = dict()
 
+
 class TimeLoggingTestResult(unittest.TextTestResult):
     """Overload the default results so that we can store the results."""
 
@@ -40,6 +41,12 @@ class TimeLoggingTestResult(unittest.TextTestResult):
         super().stopTest(test)
 
 
+def print_results(results):
+    timings = dict(sorted(results.items(), key=lambda item: item[1]))
+    for r in timings:
+        print(f"{r} ({timings[r]:.03}s)")
+
+
 if __name__ == "__main__":
     path = sys.argv[1] if len(sys.argv) > 1 else "."
     print(f"Running tests in folder: '{path}'")
@@ -51,9 +58,8 @@ if __name__ == "__main__":
     try:
         test_result = test_runner.run(tests)
         print("\n\ntests finished, printing times in ascending order...\n")
-    except KeyboardInterrupt:
+        print_results(results)
+    except Exception:
         print("\n\ntests cancelled, printing completed times in ascending order...\n")
-    finally:
-        timings = dict(sorted(results.items(), key=lambda item: item[1]))
-        for r in timings:
-            print(f"{r} ({timings[r]:.03}s)")
+        print_results(results)
+        raise

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1,0 +1,64 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+
+
+class TimeLoggingTestRunner(unittest.runner.TextTestRunner):
+    """Overload the default runner so that we can get and print the results."""
+
+    def __init__(self, *args, **kwargs):
+        return super().__init__(resultclass=TimeLoggingTestResult, *args, **kwargs)
+
+    def run(self, test):
+        result = super().run(test)
+        print("\n\ntests finished, printing times in descending order...\n")
+        timings = dict(sorted(result.getTestTimings().items(), key=lambda kv: kv[1], reverse=True))
+        for r in timings:
+            print(f"{r} ({timings[r]:.03}s)")
+        return result
+
+
+class TimeLoggingTestResult(unittest.TextTestResult):
+    """Overload the default results so that we can store the results."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.timed_tests = dict()
+
+    def startTest(self, test):  # noqa: N802
+        """Start timer, print test name, do normal test."""
+        self._started_at = time.time()
+        name = self.getDescription(test)
+        self.stream.write(f"{name}...")
+        super().startTest(test)
+
+    def stopTest(self, test):  # noqa: N802
+        """On test end, get time, print, store and do normal behaviour."""
+        elapsed = time.time() - self._started_at
+        self.stream.write(f"({elapsed:.03}s)\n")
+        name = self.getDescription(test)
+        if name in self.timed_tests:
+            raise AssertionError("expected all keys to be unique")
+        self.timed_tests[name] = elapsed
+        super().stopTest(test)
+
+    def getTestTimings(self):  # noqa: N802
+        """Get all times so they can be sorted and printed."""
+        return self.timed_tests
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    tests = loader.discover(".")
+    test_runner = TimeLoggingTestRunner()
+    test_result = test_runner.run(tests)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -47,8 +47,8 @@ def print_results(results, discovery_time):
     timings = dict(sorted(results.items(), key=lambda item: item[1]))
     for r in timings:
         print(f"{r} ({timings[r]:.03}s)")
-    print(f"test discovery time: {discovery_time}s")
-    print(f"total testing time: {sum(results.values())}s")
+    print(f"test discovery time: {discovery_time:.03}s")
+    print(f"total testing time: {sum(results.values()):.03}s")
 
 
 if __name__ == "__main__":

--- a/tests/test_ahnet.py
+++ b/tests/test_ahnet.py
@@ -102,6 +102,7 @@ TEST_CASE_AHNET_3D_WITH_PRETRAIN_3 = [
 
 class TestFCN(unittest.TestCase):
     @parameterized.expand([TEST_CASE_FCN_1, TEST_CASE_FCN_2, TEST_CASE_FCN_3])
+    @skip_if_quick
     def test_fcn_shape(self, input_param, input_shape, expected_shape):
         net = FCN(**input_param)
         net.eval()


### PR DESCRIPTION
From https://github.com/Project-MONAI/MONAI/issues/1137, I thought it would be a good idea to provide timing information for unit tests.

### Description
Create a runner script that stores the test times, at the end print the sorted results so we can have an idea of which tests are taking the most time.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
