### PR TITLE
Fix a bug in finding integration tests

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -517,7 +517,7 @@ fi
 if [ $doNetTests = true ]
 then
     echo "${separator}${blue}coverage${noColor}"
-    for i in tests/integration_*.py
+    for i in tests/*integration_*.py
     do
         echo "$i"
         ${cmdPrefix}${cmd} "$i"


### PR DESCRIPTION
Fixes #1227 

### Description
It's just a change in the bash script to find files in test/ folder with"integration" in their name. Previously it was assuming the files start with "integration" but it is not the case.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
