### PR TITLE
1190 adds lmdbdataset

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         python -m pip install torch==1.7.0 torchvision==0.8.1 -f https://download.pytorch.org/whl/torch_stable.html
         # min. requirements for windows instances
-        python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); print(txt); f=open('requirements-dev.txt', 'w'); f.writelines(txt[1:11]); f.close()"
+        python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); print(txt); f=open('requirements-dev.txt', 'w'); f.writelines(txt[1:12]); f.close()"
     - name: Install the dependencies
       run: |
         python -m pip install torch==1.7.0

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -21,6 +21,12 @@ Generic Interfaces
   :members:
   :special-members: __getitem__
 
+`LMDBDataset`
+~~~~~~~~~~~~~
+.. autoclass:: LMDBDataset
+  :members:
+  :special-members: __getitem__
+
 `CacheDataset`
 ~~~~~~~~~~~~~~
 .. autoclass:: CacheDataset

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -147,7 +147,7 @@ Since MONAI v0.2.0, the extras syntax such as `pip install 'monai[nibabel]'` is 
 
 - The options are
 ```
-[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm]
+[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb]
 ```
 which correspond to `nibabel`, `scikit-image`, `pillow`, `tensorboard`,
 `gdown`, `pytorch-ignite`, `torchvision`, `itk`, and `tqdm` respectively.

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -94,6 +94,15 @@ except (ImportError, AttributeError):
 
 
 try:
+    import lmdb
+
+    lmdb_version = lmdb.__version__
+    del lmdb
+except (ImportError, AttributeError):
+    lmdb_version = "NOT INSTALLED or UNKNOWN VERSION."
+
+
+try:
     _, HAS_EXT = optional_import("monai._C")
     USE_COMPILED = HAS_EXT and os.getenv("BUILD_MONAI", "0") == "1"
 except (OptionalImportError, ImportError, AttributeError):
@@ -130,6 +139,7 @@ def get_optional_config_values():
     output["TorchVision"] = torchvision_version
     output["ITK"] = itk_version
     output["tqdm"] = tqdm_version
+    output["lmdb"] = lmdb_version
 
     return output
 

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -11,7 +11,7 @@
 
 from .csv_saver import CSVSaver
 from .dataloader import DataLoader
-from .dataset import ArrayDataset, CacheDataset, Dataset, PersistentDataset, SmartCacheDataset, ZipDataset
+from .dataset import ArrayDataset, CacheDataset, Dataset, LMDBDataset, PersistentDataset, SmartCacheDataset, ZipDataset
 from .decathlon_datalist import load_decathlon_datalist, load_decathlon_properties
 from .grid_dataset import *
 from .image_reader import *

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 import torch
 from torch.utils.data import Dataset as _TorchDataset
 
-from monai.data.utils import default_hashing
+from monai.data.utils import json_hashing
 from monai.transforms import Compose, Randomizable, Transform, apply_transform
 from monai.utils import MAX_SEED, get_seed, min_version, optional_import
 
@@ -114,7 +114,7 @@ class PersistentDataset(Dataset):
         data: Sequence,
         transform: Union[Sequence[Callable], Callable],
         cache_dir: Optional[Union[Path, str]] = None,
-        hash_func: Callable[..., bytes] = default_hashing,
+        hash_func: Callable[..., bytes] = json_hashing,
     ) -> None:
         """
         Args:
@@ -128,7 +128,7 @@ class PersistentDataset(Dataset):
                 may share a common cache dir provided that the transforms pre-processing is consistent.
                 If the cache_dir doesn't exist, will automatically create it.
             hash_func: a callable to compute hash from data items to be cached.
-                defaults to `monai.data.utils.default_hashing`.
+                defaults to `monai.data.utils.json_hashing`.
         """
         if not isinstance(transform, Compose):
             transform = Compose(transform)
@@ -244,7 +244,7 @@ class LMDBDataset(PersistentDataset):
         data: Sequence,
         transform: Union[Sequence[Callable], Callable],
         cache_dir: Union[Path, str] = "cache",
-        hash_func: Callable[..., bytes] = default_hashing,
+        hash_func: Callable[..., bytes] = json_hashing,
         db_name: str = "monai_cache",
         pickle_protocol=pickle.HIGHEST_PROTOCOL,
         lmdb_kwargs: Optional[dict] = None,
@@ -261,7 +261,7 @@ class LMDBDataset(PersistentDataset):
                 may share a common cache dir provided that the transforms pre-processing is consistent.
                 If the cache_dir doesn't exist, will automatically create it. Defaults to "./cache".
             hash_func: a callable to compute hash from data items to be cached.
-                defaults to `monai.data.utils.default_hashing`.
+                defaults to `monai.data.utils.json_hashing`.
             db_name: lmdb database file name. Defaults to "monai_cache".
             pickle_protocol: pickle protocol version. Defaults to pickle.HIGHEST_PROTOCOL.
                 https://docs.python.org/3/library/pickle.html#pickle-protocols

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -9,13 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
-import json
+
 import math
+import pickle
 import sys
 import threading
 import time
 import warnings
+from copy import deepcopy
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 import torch
 from torch.utils.data import Dataset as _TorchDataset
 
+from monai.data.utils import default_hashing
 from monai.transforms import Compose, Randomizable, Transform, apply_transform
 from monai.utils import MAX_SEED, get_seed, min_version, optional_import
 
@@ -32,6 +34,8 @@ if TYPE_CHECKING:
     has_tqdm = True
 else:
     tqdm, has_tqdm = optional_import("tqdm", "4.47.0", min_version, "tqdm")
+
+lmdb, _ = optional_import("lmdb")
 
 
 class Dataset(_TorchDataset):
@@ -107,25 +111,30 @@ class PersistentDataset(Dataset):
 
     def __init__(
         self,
-        data: Sequence[str],
+        data: Sequence,
         transform: Union[Sequence[Callable], Callable],
         cache_dir: Optional[Union[Path, str]] = None,
+        hash_func: Callable[..., bytes] = default_hashing,
     ) -> None:
         """
         Args:
             data: input data file paths to load and transform to generate dataset for model.
-                `PersistentDataset` expects input data to be a list of file paths and hashes them as cache keys.
+                `PersistentDataset` expects input data to be a list of serializable
+                and hashes them as cache keys using `hash_func`.
             transform: transforms to execute operations on input data.
             cache_dir: If specified, this is the location for persistent storage
                 of pre-computed transformed data tensors. The cache_dir is computed once, and
                 persists on disk until explicitly removed.  Different runs, programs, experiments
                 may share a common cache dir provided that the transforms pre-processing is consistent.
                 If the cache_dir doesn't exist, will automatically create it.
+            hash_func: a callable to compute hash from data items to be cached.
+                defaults to `monai.data.utils.default_hashing`.
         """
         if not isinstance(transform, Compose):
             transform = Compose(transform)
         super().__init__(data=data, transform=transform)
         self.cache_dir = Path(cache_dir) if cache_dir is not None else None
+        self.hash_func = hash_func
         if self.cache_dir is not None:
             if not self.cache_dir.exists():
                 self.cache_dir.mkdir(parents=True)
@@ -190,33 +199,144 @@ class PersistentDataset(Dataset):
             changed in any way, the objects in the cache dir will be invalid.  The hash for the
             cache is ONLY dependant on the input filename paths.
         """
-        if item_transformed.get("cached", False) is False:
-            hashfile = None
-            if self.cache_dir is not None:
-                # TODO: Find way to hash transforms content as part of the cache
-                data_item_md5 = hashlib.md5(json.dumps(item_transformed, sort_keys=True).encode("utf-8")).hexdigest()
-                hashfile = self.cache_dir / f"{data_item_md5}.pt"
+        hashfile = None
+        if self.cache_dir is not None:
+            data_item_md5 = self.hash_func(item_transformed).decode("utf-8")
+            hashfile = self.cache_dir / f"{data_item_md5}.pt"
 
-            if hashfile is not None and hashfile.is_file():
-                item_transformed = torch.load(hashfile)
-            else:
-                item_transformed = self._pre_first_random_transform(item_transformed)
-                if hashfile is not None:
-                    # add sentinel flag to indicate that the transforms have already been computed.
-                    item_transformed["cached"] = True
-                    # NOTE: Writing to ".temp_write_cache" and then using a nearly atomic rename operation
-                    #       to make the cache more robust to manual killing of parent process
-                    #       which may leave partially written cache files in an incomplete state
-                    temp_hash_file = hashfile.with_suffix(".temp_write_cache")
-                    torch.save(item_transformed, temp_hash_file)
-                    temp_hash_file.rename(hashfile)
+        if hashfile is not None and hashfile.is_file():  # cache hit
+            return torch.load(hashfile)
 
-        return item_transformed
+        _item_transformed = self._pre_first_random_transform(deepcopy(item_transformed))  # keep the original hashed
+        if hashfile is not None:
+            # NOTE: Writing to ".temp_write_cache" and then using a nearly atomic rename operation
+            #       to make the cache more robust to manual killing of parent process
+            #       which may leave partially written cache files in an incomplete state
+            temp_hash_file = hashfile.with_suffix(".temp_write_cache")
+            torch.save(_item_transformed, temp_hash_file)
+            temp_hash_file.rename(hashfile)
+        return _item_transformed
 
     def __getitem__(self, index: int):
         pre_random_item = self._pre_first_random_cachecheck(self.data[index])
         post_random_item = self._first_random_and_beyond_transform(pre_random_item)
         return post_random_item
+
+
+class LMDBDataset(PersistentDataset):
+    """
+    Extension of `PersistentDataset` using LMDB as the backend.
+
+    See Also:
+        :py:class:`monai.data.PersistentDataset`
+
+    Examples:
+
+        >>> items = [{"data": i} for i in range(5)]
+        # [{'data': 0}, {'data': 1}, {'data': 2}, {'data': 3}, {'data': 4}]
+        >>> lmdb_ds = monai.data.LMDBDataset(items, transform=monai.transforms.SimulateDelayd("data", delay_time=1))
+        >>> print(list(lmdb_ds))  # using the cached results
+
+    """
+
+    def __init__(
+        self,
+        data: Sequence,
+        transform: Union[Sequence[Callable], Callable],
+        cache_dir: Union[Path, str] = "cache",
+        hash_func: Callable[..., bytes] = default_hashing,
+        db_name: str = "monai_cache",
+        pickle_protocol=pickle.HIGHEST_PROTOCOL,
+        lmdb_kwargs: Optional[dict] = None,
+    ) -> None:
+        """
+        Args:
+            data: input data file paths to load and transform to generate dataset for model.
+                `LMDBDataset` expects input data to be a list of serializable
+                and hashes them as cache keys using `hash_func`.
+            transform: transforms to execute operations on input data.
+            cache_dir: if specified, this is the location for persistent storage
+                of pre-computed transformed data tensors. The cache_dir is computed once, and
+                persists on disk until explicitly removed.  Different runs, programs, experiments
+                may share a common cache dir provided that the transforms pre-processing is consistent.
+                If the cache_dir doesn't exist, will automatically create it. Defaults to "./cache".
+            hash_func: a callable to compute hash from data items to be cached.
+                defaults to `monai.data.utils.default_hashing`.
+            db_name: lmdb database file name. Defaults to "monai_cache".
+            pickle_protocol: pickle protocol version. Defaults to pickle.HIGHEST_PROTOCOL.
+                https://docs.python.org/3/library/pickle.html#pickle-protocols
+            lmdb_kwargs: additional keyword arguments to the lmdb environment.
+        """
+        super().__init__(data=data, transform=transform, cache_dir=cache_dir, hash_func=hash_func)
+        if not self.cache_dir:
+            raise ValueError("cache_dir must be specified.")
+        self.db_file = self.cache_dir / f"{db_name}.lmdb"
+        self.pickle_protocol = pickle_protocol
+        self.lmdb_kwargs = lmdb_kwargs or {}
+        if not self.lmdb_kwargs.get("map_size", 0):
+            self.lmdb_kwargs["map_size"] = 1024 ** 4  # default map_size
+
+        # create cache
+        self._fill_cache()
+        # read-only database env
+        self.lmdb_kwargs["readonly"] = True
+        self._read_env = lmdb.open(path=f"{self.db_file}", subdir=False, **self.lmdb_kwargs)
+
+    def _fill_cache(self):
+        print(f"Accessing lmdb file: {self.db_file}.")
+        self.lmdb_kwargs["readonly"] = False
+        env = lmdb.open(path=f"{self.db_file}", subdir=False, **self.lmdb_kwargs)
+        if not has_tqdm:
+            warnings.warn("LMDBDataset: tqdm is not installed. not displaying the caching progress.")
+        for item in tqdm(self.data) if has_tqdm else self.data:
+            key = self.hash_func(item)
+            done, retry, val = False, 5, None
+            while not done and retry > 0:
+                try:
+                    with env.begin(write=True) as txn:
+                        with txn.cursor() as cursor:
+                            done = cursor.set_key(key)
+                            if done:
+                                continue
+                        if val is None:
+                            val = self._pre_first_random_transform(deepcopy(item))  # keep the original hashed
+                            val = pickle.dumps(val, protocol=self.pickle_protocol)
+                        txn.put(key, val)
+                    done = True
+                except lmdb.MapFullError:
+                    done, retry = False, retry - 1
+                    size = env.info()["map_size"]
+                    new_size = size * 2
+                    print(f"Resizing the cache database from {int(size) >> 20}MB to {int(new_size) >> 20}MB.")
+                    env.set_mapsize(new_size)
+            if not done:  # still has the map full error
+                size = env.info()["map_size"]
+                env.close()
+                raise ValueError(f"Please increase the map size of lmdb (current size={size}).")
+        env.close()
+
+    def _pre_first_random_cachecheck(self, item_transformed):
+        """
+        if the item is not found in the lmdb file, resolves to the persistent cache default behaviour.
+        """
+        with self._read_env.begin(write=False) as txn:
+            data = txn.get(self.hash_func(item_transformed))
+        if data is None:
+            warnings.warn("LMDBDataset: cache key not found, running fallback caching.")
+            return super()._pre_first_random_cachecheck(item_transformed)
+        try:
+            return pickle.loads(data)
+        except Exception as err:
+            raise RuntimeError("Invalid cache value, corrupted lmdb file?") from err
+
+    def info(self):
+        """
+        Returns: dataset info dictionary.
+        """
+        out = dict(self._read_env.info())
+        out["size"] = len(self.data)
+        out["filename"] = f"{self.db_file.absolute()}"
+        return out
 
 
 class CacheDataset(Dataset):

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 import torch
 from torch.utils.data import Dataset as _TorchDataset
 
-from monai.data.utils import json_hashing
+from monai.data.utils import pickle_hashing
 from monai.transforms import Compose, Randomizable, Transform, apply_transform
 from monai.utils import MAX_SEED, get_seed, min_version, optional_import
 
@@ -114,7 +114,7 @@ class PersistentDataset(Dataset):
         data: Sequence,
         transform: Union[Sequence[Callable], Callable],
         cache_dir: Optional[Union[Path, str]] = None,
-        hash_func: Callable[..., bytes] = json_hashing,
+        hash_func: Callable[..., bytes] = pickle_hashing,
     ) -> None:
         """
         Args:
@@ -128,7 +128,7 @@ class PersistentDataset(Dataset):
                 may share a common cache dir provided that the transforms pre-processing is consistent.
                 If the cache_dir doesn't exist, will automatically create it.
             hash_func: a callable to compute hash from data items to be cached.
-                defaults to `monai.data.utils.json_hashing`.
+                defaults to `monai.data.utils.pickle_hashing`.
         """
         if not isinstance(transform, Compose):
             transform = Compose(transform)
@@ -244,7 +244,7 @@ class LMDBDataset(PersistentDataset):
         data: Sequence,
         transform: Union[Sequence[Callable], Callable],
         cache_dir: Union[Path, str] = "cache",
-        hash_func: Callable[..., bytes] = json_hashing,
+        hash_func: Callable[..., bytes] = pickle_hashing,
         db_name: str = "monai_cache",
         pickle_protocol=pickle.HIGHEST_PROTOCOL,
         lmdb_kwargs: Optional[dict] = None,
@@ -261,7 +261,7 @@ class LMDBDataset(PersistentDataset):
                 may share a common cache dir provided that the transforms pre-processing is consistent.
                 If the cache_dir doesn't exist, will automatically create it. Defaults to "./cache".
             hash_func: a callable to compute hash from data items to be cached.
-                defaults to `monai.data.utils.json_hashing`.
+                defaults to `monai.data.utils.pickle_hashing`.
             db_name: lmdb database file name. Defaults to "monai_cache".
             pickle_protocol: pickle protocol version. Defaults to pickle.HIGHEST_PROTOCOL.
                 https://docs.python.org/3/library/pickle.html#pickle-protocols

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
+import json
 import math
 import os
 import warnings
@@ -762,3 +764,17 @@ class DistributedSampler(_TorchDistributedSampler):
             if self.rank + extra_size >= self.num_replicas:
                 self.num_samples -= 1
             self.total_size = data_len
+
+
+def default_hashing(item) -> bytes:
+    """
+
+    Args:
+        item: data item to be hashed
+
+    Returns: the corresponding hash key
+
+    """
+    # TODO: Find way to hash transforms content as part of the cache
+    cache_key = hashlib.md5(json.dumps(item, sort_keys=True).encode("utf-8")).hexdigest()
+    return f"{cache_key}".encode("utf-8")

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -775,6 +775,6 @@ def default_hashing(item) -> bytes:
     Returns: the corresponding hash key
 
     """
-    # TODO: Find way to hash transforms content as part of the cache
+    # TODO: Find way to hash transforms content as part of the cache, pickle.dumps?
     cache_key = hashlib.md5(json.dumps(item, sort_keys=True).encode("utf-8")).hexdigest()
     return f"{cache_key}".encode("utf-8")

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -781,13 +781,13 @@ def json_hashing(item) -> bytes:
     return f"{cache_key}".encode("utf-8")
 
 
-def pickle_hashing(item, protocol=pickle.DEFAULT_PROTOCOL) -> bytes:
+def pickle_hashing(item, protocol=pickle.HIGHEST_PROTOCOL) -> bytes:
     """
 
     Args:
         item: data item to be hashed
         protocol: protocol version used for pickling,
-            defaults to `pickle.DEFAULT_PROTOCOL`.
+            defaults to `pickle.HIGHEST_PROTOCOL`.
 
     Returns: the corresponding hash key
 

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -362,7 +362,7 @@ def apply_transform(transform: Callable, data, map_items: bool = True):
             return [transform(item) for item in data]
         return transform(data)
     except Exception as e:
-        raise type(e)(f"Applying transform {transform}.").with_traceback(e.__traceback__)
+        raise RuntimeError(f"applying transform {transform}") from e
 
 
 def create_grid(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ pillow
 tensorboard
 scikit-image>=0.14.2
 tqdm>=4.47.0
+lmdb
 flake8>=3.8.1
 flake8-bugbear
 flake8-comprehensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,8 @@ itk =
     itk
 tqdm =
     tqdm>=4.47.0
+lmdb =
+    lmdb
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -59,6 +59,7 @@ def run_testsuit():
         "test_keep_largest_connected_component",
         "test_keep_largest_connected_componentd",
         "test_lltm",
+        "test_lmdbdataset",
         "test_load_image",
         "test_load_imaged",
         "test_load_nifti",
@@ -104,9 +105,11 @@ def run_testsuit():
     for case in files:
         test_module = os.path.basename(case)[:-3]
         if test_module in exclude_cases:
+            exclude_cases.remove(test_module)
             print(f"skipping tests.{test_module}.")
         else:
             cases.append(f"tests.{test_module}")
+    assert not exclude_cases, f"items in exclude_cases not used: {exclude_cases}."
     test_suite = unittest.TestLoader().loadTestsFromNames(cases)
     return test_suite
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,0 +1,56 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+from monai.data import json_hashing, pickle_hashing
+from monai.utils import set_determinism
+
+
+class TestPickleHashing(unittest.TestCase):
+    def test_pickle(self):
+        set_determinism(0)
+        data1 = np.random.rand(10)
+        data2 = np.random.rand(10)
+        set_determinism(0)
+        data3 = np.random.rand(10)
+        data4 = np.random.rand(10)
+        set_determinism(None)
+
+        h1 = pickle_hashing(data1)
+        h2 = pickle_hashing(data3)
+        self.assertEqual(h1, h2)
+
+        data_dict1 = {"b": data2, "a": data1}
+        data_dict2 = {"a": data3, "b": data4}
+
+        h1 = pickle_hashing(data_dict1)
+        h2 = pickle_hashing(data_dict2)
+        self.assertEqual(h1, h2)
+
+        with self.assertRaises(TypeError):
+            json_hashing(data_dict1)
+
+
+class TestJSONHashing(unittest.TestCase):
+    def test_json(self):
+        data_dict1 = {"b": "str2", "a": "str1"}
+        data_dict2 = {"a": "str1", "b": "str2"}
+
+        h1 = json_hashing(data_dict1)
+        h2 = json_hashing(data_dict2)
+        self.assertEqual(h1, h2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_integration_segmentation_3d.py
+++ b/tests/test_integration_segmentation_3d.py
@@ -45,7 +45,7 @@ from tests.utils import skip_if_quick
 TASK = "integration_segmentation_3d"
 
 
-def run_training_test(root_dir, device="cuda:0", cachedataset=False):
+def run_training_test(root_dir, device="cuda:0", cachedataset=0):
     monai.config.print_config()
     images = sorted(glob(os.path.join(root_dir, "img*.nii.gz")))
     segs = sorted(glob(os.path.join(root_dir, "seg*.nii.gz")))
@@ -82,8 +82,10 @@ def run_training_test(root_dir, device="cuda:0", cachedataset=False):
     )
 
     # create a training data loader
-    if cachedataset:
+    if cachedataset == 2:
         train_ds = monai.data.CacheDataset(data=train_files, transform=train_transforms, cache_rate=0.8)
+    elif cachedataset == 3:
+        train_ds = monai.data.LMDBDataset(data=train_files, transform=train_transforms)
     else:
         train_ds = monai.data.Dataset(data=train_files, transform=train_transforms)
     # use batch_size=2 to load images and use RandCropByPosNegLabeld to generate 2 x 4 images for network training
@@ -246,12 +248,12 @@ class IntegrationSegmentation3D(unittest.TestCase):
 
     def test_training(self):
         repeated = []
-        for i in range(3):
+        for i in range(4):
             set_determinism(0)
 
             repeated.append([])
             losses, best_metric, best_metric_epoch = run_training_test(
-                self.data_dir, device=self.device, cachedataset=(i == 2)
+                self.data_dir, device=self.device, cachedataset=i
             )
 
             # check training properties

--- a/tests/test_lmdbdataset.py
+++ b/tests/test_lmdbdataset.py
@@ -17,7 +17,7 @@ import nibabel as nib
 import numpy as np
 from parameterized import parameterized
 
-from monai.data import LMDBDataset, pickle_hashing
+from monai.data import LMDBDataset, json_hashing
 from monai.transforms import Compose, LoadNiftid, SimulateDelayd, Transform
 from tests.utils import skip_if_windows
 
@@ -104,7 +104,7 @@ class TestLMDBDataset(unittest.TestCase):
                 transform=_InplaceXform(),
                 cache_dir=tempdir,
                 lmdb_kwargs={"map_size": 10 * 1024},
-                hash_func=pickle_hashing,
+                hash_func=json_hashing,
             )
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
             ds1 = LMDBDataset(
@@ -112,7 +112,7 @@ class TestLMDBDataset(unittest.TestCase):
                 transform=_InplaceXform(),
                 cache_dir=tempdir,
                 lmdb_kwargs={"map_size": 10 * 1024},
-                hash_func=pickle_hashing,
+                hash_func=json_hashing,
             )
             self.assertEqual(list(ds1), list(ds))
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])

--- a/tests/test_lmdbdataset.py
+++ b/tests/test_lmdbdataset.py
@@ -17,7 +17,7 @@ import nibabel as nib
 import numpy as np
 from parameterized import parameterized
 
-from monai.data import PersistentDataset
+from monai.data import LMDBDataset
 from monai.transforms import Compose, LoadNiftid, SimulateDelayd, Transform
 
 TEST_CASE_1 = [
@@ -38,10 +38,46 @@ TEST_CASE_2 = [
     (128, 128, 128),
 ]
 
-TEST_CASE_3 = [None, (128, 128, 128)]
+TEST_CASE_3 = [None, (128, 128, 128), None]
+
+TEST_CASE_4 = [
+    [
+        LoadNiftid(keys=["image", "label", "extra"]),
+        SimulateDelayd(keys=["image", "label", "extra"], delay_time=[1e-7, 1e-6, 1e-5]),
+    ],
+    (128, 128, 128),
+    {"db_name": "test42"},
+]
+
+TEST_CASE_5 = [
+    [
+        LoadNiftid(keys=["image", "label", "extra"]),
+        SimulateDelayd(keys=["image", "label", "extra"], delay_time=[1e-7, 1e-6, 1e-5]),
+    ],
+    (128, 128, 128),
+    {"pickle_protocol": 2, "lmdb_kwargs": {"map_size": 100 * 1024 ** 2}},
+]
+
+TEST_CASE_6 = [
+    [
+        LoadNiftid(keys=["image", "label", "extra"]),
+        SimulateDelayd(keys=["image", "label", "extra"], delay_time=[1e-7, 1e-6, 1e-5]),
+    ],
+    (128, 128, 128),
+    {"db_name": "testdb", "lmdb_kwargs": {"map_size": 100 * 1024 ** 2}},
+]
+
+TEST_CASE_7 = [
+    [
+        LoadNiftid(keys=["image", "label", "extra"]),
+        SimulateDelayd(keys=["image", "label", "extra"], delay_time=[1e-7, 1e-6, 1e-5]),
+    ],
+    (128, 128, 128),
+    {"db_name": "testdb", "lmdb_kwargs": {"map_size": 2 * 1024 ** 2}},
+]
 
 
-class TestDataset(unittest.TestCase):
+class TestLMDBDataset(unittest.TestCase):
     def test_cache(self):
         """testing no inplace change to the hashed item"""
         items = [[list(range(i))] for i in range(5)]
@@ -55,14 +91,17 @@ class TestDataset(unittest.TestCase):
                 return data
 
         with tempfile.TemporaryDirectory() as tempdir:
-            ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir)
+            ds = LMDBDataset(items, transform=_InplaceXform(), cache_dir=tempdir)
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
-            ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir)
+            ds1 = LMDBDataset(items, transform=_InplaceXform(), cache_dir=tempdir)
             self.assertEqual(list(ds1), list(ds))
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
 
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
-    def test_shape(self, transform, expected_shape):
+        self.assertTrue(isinstance(ds1.info(), dict))
+
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5, TEST_CASE_6, TEST_CASE_7])
+    def test_shape(self, transform, expected_shape, kwargs=None):
+        kwargs = kwargs or {}
         test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
@@ -85,11 +124,11 @@ class TestDataset(unittest.TestCase):
             ]
 
             cache_dir = os.path.join(os.path.join(tempdir, "cache"), "data")
-            dataset_precached = PersistentDataset(data=test_data, transform=transform, cache_dir=cache_dir)
+            dataset_precached = LMDBDataset(data=test_data, transform=transform, cache_dir=cache_dir, **kwargs)
             data1_precached = dataset_precached[0]
             data2_precached = dataset_precached[1]
 
-            dataset_postcached = PersistentDataset(data=test_data, transform=transform, cache_dir=cache_dir)
+            dataset_postcached = LMDBDataset(data=test_data, transform=transform, cache_dir=cache_dir, **kwargs)
             data1_postcached = dataset_postcached[0]
             data2_postcached = dataset_postcached[1]
 

--- a/tests/test_lmdbdataset.py
+++ b/tests/test_lmdbdataset.py
@@ -19,6 +19,7 @@ from parameterized import parameterized
 
 from monai.data import LMDBDataset
 from monai.transforms import Compose, LoadNiftid, SimulateDelayd, Transform
+from tests.utils import skip_if_windows
 
 TEST_CASE_1 = [
     Compose(
@@ -77,6 +78,7 @@ TEST_CASE_7 = [
 ]
 
 
+@skip_if_windows
 class TestLMDBDataset(unittest.TestCase):
     def test_cache(self):
         """testing no inplace change to the hashed item"""
@@ -91,9 +93,9 @@ class TestLMDBDataset(unittest.TestCase):
                 return data
 
         with tempfile.TemporaryDirectory() as tempdir:
-            ds = LMDBDataset(items, transform=_InplaceXform(), cache_dir=tempdir)
+            ds = LMDBDataset(items, transform=_InplaceXform(), cache_dir=tempdir, lmdb_kwargs={"map_size": 10 * 1024})
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
-            ds1 = LMDBDataset(items, transform=_InplaceXform(), cache_dir=tempdir)
+            ds1 = LMDBDataset(items, transform=_InplaceXform(), cache_dir=tempdir, lmdb_kwargs={"map_size": 10 * 1024})
             self.assertEqual(list(ds1), list(ds))
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
 

--- a/tests/test_nifti_dataset.py
+++ b/tests/test_nifti_dataset.py
@@ -76,12 +76,12 @@ class TestNiftiDataset(unittest.TestCase):
                 np.testing.assert_allclose(d, ref + 1, atol=1e-3)
 
             # set seg transform, but no seg_files
-            with self.assertRaises(TypeError):
+            with self.assertRaises(RuntimeError):
                 dataset = NiftiDataset(full_names, seg_transform=lambda x: x + 1, image_only=True)
                 _ = dataset[0]
 
             # set seg transform, but no seg_files
-            with self.assertRaises(TypeError):
+            with self.assertRaises(RuntimeError):
                 dataset = NiftiDataset(full_names, seg_transform=lambda x: x + 1, image_only=True)
                 _ = dataset[0]
 

--- a/tests/test_persistentdataset.py
+++ b/tests/test_persistentdataset.py
@@ -17,7 +17,7 @@ import nibabel as nib
 import numpy as np
 from parameterized import parameterized
 
-from monai.data import PersistentDataset, pickle_hashing
+from monai.data import PersistentDataset, json_hashing
 from monai.transforms import Compose, LoadNiftid, SimulateDelayd, Transform
 
 TEST_CASE_1 = [
@@ -61,9 +61,9 @@ class TestDataset(unittest.TestCase):
             self.assertEqual(list(ds1), list(ds))
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
 
-            ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir, hash_func=pickle_hashing)
+            ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir, hash_func=json_hashing)
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
-            ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir, hash_func=pickle_hashing)
+            ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir, hash_func=json_hashing)
             self.assertEqual(list(ds1), list(ds))
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
 

--- a/tests/test_persistentdataset.py
+++ b/tests/test_persistentdataset.py
@@ -17,7 +17,7 @@ import nibabel as nib
 import numpy as np
 from parameterized import parameterized
 
-from monai.data import PersistentDataset
+from monai.data import PersistentDataset, pickle_hashing
 from monai.transforms import Compose, LoadNiftid, SimulateDelayd, Transform
 
 TEST_CASE_1 = [
@@ -49,7 +49,7 @@ class TestDataset(unittest.TestCase):
         class _InplaceXform(Transform):
             def __call__(self, data):
                 if data:
-                    data[0] = data[0] + 1
+                    data[0] = data[0] + np.pi
                 else:
                     data.append(1)
                 return data
@@ -58,6 +58,12 @@ class TestDataset(unittest.TestCase):
             ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir)
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
             ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir)
+            self.assertEqual(list(ds1), list(ds))
+            self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+
+            ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir, hash_func=pickle_hashing)
+            self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+            ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir, hash_func=pickle_hashing)
             self.assertEqual(list(ds1), list(ds))
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import os
+import sys
 import tempfile
 import unittest
 from io import BytesIO
@@ -62,6 +63,13 @@ def skip_if_no_cuda(obj):
     Skip the unit tests if torch.cuda.is_available is False
     """
     return unittest.skipIf(not torch.cuda.is_available(), "Skipping CUDA-based tests")(obj)
+
+
+def skip_if_windows(obj):
+    """
+    Skip the unit tests if platform is win32
+    """
+    return unittest.skipIf(sys.platform == "win32", "Skipping tests on Windows")(obj)
 
 
 def make_nifti_image(array, affine=None):


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #1190

### Description
adds a persistent dataset based on lmdb

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
