### PR TITLE
TEST: Fix failing pytype check for predict_segmentation

### DIFF
--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -71,9 +71,7 @@ def slice_channels(tensor: torch.Tensor, *slicevals: Optional[int]) -> torch.Ten
     return tensor[slices]
 
 
-def predict_segmentation(
-    logits: torch.Tensor, mutually_exclusive: bool = False, threshold: float = 0.0
-) -> torch.Tensor:
+def predict_segmentation(logits: torch.Tensor, mutually_exclusive: bool = False, threshold: float = 0.0) -> Any:
     """
     Given the logits from a network, computing the segmentation by thresholding all values above 0
     if multi-labels task, computing the `argmax` along the channel axis if multi-classes task,


### PR DESCRIPTION
### Description
It seems like 0bd86b1 (https://github.com/Project-MONAI/MONAI/pull/1687/commits/67b2b1d77bb7f2209f633a8a2be04e1d79401eae) introduces changes which don't pass the pytype check running `./runtests.sh -f -u --net --coverage`. It's not clear to me why removing the cast in that commit should do this since the `.int()` should still return a `torch.Tensor`? But these changes make it so that pytype passes. Alternatively could do 
```
return torch.Tensor((logits >= threshold).int())
```
in the function but not sure what the original commit was trying to do by removing the cast.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
