### PR TITLE
Use numpy instead of torch to get random seed

### DIFF
--- a/monai/data/dataloader.py
+++ b/monai/data/dataloader.py
@@ -39,8 +39,7 @@ class DataLoader(_TorchDataLoader):
         if num_workers == 0:
             # when num_workers > 0, random states are determined by worker_init_fn
             # this is to make the behavior consistent when num_workers == 0
-            # torch.int64 doesn't work well on some versions of windows
-            _seed = np.random.randint(np.iinfo(np.uint32).max + 1)
+            _seed = np.random.randint(np.iinfo(np.int32).max + 1)
             set_rnd(dataset, int(_seed))
         if "collate_fn" not in kwargs:
             kwargs.update({"collate_fn": list_data_collate})

--- a/monai/data/dataloader.py
+++ b/monai/data/dataloader.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
+import numpy as np
 from torch.utils.data import DataLoader as _TorchDataLoader
 from torch.utils.data import Dataset
 
@@ -40,7 +40,7 @@ class DataLoader(_TorchDataLoader):
             # when num_workers > 0, random states are determined by worker_init_fn
             # this is to make the behavior consistent when num_workers == 0
             # torch.int64 doesn't work well on some versions of windows
-            _seed = torch.empty((), dtype=torch.int32).random_(generator=None).item()
+            _seed = np.random.randint(np.iinfo(np.uint32).max + 1)
             set_rnd(dataset, int(_seed))
         if "collate_fn" not in kwargs:
             kwargs.update({"collate_fn": list_data_collate})


### PR DESCRIPTION
Signed-off-by: YuanTingHsieh <yuantinghsieh@gmail.com>

Fixes # .

### Description
For the original way, if we load the model using TorchScript VS load the model using checkpoints.
It will affect the value generated by torch.empty().random_.
If we change to this new way, then this seed will be the same for loading model using either TorchScript or checkpoints.

Note that, even we don't make this change.
The original code is already repeatable. (run several times yield same result)
So this change is not necessary.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
