### PR TITLE
1512 rand_gaussian_noised with multiple keys

### DIFF
--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -35,7 +35,7 @@ from monai.transforms.intensity.array import (
     ShiftIntensity,
     ThresholdIntensity,
 )
-from monai.utils import dtype_torch_to_numpy, ensure_tuple_size
+from monai.utils import dtype_torch_to_numpy, ensure_tuple_rep, ensure_tuple_size
 
 __all__ = [
     "RandGaussianNoised",
@@ -110,7 +110,7 @@ class RandGaussianNoised(Randomizable, MapTransform):
     ) -> None:
         super().__init__(keys)
         self.prob = prob
-        self.mean = ensure_tuple_size(mean, len(self.keys), mean)
+        self.mean = ensure_tuple_rep(mean, len(self.keys))
         self.std = std
         self._do_transform = False
         self._noise: List[np.ndarray] = []

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -16,7 +16,7 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
 from collections.abc import Iterable
-from typing import Any, Dict, Hashable, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -113,7 +113,7 @@ class RandGaussianNoised(Randomizable, MapTransform):
         self.mean = ensure_tuple_size(mean, len(self.keys))
         self.std = std
         self._do_transform = False
-        self._noise: Sequence[np.ndarray] = []
+        self._noise: List[np.ndarray] = []
 
     def randomize(self, im_shape: Sequence[int]) -> None:
         self._do_transform = self.R.random() < self.prob

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -117,6 +117,7 @@ class RandGaussianNoised(Randomizable, MapTransform):
 
     def randomize(self, im_shape: Sequence[int]) -> None:
         self._do_transform = self.R.random() < self.prob
+        self._noise.clear()
         for m in self.mean:
             self._noise.append(self.R.normal(m, self.R.uniform(0, self.std), size=im_shape))
 
@@ -125,7 +126,7 @@ class RandGaussianNoised(Randomizable, MapTransform):
 
         image_shape = d[self.keys[0]].shape  # image shape from the first data key
         self.randomize(image_shape)
-        if not self._noise:
+        if len(self._noise) != len(self.keys):
             raise AssertionError
         if not self._do_transform:
             return d

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -110,7 +110,7 @@ class RandGaussianNoised(Randomizable, MapTransform):
     ) -> None:
         super().__init__(keys)
         self.prob = prob
-        self.mean = ensure_tuple_size(mean, len(self.keys))
+        self.mean = ensure_tuple_size(mean, len(self.keys), mean)
         self.std = std
         self._do_transform = False
         self._noise: List[np.ndarray] = []
@@ -130,9 +130,9 @@ class RandGaussianNoised(Randomizable, MapTransform):
             raise AssertionError
         if not self._do_transform:
             return d
-        for i, key in enumerate(self.keys):
+        for noise, key in zip(self._noise, self.keys):
             dtype = dtype_torch_to_numpy(d[key].dtype) if isinstance(d[key], torch.Tensor) else d[key].dtype
-            d[key] = d[key] + self._noise[i].astype(dtype)
+            d[key] = d[key] + noise.astype(dtype)
         return d
 
 

--- a/tests/test_rand_gaussian_noised.py
+++ b/tests/test_rand_gaussian_noised.py
@@ -17,38 +17,34 @@ from parameterized import parameterized
 from monai.transforms import RandGaussianNoised
 from tests.utils import NumpyImageTestCase2D, TorchImageTestCase2D
 
-TEST_CASE_0 = ["test_zero_mean", ["img"], 0, 0.1]
+TEST_CASE_0 = ["test_zero_mean", ["img", "im2"], 0, 0.1]
 TEST_CASE_1 = ["test_non_zero_mean", ["img"], 1, 0.5]
 TEST_CASES = [TEST_CASE_0, TEST_CASE_1]
 
 seed = 0
 
+def test_numpy_or_torch(keys, mean, std, imt):
+    gaussian_fn = RandGaussianNoised(keys=keys, prob=1.0, mean=mean, std=std)
+    gaussian_fn.set_random_state(seed)
+    noised = gaussian_fn({k: imt for k in keys})
+    np.random.seed(seed)
+    np.random.random()
+    for k in keys:
+        expected = imt + np.random.normal(mean, np.random.uniform(0, std), size=imt.shape)
+        np.testing.assert_allclose(expected, noised[k], atol=1e-5, rtol=1e-5)
+
 # Test with numpy
-
-
 class TestRandGaussianNoisedNumpy(NumpyImageTestCase2D):
     @parameterized.expand(TEST_CASES)
     def test_correct_results(self, _, keys, mean, std):
-        gaussian_fn = RandGaussianNoised(keys=keys, prob=1.0, mean=mean, std=std)
-        gaussian_fn.set_random_state(seed)
-        noised = gaussian_fn({"img": self.imt})
-        np.random.seed(seed)
-        np.random.random()
-        expected = self.imt + np.random.normal(mean, np.random.uniform(0, std), size=self.imt.shape)
-        np.testing.assert_allclose(expected, noised["img"], atol=1e-5, rtol=1e-5)
+        test_numpy_or_torch(keys, mean, std, self.imt)
 
 
 # Test with torch
 class TestRandGaussianNoisedTorch(TorchImageTestCase2D):
     @parameterized.expand(TEST_CASES)
     def test_correct_results(self, _, keys, mean, std):
-        gaussian_fn = RandGaussianNoised(keys=keys, prob=1.0, mean=mean, std=std)
-        gaussian_fn.set_random_state(seed)
-        noised = gaussian_fn({"img": self.imt})
-        np.random.seed(seed)
-        np.random.random()
-        expected = self.imt + np.random.normal(mean, np.random.uniform(0, std), size=self.imt.shape)
-        np.testing.assert_allclose(expected, noised["img"], atol=1e-5, rtol=1e-5)
+        test_numpy_or_torch(keys, mean, std, self.imt)
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_gaussian_noised.py
+++ b/tests/test_rand_gaussian_noised.py
@@ -23,6 +23,7 @@ TEST_CASES = [TEST_CASE_0, TEST_CASE_1]
 
 seed = 0
 
+
 def test_numpy_or_torch(keys, mean, std, imt):
     gaussian_fn = RandGaussianNoised(keys=keys, prob=1.0, mean=mean, std=std)
     gaussian_fn.set_random_state(seed)
@@ -32,6 +33,7 @@ def test_numpy_or_torch(keys, mean, std, imt):
     for k in keys:
         expected = imt + np.random.normal(mean, np.random.uniform(0, std), size=imt.shape)
         np.testing.assert_allclose(expected, noised[k], atol=1e-5, rtol=1e-5)
+
 
 # Test with numpy
 class TestRandGaussianNoisedNumpy(NumpyImageTestCase2D):

--- a/tests/test_rand_gaussian_noised.py
+++ b/tests/test_rand_gaussian_noised.py
@@ -17,8 +17,8 @@ from parameterized import parameterized
 from monai.transforms import RandGaussianNoised
 from tests.utils import NumpyImageTestCase2D, TorchImageTestCase2D
 
-TEST_CASE_0 = ["test_zero_mean", ["img", "im2"], 0, 0.1]
-TEST_CASE_1 = ["test_non_zero_mean", ["img"], 1, 0.5]
+TEST_CASE_0 = ["test_zero_mean", ["img1", "img2"], 0, 0.1]
+TEST_CASE_1 = ["test_non_zero_mean", ["img1", "img2"], 1, 0.5]
 TEST_CASES = [TEST_CASE_0, TEST_CASE_1]
 
 seed = 0


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/1512.

### Description
Create a list of noise realisations, with length equal to the number of keys. The noise realisations can all use the same mean, or a mean can be specified for each of the keys. The unit test has been updated to run for multiple labels.

@LucasFidon Does this suitably solve your problem? 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
