### PR TITLE
fixes #1074

### DIFF
--- a/tests/test_resize_with_pad_or_crop.py
+++ b/tests/test_resize_with_pad_or_crop.py
@@ -16,39 +16,43 @@ from parameterized import parameterized
 
 from monai.transforms import ResizeWithPadOrCrop
 
-TEST_CASE_1 = [
-    {"spatial_size": [15, 8, 8], "mode": "constant"},
-    np.zeros((3, 8, 8, 4)),
-    np.zeros((3, 15, 8, 8)),
-]
-
-TEST_CASE_2 = [
-    {"spatial_size": [15, 4, 8], "mode": "constant"},
-    np.zeros((3, 8, 8, 4)),
-    np.zeros((3, 15, 4, 8)),
-]
-
-TEST_CASE_3 = [
-    {"spatial_size": [15, 4, -1], "mode": "constant"},
-    np.zeros((3, 8, 8, 4)),
-    np.zeros((3, 15, 4, 4)),
-]
-
-TEST_CASE_4 = [
-    {"spatial_size": [15, 4, -1], "mode": "reflect"},
-    np.zeros((3, 8, 8, 4)),
-    np.zeros((3, 15, 4, 4)),
+TEST_CASES = [
+    [
+        {"spatial_size": [15, 8, 8], "mode": "constant"},
+        (3, 8, 8, 4),
+        (3, 15, 8, 8),
+    ],
+    [
+        {"spatial_size": [15, 4, 8], "mode": "constant"},
+        (3, 8, 8, 4),
+        (3, 15, 4, 8),
+    ],
+    [
+        {"spatial_size": [15, 4, -1], "mode": "constant"},
+        (3, 8, 8, 4),
+        (3, 15, 4, 4),
+    ],
+    [
+        {"spatial_size": [15, 4, -1], "mode": "reflect"},
+        (3, 8, 8, 4),
+        (3, 15, 4, 4),
+    ],
+    [
+        {"spatial_size": [-1, -1, -1], "mode": "reflect"},
+        (3, 8, 8, 4),
+        (3, 8, 8, 4),
+    ],
 ]
 
 
 class TestResizeWithPadOrCrop(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
-    def test_pad_shape(self, input_param, input_data, expected_val):
+    @parameterized.expand(TEST_CASES)
+    def test_pad_shape(self, input_param, input_shape, expected_shape):
         paddcroper = ResizeWithPadOrCrop(**input_param)
-        result = paddcroper(input_data)
-        np.testing.assert_allclose(result.shape, expected_val.shape)
-        result = paddcroper(input_data, mode="constant")
-        np.testing.assert_allclose(result.shape, expected_val.shape)
+        result = paddcroper(np.zeros(input_shape))
+        np.testing.assert_allclose(result.shape, expected_shape)
+        result = paddcroper(np.zeros(input_shape), mode="constant")
+        np.testing.assert_allclose(result.shape, expected_shape)
 
 
 if __name__ == "__main__":

--- a/tests/test_resize_with_pad_or_cropd.py
+++ b/tests/test_resize_with_pad_or_cropd.py
@@ -16,37 +16,41 @@ from parameterized import parameterized
 
 from monai.transforms import ResizeWithPadOrCropd
 
-TEST_CASE_1 = [
-    {"keys": "img", "spatial_size": [15, 8, 8], "mode": "constant"},
-    {"img": np.zeros((3, 8, 8, 4))},
-    np.zeros((3, 15, 8, 8)),
-]
-
-TEST_CASE_2 = [
-    {"keys": "img", "spatial_size": [15, 4, 8], "mode": "constant"},
-    {"img": np.zeros((3, 8, 8, 4))},
-    np.zeros((3, 15, 4, 8)),
-]
-
-TEST_CASE_3 = [
-    {"keys": "img", "spatial_size": [15, 4, -1], "mode": "constant"},
-    {"img": np.zeros((3, 8, 8, 4))},
-    np.zeros((3, 15, 4, 4)),
-]
-
-TEST_CASE_4 = [
-    {"keys": "img", "spatial_size": [15, 4, -1], "mode": "reflect"},
-    {"img": np.zeros((3, 8, 8, 4))},
-    np.zeros((3, 15, 4, 4)),
+TEST_CASES = [
+    [
+        {"keys": "img", "spatial_size": [15, 8, 8], "mode": "constant"},
+        {"img": np.zeros((3, 8, 8, 4))},
+        (3, 15, 8, 8),
+    ],
+    [
+        {"keys": "img", "spatial_size": [15, 4, 8], "mode": "constant"},
+        {"img": np.zeros((3, 8, 8, 4))},
+        (3, 15, 4, 8),
+    ],
+    [
+        {"keys": "img", "spatial_size": [15, 4, -1], "mode": "constant"},
+        {"img": np.zeros((3, 8, 8, 4))},
+        (3, 15, 4, 4),
+    ],
+    [
+        {"keys": "img", "spatial_size": [15, 4, -1], "mode": "reflect"},
+        {"img": np.zeros((3, 8, 8, 4))},
+        (3, 15, 4, 4),
+    ],
+    [
+        {"keys": "img", "spatial_size": [-1, -1, -1], "mode": "reflect"},
+        {"img": np.zeros((3, 8, 8, 4))},
+        (3, 8, 8, 4),
+    ],
 ]
 
 
 class TestResizeWithPadOrCropd(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
+    @parameterized.expand(TEST_CASES)
     def test_pad_shape(self, input_param, input_data, expected_val):
         paddcroper = ResizeWithPadOrCropd(**input_param)
         result = paddcroper(input_data)
-        np.testing.assert_allclose(result["img"].shape, expected_val.shape)
+        np.testing.assert_allclose(result["img"].shape, expected_val)
 
 
 if __name__ == "__main__":

--- a/tests/test_spatial_crop.py
+++ b/tests/test_spatial_crop.py
@@ -16,26 +16,36 @@ from parameterized import parameterized
 
 from monai.transforms import SpatialCrop
 
-TEST_CASE_1 = [
-    {"roi_center": [1, 1, 1], "roi_size": [2, 2, 2]},
-    np.random.randint(0, 2, size=[3, 3, 3, 3]),
-    (3, 2, 2, 2),
-]
-
-TEST_CASE_2 = [{"roi_start": [0, 0, 0], "roi_end": [2, 2, 2]}, np.random.randint(0, 2, size=[3, 3, 3, 3]), (3, 2, 2, 2)]
-
-TEST_CASE_3 = [{"roi_start": [0, 0], "roi_end": [2, 2]}, np.random.randint(0, 2, size=[3, 3, 3, 3]), (3, 2, 2, 3)]
-
-TEST_CASE_4 = [
-    {"roi_start": [0, 0, 0, 0, 0], "roi_end": [2, 2, 2, 2, 2]},
-    np.random.randint(0, 2, size=[3, 3, 3, 3]),
-    (3, 2, 2, 2),
+TEST_CASES = [
+    [
+        {"roi_center": [1, 1, 1], "roi_size": [2, 2, 2]},
+        (3, 3, 3, 3),
+        (3, 2, 2, 2),
+    ],
+    [{"roi_start": [0, 0, 0], "roi_end": [2, 2, 2]}, (3, 3, 3, 3), (3, 2, 2, 2)],
+    [{"roi_start": [0, 0], "roi_end": [2, 2]}, (3, 3, 3, 3), (3, 2, 2, 3)],
+    [
+        {"roi_start": [0, 0, 0, 0, 0], "roi_end": [2, 2, 2, 2, 2]},
+        (3, 3, 3, 3),
+        (3, 2, 2, 2),
+    ],
+    [
+        {"roi_start": [0, 0, 0, 0, 0], "roi_end": [8, 8, 8, 2, 2]},
+        (3, 3, 3, 3),
+        (3, 3, 3, 3),
+    ],
+    [
+        {"roi_start": [1, 0, 0], "roi_end": [1, 8, 8]},
+        (3, 3, 3, 3),
+        (3, 0, 3, 3),
+    ],
 ]
 
 
 class TestSpatialCrop(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
-    def test_shape(self, input_param, input_data, expected_shape):
+    @parameterized.expand(TEST_CASES)
+    def test_shape(self, input_param, input_shape, expected_shape):
+        input_data = np.random.randint(0, 2, size=input_shape)
         result = SpatialCrop(**input_param)(input_data)
         self.assertTupleEqual(result.shape, expected_shape)
 


### PR DESCRIPTION
Fixes #1074

### Description
- cropping now returns the original image, if the roi region is larger than the original size

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
