### PR TITLE
Raise import error for openslide and cuimage

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -645,7 +645,7 @@ class WSIReader(ImageReader):
         if self.reader_lib == "openslide":
             if has_osl:
                 self.wsi_reader = openslide.OpenSlide
-                print("> OpenSlide is being used.")                
+                print("> OpenSlide is being used.")
         elif self.reader_lib == "cuclaraimage":
             if has_cux:
                 self.wsi_reader = cuimage.CuImage

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -639,13 +639,13 @@ class WSIReader(ImageReader):
 
     """
 
-    def __init__(self, reader_lib: str = "cuClaraImage"):
+    def __init__(self, reader_lib: str = "OpenSlide"):
         super().__init__()
         self.reader_lib = reader_lib.lower()
         if self.reader_lib == "openslide":
             if has_osl:
                 self.wsi_reader = openslide.OpenSlide
-                print("> OpenSlide is being used.")
+                print("> OpenSlide is being used.")                
         elif self.reader_lib == "cuclaraimage":
             if has_cux:
                 self.wsi_reader = cuimage.CuImage
@@ -672,6 +672,11 @@ class WSIReader(ImageReader):
             data: file name or a list of file names to read.
 
         """
+        if (self.reader_lib == "openslide") and (not has_osl):
+            raise ImportError("No module named 'openslide'")
+        elif (self.reader_lib == "cuclaraimage") and (not has_cux):
+            raise ImportError("No module named 'cuimage'")
+
         img_: List = []
 
         filenames: Sequence[str] = ensure_tuple(data)


### PR DESCRIPTION
### Description
In order for WSIReader to be used in [LoadImage](https://github.com/Project-MONAI/MONAI/blob/232e8a524c7074ceae4c45b756bfddc67772c05f/monai/transforms/io/array.py#L93), optional import error in the `__init__` of `WSIReader` was skipped, so a secondary exception was raised instead, which is not informative and does not help the user to know the cause. This PR fixes this issue by raising the appropriate import error when `WSIReader.read` is being called.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
