### PR TITLE
Runner failfast

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -108,9 +108,10 @@ if __name__ == "__main__":
     try:
         test_result = test_runner.run(tests)
         print_results(results, discovery_time, thresh, "tests finished")
+        sys.exit(not test_result.wasSuccessful())
     except KeyboardInterrupt:
         print_results(results, discovery_time, thresh, "tests cancelled")
-        exit(1)
+        sys.exit(1)
     except Exception:
         print_results(results, discovery_time, thresh, "exception reached")
         raise

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -95,19 +95,19 @@ def parse_args():
     if args.pattern:
         print(f"With file pattern: '{args.pattern}'")
 
-    return args.path, args.pattern, args.thresh, args.verbosity, args.quick, args.failfast
+    return args
 
 
 if __name__ == "__main__":
     # Parse input arguments
-    path, pattern, thresh, verbosity, quick, failfast = parse_args()
+    args = parse_args()
 
     # If quick is desired, set environment variable
-    if quick:
+    if args.quick:
         os.environ["QUICKTEST"] = "True"
 
     # Get all test names (optionally from some path with some pattern)
-    loader_args = [path, pattern] if pattern else [path]
+    loader_args = [args.path, args.pattern] if args.pattern else [args.path]
     loader = unittest.TestLoader()
     with PerfContext() as pc:
         tests = loader.discover(*loader_args)
@@ -115,17 +115,17 @@ if __name__ == "__main__":
     print(f"time to discover tests: {discovery_time}s")
 
     test_runner = unittest.runner.TextTestRunner(
-        resultclass=TimeLoggingTestResult, verbosity=verbosity, failfast=failfast
+        resultclass=TimeLoggingTestResult, verbosity=args.verbosity, failfast=args.failfast
     )
 
     # Use try catches to print the current results if encountering exception or keyboard interruption
     try:
         test_result = test_runner.run(tests)
-        print_results(results, discovery_time, thresh, "tests finished")
+        print_results(results, discovery_time, args.thresh, "tests finished")
         sys.exit(not test_result.wasSuccessful())
     except KeyboardInterrupt:
-        print_results(results, discovery_time, thresh, "tests cancelled")
+        print_results(results, discovery_time, args.thresh, "tests cancelled")
         sys.exit(1)
     except Exception:
-        print_results(results, discovery_time, thresh, "exception reached")
+        print_results(results, discovery_time, args.thresh, "exception reached")
         raise

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -68,7 +68,11 @@ def parse_args(default_pattern):
         "-s", action="store", dest="path", default=".", help="Directory to start discovery (default: '%(default)s')"
     )
     parser.add_argument(
-        "-p", action="store", dest="pattern", default=default_pattern, help="Pattern to match tests (default: '%(default)s')"
+        "-p",
+        action="store",
+        dest="pattern",
+        default=default_pattern,
+        help="Pattern to match tests (default: '%(default)s')",
     )
     parser.add_argument(
         "-t",
@@ -101,12 +105,8 @@ def parse_args(default_pattern):
 
 def get_default_pattern(loader):
     signature = inspect.signature(loader.discover)
-    params = {
-        k: v.default
-        for k, v in signature.parameters.items()
-        if v.default is not inspect.Parameter.empty
-    }
-    return params['pattern']
+    params = {k: v.default for k, v in signature.parameters.items() if v.default is not inspect.Parameter.empty}
+    return params["pattern"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
Forward `failfast` and `verbosity` options to the test runner.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
