### PR TITLE
1651 implement RegUNet

### DIFF
--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -119,6 +119,21 @@ Blocks
 .. autoclass:: Subpixelupsample
 .. autoclass:: SubpixelUpSample
 
+`Registration Residual Conv Block`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: RegistrationResidualConvBlock
+    :members:
+
+`Registration Down Sample Block`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: RegistrationDownSampleBlock
+    :members:
+
+`Registration Extraction Block`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: RegistrationExtractionBlock
+    :members:
+
 `LocalNet DownSample Block`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: LocalNetDownSampleBlock
@@ -328,6 +343,11 @@ Nets
 `VNet`
 ~~~~~~
 .. autoclass:: VNet
+  :members:
+
+`RegUNet`
+~~~~~~~~~~
+.. autoclass:: RegUNet
   :members:
 
 `LocalNet`

--- a/monai/networks/blocks/__init__.py
+++ b/monai/networks/blocks/__init__.py
@@ -17,6 +17,7 @@ from .downsample import MaxAvgPool
 from .dynunet_block import UnetBasicBlock, UnetOutBlock, UnetResBlock, UnetUpBlock, get_output_padding, get_padding
 from .fcn import FCN, GCN, MCFCN, Refine
 from .localnet_block import LocalNetDownSampleBlock, LocalNetFeatureExtractorBlock, LocalNetUpSampleBlock
+from .regunet_block import RegistrationDownSampleBlock, RegistrationExtractionBlock, RegistrationResidualConvBlock
 from .segresnet_block import ResBlock
 from .squeeze_and_excitation import (
     ChannelSELayer,

--- a/monai/networks/blocks/regunet_block.py
+++ b/monai/networks/blocks/regunet_block.py
@@ -1,0 +1,269 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List, Optional, Sequence, Tuple, Type, Union
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from monai.networks.blocks import Convolution
+from monai.networks.layers import Conv, Norm, Pool, same_padding
+
+
+def get_conv_block(
+    spatial_dims: int,
+    in_channels: int,
+    out_channels: int,
+    kernel_size: Union[Sequence[int], int] = 3,
+    strides: int = 1,
+    padding: Optional[int] = None,
+    act: Optional[Union[Tuple, str]] = "RELU",
+    norm: Optional[Union[Tuple, str]] = "BATCH",
+    initializer: str = "kaiming_uniform",
+) -> nn.Module:
+    if padding is None:
+        padding = same_padding(kernel_size)
+    conv_block = Convolution(
+        spatial_dims,
+        in_channels,
+        out_channels,
+        kernel_size=kernel_size,
+        strides=strides,
+        act=act,
+        norm=norm,
+        bias=False,
+        conv_only=False,
+        padding=padding,
+    )
+    conv_type: Type[Union[nn.Conv1d, nn.Conv2d, nn.Conv3d]] = Conv[Conv.CONV, spatial_dims]
+    for m in conv_block.modules():
+        if isinstance(m, conv_type):
+            if initializer == "kaiming_uniform":
+                nn.init.kaiming_normal_(torch.as_tensor(m.weight))
+            elif initializer == "zeros":
+                nn.init.zeros_(torch.as_tensor(m.weight))
+            else:
+                raise ValueError(
+                    f"initializer {initializer} is not supported, " "currently supporting kaiming_uniform and zeros"
+                )
+    return conv_block
+
+
+def get_conv_layer(
+    spatial_dims: int,
+    in_channels: int,
+    out_channels: int,
+    kernel_size: Union[Sequence[int], int] = 3,
+) -> nn.Module:
+    padding = same_padding(kernel_size)
+    return Convolution(
+        spatial_dims,
+        in_channels,
+        out_channels,
+        kernel_size=kernel_size,
+        bias=False,
+        conv_only=True,
+        padding=padding,
+    )
+
+
+class RegistrationResidualConvBlock(nn.Module):
+    """
+    A block with skip links and layer - norm - activation.
+    Only changes the number of channels, the spatial size is kept same.
+    """
+
+    def __init__(
+        self,
+        spatial_dims: int,
+        in_channels: int,
+        out_channels: int,
+        num_layers: int = 2,
+        kernel_size: int = 3,
+    ):
+        """
+
+        Args:
+            spatial_dims: number of spatial dimensions
+            in_channels: number of input channels
+            out_channels: number of output channels
+            num_layers: number of layers inside the block
+            kernel_size: kernel_size
+        """
+        super(RegistrationResidualConvBlock, self).__init__()
+        self.num_layers = num_layers
+        self.layers = nn.ModuleList(
+            [
+                get_conv_layer(
+                    spatial_dims=spatial_dims,
+                    in_channels=in_channels if i == 0 else out_channels,
+                    out_channels=out_channels,
+                    kernel_size=kernel_size,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.norms = nn.ModuleList([Norm[Norm.BATCH, spatial_dims](out_channels) for _ in range(num_layers)])
+        self.acts = nn.ModuleList([nn.ReLU() for _ in range(num_layers)])
+
+    def forward(self, x) -> torch.Tensor:
+        """
+
+        Args:
+            x: Tensor in shape (batch, ``in_channels``, insize_1, insize_2, [insize_3])
+
+        Returns:
+            Tensor in shape (batch, ``out_channels``, insize_1, insize_2, [insize_3]),
+            with the same spatial size as ``x``
+        """
+        skip = x
+        for i, (conv, norm, act) in enumerate(zip(self.layers, self.norms, self.acts)):
+            x = conv(x)
+            x = norm(x)
+            if i == self.num_layers - 1:
+                # last block
+                x = x + skip
+            x = act(x)
+        return x
+
+
+class RegistrationDownSampleBlock(nn.Module):
+    """
+    A down-sample module used in RegUNet to half the spatial size.
+    The number of channels is kept same.
+
+    Adapted from:
+        DeepReg (https://github.com/DeepRegNet/DeepReg)
+    """
+
+    def __init__(
+        self,
+        spatial_dims: int,
+        channels: int,
+        pooling: bool,
+    ) -> None:
+        """
+        Args:
+            spatial_dims: number of spatial dimensions.
+            channels: channels
+            pooling: use MaxPool if True, strided conv if False
+        """
+        super(RegistrationDownSampleBlock, self).__init__()
+        if pooling:
+            self.layer = Pool[Pool.MAX, spatial_dims](kernel_size=2)
+        else:
+            self.layer = get_conv_block(
+                spatial_dims=spatial_dims,
+                in_channels=channels,
+                out_channels=channels,
+                kernel_size=2,
+                strides=2,
+                padding=0,
+            )
+
+    def forward(self, x) -> torch.Tensor:
+        """
+        Halves the spatial dimensions and keeps the same channel.
+        output in shape (batch, ``channels``, insize_1 / 2, insize_2 / 2, [insize_3 / 2]),
+
+        Args:
+            x: Tensor in shape (batch, ``channels``, insize_1, insize_2, [insize_3])
+
+        Raises:
+            ValueError: when input spatial dimensions are not even.
+        """
+        for i in x.shape[2:]:
+            if i % 2 != 0:
+                raise ValueError("expecting x spatial dimensions be even, " f"got x of shape {x.shape}")
+        return self.layer(x)
+
+
+def get_deconv_block(
+    spatial_dims: int,
+    in_channels: int,
+    out_channels: int,
+) -> nn.Module:
+    return Convolution(
+        dimensions=spatial_dims,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        strides=2,
+        act="RELU",
+        norm="BATCH",
+        bias=False,
+        is_transposed=True,
+        padding=1,
+        output_padding=1,
+    )
+
+
+class RegistrationExtractionBlock(nn.Module):
+    """
+    The Extraction Block used in RegUNet.
+    Extracts feature from each ``extract_levels`` and takes the average.
+    """
+
+    def __init__(
+        self,
+        spatial_dims: int,
+        extract_levels: Tuple[int],
+        num_channels: Union[Tuple[int], List[int]],
+        out_channels: int,
+        kernel_initializer: str = "kaiming_uniform",
+        activation: Optional[str] = None,
+    ):
+        """
+
+        Args:
+            spatial_dims: number of spatial dimensions
+            extract_levels: spatial levels to extract feature from, 0 refers to the input scale
+            num_channels: number of channels at each scale level,
+                List or Tuple of lenth equals to `depth` of the RegNet
+            out_channels: number of output channels
+            kernel_initializer: kernel initializer
+            activation: kernel activation function
+        """
+        super(RegistrationExtractionBlock, self).__init__()
+        self.extract_levels = extract_levels
+        self.max_level = max(extract_levels)
+        self.layers = nn.ModuleList(
+            [
+                get_conv_block(
+                    spatial_dims=spatial_dims,
+                    in_channels=num_channels[d],
+                    out_channels=out_channels,
+                    norm=None,
+                    act=activation,
+                    initializer=kernel_initializer,
+                )
+                for d in extract_levels
+            ]
+        )
+
+    def forward(self, x: List[torch.Tensor], image_size: List[int]) -> torch.Tensor:
+        """
+
+        Args:
+            x: Decoded feature at different spatial levels, sorted from deep to shallow
+            image_size: output image size
+
+        Returns:
+            Tensor of shape (batch, `out_channels`, size1, size2, size3), where (size1, size2, size3) = ``image_size``
+        """
+        out = [
+            F.interpolate(
+                layer(x[self.max_level - level]),
+                size=image_size,
+            )
+            for layer, level in zip(self.layers, self.extract_levels)
+        ]
+        out = torch.mean(torch.stack(out, dim=0), dim=0)
+        return out

--- a/monai/networks/nets/__init__.py
+++ b/monai/networks/nets/__init__.py
@@ -20,6 +20,7 @@ from .generator import Generator
 from .highresnet import HighResBlock, HighResNet
 from .localnet import LocalNet
 from .regressor import Regressor
+from .regunet import RegUNet
 from .segresnet import SegResNet, SegResNetVAE
 from .senet import SENet, se_resnet50, se_resnet101, se_resnet152, se_resnext50_32x4d, se_resnext101_32x4d, senet154
 from .unet import UNet, Unet, unet

--- a/monai/networks/nets/regunet.py
+++ b/monai/networks/nets/regunet.py
@@ -1,0 +1,249 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List, Optional, Tuple, Union
+
+import torch
+from torch import nn
+
+from monai.networks.blocks.regunet_block import (
+    RegistrationDownSampleBlock,
+    RegistrationExtractionBlock,
+    RegistrationResidualConvBlock,
+    get_conv_block,
+    get_deconv_block,
+)
+
+
+class RegUNet(nn.Module):
+    """
+    Class that implements an adapted UNet. This class also serve as the parent class of LocalNet and GlobalNet
+
+    Reference:
+        O. Ronneberger, P. Fischer, and T. Brox,
+        “U-net: Convolutional networks for biomedical image segmentation,”,
+        Lecture Notes in Computer Science, 2015, vol. 9351, pp. 234–241.
+        https://arxiv.org/abs/1505.04597
+
+    Adapted from:
+        DeepReg (https://github.com/DeepRegNet/DeepReg)
+    """
+
+    def __init__(
+        self,
+        spatial_dims: int,
+        in_channels: int,
+        num_channel_initial: int,
+        depth: int,
+        out_kernel_initializer: Optional[str] = "kaiming_uniform",
+        out_activation: Optional[str] = None,
+        out_channels: int = 3,
+        extract_levels: Optional[Tuple[int]] = None,
+        pooling: bool = True,
+        concat_skip: bool = False,
+        encode_kernel_sizes: Union[int, List[int]] = 3,
+    ):
+        """
+        Args:
+            spatial_dims: number of spatial dims
+            in_channels: number of input channels
+            num_channel_initial: number of initial channels
+            depth: input is at level 0, bottom is at level depth.
+            out_kernel_initializer: kernel initializer for the last layer
+            out_activation: activation at the last layer
+            out_channels: number of channels for the output
+            extract_levels: list, which levels from net to extract. The maximum level must equal to ``depth``
+            pooling: for down-sampling, use non-parameterized pooling if true, otherwise use conv3d
+            concat_skip: when up-sampling, concatenate skipped tensor if true, otherwise use addition
+            encode_kernel_sizes: kernel size for down-sampling
+        """
+        super(RegUNet, self).__init__()
+        if not extract_levels:
+            extract_levels = (depth,)
+        assert max(extract_levels) == depth
+
+        # save parameters
+        self.spatial_dims = spatial_dims
+        self.in_channels = in_channels
+        self.num_channel_initial = num_channel_initial
+        self.depth = depth
+        self.out_kernel_initializer = out_kernel_initializer
+        self.out_activation = out_activation
+        self.out_channels = out_channels
+        self.extract_levels = extract_levels
+        self.pooling = pooling
+        self.concat_skip = concat_skip
+        self.encode_kernel_sizes = encode_kernel_sizes
+
+        self.num_channels = [self.num_channel_initial * (2 ** d) for d in range(self.depth + 1)]
+        self.min_extract_level = min(self.extract_levels)
+
+        # init layers
+        # all lists start with d = 0
+        self.encode_convs = None
+        self.encode_pools = None
+        self.bottom_block = None
+        self.decode_deconvs = None
+        self.decode_convs = None
+        self.output_block = None
+
+        # build layers
+        self.build_layers()
+
+    def build_layers(
+        self,
+    ):
+        self.build_encode_layers()
+        self.build_decode_layers()
+
+    def build_encode_layers(self):
+        if isinstance(self.encode_kernel_sizes, int):
+            self.encode_kernel_sizes = [self.encode_kernel_sizes] * (self.depth + 1)
+        assert len(self.encode_kernel_sizes) == self.depth + 1
+
+        # encoding / down-sampling
+        self.encode_convs = nn.ModuleList(
+            [
+                self.build_conv_block(
+                    in_channels=self.in_channels if d == 0 else self.num_channels[d - 1],
+                    out_channels=self.num_channels[d],
+                    kernel_size=self.encode_kernel_sizes[d],
+                )
+                for d in range(self.depth)
+            ]
+        )
+        self.encode_pools = nn.ModuleList(
+            [
+                self.build_down_sampling_block(
+                    channels=self.num_channels[d],
+                )
+                for d in range(self.depth)
+            ]
+        )
+        self.bottom_block = self.build_bottom_block(
+            in_channels=self.num_channels[-2], out_channels=self.num_channels[-1]
+        )
+
+    def build_conv_block(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+    ):
+        return nn.Sequential(
+            get_conv_block(
+                spatial_dims=self.spatial_dims,
+                in_channels=in_channels,
+                out_channels=out_channels,
+                kernel_size=kernel_size,
+            ),
+            RegistrationResidualConvBlock(
+                spatial_dims=self.spatial_dims,
+                in_channels=out_channels,
+                out_channels=out_channels,
+                kernel_size=kernel_size,
+            ),
+        )
+
+    def build_down_sampling_block(
+        self,
+        channels: int,
+    ):
+        return RegistrationDownSampleBlock(spatial_dims=self.spatial_dims, channels=channels, pooling=self.pooling)
+
+    def build_bottom_block(self, in_channels: int, out_channels: int):
+        kernel_size = self.encode_kernel_sizes[self.depth]
+        return nn.Sequential(
+            get_conv_block(
+                spatial_dims=self.spatial_dims,
+                in_channels=in_channels,
+                out_channels=out_channels,
+                kernel_size=kernel_size,
+            ),
+            RegistrationResidualConvBlock(
+                spatial_dims=self.spatial_dims,
+                in_channels=out_channels,
+                out_channels=out_channels,
+                kernel_size=kernel_size,
+            ),
+        )
+
+    def build_decode_layers(self):
+        # decoding / up-sampling
+        # [depth - 1, depth - 2, ..., min_extract_level]
+        self.decode_deconvs = nn.ModuleList(
+            [
+                self.build_up_sampling_block(in_channels=self.num_channels[d + 1], out_channels=self.num_channels[d])
+                for d in range(self.depth - 1, self.min_extract_level - 1, -1)
+            ]
+        )
+        self.decode_convs = nn.ModuleList(
+            [
+                self.build_conv_block(
+                    in_channels=(2 * self.num_channels[d] if self.concat_skip else self.num_channels[d]),
+                    out_channels=self.num_channels[d],
+                    kernel_size=3,
+                )
+                for d in range(self.depth - 1, self.min_extract_level - 1, -1)
+            ]
+        )
+
+        # extraction
+        self.output_block = self.build_output_block()
+
+    def build_up_sampling_block(
+        self,
+        in_channels: int,
+        out_channels: int,
+    ) -> nn.Module:
+        return get_deconv_block(spatial_dims=self.spatial_dims, in_channels=in_channels, out_channels=out_channels)
+
+    def build_output_block(self) -> nn.Module:
+        return RegistrationExtractionBlock(
+            spatial_dims=self.spatial_dims,
+            extract_levels=self.extract_levels,
+            num_channels=self.num_channels,
+            out_channels=self.out_channels,
+            kernel_initializer=self.out_kernel_initializer,
+            activation=self.out_activation,
+        )
+
+    def forward(self, x):
+        """
+        Args:
+            x: Tensor in shape (batch, ``in_channels``, insize_1, insize_2, [insize_3])
+
+        Returns:
+            Tensor in shape (batch, ``out_channels``, insize_1, insize_2, [insize_3]), with the same spatial size as ``x``
+        """
+        image_size = x.shape[2:]
+        skips = []  # [0, ..., depth - 1]
+        encoded = x
+        for encode_conv, encode_pool in zip(self.encode_convs, self.encode_pools):
+            skip = encode_conv(encoded)
+            encoded = encode_pool(skip)
+            skips.append(skip)
+        decoded = self.bottom_block(encoded)
+
+        outs = [decoded]
+
+        # [depth - 1, ..., min_extract_level]
+        for i, (decode_deconv, decode_conv) in enumerate(zip(self.decode_deconvs, self.decode_convs)):
+            # [depth - 1, depth - 2, ..., min_extract_level]
+            decoded = decode_deconv(decoded)
+            if self.concat_skip:
+                decoded = torch.cat([decoded, skips[-i - 1]], dim=1)
+            else:
+                decoded = decoded + skips[-i - 1]
+            decoded = decode_conv(decoded)
+            outs.append(decoded)
+
+        out = self.output_block(outs, image_size=image_size)
+        return out

--- a/tests/test_regunet.py
+++ b/tests/test_regunet.py
@@ -1,0 +1,87 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from parameterized import parameterized
+
+from monai.networks import eval_mode
+from monai.networks.nets.regunet import RegUNet
+from tests.utils import test_script_save
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+TEST_CASE_REGUNET_2D = [
+    [
+        {
+            "spatial_dims": 2,
+            "in_channels": 2,
+            "num_channel_initial": 16,
+            "depth": 3,
+            "out_kernel_initializer": "kaiming_uniform",
+            "out_activation": None,
+            "out_channels": 2,
+            "pooling": False,
+            "concat_skip": True,
+            "encode_kernel_sizes": 3,
+        },
+        (1, 2, 16, 16),
+        (1, 2, 16, 16),
+    ]
+]
+
+TEST_CASE_REGUNET_3D = [
+    [
+        {
+            "spatial_dims": 3,
+            "in_channels": 2,
+            "num_channel_initial": 16,
+            "depth": 3,
+            "out_kernel_initializer": "kaiming_uniform",
+            "out_activation": "sigmoid",
+            "out_channels": 2,
+            "extract_levels": (0, 1, 2, 3),
+            "pooling": True,
+            "concat_skip": False,
+            "encode_kernel_sizes": (3, 3, 3, 7),
+        },
+        (1, 2, 16, 16, 16),
+        (1, 2, 16, 16, 16),
+    ]
+]
+
+
+class TestREGUNET(unittest.TestCase):
+    @parameterized.expand(TEST_CASE_REGUNET_2D + TEST_CASE_REGUNET_3D)
+    def test_shape(self, input_param, input_shape, expected_shape):
+        net = RegUNet(**input_param).to(device)
+        with eval_mode(net):
+            result = net(torch.randn(input_shape).to(device))
+            self.assertEqual(result.shape, expected_shape)
+
+    def test_ill_shape(self):
+        with self.assertRaisesRegex(ValueError, ""):
+            input_param, _, _ = TEST_CASE_REGUNET_2D[0]
+            input_shape = (1, input_param["in_channels"], 17, 17)
+            net = RegUNet(**input_param).to(device)
+            net.forward(torch.randn(input_shape).to(device))
+
+    def test_script(self):
+        input_param, input_shape, _ = TEST_CASE_REGUNET_2D[0]
+        net = RegUNet(**input_param)
+        test_data = torch.randn(input_shape)
+        test_script_save(net, test_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_regunet_block.py
+++ b/tests/test_regunet_block.py
@@ -1,0 +1,97 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from parameterized import parameterized
+
+from monai.networks import eval_mode
+from monai.networks.blocks.regunet_block import (
+    RegistrationDownSampleBlock,
+    RegistrationExtractionBlock,
+    RegistrationResidualConvBlock,
+)
+
+TEST_CASE_RESIDUAL = [
+    [{"spatial_dims": 2, "in_channels": 1, "out_channels": 2, "num_layers": 1}, (1, 1, 5, 5), (1, 2, 5, 5)],
+    [{"spatial_dims": 3, "in_channels": 2, "out_channels": 2, "num_layers": 2}, (1, 2, 5, 5, 5), (1, 2, 5, 5, 5)],
+]
+
+TEST_CASE_DOWN_SAMPLE = [
+    [{"spatial_dims": 2, "channels": 1, "pooling": False}, (1, 1, 4, 4), (1, 1, 2, 2)],
+    [{"spatial_dims": 3, "channels": 2, "pooling": True}, (1, 2, 4, 4, 4), (1, 2, 2, 2, 2)],
+]
+
+TEST_CASE_EXTRACTION = [
+    [
+        {
+            "spatial_dims": 2,
+            "extract_levels": (0,),
+            "num_channels": [1],
+            "out_channels": 1,
+            "out_kernel_initializer": "kaiming_uniform",
+            "out_activation": None,
+        },
+        [(1, 1, 2, 2)],
+        (3, 3),
+        (1, 1, 3, 3),
+    ],
+    [
+        {
+            "spatial_dims": 3,
+            "extract_levels": (1, 2),
+            "num_channels": [1, 2, 3],
+            "out_channels": 1,
+            "out_kernel_initializer": "zeros",
+            "out_activation": "sigmoid",
+        },
+        [(1, 3, 2, 2, 2), (1, 2, 4, 4, 4), (1, 1, 8, 8, 8)],
+        (3, 3, 3),
+        (1, 1, 3, 3, 3),
+    ],
+]
+
+
+class TestRegistrationResidualConvBlock(unittest.TestCase):
+    @parameterized.expand(TEST_CASE_RESIDUAL)
+    def test_shape(self, input_param, input_shape, expected_shape):
+        net = RegistrationResidualConvBlock(**input_param)
+        with eval_mode(net):
+            x = net(torch.randn(input_shape))
+            self.assertEqual(x.shape, expected_shape)
+
+
+class TestRegistrationDownSampleBlock(unittest.TestCase):
+    @parameterized.expand(TEST_CASE_DOWN_SAMPLE)
+    def test_shape(self, input_param, input_shape, expected_shape):
+        net = RegistrationDownSampleBlock(**input_param)
+        with eval_mode(net):
+            x = net(torch.rand(input_shape))
+            self.assertEqual(x.shape, expected_shape)
+
+    def test_ill_shape(self):
+        net = RegistrationDownSampleBlock(spatial_dims=2, channels=2, pooling=True)
+        with self.assertRaises(ValueError):
+            net(torch.rand((1, 2, 3, 3)))
+
+
+class TestRegistrationExtractionBlock(unittest.TestCase):
+    @parameterized.expand(TEST_CASE_EXTRACTION)
+    def test_shape(self, input_param, input_shapes, image_size, expected_shape):
+        net = RegistrationExtractionBlock(**input_param)
+        with eval_mode(net):
+            x = net([torch.rand(input_shape) for input_shape in input_shapes], image_size)
+            self.assertEqual(x.shape, expected_shape)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: kate-sann5100 <yiwen.li@st-annes.ox.ac.uk>

Fixes # 1651.

### Description
Implements RegUNet which will serve as the parent class of the LocalNet and GlobalNet

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
