### PR TITLE
Remove WSIReader from LoadImage

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 
 from monai.config import DtypeLike
-from monai.data.image_reader import ImageReader, ITKReader, NibabelReader, NumpyReader, PILReader, WSIReader
+from monai.data.image_reader import ImageReader, ITKReader, NibabelReader, NumpyReader, PILReader
 from monai.data.nifti_saver import NiftiSaver
 from monai.data.png_saver import PNGSaver
 from monai.transforms.transform import Transform
@@ -78,7 +78,7 @@ class LoadImage(Transform):
             reader: register reader to load image file and meta data, if None, still can register readers
                 at runtime or use the default readers. If a string of reader name provided, will construct
                 a reader object with the `*args` and `**kwargs` parameters, supported reader name: "NibabelReader",
-                "PILReader", "ITKReader", "NumpyReader", "WSIReader".
+                "PILReader", "ITKReader", "NumpyReader".
             image_only: if True return only the image volume, otherwise return image data array and header dict.
             dtype: if not None convert the loaded image to this data type.
             args: additional parameters for reader if providing a reader name.
@@ -90,7 +90,7 @@ class LoadImage(Transform):
 
         """
         # set predefined readers as default
-        self.readers: List[ImageReader] = [ITKReader(), NumpyReader(), PILReader(), NibabelReader(), WSIReader()]
+        self.readers: List[ImageReader] = [ITKReader(), NumpyReader(), PILReader(), NibabelReader()]
         if reader is not None:
             if isinstance(reader, str):
                 supported_readers = {
@@ -98,7 +98,6 @@ class LoadImage(Transform):
                     "pilreader": PILReader,
                     "itkreader": ITKReader,
                     "numpyreader": NumpyReader,
-                    "wsireader": WSIReader,
                 }
                 reader = reader.lower()
                 if reader not in supported_readers:

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -71,7 +71,7 @@ class LoadImaged(MapTransform):
             reader: register reader to load image file and meta data, if None, still can register readers
                 at runtime or use the default readers. If a string of reader name provided, will construct
                 a reader object with the `*args` and `**kwargs` parameters, supported reader name: "NibabelReader",
-                "PILReader", "ITKReader", "NumpyReader", "WSIReader".
+                "PILReader", "ITKReader", "NumpyReader".
             dtype: if not None convert the loaded image data to this data type.
             meta_key_postfix: use `key_{postfix}` to store the metadata of the nifti image,
                 default is `meta_dict`. The meta data is a dictionary object.


### PR DESCRIPTION
### Description
Since we are not using WSIReader in the same way that we use other image reader, I removed it from LoadImage to avoid any potential  issues that it may cause.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
