### PR TITLE
Add some details on weekly preview build process

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -24,12 +24,16 @@ jobs:
         sed -i 's/name\ =\ monai$/name\ =\ monai-weekly/g' setup.cfg
         echo "__commit_id__ = \"$HEAD_COMMIT_ID\"" >> monai/__init__.py
         git diff setup.cfg monai/__init__.py
-        # build tar.gz and wheel
         git config user.name "CI Builder"
         git config user.email "monai.miccai2019@gmail.com"
         git add setup.cfg monai/__init__.py
         git commit -m "Weekly build at $HEAD_COMMIT_ID"
-        git tag 0.5.dev$(date +'%y%U')
+        export YEAR_WEEK=$(date +'%y%U')
+        echo "Year week for tag is ${YEAR_WEEK}"
+        if ! [[ $YEAR_WEEK =~ ^[0-9]{4}$ ]] ; then echo "Wrong 'year week' format.  Should be 4 digits."; exit 1 ; fi
+        git tag "0.5.dev${YEAR_WEEK}"
+        git log -1
+        git tag --list
         python setup.py sdist bdist_wheel
 
     - name: Publish to PyPI


### PR DESCRIPTION
Stop build if the tag format is wrong

Signed-off-by: Isaac Yang <isaacy@nvidia.com>

Fixes #1482  .

### Description
The dev version of weekly preview build should always be NNMM, where NN is last two digits of YEAR and MM the week number of that year.  This is to ensure the format is correct before building and publishing to PyPI.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
