### PR TITLE
Make master installation clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,18 @@ Its ambitions are:
 
 
 ## Installation
-To install [the current release](https://pypi.org/project/monai/):
+
+### Installing [the current release](https://pypi.org/project/monai/):
 ```bash
 pip install monai
 ```
 
-To install from the source code repository:
+### Installing the master branch from the source code repository:
 ```bash
 pip install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
 ```
 
-Alternatively, pre-built Docker image is available via [DockerHub](https://hub.docker.com/r/projectmonai/monai):
+### Using the pre-built Docker image [DockerHub](https://hub.docker.com/r/projectmonai/monai):
   ```bash
   # with docker v19.03+
   docker run --gpus all --rm -ti --ipc=host projectmonai/monai:latest


### PR DESCRIPTION
People are asking for 0.4.0+ functionality (e.g https://github.com/Project-MONAI/MONAI/issues/1424 and https://github.com/Project-MONAI/MONAI/pull/1409#issuecomment-756745886), so by making the master installation instructions a section, we can easily copy a link pointing to the relevant bit of code.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
