### PR TITLE
Build docker images in self-hosted runners to offload dockerhub build

### DIFF
--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -142,6 +142,7 @@ jobs:
   local_docker:
     if: github.repository == 'Project-MONAI/MONAI'
     runs-on: [self-hosted, linux, x64, build_only]
+    # we only push built container if it is built from master branch
     steps:
     - uses: actions/checkout@v2
     - name: docker_build
@@ -150,7 +151,7 @@ jobs:
         docker push localhost:5000/local_monai:latest
         docker tag localhost:5000/local_monai:latest projectmonai/monai:latest
         docker login -u projectmonai -p ${{ secrets.DOCKER_PW }}
-        docker push projectmonai/monai:latest
+        if [ $(git branch --show-current) == 'master' ]; then docker push projectmonai/monai:latest; fi
         docker logout
 
   docker:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -148,6 +148,10 @@ jobs:
       run: |
         docker build -t localhost:5000/local_monai:latest -f Dockerfile .
         docker push localhost:5000/local_monai:latest
+        docker tag localhost:5000/local_monai:latest projectmonai/monai:latest
+        docker login -u projectmonai -p ${{ secrets.DOCKER_PW }}
+        docker push projectmonai/monai:latest
+        docker logout
 
   docker:
     if: github.repository == 'Project-MONAI/MONAI'


### PR DESCRIPTION
Signed-off-by: Isaac Yang <isaacy@nvidia.com>

Fixes #1252

### Description
The local docker build step (local_docker in deploy) builds the monai:latest from Dockerfile.  This PR is to push that image to dockerhub.  The build failure seemed related to the load in dockerhub.  Moving the build process to our runners can reduce load on dockerhub and the build failure.

The local_docker step takes about 4min20sec~5min, and adding this docker push step does not occupy GPU resources.

** Requiring to add credential (DOCKER_PW of projectmonai) to repo's secrets.
** This PR does `docker logout` immediately after docker push is done.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
