### PR TITLE
Update load pretrain for densenet

### DIFF
--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -210,14 +210,14 @@ def _load_state_dict(model, model_url, progress):
     <https://github.com/pytorch/vision/blob/master/torchvision/models/densenet.py>`_
     """
     pattern = re.compile(
-        r"^(.*denselayer\d+\.(?:norm|relu|conv))\.((?:[12])\.(?:weight|bias|running_mean|running_var))$"
+        r"^(.*denselayer\d+)(\.(?:norm|relu|conv))\.((?:[12])\.(?:weight|bias|running_mean|running_var))$"
     )
 
     state_dict = load_state_dict_from_url(model_url, progress=progress)
     for key in list(state_dict.keys()):
         res = pattern.match(key)
         if res:
-            new_key = res.group(1) + res.group(2)
+            new_key = res.group(1) + ".layers" + res.group(2) + res.group(3)
             state_dict[new_key] = state_dict[key]
             del state_dict[key]
 

--- a/tests/test_densenet.py
+++ b/tests/test_densenet.py
@@ -21,7 +21,6 @@ from monai.networks.nets import densenet121, densenet169, densenet201, densenet2
 from monai.utils import optional_import
 from tests.utils import skip_if_quick, test_pretrained_networks, test_script_save
 
-
 if TYPE_CHECKING:
     import torchvision
 


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #1681  .

### Description
Except for the re-implementation of load pre-trained weights function, a new test case is added. For the same input tensor, the output between the torchvision's densenet and our version should be the same.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
