### PR TITLE
Assign jobs to common runners

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,7 +9,7 @@ jobs:
     container:
       image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
       options: "--gpus all"
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, common]
     strategy:
       matrix:
         pytorch-version: [1.5.0, 1.5.1, 1.6.0, latest]
@@ -53,7 +53,7 @@ jobs:
     container:
       image: docker://projectmonai/monai:latest
       options: "--gpus all"
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, common]
     steps:
     - name: Run tests report coverage
       run: |

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -172,7 +172,7 @@ jobs:
     container:
       image: ${{ matrix.base }}
       options: --gpus all
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, common]
     steps:
     - uses: actions/checkout@v2
     - name: apt install

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
       options: --gpus all
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, common]
     steps:
     - uses: actions/checkout@v2
     - name: cache weekly timestamp
@@ -151,7 +151,7 @@ jobs:
     needs: local_docker
     container:
       image: localhost:5000/local_monai:latest
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, common]
     steps:
     - name: Import
       run: |


### PR DESCRIPTION
Fixes # .

### Description
CI jobs may be dispatched to [A,B,C] runners if its runs-on is [A,B].  This could cause issues as some jobs should be in a separate environment.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
