### PR TITLE
Fix senet pretrained weights issue

### DIFF
--- a/monai/networks/nets/senet.py
+++ b/monai/networks/nets/senet.py
@@ -275,7 +275,7 @@ def _load_state_dict(model, model_url, progress):
         if pattern_conv.match(key):
             new_key = re.sub(pattern_conv, r"\1conv.\2", key)
         elif pattern_bn.match(key):
-            new_key = re.sub(pattern_bn, r"\1conv\2norm.\3", key)
+            new_key = re.sub(pattern_bn, r"\1conv\2adn.N.\3", key)
         elif pattern_se.match(key):
             state_dict[key] = state_dict[key].squeeze()
             new_key = re.sub(pattern_se, r"\1se_layer.fc.0.\2", key)
@@ -285,7 +285,7 @@ def _load_state_dict(model, model_url, progress):
         elif pattern_down_conv.match(key):
             new_key = re.sub(pattern_down_conv, r"\1project.conv.\2", key)
         elif pattern_down_bn.match(key):
-            new_key = re.sub(pattern_down_bn, r"\1project.norm.\2", key)
+            new_key = re.sub(pattern_down_bn, r"\1project.adn.N.\2", key)
         if new_key:
             state_dict[new_key] = state_dict[key]
             del state_dict[key]


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #1688 .

### Description

Except for the re-implementation of load pre-trained weights function, a new test case is added. For the same input tensor, the output between the torchvision's densenet and our version should be close (since we use nn.Linear for the fc layer, and Cadene's version uses conv layer with kernel size =1, it brings a few difference).

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
