### PR TITLE
1378 Add output_dtype to NiftiSaver and SegmentationSaver

### DIFF
--- a/monai/data/nifti_saver.py
+++ b/monai/data/nifti_saver.py
@@ -37,6 +37,7 @@ class NiftiSaver:
         padding_mode: Union[GridSamplePadMode, str] = GridSamplePadMode.BORDER,
         align_corners: bool = False,
         dtype: Optional[np.dtype] = np.float64,
+        output_dtype: Optional[np.dtype] = np.float32,
     ) -> None:
         """
         Args:
@@ -57,6 +58,7 @@ class NiftiSaver:
             dtype: data type for resampling computation. Defaults to ``np.float64`` for best precision.
                 If None, use the data type of input data. To be compatible with other modules,
                 the output data type is always ``np.float32``.
+            output_dtype: data type for saving data. Defaults to ``np.float32``.
         """
         self.output_dir = output_dir
         self.output_postfix = output_postfix
@@ -66,6 +68,7 @@ class NiftiSaver:
         self.padding_mode: GridSamplePadMode = GridSamplePadMode(padding_mode)
         self.align_corners = align_corners
         self.dtype = dtype
+        self.output_dtype = output_dtype
         self._data_index = 0
 
     def save(self, data: Union[torch.Tensor, np.ndarray], meta_data: Optional[Dict] = None) -> None:
@@ -118,6 +121,7 @@ class NiftiSaver:
             padding_mode=self.padding_mode,
             align_corners=self.align_corners,
             dtype=self.dtype,
+            output_dtype=self.output_dtype,
         )
 
     def save_batch(self, batch_data: Union[torch.Tensor, np.ndarray], meta_data: Optional[Dict] = None) -> None:

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -38,7 +38,8 @@ class SegmentationSaver:
         mode: Union[GridSampleMode, InterpolateMode, str] = "nearest",
         padding_mode: Union[GridSamplePadMode, str] = GridSamplePadMode.BORDER,
         scale: Optional[int] = None,
-        dtype: Optional[np.dtype] = None,
+        dtype: Optional[np.dtype] = np.float64,
+        output_dtype: Optional[np.dtype] = np.float32,
         batch_transform: Callable = lambda x: x,
         output_transform: Callable = lambda x: x,
         name: Optional[str] = None,
@@ -69,8 +70,10 @@ class SegmentationSaver:
             scale: {``255``, ``65535``} postprocess data by clipping to [0, 1] and scaling
                 [0, 255] (uint8) or [0, 65535] (uint16). Default is None to disable scaling.
                 It's used for PNG format only.
-            dtype: convert the image data to save to this data type.
-                If None, keep the original type of data. It's used for Nifti format only.
+            dtype: data type for resampling computation. Defaults to ``np.float64`` for best precision.
+                If None, use the data type of input data. To be compatible with other modules,
+                the output data type is always ``np.float32``, it's used for Nifti format only.
+            output_dtype: data type for saving data. Defaults to ``np.float32``, it's used for Nifti format only.
             batch_transform: a callable that is used to transform the
                 ignite.engine.batch into expected format to extract the meta_data dictionary.
             output_transform: a callable that is used to transform the
@@ -90,6 +93,7 @@ class SegmentationSaver:
                 mode=GridSampleMode(mode),
                 padding_mode=padding_mode,
                 dtype=dtype,
+                output_dtype=output_dtype,
             )
         elif output_ext == ".png":
             self.saver = PNGSaver(


### PR DESCRIPTION
Fixes #1378 .

### Description
This PR added `output_dtype` arg to `NiftiSaver` and `SegmentationSaver` to align with `nifti_writer`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
