### PR TITLE
1500-update grid dataset to support patch level transforms

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -77,9 +77,10 @@ Patch-based dataset
 .. autoclass:: GridPatchDataset
   :members:
 
-`default_patch_iter`
-~~~~~~~~~~~~~~~~~~~~
-.. autofunction:: default_patch_iter
+`PatchIter`
+~~~~~~~~~~~
+.. autoclass:: PatchIter
+  :members:
 
 `PatchDataset`
 ~~~~~~~~~~~~~~

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -77,6 +77,10 @@ Patch-based dataset
 .. autoclass:: GridPatchDataset
   :members:
 
+`default_patch_iter`
+~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: default_patch_iter
+
 `PatchDataset`
 ~~~~~~~~~~~~~~
 .. autoclass:: PatchDataset

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -22,7 +22,7 @@ from .dataset import (
     ZipDataset,
 )
 from .decathlon_datalist import load_decathlon_datalist, load_decathlon_properties
-from .grid_dataset import GridPatchDataset, PatchDataset
+from .grid_dataset import GridPatchDataset, PatchDataset, default_patch_iter
 from .image_dataset import ImageDataset
 from .image_reader import ImageReader, ITKReader, NibabelReader, NumpyReader, PILReader, WSIReader
 from .iterable_dataset import IterableDataset
@@ -44,7 +44,7 @@ from .utils import (
     get_valid_patch_size,
     is_supported_format,
     iter_patch,
-    iter_patch_slices,
+    iter_patch_coordinates,
     json_hashing,
     list_data_collate,
     pad_list_data_collate,

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -22,7 +22,7 @@ from .dataset import (
     ZipDataset,
 )
 from .decathlon_datalist import load_decathlon_datalist, load_decathlon_properties
-from .grid_dataset import GridPatchDataset, PatchDataset, default_patch_iter
+from .grid_dataset import GridPatchDataset, PatchDataset, PatchIter
 from .image_dataset import ImageDataset
 from .image_reader import ImageReader, ITKReader, NibabelReader, NumpyReader, PILReader, WSIReader
 from .iterable_dataset import IterableDataset

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -44,7 +44,7 @@ from .utils import (
     get_valid_patch_size,
     is_supported_format,
     iter_patch,
-    iter_patch_coordinates,
+    iter_patch_slices,
     json_hashing,
     list_data_collate,
     pad_list_data_collate,

--- a/monai/data/grid_dataset.py
+++ b/monai/data/grid_dataset.py
@@ -48,12 +48,15 @@ def default_patch_iter(
         specified by a `patch_size` of (10, 10, 10).
 
     """
-    _patch_size = (None,) + tuple(patch_size)
-    _start_pos = ensure_tuple(start_pos)
 
     def patch_iter_func(image):
         yield from iter_patch(
-            image, patch_size=_patch_size, start_pos=_start_pos, copy_back=False, mode=mode, **pad_opts
+            image,
+            patch_size=(None,) + tuple(patch_size),  # expand to have the channel dim
+            start_pos=ensure_tuple(start_pos),
+            copy_back=False,
+            mode=mode,
+            **pad_opts,
         )
 
     return patch_iter_func

--- a/monai/data/grid_dataset.py
+++ b/monai/data/grid_dataset.py
@@ -89,8 +89,8 @@ class GridPatchDataset(IterableDataset):
             print("coordinates:", item[1])
 
         # >>> patch size: torch.Size([2, 1, 2, 2])
-        #     coordinates: tensor([[[1, 2], [2, 4], [4, 6]],
-        #                          [[1, 2], [4, 6], [4, 6]]])
+        #     coordinates: tensor([[[0, 1], [0, 2], [0, 2]],
+        #                          [[0, 1], [2, 4], [0, 2]]])
 
     """
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -219,7 +219,9 @@ def iter_patch(
 
     for coords in iter_patch_coordinates(iter_size, patch_size_, start_pos_padded):
         slices = tuple(slice(coord[0], coord[1]) for coord in coords)
-        yield arrpad[slices], np.asarray(coords)  # data, and coords (in numpy; so that it works with torch loader)
+        # compensate original image padding
+        coords_no_pad = tuple((coord[0] - p, coord[1] - p) for coord, p in zip(coords, patch_size_))
+        yield arrpad[slices], np.asarray(coords_no_pad)  # data and coords (in numpy; works with torch loader)
 
     # copy back data from the padded image if required
     if copy_back:

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -422,6 +422,8 @@ def set_rnd(obj, seed: int) -> int:
         obj.set_random_state(seed=seed % MAX_SEED)
         return seed + 1  # a different seed for the next component
     for key in obj.__dict__:
+        if key.startswith("__"):  # skip the private methods
+            continue
         seed = set_rnd(obj.__dict__[key], seed=seed)
     return seed
 

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -367,31 +367,6 @@ def generate_pos_neg_label_crop_centers(
     return centers
 
 
-def apply_transform(transform: Callable, data, map_items: bool = True):
-    """
-    Transform `data` with `transform`.
-    If `data` is a list or tuple and `map_data` is True, each item of `data` will be transformed
-    and this method returns a list of outcomes.
-    otherwise transform will be applied once with `data` as the argument.
-
-    Args:
-        transform: a callable to be used to transform `data`
-        data: an object to be transformed.
-        map_items: whether to apply transform to each item in `data`,
-            when `data` is a list or tuple. Defaults to True.
-
-    Raises:
-        Exception: When ``transform`` raises an exception.
-
-    """
-    try:
-        if isinstance(data, (list, tuple)) and map_items:
-            return [transform(item) for item in data]
-        return transform(data)
-    except Exception as e:
-        raise RuntimeError(f"applying transform {transform}") from e
-
-
 def create_grid(
     spatial_size: Sequence[int],
     spacing: Optional[Sequence[float]] = None,

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -367,6 +367,31 @@ def generate_pos_neg_label_crop_centers(
     return centers
 
 
+def apply_transform(transform: Callable, data, map_items: bool = True):
+    """
+    Transform `data` with `transform`.
+    If `data` is a list or tuple and `map_data` is True, each item of `data` will be transformed
+    and this method returns a list of outcomes.
+    otherwise transform will be applied once with `data` as the argument.
+
+    Args:
+        transform: a callable to be used to transform `data`
+        data: an object to be transformed.
+        map_items: whether to apply transform to each item in `data`,
+            when `data` is a list or tuple. Defaults to True.
+
+    Raises:
+        Exception: When ``transform`` raises an exception.
+
+    """
+    try:
+        if isinstance(data, (list, tuple)) and map_items:
+            return [transform(item) for item in data]
+        return transform(data)
+    except Exception as e:
+        raise RuntimeError(f"applying transform {transform}") from e
+
+
 def create_grid(
     spatial_size: Sequence[int],
     spacing: Optional[Sequence[float]] = None,

--- a/tests/test_grid_dataset.py
+++ b/tests/test_grid_dataset.py
@@ -62,7 +62,7 @@ class TestGridPatchDataset(unittest.TestCase):
         )
         np.testing.assert_allclose(
             item[1],
-            np.array([[[1, 2], [2, 4], [4, 6]], [[1, 2], [4, 6], [4, 6]]]),
+            np.array([[[0, 1], [0, 2], [2, 4]], [[0, 1], [2, 4], [2, 4]]]),
             rtol=1e-5,
         )
         if sys.platform != "win32":
@@ -75,7 +75,7 @@ class TestGridPatchDataset(unittest.TestCase):
             )
             np.testing.assert_allclose(
                 item[1],
-                np.array([[[1, 2], [2, 4], [4, 6]], [[1, 2], [4, 6], [4, 6]]]),
+                np.array([[[0, 1], [0, 2], [2, 4]], [[0, 1], [2, 4], [2, 4]]]),
                 rtol=1e-5,
             )
 

--- a/tests/test_grid_dataset.py
+++ b/tests/test_grid_dataset.py
@@ -14,7 +14,7 @@ import unittest
 
 import numpy as np
 
-from monai.data import DataLoader, GridPatchDataset, default_patch_iter
+from monai.data import DataLoader, GridPatchDataset, PatchIter
 from monai.transforms import RandShiftIntensity
 from monai.utils import set_determinism
 
@@ -23,10 +23,6 @@ def identity_generator(x):
     # simple transform that returns the input itself
     for idx, item in enumerate(x):
         yield item, idx
-
-
-# Can't pickle local object
-patch_iter = default_patch_iter(patch_size=(2, 2), start_pos=(0, 0))
 
 
 class TestGridPatchDataset(unittest.TestCase):
@@ -53,6 +49,7 @@ class TestGridPatchDataset(unittest.TestCase):
         images = [np.arange(16, dtype=float).reshape(1, 4, 4), np.arange(16, dtype=float).reshape(1, 4, 4)]
         # image level
         patch_intensity = RandShiftIntensity(offsets=1.0, prob=1.0)
+        patch_iter = PatchIter(patch_size=(2, 2), start_pos=(0, 0))
         ds = GridPatchDataset(dataset=images, patch_iter=patch_iter, transform=patch_intensity)
         # use the grid patch dataset
         for item in DataLoader(ds, batch_size=2, shuffle=False, num_workers=0):

--- a/tests/test_grid_dataset.py
+++ b/tests/test_grid_dataset.py
@@ -44,7 +44,7 @@ class TestGridPatchDataset(unittest.TestCase):
         for item in DataLoader(result, batch_size=3, num_workers=n_workers):
             output.append("".join(item))
         expected = ["vwx", "wor", "yzh", "ldf", "ell", "oob", "owo", "ar", "rld"]
-        self.assertEqual(output, expected)
+        self.assertEqual(sorted(output), sorted(expected))
         self.assertEqual(len("".join(expected)), len("".join(test_dataset)))
 
     def test_loading_array(self):

--- a/tests/test_grid_dataset.py
+++ b/tests/test_grid_dataset.py
@@ -25,6 +25,10 @@ def identity_generator(x):
         yield item, idx
 
 
+# Can't pickle local object
+patch_iter = default_patch_iter(patch_size=(2, 2), start_pos=(0, 0))
+
+
 class TestGridPatchDataset(unittest.TestCase):
     def setUp(self):
         set_determinism(seed=1234)
@@ -47,8 +51,6 @@ class TestGridPatchDataset(unittest.TestCase):
         set_determinism(seed=1234)
         # image dataset
         images = [np.arange(16, dtype=float).reshape(1, 4, 4), np.arange(16, dtype=float).reshape(1, 4, 4)]
-        # image patch sampler
-        patch_iter = default_patch_iter(patch_size=(2, 2), start_pos=(0, 0))
         # image level
         patch_intensity = RandShiftIntensity(offsets=1.0, prob=1.0)
         ds = GridPatchDataset(dataset=images, patch_iter=patch_iter, transform=patch_intensity)

--- a/tests/test_grid_dataset.py
+++ b/tests/test_grid_dataset.py
@@ -1,0 +1,84 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+import numpy as np
+
+from monai.data import DataLoader, GridPatchDataset, default_patch_iter
+from monai.transforms import RandShiftIntensity
+from monai.utils import set_determinism
+
+
+def identity_generator(x):
+    # simple transform that returns the input itself
+    for idx, item in enumerate(x):
+        yield item, idx
+
+
+class TestGridPatchDataset(unittest.TestCase):
+    def setUp(self):
+        set_determinism(seed=1234)
+
+    def tearDown(self):
+        set_determinism(None)
+
+    def test_shape(self):
+        test_dataset = ["vwxyz", "helloworld", "worldfoobar"]
+        result = GridPatchDataset(dataset=test_dataset, patch_iter=identity_generator, with_coordinates=False)
+        output = []
+        n_workers = 0 if sys.platform == "win32" else 2
+        for item in DataLoader(result, batch_size=3, num_workers=n_workers):
+            output.append("".join(item))
+        expected = ["vwx", "wor", "yzh", "ldf", "ell", "oob", "owo", "ar", "rld"]
+        self.assertEqual(output, expected)
+        self.assertEqual(len("".join(expected)), len("".join(test_dataset)))
+
+    def test_loading_array(self):
+        set_determinism(seed=1234)
+        # image dataset
+        images = [np.arange(16, dtype=float).reshape(1, 4, 4), np.arange(16, dtype=float).reshape(1, 4, 4)]
+        # image patch sampler
+        patch_iter = default_patch_iter(patch_size=(2, 2), start_pos=(0, 0))
+        # image level
+        patch_intensity = RandShiftIntensity(offsets=1.0, prob=1.0)
+        ds = GridPatchDataset(dataset=images, patch_iter=patch_iter, transform=patch_intensity)
+        # use the grid patch dataset
+        for item in DataLoader(ds, batch_size=2, shuffle=False, num_workers=0):
+            np.testing.assert_equal(tuple(item[0].shape), (2, 1, 2, 2))
+        np.testing.assert_allclose(
+            item[0],
+            np.array([[[[1.7413, 2.7413], [5.7413, 6.7413]]], [[[9.1419, 10.1419], [13.1419, 14.1419]]]]),
+            rtol=1e-5,
+        )
+        np.testing.assert_allclose(
+            item[1],
+            np.array([[[1, 2], [2, 4], [4, 6]], [[1, 2], [4, 6], [4, 6]]]),
+            rtol=1e-5,
+        )
+        if sys.platform != "win32":
+            for item in DataLoader(ds, batch_size=2, shuffle=False, num_workers=2):
+                np.testing.assert_equal(tuple(item[0].shape), (2, 1, 2, 2))
+            np.testing.assert_allclose(
+                item[0],
+                np.array([[[[2.3944, 3.3944], [6.3944, 7.3944]]], [[[10.6551, 11.6551], [14.6551, 15.6551]]]]),
+                rtol=1e-3,
+            )
+            np.testing.assert_allclose(
+                item[1],
+                np.array([[[1, 2], [2, 4], [4, 6]], [[1, 2], [4, 6], [4, 6]]]),
+                rtol=1e-5,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #1500

### Description
revised grid patch dataset to support patch level transforms and coordinates outputs.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
