### PR TITLE
Skip unittest on certain pytorch version due to API behavior change

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,4 +2,5 @@
 -r requirements.txt
 setuptools==50.3.0
 coverage
+packaging
 parameterized

--- a/tests/test_compute_meandice.py
+++ b/tests/test_compute_meandice.py
@@ -13,6 +13,7 @@ import unittest
 
 import numpy as np
 import torch
+from packaging.version import Version, parse
 from parameterized import parameterized
 
 from monai.metrics import DiceMetric, compute_meandice
@@ -32,6 +33,10 @@ TEST_CASE_1 = [  # y (1, 1, 2, 2), y_pred (1, 1, 2, 2), expected out (1, 1)
 ]
 
 # remove background and not One-Hot target
+if parse(torch.__version__) < Version("1.7.0"):
+    EXPECTED = [[0.5000, 0.0000], [0.6666, 0.6666]]
+else:
+    EXPECTED = [[0.8000, 0.0000], [1.0000, 1.0000]]
 TEST_CASE_2 = [  # y (2, 1, 2, 2), y_pred (2, 3, 2, 2), expected out (2, 2) (no background)
     {
         "y_pred": torch.tensor(
@@ -45,7 +50,7 @@ TEST_CASE_2 = [  # y (2, 1, 2, 2), y_pred (2, 3, 2, 2), expected out (2, 2) (no 
         "to_onehot_y": True,
         "mutually_exclusive": True,
     },
-    [[0.5000, 0.0000], [0.6666, 0.6666]],
+    EXPECTED,
 ]
 
 # should return Nan for all labels=0 case and skip for MeanDice


### PR DESCRIPTION
Fixes # 1149.

### Description
Run unittest with expected results on certain pytorch version only

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
