### PR TITLE
Skip/speed up tests

### DIFF
--- a/tests/test_ahnet.py
+++ b/tests/test_ahnet.py
@@ -18,84 +18,86 @@ from monai.networks.blocks import FCN, MCFCN
 from monai.networks.nets import AHNet
 from tests.utils import skip_if_quick, test_script_save
 
-TEST_CASE_FCN_1 = [
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+TEST_CASE_FCN_1 = [  # batch 2
     {"out_channels": 3, "upsample_mode": "transpose"},
-    (5, 3, 64, 64),
-    (5, 3, 64, 64),
+    (2, 3, 32, 32),
+    (2, 3, 32, 32),
 ]
 TEST_CASE_FCN_2 = [
     {"out_channels": 2, "upsample_mode": "transpose", "pretrained": True, "progress": False},
-    (5, 3, 64, 64),
-    (5, 2, 64, 64),
+    (1, 3, 32, 32),
+    (1, 2, 32, 32),
 ]
 TEST_CASE_FCN_3 = [
     {"out_channels": 1, "upsample_mode": "bilinear", "pretrained": False},
-    (5, 3, 64, 64),
-    (5, 1, 64, 64),
+    (1, 3, 32, 32),
+    (1, 1, 32, 32),
 ]
 
-TEST_CASE_MCFCN_1 = [
+TEST_CASE_MCFCN_1 = [  # batch 5
     {"out_channels": 3, "in_channels": 8, "upsample_mode": "transpose", "progress": False},
-    (5, 8, 64, 64),
-    (5, 3, 64, 64),
+    (5, 8, 32, 32),
+    (5, 3, 32, 32),
 ]
 TEST_CASE_MCFCN_2 = [
     {"out_channels": 2, "in_channels": 1, "upsample_mode": "transpose", "progress": True},
-    (5, 1, 64, 64),
-    (5, 2, 64, 64),
+    (1, 1, 32, 32),
+    (1, 2, 32, 32),
 ]
 TEST_CASE_MCFCN_3 = [
     {"out_channels": 1, "in_channels": 2, "upsample_mode": "bilinear", "pretrained": False},
-    (5, 2, 64, 64),
-    (5, 1, 64, 64),
+    (1, 2, 32, 32),
+    (1, 1, 32, 32),
 ]
 
 TEST_CASE_AHNET_2D_1 = [
     {"spatial_dims": 2, "upsample_mode": "bilinear"},
-    (3, 1, 128, 128),
-    (3, 1, 128, 128),
+    (1, 1, 128, 32),
+    (1, 1, 128, 32),
 ]
 TEST_CASE_AHNET_2D_2 = [
     {"spatial_dims": 2, "upsample_mode": "transpose", "out_channels": 2},
-    (2, 1, 128, 128),
-    (2, 2, 128, 128),
+    (1, 1, 128, 32),
+    (1, 2, 128, 32),
 ]
 TEST_CASE_AHNET_2D_3 = [
     {"spatial_dims": 2, "upsample_mode": "bilinear", "out_channels": 2},
-    (2, 1, 160, 128),
-    (2, 2, 160, 128),
+    (1, 1, 128, 32),
+    (1, 2, 128, 32),
 ]
 TEST_CASE_AHNET_3D_1 = [
     {"spatial_dims": 3, "upsample_mode": "trilinear"},
-    (3, 1, 128, 128, 64),
-    (3, 1, 128, 128, 64),
+    (2, 1, 128, 128, 32),
+    (2, 1, 128, 128, 32),
 ]
 TEST_CASE_AHNET_3D_2 = [
     {"spatial_dims": 3, "upsample_mode": "transpose", "out_channels": 2},
-    (2, 1, 128, 128, 64),
-    (2, 2, 128, 128, 64),
+    (1, 1, 128, 128, 32),
+    (1, 2, 128, 128, 32),
 ]
 TEST_CASE_AHNET_3D_3 = [
     {"spatial_dims": 3, "upsample_mode": "trilinear", "out_channels": 2},
-    (2, 1, 160, 128, 64),
-    (2, 2, 160, 128, 64),
+    (1, 1, 160, 128, 32),
+    (1, 2, 160, 128, 32),
 ]
 TEST_CASE_AHNET_3D_WITH_PRETRAIN_1 = [
     {"spatial_dims": 3, "upsample_mode": "trilinear"},
-    (3, 1, 128, 128, 64),
-    (3, 1, 128, 128, 64),
+    (2, 1, 128, 128, 64),
+    (2, 1, 128, 128, 64),
     {"out_channels": 1, "upsample_mode": "transpose"},
 ]
 TEST_CASE_AHNET_3D_WITH_PRETRAIN_2 = [
     {"spatial_dims": 3, "upsample_mode": "transpose", "out_channels": 2},
-    (2, 1, 128, 128, 64),
-    (2, 2, 128, 128, 64),
+    (1, 1, 128, 128, 64),
+    (1, 2, 128, 128, 64),
     {"out_channels": 1, "upsample_mode": "bilinear"},
 ]
 TEST_CASE_AHNET_3D_WITH_PRETRAIN_3 = [
     {"spatial_dims": 3, "upsample_mode": "transpose", "in_channels": 2, "out_channels": 3},
-    (2, 2, 128, 128, 64),
-    (2, 3, 128, 128, 64),
+    (1, 2, 128, 128, 64),
+    (1, 3, 128, 128, 64),
     {"out_channels": 1, "upsample_mode": "bilinear"},
 ]
 
@@ -104,20 +106,20 @@ class TestFCN(unittest.TestCase):
     @parameterized.expand([TEST_CASE_FCN_1, TEST_CASE_FCN_2, TEST_CASE_FCN_3])
     @skip_if_quick
     def test_fcn_shape(self, input_param, input_shape, expected_shape):
-        net = FCN(**input_param)
+        net = FCN(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
+            result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
 
 class TestMCFCN(unittest.TestCase):
     @parameterized.expand([TEST_CASE_MCFCN_1, TEST_CASE_MCFCN_2, TEST_CASE_MCFCN_3])
     def test_mcfcn_shape(self, input_param, input_shape, expected_shape):
-        net = MCFCN(**input_param)
+        net = MCFCN(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
+            result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
 
@@ -127,22 +129,34 @@ class TestAHNET(unittest.TestCase):
             TEST_CASE_AHNET_2D_1,
             TEST_CASE_AHNET_2D_2,
             TEST_CASE_AHNET_2D_3,
+        ]
+    )
+    def test_ahnet_shape_2d(self, input_param, input_shape, expected_shape):
+        net = AHNet(**input_param).to(device)
+        net.eval()
+        with torch.no_grad():
+            result = net.forward(torch.randn(input_shape).to(device))
+            self.assertEqual(result.shape, expected_shape)
+
+    @parameterized.expand(
+        [
             TEST_CASE_AHNET_3D_1,
             TEST_CASE_AHNET_3D_2,
             TEST_CASE_AHNET_3D_3,
         ]
     )
     @skip_if_quick
-    def test_ahnet_shape(self, input_param, input_shape, expected_shape):
-        net = AHNet(**input_param)
+    def test_ahnet_shape_3d(self, input_param, input_shape, expected_shape):
+        net = AHNet(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
+            result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
+    @skip_if_quick
     def test_script(self):
-        net = AHNet(spatial_dims=3, out_channels=2)
-        test_data = torch.randn(1, 1, 128, 128, 64)
+        net = AHNet(spatial_dims=2, out_channels=2)
+        test_data = torch.randn(1, 1, 128, 64)
         out_orig, out_reloaded = test_script_save(net, test_data)
         assert torch.allclose(out_orig, out_reloaded)
 
@@ -155,16 +169,16 @@ class TestAHNETWithPretrain(unittest.TestCase):
             TEST_CASE_AHNET_3D_WITH_PRETRAIN_3,
         ]
     )
-    @skip_if_quick
     def test_ahnet_shape(self, input_param, input_shape, expected_shape, fcn_input_param):
-        net = AHNet(**input_param)
-        net2d = FCN(**fcn_input_param)
+        net = AHNet(**input_param).to(device)
+        net2d = FCN(**fcn_input_param).to(device)
         net.copy_from(net2d)
         net.eval()
         with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
+            result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
+    @skip_if_quick
     def test_initialize_pretrained(self):
         net = AHNet(
             spatial_dims=3,
@@ -173,8 +187,8 @@ class TestAHNETWithPretrain(unittest.TestCase):
             out_channels=3,
             pretrained=True,
             progress=True,
-        )
-        input_data = torch.randn(2, 2, 128, 128, 64)
+        ).to(device)
+        input_data = torch.randn(2, 2, 128, 128, 64).to(device)
         with torch.no_grad():
             result = net.forward(input_data)
             self.assertEqual(result.shape, (2, 3, 128, 128, 64))

--- a/tests/test_cachedataset_parallel.py
+++ b/tests/test_cachedataset_parallel.py
@@ -20,17 +20,17 @@ from parameterized import parameterized
 from monai.data import CacheDataset
 from monai.transforms import Compose, LoadNiftid
 
-TEST_CASE_1 = [0, 100, Compose([LoadNiftid(keys=["image", "label", "extra"])])]
+TEST_CASE_1 = [0, 5, Compose([LoadNiftid(keys=["image", "label", "extra"])])]
 
-TEST_CASE_2 = [4, 100, Compose([LoadNiftid(keys=["image", "label", "extra"])])]
+TEST_CASE_2 = [4, 5, Compose([LoadNiftid(keys=["image", "label", "extra"])])]
 
-TEST_CASE_3 = [4, 100, None]
+TEST_CASE_3 = [4, 5, None]
 
 
 class TestCacheDatasetParallel(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_shape(self, num_workers, dataset_size, transform):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[8, 8, 8]), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
             nib.save(test_image, os.path.join(tempdir, "test_label1.nii.gz"))

--- a/tests/test_compute_occlusion_sensitivity.py
+++ b/tests/test_compute_occlusion_sensitivity.py
@@ -15,11 +15,15 @@ import torch
 from parameterized import parameterized
 
 from monai.metrics import compute_occlusion_sensitivity
-from monai.networks.nets import densenet121
+from monai.networks.nets import DenseNet, densenet121
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 model_2d = densenet121(spatial_dims=2, in_channels=1, out_channels=3).to(device)
-model_3d = densenet121(spatial_dims=3, in_channels=1, out_channels=2).to(device)
+model_3d = DenseNet(
+    spatial_dims=3, in_channels=1, out_channels=3, init_features=2, growth_rate=2, block_config=(6,)
+).to(device)
+model_2d.eval()
+model_3d.eval()
 
 # 2D w/ bounding box
 TEST_CASE_0 = [
@@ -35,12 +39,12 @@ TEST_CASE_0 = [
 TEST_CASE_1 = [
     {
         "model": model_3d,
-        "image": torch.rand(1, 1, 32, 48, 64).to(device),
+        "image": torch.rand(1, 1, 6, 6, 6).to(device),
         "label": 0,
-        "b_box": [-1, -1, 10, 11, -1, -1, -1, -1],
+        "b_box": [-1, -1, 2, 3, -1, -1, -1, -1],
         "n_batch": 10,
     },
-    (2, 48, 64),
+    (2, 6, 6),
 ]
 
 

--- a/tests/test_densenet.py
+++ b/tests/test_densenet.py
@@ -17,34 +17,42 @@ from parameterized import parameterized
 from monai.networks.nets import densenet121, densenet169, densenet201, densenet264
 from tests.utils import skip_if_quick
 
-TEST_CASE_1 = [  # 4-channel 3D, batch 16
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+TEST_CASE_1 = [  # 4-channel 3D, batch 2
     {"pretrained": False, "spatial_dims": 3, "in_channels": 2, "out_channels": 3},
-    (16, 2, 32, 64, 48),
-    (16, 3),
+    (2, 2, 32, 64, 48),
+    (2, 3),
 ]
 
-TEST_CASE_2 = [  # 4-channel 2D, batch 16
+TEST_CASE_2 = [  # 4-channel 2D, batch 2
     {"pretrained": False, "spatial_dims": 2, "in_channels": 2, "out_channels": 3},
-    (16, 2, 32, 64),
-    (16, 3),
+    (2, 2, 32, 64),
+    (2, 3),
 ]
 
-TEST_CASE_3 = [  # 4-channel 1D, batch 16
+TEST_CASE_3 = [  # 4-channel 1D, batch 1
     {"pretrained": False, "spatial_dims": 1, "in_channels": 2, "out_channels": 3},
-    (16, 2, 32),
-    (16, 3),
+    (1, 2, 32),
+    (1, 3),
 ]
 
-TEST_PRETRAINED_2D_CASE_1 = [  # 4-channel 2D, batch 16
+TEST_CASES = []
+for case in [TEST_CASE_1, TEST_CASE_2, TEST_CASE_3]:
+    for model in [densenet121, densenet169, densenet201, densenet264]:
+        TEST_CASES.append([model, *case])
+
+
+TEST_PRETRAINED_2D_CASE_1 = [  # 4-channel 2D, batch 2
     {"pretrained": True, "progress": True, "spatial_dims": 2, "in_channels": 2, "out_channels": 3},
-    (16, 2, 32, 64),
-    (16, 3),
+    (2, 2, 32, 64),
+    (2, 3),
 ]
 
-TEST_PRETRAINED_2D_CASE_2 = [  # 4-channel 2D, batch 16
+TEST_PRETRAINED_2D_CASE_2 = [  # 4-channel 2D, batch 2
     {"pretrained": True, "progress": False, "spatial_dims": 2, "in_channels": 2, "out_channels": 3},
-    (16, 2, 32, 64),
-    (16, 3),
+    (2, 2, 32, 64),
+    (2, 3),
 ]
 
 
@@ -60,100 +68,12 @@ class TestPretrainedDENSENET(unittest.TestCase):
 
 
 class TestDENSENET(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1])
-    def test_121_4d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet121(**input_param)
+    @parameterized.expand(TEST_CASES)
+    def test_densenet_shape(self, model, input_param, input_shape, expected_shape):
+        net = model(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_1])
-    def test_169_4d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet169(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_1])
-    def test_201_4d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet201(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_1])
-    def test_264_4d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet264(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_2])
-    def test_121_3d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet121(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_2])
-    def test_169_3d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet169(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_2])
-    def test_201_3d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet201(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_2])
-    def test_264_3d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet264(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_3])
-    def test_121_2d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet121(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_3])
-    def test_169_2d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet169(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_3])
-    def test_201_2d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet201(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
-            self.assertEqual(result.shape, expected_shape)
-
-    @parameterized.expand([TEST_CASE_3])
-    def test_264_2d_shape(self, input_param, input_shape, expected_shape):
-        net = densenet264(**input_param)
-        net.eval()
-        with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
+            result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
 

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -17,6 +17,8 @@ from parameterized import parameterized
 
 from monai.networks.nets import DynUNet
 
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 strides: Sequence[Union[Sequence[int], int]]
 kernel_size: Sequence[Any]
 expected_shape: Sequence[Any]
@@ -103,19 +105,19 @@ for spatial_dims in [2, 3]:
 class TestDynUNet(unittest.TestCase):
     @parameterized.expand(TEST_CASE_DYNUNET_2D + TEST_CASE_DYNUNET_3D)
     def test_shape(self, input_param, input_shape, expected_shape):
-        net = DynUNet(**input_param)
+        net = DynUNet(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net(torch.randn(input_shape))
+            result = net(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
 
 class TestDynUNetDeepSupervision(unittest.TestCase):
     @parameterized.expand(TEST_CASE_DEEP_SUPERVISION)
     def test_shape(self, input_param, input_shape, expected_shape):
-        net = DynUNet(**input_param)
+        net = DynUNet(**input_param).to(device)
         with torch.no_grad():
-            results = net(torch.randn(input_shape))
+            results = net(torch.randn(input_shape).to(device))
             self.assertEqual(len(results), len(expected_shape))
             for idx in range(len(results)):
                 result, sub_expected_shape = results[idx], expected_shape[idx]

--- a/tests/test_highresnet.py
+++ b/tests/test_highresnet.py
@@ -16,6 +16,8 @@ from parameterized import parameterized
 
 from monai.networks.nets import HighResNet
 
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 TEST_CASE_1 = [  # single channel 3D, batch 16
     {"spatial_dims": 3, "in_channels": 1, "out_channels": 3, "norm_type": "instance"},
     (16, 1, 32, 24, 48),
@@ -44,10 +46,10 @@ TEST_CASE_4 = [  # 4-channel 1D, batch 16
 class TestHighResNet(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
     def test_shape(self, input_param, input_shape, expected_shape):
-        net = HighResNet(**input_param)
+        net = HighResNet(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
+            result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
 

--- a/tests/test_load_image.py
+++ b/tests/test_load_image.py
@@ -21,6 +21,7 @@ from PIL import Image
 
 from monai.data import ITKReader, NibabelReader
 from monai.transforms import LoadImage
+from tests.utils import SkipIfNoModule
 
 TEST_CASE_1 = [
     {"reader": NibabelReader(), "image_only": True},
@@ -112,6 +113,7 @@ class TestLoadImage(unittest.TestCase):
             self.assertTupleEqual(result.shape, expected_shape)
 
     @parameterized.expand([TEST_CASE_10])
+    @SkipIfNoModule("itk")
     def test_itk_dicom_series_reader(self, input_param, filenames, expected_shape):
         result, header = LoadImage(**input_param)(filenames)
         self.assertTrue("affine" in header)

--- a/tests/test_se_block.py
+++ b/tests/test_se_block.py
@@ -17,6 +17,8 @@ from parameterized import parameterized
 from monai.networks.blocks import SEBlock
 from monai.networks.layers.factories import Act, Norm
 
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 TEST_CASES = [
     [
         {"spatial_dims": 2, "in_channels": 4, "n_chns_1": 20, "n_chns_2": 30, "n_chns_3": 4, "r": 2},
@@ -59,10 +61,10 @@ for type_1 in (
 class TestSEBlockLayer(unittest.TestCase):
     @parameterized.expand(TEST_CASES + TEST_CASES_3D)
     def test_shape(self, input_param, input_shape, expected_shape):
-        net = SEBlock(**input_param)
+        net = SEBlock(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net(torch.randn(input_shape))
+            result = net(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
     def test_ill_arg(self):

--- a/tests/test_segresnet.py
+++ b/tests/test_segresnet.py
@@ -17,6 +17,8 @@ from parameterized import parameterized
 from monai.networks.nets import SegResNet, SegResNetVAE
 from monai.utils import UpsampleMode
 
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 TEST_CASE_SEGRESNET = []
 for spatial_dims in range(2, 4):
     for init_filters in [8, 16]:
@@ -78,10 +80,10 @@ for spatial_dims in range(2, 4):
 class TestResBlock(unittest.TestCase):
     @parameterized.expand(TEST_CASE_SEGRESNET + TEST_CASE_SEGRESNET_2)
     def test_shape(self, input_param, input_shape, expected_shape):
-        net = SegResNet(**input_param)
+        net = SegResNet(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net(torch.randn(input_shape))
+            result = net(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
     def test_ill_arg(self):
@@ -92,9 +94,9 @@ class TestResBlock(unittest.TestCase):
 class TestResBlockVAE(unittest.TestCase):
     @parameterized.expand(TEST_CASE_SEGRESNET_VAE)
     def test_vae_shape(self, input_param, input_shape, expected_shape):
-        net = SegResNetVAE(**input_param)
+        net = SegResNetVAE(**input_param).to(device)
         with torch.no_grad():
-            result, _ = net(torch.randn(input_shape))
+            result, _ = net(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
 

--- a/tests/test_senet.py
+++ b/tests/test_senet.py
@@ -22,22 +22,23 @@ from monai.networks.nets import (
     se_resnext101_32x4d,
     senet154,
 )
-from tests.utils import skip_if_quick
 
-TEST_CASE_1 = [senet154(3, 2, 2)]
-TEST_CASE_2 = [se_resnet50(3, 2, 2)]
-TEST_CASE_3 = [se_resnet101(3, 2, 2)]
-TEST_CASE_4 = [se_resnet152(3, 2, 2)]
-TEST_CASE_5 = [se_resnext50_32x4d(3, 2, 2)]
-TEST_CASE_6 = [se_resnext101_32x4d(3, 2, 2)]
+device = "cuda" if torch.cuda.is_available() else "cpu"
 
-TEST_CASE_PRETRAINED = [se_resnet50(2, 3, 2, pretrained=True)]
+TEST_CASE_1 = [senet154(3, 2, 2).to(device)]
+TEST_CASE_2 = [se_resnet50(3, 2, 2).to(device)]
+TEST_CASE_3 = [se_resnet101(3, 2, 2).to(device)]
+TEST_CASE_4 = [se_resnet152(3, 2, 2).to(device)]
+TEST_CASE_5 = [se_resnext50_32x4d(3, 2, 2).to(device)]
+TEST_CASE_6 = [se_resnext101_32x4d(3, 2, 2).to(device)]
+
+TEST_CASE_PRETRAINED = [se_resnet50(2, 3, 2, pretrained=True).to(device)]
 
 
 class TestSENET(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5, TEST_CASE_6])
     def test_senet_shape(self, net):
-        input_data = torch.randn(2, 2, 64, 64, 64)
+        input_data = torch.randn(2, 2, 64, 64, 64).to(device)
         expected_shape = (2, 2)
         net.eval()
         with torch.no_grad():
@@ -51,9 +52,8 @@ class TestPretrainedSENET(unittest.TestCase):
             TEST_CASE_PRETRAINED,
         ]
     )
-    @skip_if_quick
     def test_senet_shape(self, net):
-        input_data = torch.randn(3, 3, 64, 64)
+        input_data = torch.randn(3, 3, 64, 64).to(device)
         expected_shape = (3, 2)
         net.eval()
         with torch.no_grad():

--- a/tests/test_smartcachedataset.py
+++ b/tests/test_smartcachedataset.py
@@ -32,7 +32,7 @@ TEST_CASE_4 = [0.5, 2, Compose([LoadNiftid(keys=["image", "label", "extra"])])]
 class TestSmartCacheDataset(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
     def test_shape(self, replace_rate, num_replace_workers, transform):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[8, 8, 8]), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
             nib.save(test_image, os.path.join(tempdir, "test_label1.nii.gz"))

--- a/tests/test_unet.py
+++ b/tests/test_unet.py
@@ -18,6 +18,8 @@ from monai.networks.layers import Act, Norm
 from monai.networks.nets import UNet
 from tests.utils import test_script_save
 
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 TEST_CASE_0 = [  # single channel 2D, batch 16, no residual
     {
         "dimensions": 2,
@@ -118,10 +120,10 @@ CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_C
 class TestUNET(unittest.TestCase):
     @parameterized.expand(CASES)
     def test_shape(self, input_param, input_shape, expected_shape):
-        net = UNet(**input_param)
+        net = UNet(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
+            result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
     def test_script(self):

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -17,6 +17,8 @@ from parameterized import parameterized
 from monai.networks.nets import VNet
 from tests.utils import test_script_save
 
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 TEST_CASE_VNET_2D_1 = [
     {"spatial_dims": 2, "in_channels": 4, "out_channels": 1, "act": "elu", "dropout_dim": 1},
     (1, 4, 32, 32),
@@ -61,10 +63,10 @@ class TestVNet(unittest.TestCase):
         ]
     )
     def test_vnet_shape(self, input_param, input_shape, expected_shape):
-        net = VNet(**input_param)
+        net = VNet(**input_param).to(device)
         net.eval()
         with torch.no_grad():
-            result = net.forward(torch.randn(input_shape))
+            result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
     def test_script(self):


### PR DESCRIPTION
Continued fix of https://github.com/Project-MONAI/MONAI/issues/1137.

### Description
Where possible we should speed slow tests up and if not possible, they should be given the `skip_if_quick` decorator.

### Status
**ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
