### PR TITLE
Temporarily switch to local docker registry

### DIFF
--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -138,10 +138,19 @@ jobs:
       env:
         QUICKTEST: True
 
+  local_docker:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+    - uses: actions/checkout@v2
+    - name: docker_build
+      run: |
+        docker build -t localhost:5000/local_monai:latest -f Dockerfile .
+        docker push localhost:5000/local_monai:latest
 
   docker:
+    needs: local_docker
     container:
-      image: docker://projectmonai/monai:latest
+      image: localhost:5000/local_monai:latest
     runs-on: [self-hosted, linux, x64]
     steps:
     - name: Import


### PR DESCRIPTION
Temporarily switch to local docker registry to avoid dockerhub rate limit on self-hosted runners

Fixes https://github.com/Project-MONAI/MONAI/issues/1209

### Description
Push/pull new docker images to/from local registry so self-hosted runners will not be blocked by dockerhub.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
