### PR TITLE
Prepare Batch

### DIFF
--- a/monai/engines/prepare_batch.py
+++ b/monai/engines/prepare_batch.py
@@ -1,4 +1,3 @@
-
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Sequence, Tuple, Union
 
@@ -21,6 +20,7 @@ class PrepareBatch(ABC):
         otherwise, it should update the batchdata dict and return it directly.
 
     """
+
     @abstractmethod
     def __call__(
         self,
@@ -38,6 +38,7 @@ class PrepareBatchDefault(PrepareBatch):
     it should be the last component in the prepare_batch chain.
 
     """
+
     def __call__(
         self,
         batchdata: Dict[str, torch.Tensor],
@@ -60,6 +61,7 @@ class PrepareBatchExtraInput(PrepareBatch):
             dict to the network(**kwargs).
 
     """
+
     def __init__(self, extra_keys: Union[str, Sequence[str], Dict[str, str]]) -> None:
         self.extra_keys = extra_keys
 
@@ -100,8 +102,7 @@ class PrepareBatchShuffle(PrepareBatch):
         non_blocking: bool = False,
     ) -> Union[Tuple[torch.Tensor, Optional[torch.Tensor]], torch.Tensor]:
 
-        images = batchdata["image"].to(device=device, non_blocking=non_blocking)
-        labels = batchdata["label"].to(device=device, non_blocking=non_blocking)
+        images, labels = default_prepare_batch(batchdata, device, non_blocking)
         idx_rand = torch.randperm(len(labels)).to(device=device, non_blocking=non_blocking)
 
         return images[idx_rand], labels[idx_rand]

--- a/monai/engines/prepare_batch.py
+++ b/monai/engines/prepare_batch.py
@@ -101,8 +101,9 @@ class PrepareBatchShuffle(PrepareBatch):
         device: Optional[Union[str, torch.device]] = None,
         non_blocking: bool = False,
     ) -> Union[Tuple[torch.Tensor, Optional[torch.Tensor]], torch.Tensor]:
-
         images, labels = default_prepare_batch(batchdata, device, non_blocking)
-        idx_rand = torch.randperm(len(labels)).to(device=device, non_blocking=non_blocking)
+        idx_rand = torch.randperm(len(images)).to(device=device, non_blocking=non_blocking)
 
-        return images[idx_rand], labels[idx_rand]
+        if labels is not None:
+            return images[idx_rand], labels[idx_rand]
+        return images[idx_rand], None

--- a/monai/engines/prepare_batch.py
+++ b/monai/engines/prepare_batch.py
@@ -1,0 +1,107 @@
+
+from abc import ABC, abstractmethod
+from typing import Dict, Optional, Sequence, Tuple, Union
+
+import torch
+
+from ..utils import ensure_tuple
+from .utils import default_prepare_batch
+
+
+class PrepareBatch(ABC):
+    """
+    Base class of customized prepare_batch in the trainer or evaluator workflows.
+    It takes the data of current batch, target device and non_blocking flag as input.
+    Default to run the default_prepare_batch of MONAI, which is consistent with ignite:
+    https://github.com/pytorch/ignite/blob/v0.4.2/ignite/engine/__init__.py#L28.
+
+    Note: if it is designed to be the last component in the prepare_batch chain,
+        it should return either (image, label(optional)) or (image, label(optional), tuple, dict).
+        the `tuple` and `dict` here are the `*args **kwargs` parameters for the network.
+        otherwise, it should update the batchdata dict and return it directly.
+
+    """
+    @abstractmethod
+    def __call__(
+        self,
+        batchdata: Dict[str, torch.Tensor],
+        device: Optional[Union[str, torch.device]] = None,
+        non_blocking: bool = False,
+    ):
+        raise NotImplementedError(f"Subclass {self.__class__.__name__} must implement this method.")
+
+
+class PrepareBatchDefault(PrepareBatch):
+    """
+    Default prepare_batch method to return `image` and `label` only,
+    it's consistent with MONAI `default_prerpare_batch` API.
+    it should be the last component in the prepare_batch chain.
+
+    """
+    def __call__(
+        self,
+        batchdata: Dict[str, torch.Tensor],
+        device: Optional[Union[str, torch.device]] = None,
+        non_blocking: bool = False,
+    ):
+        return default_prepare_batch(batchdata, device, non_blocking)
+
+
+class PrepareBatchExtraInput(PrepareBatch):
+    """
+    Customized prepare_batch for trainer or evalutor that support extra input data.
+    it should be the last component in the prepare_batch chain.
+
+    Args:
+        extra_keys: if a string or list provided, every item is the key of extra data in current batch,
+            and will pass the extra data to the network(*args) in order. if a dict provided,
+            every {k, v} pair is the key of extra data in current batch, k the param name in network,
+            v is the key of extra data in current batch, and will pass the {k1: d1, k2: d2, ...}
+            dict to the network(**kwargs).
+
+    """
+    def __init__(self, extra_keys: Union[str, Sequence[str], Dict[str, str]]) -> None:
+        self.extra_keys = extra_keys
+
+    def __call__(
+        self,
+        batchdata: Dict[str, torch.Tensor],
+        device: Optional[Union[str, torch.device]] = None,
+        non_blocking: bool = False,
+    ):
+        image, label = default_prepare_batch(batchdata, device, non_blocking)
+        args = list()
+        kwargs = dict()
+
+        def _get_data(key: str):
+            data = batchdata[key]
+            return data.to(device=device, non_blocking=non_blocking) if torch.is_tensor(data) else data
+
+        if isinstance(self.extra_keys, (str, list, tuple)):
+            for k in ensure_tuple(self.extra_keys):
+                args.append(_get_data(k))
+        elif isinstance(self.extra_keys, dict):
+            for k, v in self.extra_keys.items():
+                kwargs.update({k: _get_data(v)})
+
+        return image, label, tuple(args), kwargs
+
+
+class PrepareBatchShuffle(PrepareBatch):
+    """
+    Prepare shuffled batches by random permutation of samples within each batch.
+
+    """
+
+    def __call__(
+        self,
+        batchdata: Dict[str, torch.Tensor],
+        device: Optional[Union[str, torch.device]] = None,
+        non_blocking: bool = False,
+    ) -> Union[Tuple[torch.Tensor, Optional[torch.Tensor]], torch.Tensor]:
+
+        images = batchdata["image"].to(device=device, non_blocking=non_blocking)
+        labels = batchdata["label"].to(device=device, non_blocking=non_blocking)
+        idx_rand = torch.randperm(len(labels)).to(device=device, non_blocking=non_blocking)
+
+        return images[idx_rand], labels[idx_rand]

--- a/tests/test_prepare_batch.py
+++ b/tests/test_prepare_batch.py
@@ -6,8 +6,6 @@ from parameterized import parameterized
 from monai.engines.prepare_batch import PrepareBatchShuffle
 from monai.utils import set_determinism
 
-set_determinism(0)
-
 TEST_CASE_1 = [
     {"image": torch.Tensor([1.0, 2.0, 3.0]), "label": torch.Tensor([11.0, 22.0, 33.0])},
     (torch.Tensor([3.0, 1.0, 2.0]), torch.Tensor([33.0, 11.0, 22.0])),
@@ -19,19 +17,25 @@ TEST_CASE_2 = [
         "label": torch.Tensor([11.0, 22.0, 33.0]),
     },
     (
-        torch.stack([3.0 * torch.ones((2, 2)), 2.0 * torch.ones((2, 2)), 1.0 * torch.ones((2, 2))]),
-        torch.Tensor([33.0, 22.0, 11.0]),
+        torch.stack([3.0 * torch.ones((2, 2)), 1.0 * torch.ones((2, 2)), 2.0 * torch.ones((2, 2))]),
+        torch.Tensor([33.0, 11.0, 22.0]),
     ),
 ]
 
 # Image only
 TEST_CASE_3 = [
     {"image": torch.stack([1.0 * torch.ones((2, 2)), 2.0 * torch.ones((2, 2)), 3.0 * torch.ones((2, 2))])},
-    (torch.stack([2.0 * torch.ones((2, 2)), 3.0 * torch.ones((2, 2)), 1.0 * torch.ones((2, 2))]), None),
+    (torch.stack([3.0 * torch.ones((2, 2)), 1.0 * torch.ones((2, 2)), 2.0 * torch.ones((2, 2))]), None),
 ]
 
 
 class TestPrepareBatch(unittest.TestCase):
+    def setUp(self):
+        set_determinism(0)
+
+    def tearDown(self):
+        set_determinism(None)
+
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_prepare_batch_shuffle(self, data, expected_output):
         prepare_batch = PrepareBatchShuffle()

--- a/tests/test_prepare_batch.py
+++ b/tests/test_prepare_batch.py
@@ -26,15 +26,9 @@ TEST_CASE_2 = [
 
 # Image only
 TEST_CASE_3 = [
-    {
-        "image": torch.stack([1.0 * torch.ones((2, 2)), 2.0 * torch.ones((2, 2)), 3.0 * torch.ones((2, 2))])
-    },
-    (
-        torch.stack([2.0 * torch.ones((2, 2)), 3.0 * torch.ones((2, 2)), 1.0 * torch.ones((2, 2))]),
-        None
-    ),
+    {"image": torch.stack([1.0 * torch.ones((2, 2)), 2.0 * torch.ones((2, 2)), 3.0 * torch.ones((2, 2))])},
+    (torch.stack([2.0 * torch.ones((2, 2)), 3.0 * torch.ones((2, 2)), 1.0 * torch.ones((2, 2))]), None),
 ]
-
 
 
 class TestPrepareBatch(unittest.TestCase):

--- a/tests/test_prepare_batch.py
+++ b/tests/test_prepare_batch.py
@@ -24,15 +24,29 @@ TEST_CASE_2 = [
     ),
 ]
 
+# Image only
+TEST_CASE_3 = [
+    {
+        "image": torch.stack([1.0 * torch.ones((2, 2)), 2.0 * torch.ones((2, 2)), 3.0 * torch.ones((2, 2))])
+    },
+    (
+        torch.stack([2.0 * torch.ones((2, 2)), 3.0 * torch.ones((2, 2)), 1.0 * torch.ones((2, 2))]),
+        None
+    ),
+]
+
+
 
 class TestPrepareBatch(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_prepare_batch_shuffle(self, data, expected_output):
         prepare_batch = PrepareBatchShuffle()
         output = prepare_batch(batchdata=data)
-        print(output)
         self.assertTrue(torch.equal(output[0], expected_output[0]))
-        self.assertTrue(torch.equal(output[1], expected_output[1]))
+        if expected_output[1] is None:
+            self.assertIsNone(output[1])
+        else:
+            self.assertTrue(torch.equal(output[1], expected_output[1]))
 
 
 if __name__ == "__main__":

--- a/tests/test_prepare_batch.py
+++ b/tests/test_prepare_batch.py
@@ -1,0 +1,39 @@
+import unittest
+
+import torch
+from parameterized import parameterized
+
+from monai.engines.prepare_batch import PrepareBatchShuffle
+from monai.utils import set_determinism
+
+set_determinism(0)
+
+TEST_CASE_1 = [
+    {"image": torch.Tensor([1.0, 2.0, 3.0]), "label": torch.Tensor([11.0, 22.0, 33.0])},
+    (torch.Tensor([3.0, 1.0, 2.0]), torch.Tensor([33.0, 11.0, 22.0])),
+]
+
+TEST_CASE_2 = [
+    {
+        "image": torch.stack([1.0 * torch.ones((2, 2)), 2.0 * torch.ones((2, 2)), 3.0 * torch.ones((2, 2))]),
+        "label": torch.Tensor([11.0, 22.0, 33.0]),
+    },
+    (
+        torch.stack([3.0 * torch.ones((2, 2)), 2.0 * torch.ones((2, 2)), 1.0 * torch.ones((2, 2))]),
+        torch.Tensor([33.0, 22.0, 11.0]),
+    ),
+]
+
+
+class TestPrepareBatch(unittest.TestCase):
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
+    def test_prepare_batch_shuffle(self, data, expected_output):
+        prepare_batch = PrepareBatchShuffle()
+        output = prepare_batch(batchdata=data)
+        print(output)
+        self.assertTrue(torch.equal(output[0], expected_output[0]))
+        self.assertTrue(torch.equal(output[1], expected_output[1]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extend default prepare batch in Trainer

### Description
This PR implements the abstract `PrepareBatch` and concrete classes:
- PrepareBatchDefault
- PrepareBatchExtraInput
- PrepareBatchShuffle

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
