### PR TITLE
Torchscript Fixes

### DIFF
--- a/monai/networks/nets/autoencoder.py
+++ b/monai/networks/nets/autoencoder.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -194,11 +194,7 @@ class AutoEncoder(nn.Module):
 
         return decode
 
-    def forward(
-        self, x: torch.Tensor
-    ) -> Union[
-        torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
-    ]:  # big tuple return necessary for VAE, which inherits
+    def forward(self, x: torch.Tensor) -> Any:
         x = self.encode(x)
         x = self.intermediate(x)
         x = self.decode(x)

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -87,7 +87,7 @@ class UNet(nn.Module):
             c = channels[0]
             s = strides[0]
 
-            subblock: Union[nn.Sequential, ResidualUnit, Convolution]
+            subblock: nn.Module
 
             if len(channels) > 2:
                 subblock = _create_block(c, c, channels[1:], strides[1:], False)  # continue recursion down
@@ -104,9 +104,7 @@ class UNet(nn.Module):
 
         self.model = _create_block(in_channels, out_channels, self.channels, self.strides, True)
 
-    def _get_down_layer(
-        self, in_channels: int, out_channels: int, strides: int, is_top: bool
-    ) -> Union[ResidualUnit, Convolution]:
+    def _get_down_layer(self, in_channels: int, out_channels: int, strides: int, is_top: bool) -> nn.Module:
         """
         Args:
             in_channels: number of input channels.
@@ -138,7 +136,7 @@ class UNet(nn.Module):
                 dropout=self.dropout,
             )
 
-    def _get_bottom_layer(self, in_channels: int, out_channels: int) -> Union[ResidualUnit, Convolution]:
+    def _get_bottom_layer(self, in_channels: int, out_channels: int) -> nn.Module:
         """
         Args:
             in_channels: number of input channels.
@@ -146,9 +144,7 @@ class UNet(nn.Module):
         """
         return self._get_down_layer(in_channels, out_channels, 1, False)
 
-    def _get_up_layer(
-        self, in_channels: int, out_channels: int, strides: int, is_top: bool
-    ) -> Union[Convolution, nn.Sequential]:
+    def _get_up_layer(self, in_channels: int, out_channels: int, strides: int, is_top: bool) -> nn.Module:
         """
         Args:
             in_channels: number of input channels.

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -34,7 +34,7 @@ def one_hot(labels: torch.Tensor, num_classes: int, dtype: torch.dtype = torch.f
     assert labels.dim() > 0, "labels should have dim of 1 or more."
 
     # if `dim` is bigger, add singleton dim at the end
-    if labels.ndimension() < dim + 1:
+    if labels.ndim < dim + 1:
         shape = ensure_tuple_size(labels.shape, dim + 1, 1)
         labels = labels.reshape(*shape)
 

--- a/tests/test_autoencoder.py
+++ b/tests/test_autoencoder.py
@@ -5,6 +5,7 @@ from parameterized import parameterized
 
 from monai.networks.layers import Act
 from monai.networks.nets import AutoEncoder
+from tests.utils import test_script_save
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -69,6 +70,12 @@ class TestAutoEncoder(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        net = AutoEncoder(dimensions=2, in_channels=1, out_channels=1, channels=(4, 8), strides=(2, 2))
+        test_data = torch.randn(2, 1, 32, 32)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
 
 
 if __name__ == "__main__":

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -17,6 +17,8 @@ from parameterized import parameterized
 
 from monai.networks.nets import DynUNet
 
+# from tests.utils import test_script_save
+
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
 strides: Sequence[Union[Sequence[int], int]]
@@ -110,6 +112,14 @@ class TestDynUNet(unittest.TestCase):
         with torch.no_grad():
             result = net(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
+
+
+#     def test_script(self):
+#         input_param, input_shape, _ = TEST_CASE_DYNUNET_2D[0]
+#         net = DynUNet(**input_param)
+#         test_data = torch.randn(input_shape)
+#         out_orig, out_reloaded = test_script_save(net, test_data)
+#         assert torch.allclose(out_orig, out_reloaded)
 
 
 class TestDynUNetDeepSupervision(unittest.TestCase):

--- a/tests/test_highresnet.py
+++ b/tests/test_highresnet.py
@@ -15,6 +15,7 @@ import torch
 from parameterized import parameterized
 
 from monai.networks.nets import HighResNet
+from tests.utils import test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -51,6 +52,13 @@ class TestHighResNet(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        input_param, input_shape, expected_shape = TEST_CASE_1
+        net = HighResNet(**input_param)
+        test_data = torch.randn(input_shape)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
 
 
 if __name__ == "__main__":

--- a/tests/test_se_block.py
+++ b/tests/test_se_block.py
@@ -16,6 +16,7 @@ from parameterized import parameterized
 
 from monai.networks.blocks import SEBlock
 from monai.networks.layers.factories import Act, Norm
+from tests.utils import test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -66,6 +67,13 @@ class TestSEBlockLayer(unittest.TestCase):
         with torch.no_grad():
             result = net(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        input_param, input_shape, _ = TEST_CASES[0]
+        net = SEBlock(**input_param)
+        test_data = torch.randn(input_shape)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
 
     def test_ill_arg(self):
         with self.assertRaises(ValueError):

--- a/tests/test_se_blocks.py
+++ b/tests/test_se_blocks.py
@@ -15,6 +15,7 @@ import torch
 from parameterized import parameterized
 
 from monai.networks.blocks import ChannelSELayer, ResidualSELayer
+from tests.utils import test_script_save
 
 TEST_CASES = [  # single channel 3D, batch 16
     [{"spatial_dims": 2, "in_channels": 4, "r": 3}, (7, 4, 64, 48), (7, 4, 64, 48)],  # 4-channel 2D, batch 7
@@ -45,6 +46,13 @@ class TestChannelSELayer(unittest.TestCase):
             result = net(torch.randn(input_shape))
             self.assertEqual(result.shape, expected_shape)
 
+    def test_script(self):
+        input_param, input_shape, _ = TEST_CASES[0]
+        net = ChannelSELayer(**input_param)
+        test_data = torch.randn(input_shape)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
+
     def test_ill_arg(self):
         with self.assertRaises(ValueError):
             ChannelSELayer(spatial_dims=1, in_channels=4, r=100)
@@ -58,6 +66,13 @@ class TestResidualSELayer(unittest.TestCase):
         with torch.no_grad():
             result = net(torch.randn(input_shape))
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        input_param, input_shape, _ = TEST_CASES[0]
+        net = ResidualSELayer(**input_param)
+        test_data = torch.randn(input_shape)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig, out_reloaded)
 
 
 if __name__ == "__main__":

--- a/tests/test_varautoencoder.py
+++ b/tests/test_varautoencoder.py
@@ -5,6 +5,7 @@ from parameterized import parameterized
 
 from monai.networks.layers import Act
 from monai.networks.nets import VarAutoEncoder
+from tests.utils import test_script_save
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -73,6 +74,14 @@ class TestVarAutoEncoder(unittest.TestCase):
         with torch.no_grad():
             result = net.forward(torch.randn(input_shape).to(device))[0]
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        net = VarAutoEncoder(
+            dimensions=2, in_shape=(1, 32, 32), out_channels=1, latent_size=2, channels=(4, 8), strides=(2, 2)
+        )
+        test_data = torch.randn(2, 1, 32, 32)
+        out_orig, out_reloaded = test_script_save(net, test_data)
+        assert torch.allclose(out_orig[0], out_reloaded[0])
 
 
 if __name__ == "__main__":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -123,15 +123,25 @@ class TorchImageTestCase3D(NumpyImageTestCase3D):
         self.segn = torch.tensor(self.segn)
 
 
-def test_script_save(net, inputs):
+def test_script_save(net, *inputs, eval_nets=True):
+    """
+    Test the ability to save `net` as a Torchscript object, reload it, and apply inference. The value `inputs` is
+    forward-passed through the original and loaded copy of the network and their results returned. Both `net` and its
+    reloaded copy are set to evaluation mode if `eval_nets` is True. The forward pass for both is done without
+    gradient accumulation.
+    """
+
     scripted = torch.jit.script(net)
     buffer = scripted.save_to_buffer()
     reloaded_net = torch.jit.load(BytesIO(buffer))
-    net.eval()
-    reloaded_net.eval()
+
+    if eval_nets:
+        net.eval()
+        reloaded_net.eval()
+
     with torch.no_grad():
-        result1 = net(inputs)
-        result2 = reloaded_net(inputs)
+        result1 = net(*inputs)
+        result2 = reloaded_net(*inputs)
 
     return result1, result2
 


### PR DESCRIPTION
Signed-off-by: Eric Kerfoot <eric.kerfoot@kcl.ac.uk>

Fixes #1160.

### Description
This introduces a number of changes to networks and their components to be compatible with Torchscript. Every network is being tested, except `DynUNet`, by converting it to a Torchscript script then back to a network before running a forward pass of synthetic data through it. This should ensure that a saved network represents a valid Pytorch object which can be reloaded and used without needing the original codebase. Going forward new networks need to check for Torchscript compatibility by including the sort of tests that have been added here, avoid using `super` in their definition, avoiding inheritance definitions that require `super`, and iterating over indices (eg. `for i in range(t.shape[0])`) in favour of using `enumerate` and `zip` when traversing lists.

The `DynUNet` is not currently compatible because it relies on iteration through lists of modules or the ListModule class. These are not currently compatible with Torchscript so a different architecture for this class is needed. It's possible to inherit from the existing UNet which is structured differently for this reason, however Torchscript does also have issues with the `super` keyword so a little more design thought is needed to account for the variation in the `DynUNet.forward` method which would need to use `super` in such a case. 

Changes were made to the squeeze and excitation classes to also account for Torchscript's lack of support for `forward`. Other things not supported and removed include the `reverse` function and `Tensor.ndimension` method. 

The return types for some methods of `UNet` were also made more general to accommodate future subtypes which might override these methods to return different subtypes of `nn.Module`. Other classes might need to be modified in a similar way in the future for the same reason.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
