### PR TITLE
1567 add deletechanneld

### DIFF
--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -31,6 +31,7 @@ __all__ = [
     "AsChannelLast",
     "AddChannel",
     "RepeatChannel",
+    "DeleteChannel",
     "SplitChannel",
     "CastToType",
     "ToTensor",
@@ -159,6 +160,32 @@ class RepeatChannel(Transform):
         Apply the transform to `img`, assuming `img` is a "channel-first" array.
         """
         return np.repeat(img, self.repeats, 0)
+
+
+class DeleteChannel(Transform):
+    """
+    DeleteChannel data to undo RepeatChannel
+    The `repeats` count specifies the deletion of the origin data, for example:
+    ``DeleteChannel(repeats=2)([[1, 2], [1, 2], [3, 4], [3, 4]])`` generates: ``[[1, 2], [3, 4]]``
+
+    Args:
+        repeats: the number of repetitions to be deleted for each element.
+    """
+
+    def __init__(self, repeats: int) -> None:
+        if repeats <= 0:
+            raise AssertionError("repeats count must be greater than 0.")
+
+        self.repeats = repeats
+
+    def __call__(self, img: np.ndarray) -> np.ndarray:
+        """
+        Apply the transform to `img`, assuming `img` is a "channel-first" array.
+        """
+        if np.shape(img)[0] < 2:
+            raise AssertionError("Image must have more than one channel")
+
+        return img[:: self.repeats, :]
 
 
 class SplitChannel(Transform):

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -31,6 +31,7 @@ from monai.transforms.utility.array import (
     CastToType,
     ConvertToMultiChannelBasedOnBratsClasses,
     DataStats,
+    DeleteChannel,
     FgBgToIndices,
     Identity,
     LabelToMask,
@@ -52,6 +53,7 @@ __all__ = [
     "AsChannelLastd",
     "AddChanneld",
     "RepeatChanneld",
+    "DeleteChanneld",
     "SplitChanneld",
     "CastToTyped",
     "ToTensord",
@@ -218,6 +220,28 @@ class RepeatChanneld(MapTransform):
         """
         super().__init__(keys)
         self.repeater = RepeatChannel(repeats)
+
+    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
+        d = dict(data)
+        for key in self.keys:
+            d[key] = self.repeater(d[key])
+        return d
+
+
+class DeleteChanneld(MapTransform):
+    """
+    Dictionary-based wrapper of :py:class:`monai.transforms.DeleteChannel`.
+    """
+
+    def __init__(self, keys: KeysCollection, repeats: int) -> None:
+        """
+        Args:
+            keys: keys of the corresponding items to be transformed.
+                See also: :py:class:`monai.transforms.compose.MapTransform`
+            repeats: the number of repetitions for each element.
+        """
+        super().__init__(keys)
+        self.repeater = DeleteChannel(repeats)
 
     def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
         d = dict(data)
@@ -836,6 +860,7 @@ IdentityD = IdentityDict = Identityd
 AsChannelFirstD = AsChannelFirstDict = AsChannelFirstd
 AsChannelLastD = AsChannelLastDict = AsChannelLastd
 AddChannelD = AddChannelDict = AddChanneld
+DeleteChannelD = DeleteChannelDict = DeleteChanneld
 RepeatChannelD = RepeatChannelDict = RepeatChanneld
 SplitChannelD = SplitChannelDict = SplitChanneld
 CastToTypeD = CastToTypeDict = CastToTyped

--- a/tests/test_delete_channel.py
+++ b/tests/test_delete_channel.py
@@ -1,0 +1,32 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+from monai.transforms import DeleteChannel
+
+# TEST_CASE_1 = [{"repeats": 3}, np.array([[[0, 1], [1, 2]]]), (3, 2, 2)]
+
+TEST_CASE_1 = [{"repeats": 2}, np.array([[1, 2], [1, 2], [3, 4], [3, 4]]), (2, 2)]
+
+
+class TestRepeatChannel(unittest.TestCase):
+    @parameterized.expand([TEST_CASE_1])
+    def test_shape(self, input_param, input_data, expected_shape):
+        result = DeleteChannel(**input_param)(input_data)
+        self.assertEqual(result.shape, expected_shape)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_delete_channeld.py
+++ b/tests/test_delete_channeld.py
@@ -1,0 +1,34 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+from monai.transforms import DeleteChanneld
+
+TEST_CASE_1 = [
+    {"keys": ["img"], "repeats": 2},
+    {"img": np.array([[1, 2], [1, 2], [3, 4], [3, 4]]), "seg": np.array([[1, 2], [1, 2], [3, 4], [3, 4]])},
+    (2, 2),
+]
+
+
+class TestAddChanneld(unittest.TestCase):
+    @parameterized.expand([TEST_CASE_1])
+    def test_shape(self, input_param, input_data, expected_shape):
+        result = DeleteChanneld(**input_param)(input_data)
+        self.assertEqual(result["img"].shape, expected_shape)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: Leo Tam <leot@nvidia.com>

Fixes # .

### Description
Add DeleteChannel inverse operation to RepeatChannel via slicing. I tried squashing the commits which hilarious duplicated them instead. Anyways if it passes review, can fight git more. 

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
