### PR TITLE
Run self-hosted only if not forked

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   cron-gpu:
+    if: github.repository == 'Project-MONAI/MONAI'
     container:
       image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
       options: "--gpus all"
@@ -50,6 +51,7 @@ jobs:
         file: ./coverage.xml
 
   cron-docker:
+    if: github.repository == 'Project-MONAI/MONAI'
     container:
       image: docker://projectmonai/monai:latest
       options: "--gpus all"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -143,6 +143,7 @@ jobs:
         QUICKTEST: True
 
   GPU-quick-py3:  # GPU with full dependencies
+    if: github.repository == 'Project-MONAI/MONAI'
     strategy:
       matrix:
         environment:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -12,6 +12,7 @@ jobs:
   #   - ubuntu py36 37 38-pip-
   #   - os-latest-pip (shared)
   coverage-py3:
+    if: github.repository == 'Project-MONAI/MONAI'
     container:
       image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
       options: --gpus all
@@ -139,6 +140,7 @@ jobs:
         QUICKTEST: True
 
   local_docker:
+    if: github.repository == 'Project-MONAI/MONAI'
     runs-on: [self-hosted, linux, x64, build_only]
     steps:
     - uses: actions/checkout@v2
@@ -148,6 +150,7 @@ jobs:
         docker push localhost:5000/local_monai:latest
 
   docker:
+    if: github.repository == 'Project-MONAI/MONAI'
     needs: local_docker
     container:
       image: localhost:5000/local_monai:latest


### PR DESCRIPTION
Fixes #799  .

### Description
Disabled the tests that run on self-hosted if the repo name is not Project-MONAI/MONAI.
Which means the repo is forked.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
