### PR TITLE
adds jpeg in supported format -- PILReader

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -525,7 +525,7 @@ class PILReader(ImageReader):
             filename: file name or a list of file names to read.
                 if a list of files, verify all the suffixes.
         """
-        suffixes: Sequence[str] = ["png", "jpg", "bmp"]
+        suffixes: Sequence[str] = ["png", "jpg", "jpeg", "bmp"]
         return has_pil and is_supported_format(filename, suffixes)
 
     def read(self, data: Union[Sequence[str], str, np.ndarray], **kwargs):


### PR DESCRIPTION
jpeg is effectively the same as jpg
(this is needed by Mednist dataset, the filename ends with 'jpeg' instead of 'jpg')


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).

