### PR TITLE
[1798] fix RandZoomd collation

### DIFF
--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -257,7 +257,7 @@ def list_data_collate(batch: Sequence):
         return default_collate(data)
     except RuntimeError as re:
         re_str = str(re)
-        if "stack expects each tensor to be equal size" in re_str:
+        if "equal size" in re_str:
             re_str += (
                 "\nMONAI hint: if your transforms intentionally create images of different shapes, creating your "
                 + "`DataLoader` with `collate_fn=pad_list_data_collate` might solve this problem (check its "

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -9,10 +9,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
 from typing import Dict, Hashable, Optional, Tuple
 
 import numpy as np
+import torch
 
 from monai.transforms.transform import RandomizableTransform, Transform
 from monai.utils.enums import InverseKeys

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -94,7 +94,7 @@ class InvertibleTransform(Transform):
             return
         # basic check if multiprocessing uses 'spawn' (objects get recreated so don't have same ID)
         if (
-            torch.multiprocessing.get_start_method(allow_none=True) == "spawn"
+            torch.multiprocessing.get_start_method(allow_none=False) == "spawn"
             and transform[InverseKeys.CLASS_NAME.value] == self.__class__.__name__
         ):
             return

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import torch
 from typing import Dict, Hashable, Optional, Tuple
 
 import numpy as np
@@ -92,8 +92,11 @@ class InvertibleTransform(Transform):
         """Check transforms are of same instance."""
         if transform[InverseKeys.ID.value] == id(self):
             return
-        # basic check if windows because of multiprocessing differences (objects get recreated so don't have same ID)
-        if sys.platform == "win32" and transform[InverseKeys.CLASS_NAME.value] == self.__class__.__name__:
+        # basic check if multiprocessing uses 'spawn' (objects get recreated so don't have same ID)
+        if (
+            torch.multiprocessing.get_start_method(allow_none=True) == "spawn"
+            and transform[InverseKeys.CLASS_NAME.value] == self.__class__.__name__
+        ):
             return
         raise RuntimeError("Should inverse most recently applied invertible transform first")
 

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -93,7 +93,7 @@ class InvertibleTransform(Transform):
         if transform[InverseKeys.ID.value] == id(self):
             return
         # basic check if windows because of multiprocessing differences (objects get recreated so don't have same ID)
-        elif sys.platform == "win32" and transform[InverseKeys.CLASS_NAME.value] == self.__class__.__name__:
+        if sys.platform == "win32" and transform[InverseKeys.CLASS_NAME.value] == self.__class__.__name__:
             return
         raise RuntimeError("Should inverse most recently applied invertible transform first")
 

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from typing import Dict, Hashable, Optional, Tuple
 
 import numpy as np
@@ -89,8 +90,12 @@ class InvertibleTransform(Transform):
 
     def check_transforms_match(self, transform: dict) -> None:
         """Check transforms are of same instance."""
-        if transform[InverseKeys.ID.value] != id(self):
-            raise RuntimeError("Should inverse most recently applied invertible transform first")
+        if transform[InverseKeys.ID.value] == id(self):
+            return
+        # basic check if windows because of multiprocessing differences (objects get recreated so don't have same ID)
+        elif sys.platform == "win32" and transform[InverseKeys.CLASS_NAME.value] == self.__class__.__name__:
+            return
+        raise RuntimeError("Should inverse most recently applied invertible transform first")
 
     def get_most_recent_transform(self, data: dict, key: Hashable) -> dict:
         """Get most recent transform."""

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -1484,10 +1484,6 @@ class RandZoomd(RandomizableTransform, MapTransform, InvertibleTransform):
         # match the spatial dim of first item
         self.randomize()
         d = dict(data)
-        if not self._do_transform:
-            for key in self.keys:
-                self.push_transform(d, key, extra_info={"zoom": self._zoom})
-            return d
 
         img_dims = data[self.keys[0]].ndim
         if len(self._zoom) == 1:
@@ -1501,12 +1497,13 @@ class RandZoomd(RandomizableTransform, MapTransform, InvertibleTransform):
             d, self.mode, self.padding_mode, self.align_corners
         ):
             self.push_transform(d, key, extra_info={"zoom": self._zoom})
-            d[key] = zoomer(
-                d[key],
-                mode=mode,
-                padding_mode=padding_mode,
-                align_corners=align_corners,
-            )
+            if self._do_transform:
+                d[key] = zoomer(
+                    d[key],
+                    mode=mode,
+                    padding_mode=padding_mode,
+                    align_corners=align_corners,
+                )
         return d
 
     def inverse(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -1090,7 +1090,7 @@ class RandAxisFlipd(RandomizableTransform, MapTransform, InvertibleTransform):
         for key in self.key_iterator(d):
             if self._do_transform:
                 d[key] = flipper(d[key])
-                self.push_transform(d, key, extra_info={"axis": self._axis})
+            self.push_transform(d, key, extra_info={"axis": self._axis})
         return d
 
     def inverse(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -514,8 +514,8 @@ class TestInverse(unittest.TestCase):
 
         # Check that error is thrown when inverse are used out of order.
         t = SpatialPadd("image", [10, 5])
-        # on windows we only check the name, so in this case we need to use a different transform
-        if sys.platform == "win32" and isinstance(transforms[-1], SpatialPadd):
+        # if multiprocessing uses 'spawn', only name is checked, so we need to use a different transform
+        if torch.multiprocessing.get_start_method(allow_none=True) == "spawn" and isinstance(transforms[-1], SpatialPadd):
             t = ResizeWithPadOrCropd("image", [10, 5])
         with self.assertRaises(RuntimeError):
             t.inverse(forwards[-1])

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -515,8 +515,9 @@ class TestInverse(unittest.TestCase):
         # Check that error is thrown when inverse are used out of order.
         t = SpatialPadd("image", [10, 5])
         # if multiprocessing uses 'spawn', only name is checked, so we need to use a different transform
-        if torch.multiprocessing.get_start_method(allow_none=True) == "spawn" and isinstance(transforms[-1], SpatialPadd):
-            t = ResizeWithPadOrCropd("image", [10, 5])
+        if torch.multiprocessing.get_start_method(allow_none=True) == "spawn":
+            if isinstance(transforms[-1], SpatialPadd):
+                t = ResizeWithPadOrCropd("image", [10, 5])
         with self.assertRaises(RuntimeError):
             t.inverse(forwards[-1])
 

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -521,7 +521,7 @@ class TestInverse(unittest.TestCase):
                 self.check_inverse(name, data.keys(), forwards[-i - 2], fwd_bck, forwards[-1], acceptable_diff)
 
     # skip this test if multiprocessing uses 'spawn', as the check is only basic anyway
-    @skipUnless(torch.multiprocessing.get_start_method(allow_none=False) == "spawn")
+    @skipUnless(torch.multiprocessing.get_start_method(allow_none=False) == "spawn", "requires spawn")
     def test_fail(self):
 
         t1 = SpatialPadd("image", [10, 5])

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -513,7 +513,7 @@ class TestInverse(unittest.TestCase):
             forwards.append(t(forwards[-1]))
 
         # skip this test if multiprocessing uses 'spawn', as the check is only basic anyway
-        if torch.multiprocessing.get_start_method(allow_none=True) == "spawn":
+        if torch.multiprocessing.get_start_method(allow_none=False) == "spawn":
             # Check that error is thrown when inverse are used out of order.
             t = SpatialPadd("image", [10, 5])
             with self.assertRaises(RuntimeError):

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -512,14 +512,12 @@ class TestInverse(unittest.TestCase):
                 t.set_random_state(seed=get_seed())
             forwards.append(t(forwards[-1]))
 
-        # Check that error is thrown when inverse are used out of order.
-        t = SpatialPadd("image", [10, 5])
-        # if multiprocessing uses 'spawn', only name is checked, so we need to use a different transform
+        # skip this test if multiprocessing uses 'spawn', as the check is only basic anyway
         if torch.multiprocessing.get_start_method(allow_none=True) == "spawn":
-            if isinstance(transforms[-1], SpatialPadd):
-                t = ResizeWithPadOrCropd("image", [10, 5])
-        with self.assertRaises(RuntimeError):
-            t.inverse(forwards[-1])
+            # Check that error is thrown when inverse are used out of order.
+            t = SpatialPadd("image", [10, 5])
+            with self.assertRaises(RuntimeError):
+                t.inverse(forwards[-1])
 
         # Apply inverses
         fwd_bck = forwards[-1].copy()

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -514,6 +514,9 @@ class TestInverse(unittest.TestCase):
 
         # Check that error is thrown when inverse are used out of order.
         t = SpatialPadd("image", [10, 5])
+        # on windows we only check the name, so in this case we need to use a different transform
+        if sys.platform == "win32" and isinstance(t[-1], SpatialPadd):
+            t = ResizeWithPadOrCropd("image", [10, 5])
         with self.assertRaises(RuntimeError):
             t.inverse(forwards[-1])
 

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -515,7 +515,7 @@ class TestInverse(unittest.TestCase):
         # Check that error is thrown when inverse are used out of order.
         t = SpatialPadd("image", [10, 5])
         # on windows we only check the name, so in this case we need to use a different transform
-        if sys.platform == "win32" and isinstance(t[-1], SpatialPadd):
+        if sys.platform == "win32" and isinstance(transforms[-1], SpatialPadd):
             t = ResizeWithPadOrCropd("image", [10, 5])
         with self.assertRaises(RuntimeError):
             t.inverse(forwards[-1])

--- a/tests/test_inverse_collation.py
+++ b/tests/test_inverse_collation.py
@@ -1,0 +1,91 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+from typing import TYPE_CHECKING
+
+import numpy as np
+from parameterized import parameterized
+
+from monai.data import CacheDataset, DataLoader, create_test_image_3d, pad_list_data_collate
+from monai.transforms import (
+    AddChanneld,
+    Compose,
+    LoadImaged,
+    RandAffined,
+    RandAxisFlipd,
+    RandFlipd,
+    RandRotate90d,
+    RandRotated,
+    RandZoomd,
+)
+from monai.utils import optional_import, set_determinism
+from tests.utils import make_nifti_image
+
+if TYPE_CHECKING:
+
+    has_nib = True
+else:
+    _, has_nib = optional_import("nibabel")
+
+KEYS = ["image", "label"]
+
+TESTS = [
+    [RandFlipd(keys=KEYS, spatial_axis=[1, 2])],
+    [RandAxisFlipd(keys=KEYS)],
+    [RandRotate90d(keys=KEYS, spatial_axes=(1, 2))],
+    [RandZoomd(keys=KEYS, prob=0.5, min_zoom=0.5, max_zoom=1.1, keep_size=True)],
+    [RandRotated(keys=KEYS, range_x=np.pi)],
+    [RandAffined(keys=KEYS, rotate_range=np.pi)],
+]
+
+
+class TestInverseCollation(unittest.TestCase):
+    """Test collation for of random transformations with prob == 0 and 1."""
+
+    def setUp(self):
+        if not has_nib:
+            self.skipTest("nibabel required for test_inverse")
+
+        set_determinism(seed=0)
+
+        im_fname, seg_fname = [make_nifti_image(i) for i in create_test_image_3d(100, 101, 107)]
+        load_ims = Compose([LoadImaged(KEYS), AddChanneld(KEYS)])
+        self.batch_size = 10
+        self.data = [load_ims({"image": im_fname, "label": seg_fname}) for _ in range(self.batch_size)]
+
+    def tearDown(self):
+        set_determinism(seed=None)
+
+    @parameterized.expand(TESTS)
+    def test_inverse(self, transform):
+        # num workers = 0 for mac
+        num_workers = 2 if sys.platform != "darwin" else 0
+
+        dataset = CacheDataset(self.data, transform=transform, progress=False)
+        loader = DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+            collate_fn=pad_list_data_collate,
+        )
+
+        try:
+            for _ in loader:
+                pass
+        except RuntimeError:
+            print("here")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_inverse_collation.py
+++ b/tests/test_inverse_collation.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from parameterized import parameterized
 
-from monai.data import CacheDataset, DataLoader, create_test_image_3d, pad_list_data_collate
+from monai.data import CacheDataset, DataLoader, create_test_image_3d
 from monai.transforms import (
     AddChanneld,
     Compose,

--- a/tests/test_inverse_collation.py
+++ b/tests/test_inverse_collation.py
@@ -58,7 +58,7 @@ class TestInverseCollation(unittest.TestCase):
 
         set_determinism(seed=0)
 
-        im_fname, seg_fname = [make_nifti_image(i) for i in create_test_image_3d(100, 101, 107)]
+        im_fname, seg_fname = [make_nifti_image(i) for i in create_test_image_3d(100, 100, 100)]
         load_ims = Compose([LoadImaged(KEYS), AddChanneld(KEYS)])
         self.batch_size = 10
         self.data = [load_ims({"image": im_fname, "label": seg_fname}) for _ in range(self.batch_size)]
@@ -72,19 +72,10 @@ class TestInverseCollation(unittest.TestCase):
         num_workers = 2 if sys.platform != "darwin" else 0
 
         dataset = CacheDataset(self.data, transform=transform, progress=False)
-        loader = DataLoader(
-            dataset,
-            batch_size=self.batch_size,
-            shuffle=False,
-            num_workers=num_workers,
-            collate_fn=pad_list_data_collate,
-        )
+        loader = DataLoader(dataset, num_workers, batch_size=self.batch_size)
 
-        try:
-            for _ in loader:
-                pass
-        except RuntimeError:
-            print("here")
+        for _ in loader:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/1798.

### Description
`self._zoom` was handled differently depending on `self._do_transform`. Modified to be the same, such that they can be collated together. 

Also add testing for all invertible random transforms.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
