### PR TITLE
1541 update coverage report config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,9 @@ __pycache__/
 docs/
 
 .coverage
+.coverage.*
+.coverage/
+coverage.xml
 .readthedocs.yml
 *.md
 *.toml

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - 1541-coverage-config
 
 jobs:
   # caching of these jobs:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 1541-coverage-config
 
 jobs:
   # caching of these jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ temp/
 # temporary testing data MedNIST
 tests/testing_data/MedNIST*
 tests/testing_data/*Hippocampus*
+tests/testing_data/CMU-1.tiff
 
 # clang format tool
 .clang-format-bin/

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .tox/
 .coverage
 .coverage.*
+.coverage/
 .cache
 nosetests.xml
 coverage.xml

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -14,6 +14,7 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
 import logging
+import sys
 import time
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -409,6 +410,7 @@ class DataStats(Transform):
             additional_info: user can define callable function to extract additional info from input data.
             logger_handler: add additional handler to output data: save to file, etc.
                 add existing python logging handlers: https://docs.python.org/3/library/logging.handlers.html
+                the handler should have a logging level of at least `INFO`.
 
         Raises:
             TypeError: When ``additional_info`` is not an ``Optional[Callable]``.
@@ -424,8 +426,11 @@ class DataStats(Transform):
             raise TypeError(f"additional_info must be None or callable but is {type(additional_info).__name__}.")
         self.additional_info = additional_info
         self.output: Optional[str] = None
-        logging.basicConfig(level=logging.NOTSET)
         self._logger = logging.getLogger("DataStats")
+        self._logger.setLevel(logging.INFO)
+        console = logging.StreamHandler(sys.stdout)  # always stdout
+        console.setLevel(logging.INFO)
+        self._logger.addHandler(console)
         if logger_handler is not None:
             self._logger.addHandler(logger_handler)
 
@@ -459,7 +464,7 @@ class DataStats(Transform):
             lines.append(f"Additional info: {additional_info(img)}")
         separator = "\n"
         self.output = f"{separator.join(lines)}"
-        self._logger.debug(self.output)
+        self._logger.info(self.output)
 
         return img
 

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -532,6 +532,7 @@ class DataStatsd(MapTransform):
                 corresponds to a key in ``keys``.
             logger_handler: add additional handler to output data: save to file, etc.
                 add existing python logging handlers: https://docs.python.org/3/library/logging.handlers.html
+                the handler should have a logging level of at least `INFO`.
             allow_missing_keys: don't raise exception if key is missing.
 
         """

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,5 +1,5 @@
 # Requirements for minimal tests
 -r requirements.txt
 setuptools>=50.3.0
-coverage
+coverage>=5.5
 parameterized

--- a/runtests.sh
+++ b/runtests.sh
@@ -516,7 +516,7 @@ if [ $doUnitTests = true ]
 then
     echo "${separator}${blue}unittests${noColor}"
     torch_validate
-    ${cmdPrefix}${cmd} ./tests/runner.py -p "test_[!integration]*py"
+    ${cmdPrefix}${cmd} ./tests/runner.py -p "test_((?!integration).)"
 fi
 
 # network training/inference/eval integration tests

--- a/runtests.sh
+++ b/runtests.sh
@@ -138,6 +138,9 @@ function clang_format {
 }
 
 function clean_py {
+    # remove coverage history
+    ${cmdPrefix}${PY_EXE} -m coverage erase
+
     # uninstall the development package
     echo "Uninstalling MONAI development files..."
     ${cmdPrefix}${PY_EXE} setup.py develop --user --uninstall
@@ -149,7 +152,7 @@ function clean_py {
     find ${TO_CLEAN}/monai -type f -name "*.py[co]" -delete
     find ${TO_CLEAN}/monai -type f -name "*.so" -delete
     find ${TO_CLEAN}/monai -type d -name "__pycache__" -delete
-    find ${TO_CLEAN} -maxdepth 1 -type f -name ".coverage" -delete
+    find ${TO_CLEAN} -maxdepth 1 -type f -name ".coverage.*" -delete
 
     find ${TO_CLEAN} -depth -maxdepth 1 -type d -name ".eggs" -exec rm -r "{}" +
     find ${TO_CLEAN} -depth -maxdepth 1 -type d -name "monai.egg-info" -exec rm -r "{}" +
@@ -496,12 +499,11 @@ then
     export QUICKTEST=True
 fi
 
-# set command and clear previous coverage data
+# set coverage command
 if [ $doCoverage = true ]
 then
     echo "${separator}${blue}coverage${noColor}"
-    cmd="${PY_EXE} -m coverage run -a --source ."
-    ${cmdPrefix}${PY_EXE} -m coverage erase
+    cmd="${PY_EXE} -m coverage run --append"
 fi
 
 # # download test data if needed
@@ -540,5 +542,6 @@ fi
 if [ $doCoverage = true ]
 then
     echo "${separator}${blue}coverage${noColor}"
-    ${cmdPrefix}${PY_EXE} -m coverage report --skip-covered -m
+    ${cmdPrefix}${PY_EXE} -m coverage combine --append .coverage/
+    ${cmdPrefix}${PY_EXE} -m coverage report
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -153,12 +153,14 @@ strict_import = False
 concurrency = multiprocessing
 source = .
 data_file = .coverage/.coverage
+omit = setup.py
 
 [coverage:report]
 exclude_lines =
     pragma: no cover
     # Don't complain if tests don't hit code:
     raise NotImplementedError
+    if __name__ == .__main__.:
 show_missing = True
 skip_covered = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,19 +55,19 @@ lmdb =
     lmdb
 psutil =
     psutil
-openslide = 
+openslide =
     openslide-python==1.1.2
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9
-max-line-length = 120
+max_line_length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
 ignore =
     E203,E305,E402,E501,E721,E741,F821,F841,F999,W503,W504,C408,E302,W291,E303,
     # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
     N812
-per-file-ignores = __init__.py: F401
+per_file_ignores = __init__.py: F401
 exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,.venv,_version.py
 
 [isort]
@@ -148,3 +148,19 @@ precise_return = True
 protocols = True
 # Experimental: Only load submodules that are explicitly imported.
 strict_import = False
+
+[coverage:run]
+concurrency = multiprocessing
+source = .
+data_file = .coverage/.coverage
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    # Don't complain if tests don't hit code:
+    raise NotImplementedError
+show_missing = True
+skip_covered = True
+
+[coverage:xml]
+output = coverage.xml

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -80,10 +80,7 @@ class TestAffine(unittest.TestCase):
         g = Affine(**input_param)
         result = g(**input_data)
         self.assertEqual(isinstance(result, torch.Tensor), isinstance(expected_val, torch.Tensor))
-        if isinstance(result, torch.Tensor):
-            np.testing.assert_allclose(result.cpu().numpy(), expected_val.cpu().numpy(), rtol=1e-4, atol=1e-4)
-        else:
-            np.testing.assert_allclose(result, expected_val, rtol=1e-4, atol=1e-4)
+        np.testing.assert_allclose(result, expected_val, rtol=1e-4, atol=1e-4)
 
 
 if __name__ == "__main__":

--- a/tests/test_affined.py
+++ b/tests/test_affined.py
@@ -94,10 +94,7 @@ class TestAffined(unittest.TestCase):
         g = Affined(**input_param)
         result = g(input_data)["img"]
         self.assertEqual(isinstance(result, torch.Tensor), isinstance(expected_val, torch.Tensor))
-        if isinstance(result, torch.Tensor):
-            np.testing.assert_allclose(result.cpu().numpy(), expected_val.cpu().numpy(), rtol=1e-4, atol=1e-4)
-        else:
-            np.testing.assert_allclose(result, expected_val, rtol=1e-4, atol=1e-4)
+        np.testing.assert_allclose(result, expected_val, rtol=1e-4, atol=1e-4)
 
 
 if __name__ == "__main__":

--- a/tests/test_data_stats.py
+++ b/tests/test_data_stats.py
@@ -129,7 +129,7 @@ class TestDataStats(unittest.TestCase):
             }
             transform = DataStats(**input_param)
             _ = transform(input_data)
-            handler.stream.close()
+            handler.close()
             transform._logger.removeHandler(handler)
             with open(filename, "r") as f:
                 content = f.read()

--- a/tests/test_data_stats.py
+++ b/tests/test_data_stats.py
@@ -119,6 +119,7 @@ class TestDataStats(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             filename = os.path.join(tempdir, "test_data_stats.log")
             handler = logging.FileHandler(filename, mode="w")
+            handler.setLevel(logging.INFO)
             input_param = {
                 "prefix": "test data",
                 "data_shape": True,
@@ -129,8 +130,9 @@ class TestDataStats(unittest.TestCase):
             }
             transform = DataStats(**input_param)
             _ = transform(input_data)
-            handler.close()
-            transform._logger.removeHandler(handler)
+            for h in transform._logger.handlers[:]:
+                h.close()
+                transform._logger.removeHandler(h)
             with open(filename, "r") as f:
                 content = f.read()
             self.assertEqual(content, expected_print)

--- a/tests/test_data_statsd.py
+++ b/tests/test_data_statsd.py
@@ -143,7 +143,7 @@ class TestDataStatsd(unittest.TestCase):
             }
             transform = DataStatsd(**input_param)
             _ = transform(input_data)
-            handler.stream.close()
+            handler.close()
             transform.printer._logger.removeHandler(handler)
             with open(filename, "r") as f:
                 content = f.read()

--- a/tests/test_data_statsd.py
+++ b/tests/test_data_statsd.py
@@ -132,6 +132,7 @@ class TestDataStatsd(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             filename = os.path.join(tempdir, "test_stats.log")
             handler = logging.FileHandler(filename, mode="w")
+            handler.setLevel(logging.INFO)
             input_param = {
                 "keys": "img",
                 "prefix": "test data",
@@ -143,8 +144,10 @@ class TestDataStatsd(unittest.TestCase):
             }
             transform = DataStatsd(**input_param)
             _ = transform(input_data)
-            handler.close()
-            transform.printer._logger.removeHandler(handler)
+            for h in transform.printer._logger.handlers[:]:
+                h.close()
+                transform.printer._logger.removeHandler(h)
+            del handler
             with open(filename, "r") as f:
                 content = f.read()
             self.assertEqual(content, expected_print)

--- a/tests/test_openslide_reader.py
+++ b/tests/test_openslide_reader.py
@@ -61,11 +61,20 @@ TEST_CASE_4 = [
 ]
 
 
+def camelyon_data_download(file_url):
+    filename = os.path.basename(file_url)
+    fullname = os.path.join("tests", "testing_data", filename)
+    if not os.path.exists(fullname):
+        print(f"Test image [{fullname}] does not exist. Downloading...")
+        request.urlretrieve(file_url, fullname)
+    return fullname
+
+
 class TestOpenSlideReader(unittest.TestCase):
     @parameterized.expand([TEST_CASE_0])
     @skipUnless(has_osl, "Requires OpenSlide")
     def test_read_whole_image(self, file_url, expected_shape):
-        filename = self.camelyon_data_download(file_url)
+        filename = camelyon_data_download(file_url)
         reader = WSIReader("OpenSlide")
         img_obj = reader.read(filename)
         img = reader.get_data(img_obj)[0]
@@ -74,7 +83,7 @@ class TestOpenSlideReader(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     @skipUnless(has_osl, "Requires OpenSlide")
     def test_read_region(self, file_url, patch_info, expected_img):
-        filename = self.camelyon_data_download(file_url)
+        filename = camelyon_data_download(file_url)
         reader = WSIReader("OpenSlide")
         img_obj = reader.read(filename)
         img = reader.get_data(img_obj, **patch_info)[0]
@@ -84,19 +93,12 @@ class TestOpenSlideReader(unittest.TestCase):
     @parameterized.expand([TEST_CASE_3, TEST_CASE_4])
     @skipUnless(has_osl, "Requires OpenSlide")
     def test_read_patches(self, file_url, patch_info, expected_img):
-        filename = self.camelyon_data_download(file_url)
+        filename = camelyon_data_download(file_url)
         reader = WSIReader("OpenSlide")
         img_obj = reader.read(filename)
         img = reader.get_data(img_obj, **patch_info)[0]
         self.assertTupleEqual(img.shape, expected_img.shape)
         self.assertIsNone(assert_array_equal(img, expected_img))
-
-    def camelyon_data_download(self, file_url):
-        filename = os.path.basename(file_url)
-        if not os.path.exists(filename):
-            print(f"Test image [{filename}] does not exist. Downloading...")
-            request.urlretrieve(file_url, filename)
-        return filename
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_rotate.py
+++ b/tests/test_rand_rotate.py
@@ -52,7 +52,8 @@ class TestRandRotate2D(NumpyImageTestCase2D):
             self.imt[0, 0], -np.rad2deg(angle), (0, 1), not keep_size, order=_order, mode=_mode, prefilter=False
         )
         expected = np.stack(expected).astype(np.float32)
-        np.testing.assert_allclose(expected, rotated[0])
+        good = np.sum(np.isclose(expected, rotated[0], atol=1e-3))
+        self.assertLessEqual(np.abs(good - expected.size), 5, "diff at most 5 pixels")
 
 
 class TestRandRotate3D(NumpyImageTestCase3D):

--- a/tests/test_rand_rotated.py
+++ b/tests/test_rand_rotated.py
@@ -54,7 +54,8 @@ class TestRandRotated2D(NumpyImageTestCase2D):
             self.imt[0, 0], -np.rad2deg(angle), (0, 1), not keep_size, order=_order, mode=_mode, prefilter=False
         )
         expected = np.stack(expected).astype(np.float32)
-        self.assertTrue(np.allclose(expected, rotated["img"][0]))
+        good = np.sum(np.isclose(expected, rotated["img"][0], atol=1e-3))
+        self.assertLessEqual(np.abs(good - expected.size), 5, "diff at most 5 pixels")
 
 
 class TestRandRotated3D(NumpyImageTestCase3D):

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -70,7 +70,8 @@ class TestRotate2D(NumpyImageTestCase2D):
                 )
             )
         expected = np.stack(expected).astype(np.float32)
-        np.testing.assert_allclose(expected, rotated, atol=1e-1)
+        good = np.sum(np.isclose(expected, rotated, atol=1e-3))
+        self.assertLessEqual(np.abs(good - expected.size), 5, "diff at most 5 pixels")
 
 
 class TestRotate3D(NumpyImageTestCase3D):


### PR DESCRIPTION
Fixes #1541

### Description
- adds coverage config to `setup.cfg` with a multiprocessing mode
- support accumulating reports from `runtests.sh --net` and `runtests.sh --unittests`
- fixes https://github.com/Project-MONAI/MONAI/runs/2083800079?check_suite_focus=true#step:5:13886
- fixes https://github.com/Project-MONAI/MONAI/runs/2086767998?check_suite_focus=true#step:7:5955

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
