### PR TITLE
1337 profiling tools

### DIFF
--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -15,3 +15,4 @@ from .decorators import *
 from .enums import *
 from .misc import *
 from .module import *
+from .profiling import *

--- a/monai/utils/decorators.py
+++ b/monai/utils/decorators.py
@@ -11,6 +11,7 @@
 
 from functools import wraps
 
+
 class RestartGenerator:
     """
     Wraps a generator callable which will be called whenever this class is iterated and its result returned. This is

--- a/monai/utils/decorators.py
+++ b/monai/utils/decorators.py
@@ -9,27 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 from functools import wraps
-
-
-def timing(func):
-    """
-    This simple timing function decorator prints to stdout/logfile (it uses printFlush) how many seconds a call to the
-    original function took to execute, as well as the name before and after the call.
-    """
-
-    @wraps(func)
-    def timingwrap(*args, **kwargs):
-        print(func.__name__, flush=True)
-        start = time.perf_counter()
-        res = func(*args, **kwargs)
-        end = time.perf_counter()
-        print(func.__name__, "dT (s) =", (end - start), flush=True)
-        return res
-
-    return timingwrap
-
 
 class RestartGenerator:
     """

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -9,36 +9,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
 import time
 from functools import wraps
 
-def torch_profiler_full(func):    
+import torch
+
+
+def torch_profiler_full(func):
     """
-    A decorator which will run the torch profiler for the decorated function, 
-    printing the results in full. 
+    A decorator which will run the torch profiler for the decorated function,
+    printing the results in full.
     Note: Enforces a gpu sync point which could slow down pipelines.
     """
-    
+
     @wraps(func)
     def wrapper(*args, **kwargs):
 
         with torch.autograd.profiler.profile(use_cuda=True) as prof:
             result = func(*args, **kwargs)
-            
+
         print(prof, flush=True)
 
         return result
 
     return wrapper
 
-def torch_profiler_time_cpu_gpu(func):    
+
+def torch_profiler_time_cpu_gpu(func):
     """
     A decorator which measures the execution time of both the CPU and GPU components
-    of the decorated function, printing both results. 
+    of the decorated function, printing both results.
     Note: Enforces a gpu sync point which could slow down pipelines.
     """
-    
+
     @wraps(func)
     def wrapper(*args, **kwargs):
 
@@ -50,20 +53,21 @@ def torch_profiler_time_cpu_gpu(func):
 
         cpu_time = torch.autograd.profiler.format_time(cpu_time)
         gpu_time = torch.autograd.profiler.format_time(gpu_time)
-        
+
         print("cpu time: {}, gpu time: {}".format(cpu_time, gpu_time), flush=True)
 
         return result
 
     return wrapper
 
-def torch_profiler_time_end_to_end(func):    
+
+def torch_profiler_time_end_to_end(func):
     """
-    A decorator which measures the total execution time from when the decorated 
-    function is called to when the last cuda operation finishes, printing the result. 
+    A decorator which measures the total execution time from when the decorated
+    function is called to when the last cuda operation finishes, printing the result.
     Note: Enforces a gpu sync point which could slow down pipelines.
     """
-    
+
     @wraps(func)
     def wrapper(*args, **kwargs):
 
@@ -82,4 +86,3 @@ def torch_profiler_time_end_to_end(func):
         return result
 
     return wrapper
-    

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -49,7 +49,7 @@ def torch_profiler_time_cpu_gpu(func):
             result = func(*args, **kwargs)
 
         cpu_time = prof.self_cpu_time_total
-        gpu_time = sum([evt.self_cuda_time_total for evt in prof.function_events])
+        gpu_time = sum(evt.self_cuda_time_total for evt in prof.function_events)
 
         cpu_time = torch.autograd.profiler.format_time(cpu_time)
         gpu_time = torch.autograd.profiler.format_time(gpu_time)

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -15,6 +15,13 @@ from functools import wraps
 import torch
 
 
+__all__ = [
+    "torch_profiler_full",
+    "torch_profiler_time_cpu_gpu",
+    "torch_profiler_time_end_to_end"
+]
+
+
 def torch_profiler_full(func):
     """
     A decorator which will run the torch profiler for the decorated function,

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -14,12 +14,7 @@ from functools import wraps
 
 import torch
 
-
-__all__ = [
-    "torch_profiler_full",
-    "torch_profiler_time_cpu_gpu",
-    "torch_profiler_time_end_to_end"
-]
+__all__ = ["torch_profiler_full", "torch_profiler_time_cpu_gpu", "torch_profiler_time_end_to_end"]
 
 
 def torch_profiler_full(func):

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -1,0 +1,85 @@
+# Copyright 2020 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import time
+from functools import wraps
+
+def torch_profiler_full(func):    
+    """
+    A decorator which will run the torch profiler for the decorated function, 
+    printing the results in full. 
+    Note: Enforces a gpu sync point which could slow down pipelines.
+    """
+    
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        with torch.autograd.profiler.profile(use_cuda=True) as prof:
+            result = func(*args, **kwargs)
+            
+        print(prof, flush=True)
+
+        return result
+
+    return wrapper
+
+def torch_profiler_time_cpu_gpu(func):    
+    """
+    A decorator which measures the execution time of both the CPU and GPU components
+    of the decorated function, printing both results. 
+    Note: Enforces a gpu sync point which could slow down pipelines.
+    """
+    
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        with torch.autograd.profiler.profile(use_cuda=True) as prof:
+            result = func(*args, **kwargs)
+
+        cpu_time = prof.self_cpu_time_total
+        gpu_time = sum([evt.self_cuda_time_total for evt in prof.function_events])
+
+        cpu_time = torch.autograd.profiler.format_time(cpu_time)
+        gpu_time = torch.autograd.profiler.format_time(gpu_time)
+        
+        print("cpu time: {}, gpu time: {}".format(cpu_time, gpu_time), flush=True)
+
+        return result
+
+    return wrapper
+
+def torch_profiler_time_end_to_end(func):    
+    """
+    A decorator which measures the total execution time from when the decorated 
+    function is called to when the last cuda operation finishes, printing the result. 
+    Note: Enforces a gpu sync point which could slow down pipelines.
+    """
+    
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+
+        result = func(*args, **kwargs)
+
+        torch.cuda.synchronize()
+        end = time.perf_counter()
+
+        total_time = (end - start) * 1e6
+        total_time_str = torch.autograd.profiler.format_time(total_time)
+        print("end to end time: {}".format(total_time_str), flush=True)
+
+        return result
+
+    return wrapper
+    


### PR DESCRIPTION
Signed-off-by: charliebudd <charles.budd@kcl.ac.uk>

Addresses #1337.

### Description
Adds a few easy to use function decorators which aim to give limited but accurate profiling information.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
