### PR TITLE
BUG: MedNISTDataset returns differently sized datasets for different seeds

### DIFF
--- a/tests/test_mednistdataset.py
+++ b/tests/test_mednistdataset.py
@@ -18,6 +18,8 @@ from monai.apps import MedNISTDataset
 from monai.transforms import AddChanneld, Compose, LoadImaged, ScaleIntensityd, ToTensord
 from tests.utils import skip_if_quick
 
+MEDNIST_FULL_DATASET_LENGTH = 58954
+
 
 class TestMedNISTDataset(unittest.TestCase):
     @skip_if_quick
@@ -33,7 +35,7 @@ class TestMedNISTDataset(unittest.TestCase):
         )
 
         def _test_dataset(dataset):
-            self.assertEqual(len(dataset), 5986)
+            self.assertEqual(len(dataset), int(MEDNIST_FULL_DATASET_LENGTH * dataset.test_frac))
             self.assertTrue("image" in dataset[0])
             self.assertTrue("label" in dataset[0])
             self.assertTrue("image_meta_dict" in dataset[0])
@@ -56,6 +58,9 @@ class TestMedNISTDataset(unittest.TestCase):
         _test_dataset(data)
         data = MedNISTDataset(root_dir=testing_dir, section="test", download=False)
         self.assertTupleEqual(data[0]["image"].shape, (64, 64))
+        # test same dataset length with different random seed
+        data = MedNISTDataset(root_dir=testing_dir, transform=transform, section="test", download=False, seed=42)
+        _test_dataset(data)
         shutil.rmtree(os.path.join(testing_dir, "MedNIST"))
         try:
             data = MedNISTDataset(root_dir=testing_dir, transform=transform, section="test", download=False)


### PR DESCRIPTION
### Description
Fixes an issue with MedNISTDataset where choosing a different random seed returns a differently sized dataset. 
Reproduce by running

```
data0 = monai.apps.datasets.MedNISTDataset(root_dir="./tmp", transform=[], section="test", download=False, seed=0)
data42 = monai.apps.datasets.MedNISTDataset(root_dir="./tmp", transform=[], section="test", download=False, seed=42)
assert len(data0) != len(data42)
```

Instead of seeing whether a chosen random value falls between the train/val/test split serially, this PR uses the same kind of implementation for choosing random indices all at once like how it's done in `DecathlonDataset`.

Also modified the existing MedNIST test to use the full dataset length for comparison and to test dataset lengths for different seeds.

It seems like https://github.com/Project-MONAI/tutorials/blob/master/2d_classification/mednist_tutorial.ipynb may also need these changes.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
