### PR TITLE
New simplelayer HilbertTransform implemented, and wrapped in new intensity transform DetectEnvelope.

### DIFF
--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -179,6 +179,11 @@ Layers
 .. autoclass:: GaussianFilter
     :members:
 
+`HilbertTransform`
+~~~~~~~~~~~~~~~~~~
+.. autoclass:: HilbertTransform
+    :members:
+
 `Affine Transform`
 ~~~~~~~~~~~~~~~~~~
 .. autoclass:: monai.networks.layers.AffineTransform

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -216,6 +216,12 @@ Intensity
     :members:
     :special-members: __call__
 
+`DetectEnvelope`
+"""""""""""""""""""""
+.. autoclass:: DetectEnvelope
+    :members:
+    :special-members: __call__
+
 IO
 ^^
 

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -21,6 +21,7 @@ from .misc import ensure_tuple
 OPTIONAL_IMPORT_MSG_FMT = "{}"
 
 __all__ = [
+    "InvalidPyTorchVersionError",
     "OptionalImportError",
     "exact_version",
     "export",
@@ -103,6 +104,17 @@ def exact_version(the_module, version_str: str = "") -> bool:
     Returns True if the module's __version__ matches version_str
     """
     return bool(the_module.__version__ == version_str)
+
+
+class InvalidPyTorchVersionError(Exception):
+    """
+    Raised when called function or method requires a more recent
+    PyTorch version than that installed.
+    """
+
+    def __init__(self, required_version, name):
+        message = f"{name} requires PyTorch version {required_version} or later"
+        super().__init__(message)
 
 
 class OptionalImportError(ImportError):

--- a/tests/test_detect_envelope.py
+++ b/tests/test_detect_envelope.py
@@ -1,0 +1,165 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+from monai.transforms import DetectEnvelope
+from monai.utils import InvalidPyTorchVersionError, OptionalImportError
+from tests.utils import SkipIfAtLeastPyTorchVersion, SkipIfBeforePyTorchVersion, SkipIfModule, SkipIfNoModule
+
+n_samples = 500
+hann_windowed_sine = np.sin(2 * np.pi * 10 * np.linspace(0, 1, n_samples)) * np.hanning(n_samples)
+
+# SINGLE-CHANNEL VALUE TESTS
+# using np.expand_dims() to add length 1 channel dimension at dimension 0
+
+TEST_CASE_1D_SINE = [
+    {},  # args (empty, so use default)
+    np.expand_dims(hann_windowed_sine, 0),  # Input data: Hann windowed sine wave
+    np.expand_dims(np.hanning(n_samples), 0),  # Expected output: the Hann window
+    1e-4,  # absolute tolerance
+]
+
+TEST_CASE_2D_SINE = [
+    {},  # args (empty, so use default (i.e. process along first spatial dimension, axis=1)
+    # Create 10 identical windowed sine waves as a 2D numpy array
+    np.expand_dims(np.stack([hann_windowed_sine] * 10, axis=1), 0),
+    # Expected output: Set of 10 identical Hann windows
+    np.expand_dims(np.stack([np.hanning(n_samples)] * 10, axis=1), 0),
+    1e-4,  # absolute tolerance
+]
+
+TEST_CASE_3D_SINE = [
+    {},  # args (empty, so use default (i.e. process along first spatial dimension, axis=1)
+    # Create 100 identical windowed sine waves as a (n_samples x 10 x 10) 3D numpy array
+    np.expand_dims(np.stack([np.stack([hann_windowed_sine] * 10, axis=1)] * 10, axis=2), 0),
+    # Expected output: Set of 100 identical Hann windows in (n_samples x 10 x 10) 3D numpy array
+    np.expand_dims(np.stack([np.stack([np.hanning(n_samples)] * 10, axis=1)] * 10, axis=2), 0),
+    1e-4,  # absolute tolerance
+]
+
+TEST_CASE_2D_SINE_AXIS_1 = [
+    {"axis": 2},  # set axis argument to 1
+    # Create 10 identical windowed sine waves as a 2D numpy array
+    np.expand_dims(np.stack([hann_windowed_sine] * 10, axis=1), 0),
+    # Expected output: absolute value of each sample of the waveform, repeated (i.e. flat envelopes)
+    np.expand_dims(np.abs(np.repeat(hann_windowed_sine, 10).reshape((n_samples, 10))), 0),
+    1e-4,  # absolute tolerance
+]
+
+TEST_CASE_1D_SINE_PADDING_N = [
+    {"n": 512},  # args (empty, so use default)
+    np.expand_dims(hann_windowed_sine, 0),  # Input data: Hann windowed sine wave
+    np.expand_dims(np.concatenate([np.hanning(500), np.zeros(12)]), 0),  # Expected output: the Hann window
+    1e-3,  # absolute tolerance
+]
+
+# MULTI-CHANNEL VALUE TEST
+
+TEST_CASE_2_CHAN_3D_SINE = [
+    {},  # args (empty, so use default (i.e. process along first spatial dimension, axis=1)
+    # Create 100 identical windowed sine waves as a (n_samples x 10 x 10) 3D numpy array, twice (2 channels)
+    np.stack([np.stack([np.stack([hann_windowed_sine] * 10, axis=1)] * 10, axis=2)] * 2, axis=0),
+    # Expected output: Set of 100 identical Hann windows in (n_samples x 10 x 10) 3D numpy array, twice (2 channels)
+    np.stack([np.stack([np.stack([np.hanning(n_samples)] * 10, axis=1)] * 10, axis=2)] * 2, axis=0),
+    1e-4,  # absolute tolerance
+]
+
+# EXCEPTION TESTS
+
+TEST_CASE_INVALID_AXIS_1 = [
+    {"axis": 3},  # set axis argument to 3 when only 3 dimensions (1 channel + 2 spatial)
+    np.expand_dims(np.stack([hann_windowed_sine] * 10, axis=1), 0),  # Create 2D dataset
+    "__call__",  # method expected to raise exception
+]
+
+TEST_CASE_INVALID_AXIS_2 = [
+    {"axis": -1},  # set axis argument negative
+    np.expand_dims(np.stack([hann_windowed_sine] * 10, axis=1), 0),  # Create 2D dataset
+    "__init__",  # method expected to raise exception
+]
+
+TEST_CASE_INVALID_N = [
+    {"n": 0},  # set FFT length to zero
+    np.expand_dims(np.stack([hann_windowed_sine] * 10, axis=1), 0),  # Create 2D dataset
+    "__call__",  # method expected to raise exception
+]
+
+TEST_CASE_INVALID_DTYPE = [
+    {},
+    np.expand_dims(np.array(hann_windowed_sine, dtype=np.complex), 0),  # complex numbers are invalid
+    "__call__",  # method expected to raise exception
+]
+
+TEST_CASE_INVALID_IMG_LEN = [
+    {},
+    np.expand_dims(np.array([]), 0),  # empty array is invalid
+    "__call__",  # method expected to raise exception
+]
+
+TEST_CASE_INVALID_OBJ = [{}, "a string", "__call__"]  # method expected to raise exception
+
+
+@SkipIfBeforePyTorchVersion((1, 7))
+@SkipIfNoModule("torch.fft")
+class TestDetectEnvelope(unittest.TestCase):
+    @parameterized.expand(
+        [
+            TEST_CASE_1D_SINE,
+            TEST_CASE_2D_SINE,
+            TEST_CASE_3D_SINE,
+            TEST_CASE_2D_SINE_AXIS_1,
+            TEST_CASE_1D_SINE_PADDING_N,
+            TEST_CASE_2_CHAN_3D_SINE,
+        ]
+    )
+    def test_value(self, arguments, image, expected_data, atol):
+        result = DetectEnvelope(**arguments)(image)
+        np.testing.assert_allclose(result, expected_data, atol=atol)
+
+    @parameterized.expand(
+        [
+            TEST_CASE_INVALID_AXIS_1,
+            TEST_CASE_INVALID_AXIS_2,
+            TEST_CASE_INVALID_N,
+            TEST_CASE_INVALID_DTYPE,
+            TEST_CASE_INVALID_IMG_LEN,
+        ]
+    )
+    def test_value_error(self, arguments, image, method):
+        if method == "__init__":
+            self.assertRaises(ValueError, DetectEnvelope, **arguments)
+        elif method == "__call__":
+            self.assertRaises(ValueError, DetectEnvelope(**arguments), image)
+        else:
+            raise ValueError("Expected raising method invalid. Should be __init__ or __call__.")
+
+
+@SkipIfBeforePyTorchVersion((1, 7))
+@SkipIfModule("torch.fft")
+class TestHilbertTransformNoFFTMod(unittest.TestCase):
+    def test_no_fft_module_error(self):
+        self.assertRaises(OptionalImportError, DetectEnvelope(), np.random.rand(1, 10))
+
+
+@SkipIfAtLeastPyTorchVersion((1, 7))
+class TestDetectEnvelopeInvalidPyTorch(unittest.TestCase):
+    def test_invalid_pytorch_error(self):
+        with self.assertRaises(InvalidPyTorchVersionError) as cm:
+            DetectEnvelope()
+            self.assertEqual("DetectEnvelope requires PyTorch version 1.7.0 or later", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hilbert_transform.py
+++ b/tests/test_hilbert_transform.py
@@ -1,0 +1,226 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import torch
+from parameterized import parameterized
+
+from monai.networks.layers import HilbertTransform
+from monai.utils import InvalidPyTorchVersionError, OptionalImportError
+from tests.utils import (
+    SkipIfAtLeastPyTorchVersion,
+    SkipIfBeforePyTorchVersion,
+    SkipIfModule,
+    SkipIfNoModule,
+    skip_if_no_cuda,
+)
+
+
+def create_expected_numpy_output(input_datum, **kwargs):
+
+    x = np.fft.fft(
+        input_datum.cpu().numpy() if input_datum.device.type == "cuda" else input_datum.numpy(),
+        **kwargs,
+    )
+    f = np.fft.fftfreq(x.shape[kwargs["axis"]])
+    u = np.heaviside(f, 0.5)
+    new_dims_before = kwargs["axis"]
+    new_dims_after = len(x.shape) - kwargs["axis"] - 1
+    for _ in range(new_dims_before):
+        u = np.expand_dims(u, 0)
+    for _ in range(new_dims_after):
+        u = np.expand_dims(u, -1)
+    ht = np.fft.ifft(x * 2 * u, axis=kwargs["axis"])
+
+    return ht
+
+
+cpu = torch.device("cpu")
+n_samples = 500
+hann_windowed_sine = np.sin(2 * np.pi * 10 * np.linspace(0, 1, n_samples)) * np.hanning(n_samples)
+
+# CPU TEST DATA
+
+cpu_input_data = dict()
+cpu_input_data["1D"] = torch.as_tensor(hann_windowed_sine, device=cpu).unsqueeze(0).unsqueeze(0)
+cpu_input_data["2D"] = (
+    torch.as_tensor(np.stack([hann_windowed_sine] * 10, axis=1), device=cpu).unsqueeze(0).unsqueeze(0)
+)
+cpu_input_data["3D"] = (
+    torch.as_tensor(np.stack([np.stack([hann_windowed_sine] * 10, axis=1)] * 10, axis=2), device=cpu)
+    .unsqueeze(0)
+    .unsqueeze(0)
+)
+cpu_input_data["1D 2CH"] = torch.as_tensor(np.stack([hann_windowed_sine] * 10, axis=1), device=cpu).unsqueeze(0)
+cpu_input_data["2D 2CH"] = torch.as_tensor(
+    np.stack([np.stack([hann_windowed_sine] * 10, axis=1)] * 10, axis=2), device=cpu
+).unsqueeze(0)
+
+# SINGLE-CHANNEL CPU VALUE TESTS
+
+TEST_CASE_1D_SINE_CPU = [
+    {},  # args (empty, so use default)
+    cpu_input_data["1D"],  # Input data: Random 1D signal
+    create_expected_numpy_output(cpu_input_data["1D"], axis=2),  # Expected output: FFT of signal
+    1e-5,  # absolute tolerance
+]
+
+TEST_CASE_2D_SINE_CPU = [
+    {},  # args (empty, so use default)
+    cpu_input_data["2D"],  # Input data: Random 1D signal
+    create_expected_numpy_output(cpu_input_data["2D"], axis=2),  # Expected output: FFT of signal
+    1e-5,  # absolute tolerance
+]
+
+TEST_CASE_3D_SINE_CPU = [
+    {},  # args (empty, so use default)
+    cpu_input_data["3D"],  # Input data: Random 1D signal
+    create_expected_numpy_output(cpu_input_data["3D"], axis=2),
+    1e-5,  # absolute tolerance
+]
+
+# MULTICHANNEL CPU VALUE TESTS, PROCESS ALONG FIRST SPATIAL AXIS
+
+TEST_CASE_1D_2CH_SINE_CPU = [
+    {},  # args (empty, so use default)
+    cpu_input_data["1D 2CH"],  # Input data: Random 1D signal
+    create_expected_numpy_output(cpu_input_data["1D 2CH"], axis=2),
+    1e-5,  # absolute tolerance
+]
+
+TEST_CASE_2D_2CH_SINE_CPU = [
+    {},  # args (empty, so use default)
+    cpu_input_data["2D 2CH"],  # Input data: Random 1D signal
+    create_expected_numpy_output(cpu_input_data["2D 2CH"], axis=2),
+    1e-5,  # absolute tolerance
+]
+
+# GPU TEST DATA
+
+if torch.cuda.is_available():
+    gpu = torch.device("cuda")
+
+    gpu_input_data = dict()
+    gpu_input_data["1D"] = torch.as_tensor(hann_windowed_sine, device=gpu).unsqueeze(0).unsqueeze(0)
+    gpu_input_data["2D"] = (
+        torch.as_tensor(np.stack([hann_windowed_sine] * 10, axis=1), device=gpu).unsqueeze(0).unsqueeze(0)
+    )
+    gpu_input_data["3D"] = (
+        torch.as_tensor(np.stack([np.stack([hann_windowed_sine] * 10, axis=1)] * 10, axis=2), device=gpu)
+        .unsqueeze(0)
+        .unsqueeze(0)
+    )
+    gpu_input_data["1D 2CH"] = torch.as_tensor(np.stack([hann_windowed_sine] * 10, axis=1), device=gpu).unsqueeze(0)
+    gpu_input_data["2D 2CH"] = torch.as_tensor(
+        np.stack([np.stack([hann_windowed_sine] * 10, axis=1)] * 10, axis=2), device=gpu
+    ).unsqueeze(0)
+
+    # SINGLE CHANNEL GPU VALUE TESTS
+
+    TEST_CASE_1D_SINE_GPU = [
+        {},  # args (empty, so use default)
+        gpu_input_data["1D"],  # Input data: Random 1D signal
+        create_expected_numpy_output(gpu_input_data["1D"], axis=2),  # Expected output: FFT of signal
+        1e-5,  # absolute tolerance
+    ]
+
+    TEST_CASE_2D_SINE_GPU = [
+        {},  # args (empty, so use default)
+        gpu_input_data["2D"],  # Input data: Random 1D signal
+        create_expected_numpy_output(gpu_input_data["2D"], axis=2),  # Expected output: FFT of signal
+        1e-5,  # absolute tolerance
+    ]
+
+    TEST_CASE_3D_SINE_GPU = [
+        {},  # args (empty, so use default)
+        gpu_input_data["3D"],  # Input data: Random 1D signal
+        create_expected_numpy_output(gpu_input_data["3D"], axis=2),  # Expected output: FFT of signal
+        1e-5,  # absolute tolerance
+    ]
+
+    # MULTICHANNEL GPU VALUE TESTS, PROCESS ALONG FIRST SPATIAL AXIS
+
+    TEST_CASE_1D_2CH_SINE_GPU = [
+        {},  # args (empty, so use default)
+        gpu_input_data["1D 2CH"],  # Input data: Random 1D signal
+        create_expected_numpy_output(gpu_input_data["1D 2CH"], axis=2),
+        1e-5,  # absolute tolerance
+    ]
+
+    TEST_CASE_2D_2CH_SINE_GPU = [
+        {},  # args (empty, so use default)
+        gpu_input_data["2D 2CH"],  # Input data: Random 1D signal
+        create_expected_numpy_output(gpu_input_data["2D 2CH"], axis=2),
+        1e-5,  # absolute tolerance
+    ]
+
+# TESTS CHECKING PADDING, AXIS SELECTION ETC ARE COVERED BY test_detect_envelope.py
+
+
+@SkipIfBeforePyTorchVersion((1, 7))
+@SkipIfNoModule("torch.fft")
+class TestHilbertTransformCPU(unittest.TestCase):
+    @parameterized.expand(
+        [
+            TEST_CASE_1D_SINE_CPU,
+            TEST_CASE_2D_SINE_CPU,
+            TEST_CASE_3D_SINE_CPU,
+            TEST_CASE_1D_2CH_SINE_CPU,
+            TEST_CASE_2D_2CH_SINE_CPU,
+        ]
+    )
+    def test_value(self, arguments, image, expected_data, atol):
+        result = HilbertTransform(**arguments)(image)
+        result = result.squeeze(0).squeeze(0).numpy()
+        np.testing.assert_allclose(result, expected_data.squeeze(), atol=atol)
+
+
+@skip_if_no_cuda
+@SkipIfBeforePyTorchVersion((1, 7))
+@SkipIfNoModule("torch.fft")
+class TestHilbertTransformGPU(unittest.TestCase):
+    @parameterized.expand(
+        []
+        if not torch.cuda.is_available()
+        else [
+            TEST_CASE_1D_SINE_GPU,
+            TEST_CASE_2D_SINE_GPU,
+            TEST_CASE_3D_SINE_GPU,
+            TEST_CASE_1D_2CH_SINE_GPU,
+            TEST_CASE_2D_2CH_SINE_GPU,
+        ],
+        skip_on_empty=True,
+    )
+    def test_value(self, arguments, image, expected_data, atol):
+        result = HilbertTransform(**arguments)(image)
+        result = result.squeeze(0).squeeze(0).cpu().numpy()
+        np.testing.assert_allclose(result, expected_data.squeeze(), atol=atol)
+
+
+@SkipIfBeforePyTorchVersion((1, 7))
+@SkipIfModule("torch.fft")
+class TestHilbertTransformNoFFTMod(unittest.TestCase):
+    def test_no_fft_module_error(self):
+        self.assertRaises(OptionalImportError, HilbertTransform(), torch.randn(1, 1, 10))
+
+
+@SkipIfAtLeastPyTorchVersion((1, 7))
+class TestHilbertTransformInvalidPyTorch(unittest.TestCase):
+    def test_invalid_pytorch_error(self):
+        with self.assertRaises(InvalidPyTorchVersionError) as cm:
+            HilbertTransform()
+            self.assertEqual("HilbertTransform requires PyTorch version 1.7.0 or later", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1210 

### Description
A new class `HilbertTransform` has been implemented in `monai/networks/layers/simplelayers.py` using the `torch.fft` module. Another new class `DetectEnvelope`, which wraps `HilbertTransform`, has been implemented in  `monai/transforms/intensity/array.py`. Unit testing of `DetectEnvelope` is implemented in `tests/test_detect_envelope.py`. Documentation has been updated and tested locally. Tests have been passed locally. Commits have been squashed.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.

### Details

Running on a Google CoLab VM with a GPU, `HilbertTransform` is faster than the SciPy equivalent for Tensors with more than about 10^4 elements:
![image](https://user-images.githubusercontent.com/31904251/100132583-89a4ca00-2e7d-11eb-9502-4725d9df8df1.png)
Notebook demonstrating this is [here](https://colab.research.google.com/drive/1AbYVL7C7muZ5iPwSzI_riQP3ElZoEvcs?usp=sharing).
I also implemented a Hilbert transform using `torch.nn.functional.conv1d` but its performance was poor compared to the FFT implementation.