### PR TITLE
Fix CI script for weekly PyPi build

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -2,7 +2,7 @@ name: weekly-preview
 
 on:
   schedule:
-  - cron: "0 2 * * 6"  # 02:00 of every Saturday
+  - cron: "0 2 * * 0"  # 02:00 of every Sunday
 
 jobs:
   packaging:
@@ -27,7 +27,7 @@ jobs:
         # build tar.gz and wheel
         git config user.name "CI Builder"
         git config user.email "monai.miccai2019@gmail.com"
-        git add setup.cfg setup.py
+        git add setup.cfg monai/__init__.py
         git commit -m "Weekly build at $HEAD_COMMIT_ID"
         git tag 0.4.dev$(date +'%y%U')
         python setup.py sdist bdist_wheel


### PR DESCRIPTION
Signed-off-by: Isaac Yang <isaacy@nvidia.com>

Fixes # .

### Description
Two files are modified locally prior to CI build process.  Both have to be committed into local repo so versioneer will not include 'dirty' in the version string.  This PR fixes the `git add` statement to properly add those two 'dirty' files.

Additionally, change cron job to 2AM UTC Time every Sunday, which should be a 'non-busy' hour globally.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
