### PR TITLE
Fix MONAI docker dependency

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -58,7 +58,11 @@ jobs:
     runs-on: [self-hosted, linux, x64, common]
     steps:
     - uses: actions/checkout@v2
-    - name: Install the dependencies
+    - name: Install APT dependencies
+      run: |
+        apt-get update
+        DEBIAN_FRONTEND="noninteractive" apt-get install -y libopenslide0
+    - name: Install Python dependencies
       run: |
         which python
         python -m pip install --upgrade pip wheel

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN wget -q ${NGC_CLI_URI} && \
     unzip ngccli_cat_linux.zip && chmod u+x ngc && \
     md5sum -c ngc.md5 && \
     rm -rf ngccli_cat_linux.zip ngc.md5
+RUN apt-get update \
+  && DEBIAN_FRONTEND="noninteractive" apt-get install -y libopenslide0  \
+  && rm -rf /var/lib/apt/lists/*
 # append /opt/tools to runtime path for NGC CLI to be accessible from all file system locations
 ENV PATH=${PATH}:/opt/tools
 WORKDIR /opt/monai


### PR DESCRIPTION
Fixes #1721 

### Description
Update MONAI docker and nightly tests docker (` cron-pt-image`) to include OpenSlide library dependencies

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
