### PR TITLE
Revert "1568 Enhance tests to use self random state (#1599)"

### DIFF
--- a/tests/test_rand_rotate.py
+++ b/tests/test_rand_rotate.py
@@ -52,7 +52,7 @@ class TestRandRotate2D(NumpyImageTestCase2D):
             self.imt[0, 0], -np.rad2deg(angle), (0, 1), not keep_size, order=_order, mode=_mode, prefilter=False
         )
         expected = np.stack(expected).astype(np.float32)
-        np.testing.assert_allclose(expected, rotated[0], rtol=1e-2, atol=1)
+        np.testing.assert_allclose(expected, rotated[0])
 
 
 class TestRandRotate3D(NumpyImageTestCase3D):

--- a/tests/test_rand_rotated.py
+++ b/tests/test_rand_rotated.py
@@ -54,7 +54,7 @@ class TestRandRotated2D(NumpyImageTestCase2D):
             self.imt[0, 0], -np.rad2deg(angle), (0, 1), not keep_size, order=_order, mode=_mode, prefilter=False
         )
         expected = np.stack(expected).astype(np.float32)
-        self.assertTrue(np.allclose(expected, rotated["img"][0], rtol=1e-2, atol=1))
+        self.assertTrue(np.allclose(expected, rotated["img"][0]))
 
 
 class TestRandRotated3D(NumpyImageTestCase3D):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,7 +30,6 @@ import torch.distributed as dist
 
 from monai.config.deviceconfig import USE_COMPILED
 from monai.data import create_test_image_2d, create_test_image_3d
-from monai.transforms import Randomizable
 from monai.utils import ensure_tuple, optional_import, set_determinism
 from monai.utils.module import get_torch_version_tuple
 
@@ -435,25 +434,14 @@ def _call_original_func(name, module, *args, **kwargs):
     return f(*args, **kwargs)
 
 
-class NumpyImageTestCase2D(unittest.TestCase, Randomizable):
+class NumpyImageTestCase2D(unittest.TestCase):
     im_shape = (128, 64)
     input_channels = 1
     output_channels = 4
     num_classes = 3
 
-    def randomize(self, data=None):
-        return create_test_image_2d(
-            width=self.im_shape[0],
-            height=self.im_shape[1],
-            num_objs=4,
-            rad_max=20,
-            noise_max=0,
-            num_seg_classes=self.num_classes,
-            random_state=self.R,
-        )
-
     def setUp(self):
-        im, msk = self.randomize()
+        im, msk = create_test_image_2d(self.im_shape[0], self.im_shape[1], 4, 20, 0, self.num_classes)
 
         self.imt = im[None, None]
         self.seg1 = (msk[None, None] > 0).astype(np.float32)
@@ -468,26 +456,14 @@ class TorchImageTestCase2D(NumpyImageTestCase2D):
         self.segn = torch.tensor(self.segn)
 
 
-class NumpyImageTestCase3D(unittest.TestCase, Randomizable):
+class NumpyImageTestCase3D(unittest.TestCase):
     im_shape = (64, 48, 80)
     input_channels = 1
     output_channels = 4
     num_classes = 3
 
-    def randomize(self, data=None):
-        return create_test_image_3d(
-            height=self.im_shape[0],
-            width=self.im_shape[1],
-            depth=self.im_shape[2],
-            num_objs=4,
-            rad_max=20,
-            noise_max=0,
-            num_seg_classes=self.num_classes,
-            random_state=self.R,
-        )
-
     def setUp(self):
-        im, msk = self.randomize()
+        im, msk = create_test_image_3d(self.im_shape[0], self.im_shape[1], self.im_shape[2], 4, 20, 0, self.num_classes)
 
         self.imt = im[None, None]
         self.seg1 = (msk[None, None] > 0).astype(np.float32)


### PR DESCRIPTION
This reverts commit 181f633f847ae1594a627f123931827b8e6d2995.

Signed-off-by: Wenqi Li <wenqil@nvidia.com>

fixes #1599 

### Description
#1599 still generates nondeterministic results

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
