### PR TITLE
Update docs for GitHub Discussion tab

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,7 +6,7 @@ labels: ''
 assignees: ''
 ---
 
-**Please use MONAI's Discussion tab**
+**Please use MONAI's Discussions tab**
 For questions relating to MONAI usage, please do not create an issue.
 
-Instead, use [MONAI's GitHub Discussion tab](https://github.com/Project-MONAI/MONAI/discussions). This can be found next to Issues and Pull Requests along the top of our repository.
+Instead, use [MONAI's GitHub Discussions tab](https://github.com/Project-MONAI/MONAI/discussions). This can be found next to Issues and Pull Requests along the top of our repository.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,12 @@
+---
+name: Question
+about: Question relating to MONAI
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Please use MONAI's Discussion tab**
+For questions relating to MONAI usage, please do not create an issue.
+
+Instead, use [MONAI's GitHub Discussion tab](https://github.com/Project-MONAI/MONAI/discussions). This can be found next to Issues and Pull Requests along the top of our repository.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For guidance on making a contribution to MONAI, see the [contributing guidelines
 ## Community
 Join the conversation on Twitter [@ProjectMONAI](https://twitter.com/ProjectMONAI) or join our [Slack channel](https://forms.gle/QTxJq3hFictp31UM9).
 
-Ask and answer questions over on the [PyTorch Forums](https://discuss.pytorch.org/) or [StackOverflow](https://stackoverflow.com/tags/monai). Make sure to tag @monai.
+Ask and answer questions over on [MONAI's GitHub Discussion tab](https://github.com/Project-MONAI/MONAI/discussions).
 
 ## Links
 - Website: https://monai.io/

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For guidance on making a contribution to MONAI, see the [contributing guidelines
 ## Community
 Join the conversation on Twitter [@ProjectMONAI](https://twitter.com/ProjectMONAI) or join our [Slack channel](https://forms.gle/QTxJq3hFictp31UM9).
 
-Ask and answer questions over on [MONAI's GitHub Discussion tab](https://github.com/Project-MONAI/MONAI/discussions).
+Ask and answer questions over on [MONAI's GitHub Discussions tab](https://github.com/Project-MONAI/MONAI/discussions).
 
 ## Links
 - Website: https://monai.io/


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/1358.

### Description
Update the docs (issue template and README) to inform users to use the Discussions tab for any questions. 

On the README, I've removed links to Pytorch forums and the slack channel for asking questions. I thought it would be better to get everyone posting in the same place. Does anyone think it would be better to keep the old links, too?

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).