### PR TITLE
RandCropByPosNegLabel(d) to return 1 element if num_samples==1

### DIFF
--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -574,7 +574,7 @@ class RandCropByPosNegLabel(Randomizable, Transform):
         image: Optional[np.ndarray] = None,
         fg_indices: Optional[np.ndarray] = None,
         bg_indices: Optional[np.ndarray] = None,
-    ) -> List[np.ndarray]:
+    ) -> Union[List[np.ndarray], np.ndarray]:
         """
         Args:
             img: input data to crop samples from based on the pos/neg ratio of `label` and `image`.
@@ -607,6 +607,10 @@ class RandCropByPosNegLabel(Randomizable, Transform):
             for center in self.centers:
                 cropper = SpatialCrop(roi_center=tuple(center), roi_size=self.spatial_size)  # type: ignore
                 results.append(cropper(img))
+
+        # if only 1 sample requested, no point returning list
+        if len(results) == 1:
+            return results[0]
 
         return results
 

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -566,7 +566,9 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
             self.spatial_size, self.num_samples, self.pos_ratio, label.shape[1:], fg_indices_, bg_indices_, self.R
         )
 
-    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Union[List[Dict[Hashable, np.ndarray]], Dict[Hashable, np.ndarray]]:
+    def __call__(
+        self, data: Mapping[Hashable, np.ndarray]
+    ) -> Union[List[Dict[Hashable, np.ndarray]], Dict[Hashable, np.ndarray]]:
         d = dict(data)
         label = d[self.label_key]
         image = d[self.image_key] if self.image_key else None

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -566,7 +566,7 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
             self.spatial_size, self.num_samples, self.pos_ratio, label.shape[1:], fg_indices_, bg_indices_, self.R
         )
 
-    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> List[Dict[Hashable, np.ndarray]]:
+    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Union[List[Dict[Hashable, np.ndarray]], Dict[Hashable, np.ndarray]]:
         d = dict(data)
         label = d[self.label_key]
         image = d[self.image_key] if self.image_key else None
@@ -588,6 +588,10 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
             else:
                 for i in range(self.num_samples):
                     results[i][key] = data[key]
+
+        # if only 1 sample requested, no point returning list
+        if len(results) == 1:
+            return results[0]
 
         return results
 

--- a/tests/test_rand_crop_by_pos_neg_label.py
+++ b/tests/test_rand_crop_by_pos_neg_label.py
@@ -65,9 +65,28 @@ TEST_CASE_2 = [
     (3, 2, 2, 2),
 ]
 
+TEST_CASE_3 = [
+    {
+        "label": None,
+        "spatial_size": [2, 2, 2],
+        "pos": 1,
+        "neg": 1,
+        "num_samples": 1,
+        "image": np.random.randint(0, 2, size=[3, 3, 3, 3]),
+        "image_threshold": 0,
+    },
+    {
+        "img": np.random.randint(0, 2, size=[3, 3, 3, 3]),
+        "label": np.random.randint(0, 2, size=[3, 3, 3, 3]),
+        "image": np.random.randint(0, 2, size=[3, 3, 3, 3]),
+    },
+    np.ndarray,
+    (2, 2, 2),
+]
 
+TESTS = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3]
 class TestRandCropByPosNegLabel(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2])
+    @parameterized.expand(TESTS)
     def test_type_shape(self, input_param, input_data, expected_type, expected_shape):
         result = RandCropByPosNegLabel(**input_param)(**input_data)
         self.assertIsInstance(result, expected_type)

--- a/tests/test_rand_crop_by_pos_neg_label.py
+++ b/tests/test_rand_crop_by_pos_neg_label.py
@@ -85,6 +85,8 @@ TEST_CASE_3 = [
 ]
 
 TESTS = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3]
+
+
 class TestRandCropByPosNegLabel(unittest.TestCase):
     @parameterized.expand(TESTS)
     def test_type_shape(self, input_param, input_data, expected_type, expected_shape):

--- a/tests/test_rand_crop_by_pos_neg_labeld.py
+++ b/tests/test_rand_crop_by_pos_neg_labeld.py
@@ -82,15 +82,39 @@ TEST_CASE_2 = [
     (3, 2, 2, 2),
 ]
 
+TEST_CASE_3 = [
+    {
+        "keys": ["image", "extral", "label"],
+        "label_key": "label",
+        "spatial_size": [2, 2, 2],
+        "pos": 1,
+        "neg": 1,
+        "num_samples": 1,
+        "image_key": None,
+        "image_threshold": 0,
+    },
+    {
+        "image": np.zeros([3, 3, 3, 3]) - 1,
+        "extral": np.zeros([3, 3, 3, 3]),
+        "label": np.ones([3, 3, 3, 3]),
+        "affine": np.eye(3),
+        "shape": "CHWD",
+    },
+    dict,
+    (3, 2, 2, 2),
+]
+
+TESTS = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3]
 
 class TestRandCropByPosNegLabeld(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2])
+    @parameterized.expand(TESTS)
     def test_type_shape(self, input_param, input_data, expected_type, expected_shape):
         result = RandCropByPosNegLabeld(**input_param)(input_data)
         self.assertIsInstance(result, expected_type)
-        self.assertTupleEqual(result[0]["image"].shape, expected_shape)
-        self.assertTupleEqual(result[0]["extral"].shape, expected_shape)
-        self.assertTupleEqual(result[0]["label"].shape, expected_shape)
+        out = result[0] if isinstance(result, list) else result
+        self.assertTupleEqual(out["image"].shape, expected_shape)
+        self.assertTupleEqual(out["extral"].shape, expected_shape)
+        self.assertTupleEqual(out["label"].shape, expected_shape)
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_crop_by_pos_neg_labeld.py
+++ b/tests/test_rand_crop_by_pos_neg_labeld.py
@@ -106,6 +106,7 @@ TEST_CASE_3 = [
 
 TESTS = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3]
 
+
 class TestRandCropByPosNegLabeld(unittest.TestCase):
     @parameterized.expand(TESTS)
     def test_type_shape(self, input_param, input_data, expected_type, expected_shape):


### PR DESCRIPTION
### Description
If `RandCropByPosNegLabel` or `RandCropByPosNegLabeld` is called with `num_samples==1`, then return just an element, rather than a list containing 1 element. This is useful if followed by something that doesn't expect a list of results or debugging (e.g., `DataStatsd`).

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
