### PR TITLE
update contributing and normalis* -> normaliz*

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ _Pull request early_
 
 We encourage you to create pull requests early. It helps us track the contributions under development, whether they are ready to be merged or not. Change your pull request's title to begin with `[WIP]` until it is ready for formal review.
 
+Please note that, as per PyTorch, MONAI uses American English spelling. This means classes and variables should be: normali**z**e, visuali**z**e, colo~~u~~r, etc.
+
 ### Preparing pull requests
 To ensure the code quality, MONAI relies on several linting tools ([flake8 and its plugins](https://gitlab.com/pycqa/flake8), [black](https://github.com/psf/black), [isort](https://github.com/timothycrosley/isort)),
 static type analysis tools ([mypy](https://github.com/python/mypy), [pytype](https://github.com/google/pytype)), as well as a set of unit/integration tests.

--- a/monai/networks/blocks/acti_norm.py
+++ b/monai/networks/blocks/acti_norm.py
@@ -80,7 +80,7 @@ class ADN(nn.Sequential):
         super().__init__()
 
         op_dict = {"A": None, "D": None, "N": None}
-        # define the normalisation type and the arguments to the constructor
+        # define the normalization type and the arguments to the constructor
         if norm is not None:
             if norm_dim is None and dropout_dim is None:
                 raise ValueError("norm_dim or dropout_dim needs to be specified.")

--- a/monai/networks/layers/factories.py
+++ b/monai/networks/layers/factories.py
@@ -16,7 +16,7 @@ a layer is requested the factory name and any necessary arguments are passed to 
 is typically a type but can be any callable producing a layer object.
 
 The factory objects contain functions keyed to names converted to upper case, these names can be referred to as members
-of the factory so that they can function as constant identifiers. eg. instance normalisation is named `Norm.INSTANCE`.
+of the factory so that they can function as constant identifiers. eg. instance normalization is named `Norm.INSTANCE`.
 
 For example, to get a transpose convolution layer the name is needed and then a dimension argument is provided which is
 passed to the factory function:

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -518,7 +518,7 @@ class AffineTransform(nn.Module):
         if spatial_size is not None:
             dst_size = src_size[:2] + ensure_tuple(spatial_size)
 
-        # reverse and normalise theta if needed
+        # reverse and normalize theta if needed
         if not self.normalized:
             theta = to_norm_affine(
                 affine=theta, src_size=src_size[2:], dst_size=dst_size[2:], align_corners=self.align_corners

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -194,7 +194,7 @@ class Compose(Randomizable, Transform):
         set of functions must be called as if it were a sequence.
 
         Example: images and labels
-        Images typically require some kind of normalisation that labels do not.
+        Images typically require some kind of normalization that labels do not.
         Both are then typically augmented through the use of random rotations,
         flips, and deformations.
         Compose can be used with a series of transforms that take a dictionary

--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -144,7 +144,7 @@ class Weight(Enum):
     UNIFORM = "uniform"
 
 
-class Normalisation(Enum):
+class Normalization(Enum):
     """
     See also:
         - :py:class:`monai.networks.nets.ConvNormActi`

--- a/tests/test_unet.py
+++ b/tests/test_unet.py
@@ -72,7 +72,7 @@ TEST_CASE_3 = [  # 4-channel 3D, batch 16
     (16, 3, 32, 64, 48),
 ]
 
-TEST_CASE_4 = [  # 4-channel 3D, batch 16, batch normalisation
+TEST_CASE_4 = [  # 4-channel 3D, batch 16, batch normalization
     {
         "dimensions": 3,
         "in_channels": 4,


### PR DESCRIPTION
Fixes #1382.

### Description
CONTRIBUTING.md to state spelling convention and normalis* -> normaliz*. 

Strangely it looks like nothing uses the enum `Normalization`, should I raise an issue for that?

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
