### PR TITLE
Update cuCim to remove warning message

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ pytorch-ignite==0.4.4
 numpy>=1.17
 itk>=5.0
 nibabel
-cucim==0.18.0
+cucim==0.18.1
 openslide-python==1.1.2
 parameterized
 scikit-image>=0.14.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,5 +30,5 @@ Sphinx==3.3.0
 recommonmark==0.6.0
 sphinx-autodoc-typehints==1.11.1
 sphinx-rtd-theme==0.5.0
-cucim==0.18.0
+cucim==0.18.1
 openslide-python==1.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ all =
     torchvision
     itk>=5.0
     tqdm>=4.47.0
-    cucim==0.18.0
+    cucim==0.18.1
     openslide-python==1.1.2
 nibabel =
     nibabel
@@ -57,7 +57,7 @@ lmdb =
 psutil =
     psutil
 cucim =
-    cucim==0.18.0
+    cucim==0.18.1
 openslide =
     openslide-python==1.1.2
 


### PR DESCRIPTION
Fixes #1791 

### Description
It updates the cucim to 0.18.1 to remove the warning about CuFileDriver.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
