### PR TITLE
Point local docker build to runner of build_only label

### DIFF
--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -139,7 +139,7 @@ jobs:
         QUICKTEST: True
 
   local_docker:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, build_only]
     steps:
     - uses: actions/checkout@v2
     - name: docker_build


### PR DESCRIPTION
Fixes # .

### Description
Use a dedicate runner for local docker build to avoid permission issue.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
