### PR TITLE
Remove flake8 from requirements-dev.txt

### DIFF
--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -151,7 +151,8 @@ jobs:
       run: |
         docker build -t localhost:5000/local_monai:latest -f Dockerfile .
         docker push localhost:5000/local_monai:latest
-        docker tag localhost:5000/local_monai:latest projectmonai/monai:latest
+        sed -i '/flake/d' requirements-dev.txt 
+        docker build -t projectmonai/monai:latest -f Dockerfile .
         docker login -u projectmonai -p ${{ secrets.DOCKER_PW }}
         docker push projectmonai/monai:latest
         docker logout


### PR DESCRIPTION

Signed-off-by: Isaac Yang <isaacy@nvidia.com>

Fixes # .

### Description
Flake8-executable is GPL'ed and flake8 is used for test stage only.  We can safely remove them from release container images

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
