### PR TITLE
1285 adds module list

### DIFF
--- a/monai/__init__.py
+++ b/monai/__init__.py
@@ -44,3 +44,19 @@ load_submodules(sys.modules[__name__], False, exclude_pattern=excludes)
 
 # load all modules, this will trigger all export decorations
 load_submodules(sys.modules[__name__], True, exclude_pattern=excludes)
+
+__all__ = [
+    "apps",
+    "config",
+    "data",
+    "engines",
+    "handlers",
+    "inferers",
+    "losses",
+    "metrics",
+    "networks",
+    "optimizers",
+    "transforms",
+    "utils",
+    "visualize",
+]

--- a/tests/test_module_list.py
+++ b/tests/test_module_list.py
@@ -1,0 +1,38 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import os
+import unittest
+
+import monai
+
+
+class TestAllImport(unittest.TestCase):
+    def test_public_api(self):
+        """
+        This is to check "monai.__all__" should be consistent with
+        the top-level folders except for "__pycache__" and "csrc" (cpp/cuda src)
+        """
+        base_folder = os.path.dirname(monai.__file__)
+        to_search = os.path.join(base_folder, "*", "")
+        subfolders = [os.path.basename(x[:-1]) for x in glob.glob(to_search)]
+        to_exclude = ("__pycache__", "csrc")
+        mod = []
+        for code_folder in subfolders:
+            if code_folder in to_exclude:
+                continue
+            mod.append(code_folder)
+        self.assertEqual(sorted(monai.__all__), sorted(mod))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fixes #1285

### Description
- pycharm 2020 works fine with this pattern
```py
if TYPE_CHECKING:
    from ignite.engine import Engine
    from ignite.metrics import Metric
else:
    Engine, _ = optional_import("ignite.engine", "0.4.2", exact_version, "Engine")
    Metric, _ = optional_import("ignite.metrics", "0.4.2", exact_version, "Metric")
```
- this PR adds the missing top-level module list

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
