### PR TITLE
[1710] Gradcam eval

### DIFF
--- a/monai/visualize/class_activation_maps.py
+++ b/monai/visualize/class_activation_maps.py
@@ -17,7 +17,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from monai.networks.utils import eval_mode, train_mode
 from monai.transforms import ScaleIntensity
 from monai.utils import ensure_tuple
 from monai.visualize.visualizer import default_upsampler

--- a/tests/test_vis_gradcam.py
+++ b/tests/test_vis_gradcam.py
@@ -11,6 +11,7 @@
 
 import unittest
 
+import numpy as np
 import torch
 from parameterized import parameterized
 
@@ -79,6 +80,7 @@ class TestGradientClassActivationMap(unittest.TestCase):
         cam = GradCAM(nn_module=model, target_layers=input_data["target_layers"])
         image = torch.rand(input_data["shape"], device=device)
         result = cam(x=image, layer_idx=-1)
+        np.testing.assert_array_equal(cam.nn_module.class_idx, model(image).max(1)[-1])
         fea_shape = cam.feature_map_size(input_data["shape"], device=device)
         self.assertTupleEqual(fea_shape, input_data["feature_shape"])
         self.assertTupleEqual(result.shape, expected_shape)

--- a/tests/test_vis_gradcam.py
+++ b/tests/test_vis_gradcam.py
@@ -64,7 +64,6 @@ TEST_CASE_3 = [
 class TestGradientClassActivationMap(unittest.TestCase):
     @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_shape(self, input_data, expected_shape):
-        device = "cuda:0" if torch.cuda.is_available() else "cpu"
         if input_data["model"] == "densenet2d":
             model = densenet121(spatial_dims=2, in_channels=1, out_channels=3)
         if input_data["model"] == "densenet3d":
@@ -75,7 +74,8 @@ class TestGradientClassActivationMap(unittest.TestCase):
             model = se_resnet50(spatial_dims=2, in_channels=3, num_classes=4)
         if input_data["model"] == "senet3d":
             model = se_resnet50(spatial_dims=3, in_channels=3, num_classes=4)
-        model = model.to(device)
+        device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        model.to(device)
         model.eval()
         cam = GradCAM(nn_module=model, target_layers=input_data["target_layers"])
         image = torch.rand(input_data["shape"], device=device)

--- a/tests/test_vis_gradcam.py
+++ b/tests/test_vis_gradcam.py
@@ -62,23 +62,20 @@ TEST_CASE_3 = [
 
 
 class TestGradientClassActivationMap(unittest.TestCase):
-    @staticmethod
-    def get_model(model_name):
-        if model_name == "densenet2d":
-            return densenet121(spatial_dims=2, in_channels=1, out_channels=3)
-        if model_name == "densenet3d":
-            return DenseNet(
-                spatial_dims=3, in_channels=1, out_channels=3, init_features=2, growth_rate=2, block_config=(6,)
-            )
-        if model_name == "senet2d":
-            return se_resnet50(spatial_dims=2, in_channels=3, num_classes=4)
-        if model_name == "senet3d":
-            return se_resnet50(spatial_dims=3, in_channels=3, num_classes=4)
-
     @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_shape(self, input_data, expected_shape):
         device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        model = self.get_model(input_data["model"]).to(device)
+        if input_data["model"] == "densenet2d":
+            model = densenet121(spatial_dims=2, in_channels=1, out_channels=3)
+        if input_data["model"] == "densenet3d":
+            model = DenseNet(
+                spatial_dims=3, in_channels=1, out_channels=3, init_features=2, growth_rate=2, block_config=(6,)
+            )
+        if input_data["model"] == "senet2d":
+            model = se_resnet50(spatial_dims=2, in_channels=3, num_classes=4)
+        if input_data["model"] == "senet3d":
+            model = se_resnet50(spatial_dims=3, in_channels=3, num_classes=4)
+        model = model.to(device)
         model.eval()
         cam = GradCAM(nn_module=model, target_layers=input_data["target_layers"])
         image = torch.rand(input_data["shape"], device=device)
@@ -87,6 +84,9 @@ class TestGradientClassActivationMap(unittest.TestCase):
         fea_shape = cam.feature_map_size(input_data["shape"], device=device)
         self.assertTupleEqual(fea_shape, input_data["feature_shape"])
         self.assertTupleEqual(result.shape, expected_shape)
+        # check result is same whether class_idx=None is used or not
+        result2 = cam(x=image, layer_idx=-1, class_idx=model(image).max(1)[-1].cpu())
+        np.testing.assert_array_almost_equal(result, result2)
 
 
 if __name__ == "__main__":

--- a/tests/test_vis_gradcam.py
+++ b/tests/test_vis_gradcam.py
@@ -62,29 +62,42 @@ TEST_CASE_3 = [
 
 
 class TestGradientClassActivationMap(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
-    def test_shape(self, input_data, expected_shape):
-        if input_data["model"] == "densenet2d":
-            model = densenet121(spatial_dims=2, in_channels=1, out_channels=3)
-        if input_data["model"] == "densenet3d":
-            model = DenseNet(
+    @staticmethod
+    def get_model(model_name):
+        if model_name == "densenet2d":
+            return densenet121(spatial_dims=2, in_channels=1, out_channels=3)
+        if model_name == "densenet3d":
+            return DenseNet(
                 spatial_dims=3, in_channels=1, out_channels=3, init_features=2, growth_rate=2, block_config=(6,)
             )
-        if input_data["model"] == "senet2d":
-            model = se_resnet50(spatial_dims=2, in_channels=3, num_classes=4)
-        if input_data["model"] == "senet3d":
-            model = se_resnet50(spatial_dims=3, in_channels=3, num_classes=4)
+        if model_name == "senet2d":
+            return se_resnet50(spatial_dims=2, in_channels=3, num_classes=4)
+        if model_name == "senet3d":
+            return se_resnet50(spatial_dims=3, in_channels=3, num_classes=4)
+
+    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
+    def test_shape(self, input_data, expected_shape):
         device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        model.to(device)
+        model = self.get_model(input_data["model"]).to(device)
         model.eval()
         cam = GradCAM(nn_module=model, target_layers=input_data["target_layers"])
         image = torch.rand(input_data["shape"], device=device)
         result = cam(x=image, layer_idx=-1)
-        np.testing.assert_array_equal(cam.nn_module.class_idx, model(image).max(1)[-1])
+        np.testing.assert_array_equal(cam.nn_module.class_idx.cpu(), model(image).max(1)[-1].cpu())
         fea_shape = cam.feature_map_size(input_data["shape"], device=device)
         self.assertTupleEqual(fea_shape, input_data["feature_shape"])
         self.assertTupleEqual(result.shape, expected_shape)
 
+    @parameterized.expand([TEST_CASE_0])
+    def test_consistency(self, input_data, _):
+        device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        model = self.get_model(input_data["model"]).to(device)
+        model.eval()
+        cam_persist = GradCAM(nn_module=model, target_layers=input_data["target_layers"])
+        for _ in range(3):
+            cam_fresh = GradCAM(nn_module=model, target_layers=input_data["target_layers"])
+            image = torch.rand(input_data["shape"], device=device)
+            np.testing.assert_array_almost_equal(cam_persist(image), cam_fresh(image))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_vis_gradcam.py
+++ b/tests/test_vis_gradcam.py
@@ -88,16 +88,6 @@ class TestGradientClassActivationMap(unittest.TestCase):
         self.assertTupleEqual(fea_shape, input_data["feature_shape"])
         self.assertTupleEqual(result.shape, expected_shape)
 
-    @parameterized.expand([TEST_CASE_0])
-    def test_consistency(self, input_data, _):
-        device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        model = self.get_model(input_data["model"]).to(device)
-        model.eval()
-        cam_persist = GradCAM(nn_module=model, target_layers=input_data["target_layers"])
-        for _ in range(3):
-            cam_fresh = GradCAM(nn_module=model, target_layers=input_data["target_layers"])
-            image = torch.rand(input_data["shape"], device=device)
-            np.testing.assert_array_almost_equal(cam_persist(image), cam_fresh(image))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/1710.

### Description
The problem was that for `class_idx=None`, the `argmax` was used in `training_mode`, resulting in different inferred classes compared to `eval_mode`. Secondly, the model was getting silently updated. Solved by using `self.model.eval()` but not using `with torch.no_grad()` or `with eval_mode(self.model)`.

I've added a new test to check that when class_idx=None` the inferred model is the same as that using `eval_mode`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh --codeformat --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick`.
