### PR TITLE
Adds an image to bounding box transform

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -105,6 +105,12 @@ Crop and Pad
     :members:
     :special-members: __call__
 
+`BoundingRect`
+""""""""""""""
+.. autoclass:: BoundingRect
+    :members:
+    :special-members: __call__
+
 Intensity
 ^^^^^^^^^
 
@@ -561,6 +567,12 @@ Crop and Pad (Dict)
 `ResizeWithPadOrCropd`
 """"""""""""""""""""""
 .. autoclass:: ResizeWithPadOrCropd
+    :members:
+    :special-members: __call__
+
+`BoundingRectd`
+"""""""""""""""
+.. autoclass:: BoundingRectd
     :members:
     :special-members: __call__
 

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -21,6 +21,7 @@ from monai.config import IndexSelection
 from monai.data.utils import get_random_patch, get_valid_patch_size
 from monai.transforms.compose import Randomizable, Transform
 from monai.transforms.utils import (
+    compute_bounding_rect,
     generate_pos_neg_label_crop_centers,
     generate_spatial_bounding_box,
     map_binary_to_indices,
@@ -632,3 +633,16 @@ class ResizeWithPadOrCrop(Transform):
                 See also: https://numpy.org/doc/1.18/reference/generated/numpy.pad.html
         """
         return self.padder(self.cropper(img), mode=mode)
+
+
+class BoundingRect(Transform):
+    """
+    Compute coordinates of axis-aligned bounding rectangles from input image `img`.
+    """
+
+    def __call__(self, img: np.ndarray) -> np.ndarray:
+        """
+        See also: :py:class:`monai.transforms.utils.compute_bounding_rect`.
+        """
+        bbox = [compute_bounding_rect(channel) for channel in img]
+        return np.stack(bbox, axis=0)

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -24,6 +24,7 @@ from monai.data.utils import get_random_patch, get_valid_patch_size
 from monai.transforms.compose import MapTransform, Randomizable
 from monai.transforms.croppad.array import (
     BorderPad,
+    BoundingRect,
     CenterSpatialCrop,
     DivisiblePad,
     ResizeWithPadOrCrop,
@@ -580,6 +581,36 @@ class ResizeWithPadOrCropd(MapTransform):
         return d
 
 
+class BoundingRectd(MapTransform):
+    """
+    Dictionary-based wrapper of :py:class:`monai.transforms.BoundingRect`.
+
+    Args:
+        keys: keys of the corresponding items to be transformed.
+            See also: monai.transforms.MapTransform
+        bbox_key_postfix: the output bounding box coordinates will be
+            written to the value of `{key}_{bbox_key_postfix}`.
+    """
+
+    def __init__(self, keys: KeysCollection, bbox_key_postfix: str = "bbox"):
+        super().__init__(keys=keys)
+        self.bbox = BoundingRect()
+        self.bbox_key_postfix = bbox_key_postfix
+
+    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
+        """
+        See also: :py:class:`monai.transforms.utils.compute_bounding_rect`.
+        """
+        d = dict(data)
+        for key in self.keys:
+            bbox = self.bbox(d[key])
+            key_to_add = f"{key}_{self.bbox_key_postfix}"
+            if key_to_add in d:
+                raise KeyError(f"Bounding box data with key {key_to_add} already exists.")
+            d[key_to_add] = bbox
+        return d
+
+
 SpatialPadD = SpatialPadDict = SpatialPadd
 BorderPadD = BorderPadDict = BorderPadd
 DivisiblePadD = DivisiblePadDict = DivisiblePadd
@@ -591,3 +622,4 @@ CropForegroundD = CropForegroundDict = CropForegroundd
 RandWeightedCropD = RandWeightedCropDict = RandWeightedCropd
 RandCropByPosNegLabelD = RandCropByPosNegLabelDict = RandCropByPosNegLabeld
 ResizeWithPadOrCropD = ResizeWithPadOrCropDict = ResizeWithPadOrCropd
+BoundingRectD = BoundingRectDict = BoundingRectd

--- a/tests/test_bounding_rect.py
+++ b/tests/test_bounding_rect.py
@@ -1,0 +1,43 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+import monai
+from monai.transforms import BoundingRect
+
+TEST_CASE_1 = [(2, 3), [[-1, -1], [1, 2]]]
+
+TEST_CASE_2 = [(1, 8, 10), [[0, 7, 1, 9]]]
+
+TEST_CASE_3 = [(2, 16, 20, 18), [[0, 16, 0, 20, 0, 18], [0, 16, 0, 20, 0, 18]]]
+
+
+class TestBoundingRect(unittest.TestCase):
+    def setUp(self):
+        monai.utils.set_determinism(1)
+
+    def tearDown(self):
+        monai.utils.set_determinism(None)
+
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
+    def test_shape(self, input_shape, expected):
+        test_data = np.random.randint(0, 8, size=input_shape)
+        test_data = test_data == 7
+        result = BoundingRect()(test_data)
+        np.testing.assert_allclose(result, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bounding_rectd.py
+++ b/tests/test_bounding_rectd.py
@@ -1,0 +1,49 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+import monai
+from monai.transforms import BoundingRectD
+
+TEST_CASE_1 = [(2, 3), [[-1, -1], [1, 2]]]
+
+TEST_CASE_2 = [(1, 8, 10), [[0, 7, 1, 9]]]
+
+TEST_CASE_3 = [(2, 16, 20, 18), [[0, 16, 0, 20, 0, 18], [0, 16, 0, 20, 0, 18]]]
+
+
+class TestBoundingRectD(unittest.TestCase):
+    def setUp(self):
+        monai.utils.set_determinism(1)
+
+    def tearDown(self):
+        monai.utils.set_determinism(None)
+
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
+    def test_shape(self, input_shape, expected):
+        test_data = np.random.randint(0, 8, size=input_shape)
+        test_data = test_data == 7
+        result = BoundingRectD("image")({"image": test_data})
+        np.testing.assert_allclose(result["image_bbox"], expected)
+
+        result = BoundingRectD("image", "cc")({"image": test_data})
+        np.testing.assert_allclose(result["image_cc"], expected)
+
+        with self.assertRaises(KeyError):
+            BoundingRectD("image", "cc")({"image": test_data, "image_cc": None})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_integration_classification_2d.py
+++ b/tests/test_integration_classification_2d.py
@@ -243,7 +243,7 @@ class IntegrationClassification2D(DistTestCase):
             repeated.append(results)
         np.testing.assert_allclose(repeated[0], repeated[1])
 
-    @TimedCall(seconds=1000, skip_timing=not torch.cuda.is_available(), daemon=False, force_quit=False)
+    @TimedCall(seconds=1000, skip_timing=not torch.cuda.is_available(), daemon=False)
     def test_timing(self):
         self.train_and_infer()
 


### PR DESCRIPTION
### Description
a transform that computes nd coordinates of a bounding rectangle from the positive intensities.


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
