### PR TITLE
adding .venv directory to ignores for flake8 and isort

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,13 +65,13 @@ ignore =
     # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
     N812
 per-file-ignores = __init__.py: F401
-exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,_version.py
+exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,.venv,_version.py
 
 [isort]
 known_first_party = monai
 profile = black
 line_length = 120
-skip = .git, .eggs, venv, versioneer.py, _version.py, conf.py, monai/__init__.py
+skip = .git, .eggs, venv, .venv, versioneer.py, _version.py, conf.py, monai/__init__.py
 skip_glob = *.pyi
 
 [versioneer]


### PR DESCRIPTION
Signed-off-by: charliebudd <charles.budd@kcl.ac.uk>

Fixes #1370 .

### Description
Simply adds '.venv' to the list of ignores. It would be nice to use the VIRTUAL_ENV environment variable which I believe is accessable on linux and windows. However as we use a .cfg file I don't think it can be evaluated when the config is loaded.

I can use the environment variable by directly adding the ignore in runtests.sh however this then overwrites the ignores in the .cfg files

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
