### PR TITLE
AE: check lens of stride and channel match

### DIFF
--- a/monai/networks/nets/autoencoder.py
+++ b/monai/networks/nets/autoencoder.py
@@ -53,6 +53,10 @@ class AutoEncoder(nn.Module):
         self.inter_channels = inter_channels if inter_channels is not None else list()
         self.inter_dilations = list(inter_dilations or [1] * len(self.inter_channels))
 
+        # The number of channels and strides should match
+        if len(channels) != len(strides):
+            raise ValueError("Autoencoder expects matching number of channels and strides")
+
         self.encoded_channels = in_channels
         decode_channel_list = list(channels[-2::-1]) + [out_channels]
 

--- a/tests/test_autoencoder.py
+++ b/tests/test_autoencoder.py
@@ -62,6 +62,14 @@ TEST_CASE_3 = [  # 4-channel 3D, batch 4
 CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3]
 
 
+TEST_CASE_FAIL = {  # 2-channel 2D, should fail because of stride/channel mismatch.
+    "dimensions": 2,
+    "in_channels": 2,
+    "out_channels": 2,
+    "channels": (4, 8, 16),
+    "strides": (2, 2),
+}
+
 class TestAutoEncoder(unittest.TestCase):
     @parameterized.expand(CASES)
     def test_shape(self, input_param, input_shape, expected_shape):
@@ -75,6 +83,10 @@ class TestAutoEncoder(unittest.TestCase):
         net = AutoEncoder(dimensions=2, in_channels=1, out_channels=1, channels=(4, 8), strides=(2, 2))
         test_data = torch.randn(2, 1, 32, 32)
         test_script_save(net, test_data)
+
+    def test_channel_stride_difference(self):
+        with self.assertRaises(ValueError):
+            net = AutoEncoder(**TEST_CASE_FAIL)
 
 
 if __name__ == "__main__":

--- a/tests/test_autoencoder.py
+++ b/tests/test_autoencoder.py
@@ -70,6 +70,7 @@ TEST_CASE_FAIL = {  # 2-channel 2D, should fail because of stride/channel mismat
     "strides": (2, 2),
 }
 
+
 class TestAutoEncoder(unittest.TestCase):
     @parameterized.expand(CASES)
     def test_shape(self, input_param, input_shape, expected_shape):


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/1367.

### Description
Improves error checking that for (V)AEs, the number of strides and channels should match.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
