### PR TITLE
remove isort:skip

### DIFF
--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -9,32 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .utils import (  # isort:skip
-    apply_transform,
-    copypaste_arrays,
-    create_control_grid,
-    create_grid,
-    create_rotate,
-    create_scale,
-    create_shear,
-    create_translate,
-    extreme_points_to_image,
-    generate_pos_neg_label_crop_centers,
-    generate_spatial_bounding_box,
-    get_extreme_points,
-    get_largest_connected_component_mask,
-    img_bounds,
-    in_bounds,
-    is_empty,
-    map_binary_to_indices,
-    rand_choice,
-    rescale_array,
-    rescale_array_int_max,
-    rescale_instance_array,
-    resize_center,
-    weighted_patch_samples,
-    zero_margins,
-)
 from .adaptors import FunctionSignature, adaptor, apply_alias, to_kwargs
 from .compose import Compose, MapTransform, Randomizable, Transform
 from .croppad.array import (
@@ -260,4 +234,30 @@ from .utility.dictionary import (
     SqueezeDimd,
     ToNumpyd,
     ToTensord,
+)
+from .utils import (
+    apply_transform,
+    copypaste_arrays,
+    create_control_grid,
+    create_grid,
+    create_rotate,
+    create_scale,
+    create_shear,
+    create_translate,
+    extreme_points_to_image,
+    generate_pos_neg_label_crop_centers,
+    generate_spatial_bounding_box,
+    get_extreme_points,
+    get_largest_connected_component_mask,
+    img_bounds,
+    in_bounds,
+    is_empty,
+    map_binary_to_indices,
+    rand_choice,
+    rescale_array,
+    rescale_array_int_max,
+    rescale_instance_array,
+    resize_center,
+    weighted_patch_samples,
+    zero_margins,
 )

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -23,7 +23,6 @@ import numpy as np
 import torch
 
 from monai.config import KeysCollection
-from monai.transforms import extreme_points_to_image, get_extreme_points
 from monai.transforms.compose import MapTransform, Randomizable
 from monai.transforms.utility.array import (
     AddChannel,
@@ -42,6 +41,7 @@ from monai.transforms.utility.array import (
     ToNumpy,
     ToTensor,
 )
+from monai.transforms.utils import extreme_points_to_image, get_extreme_points
 from monai.utils import ensure_tuple, ensure_tuple_rep
 
 __all__ = [


### PR DESCRIPTION
Removes unecessary `isort:skip`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
