### PR TITLE
PadListDataCollate transform

### DIFF
--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -337,64 +337,25 @@ def pad_list_data_collate(
     mode: Union[NumpyPadMode, str] = NumpyPadMode.CONSTANT,
 ):
     """
-    Same as MONAI's ``list_data_collate``, except any tensors are centrally padded to match the shape of the biggest
-    tensor in each dimension.
+    Function version of :py:class:`monai.transforms.croppad.batch.PadListDataCollate`.
 
-    Note:
-        Need to use this collate if apply some transforms that can generate batch data.
+    Same as MONAI's ``list_data_collate``, except any tensors are centrally padded to match the shape of the biggest
+    tensor in each dimension. This transform is useful if some of the applied transforms generate batch data of
+    different sizes.
+
+    This can be used on both list and dictionary data. In the case of the dictionary data, this transform will be added
+    to the list of invertible transforms.
+
+    The inverse can be called using the static method: `monai.transforms.croppad.batch.PadListDataCollate.inverse`.
 
     Args:
         batch: batch of data to pad-collate
         method: padding method (see :py:class:`monai.transforms.SpatialPad`)
         mode: padding mode (see :py:class:`monai.transforms.SpatialPad`)
     """
-    list_of_dicts = isinstance(batch[0], dict)
-    for key_or_idx in batch[0].keys() if list_of_dicts else range(len(batch[0])):
-        max_shapes = []
-        for elem in batch:
-            if not isinstance(elem[key_or_idx], (torch.Tensor, np.ndarray)):
-                break
-            max_shapes.append(elem[key_or_idx].shape[1:])
-        # len > 0 if objects were arrays
-        if len(max_shapes) == 0:
-            continue
-        max_shape = np.array(max_shapes).max(axis=0)
-        # If all same size, skip
-        if np.all(np.array(max_shapes).min(axis=0) == max_shape):
-            continue
-        # Do we need to convert output to Tensor?
-        output_to_tensor = isinstance(batch[0][key_or_idx], torch.Tensor)
+    from monai.transforms.croppad.batch import PadListDataCollate  # needs to be here to avoid circular import
 
-        # Use `SpatialPadd` or `SpatialPad` to match sizes
-        # Default params are central padding, padding with 0's
-        # If input is dictionary, use the dictionary version so that the transformation is recorded
-        padder: Union[SpatialPadd, SpatialPad]
-        if list_of_dicts:
-            from monai.transforms.croppad.dictionary import SpatialPadd  # needs to be here to avoid circular import
-
-            padder = SpatialPadd(key_or_idx, max_shape, method, mode)  # type: ignore
-
-        else:
-            from monai.transforms.croppad.array import SpatialPad  # needs to be here to avoid circular import
-
-            padder = SpatialPad(max_shape, method, mode)  # type: ignore
-
-        for idx in range(len(batch)):
-            padded = padder(batch[idx])[key_or_idx] if list_of_dicts else padder(batch[idx][key_or_idx])
-            # since tuple is immutable we'll have to recreate
-            if isinstance(batch[idx], tuple):
-                batch[idx] = list(batch[idx])  # type: ignore
-                batch[idx][key_or_idx] = padded
-                batch[idx] = tuple(batch[idx])  # type: ignore
-            # else, replace
-            else:
-                batch[idx][key_or_idx] = padder(batch[idx])[key_or_idx]
-
-            if output_to_tensor:
-                batch[idx][key_or_idx] = torch.Tensor(batch[idx][key_or_idx])
-
-    # After padding, use default list collator
-    return list_data_collate(batch)
+    return PadListDataCollate(method, mode)(batch)
 
 
 def worker_init_fn(worker_id: int) -> None:

--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -25,6 +25,7 @@ from .croppad.array import (
     SpatialCrop,
     SpatialPad,
 )
+from .croppad.batch import PadListDataCollate
 from .croppad.dictionary import (
     BorderPadd,
     BorderPadD,

--- a/monai/transforms/croppad/batch.py
+++ b/monai/transforms/croppad/batch.py
@@ -1,0 +1,129 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+A collection of "vanilla" transforms for crop and pad operations acting on batches of data
+https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
+"""
+
+from copy import deepcopy
+from typing import Any, Dict, Hashable, Union
+
+import numpy as np
+import torch
+
+from monai.data.utils import list_data_collate
+from monai.transforms.compose import Compose
+from monai.transforms.croppad.array import CenterSpatialCrop, SpatialPad
+from monai.transforms.inverse import InvertibleTransform
+from monai.transforms.utility.array import ToTensor
+from monai.utils.enums import InverseKeys, Method, NumpyPadMode
+
+__all__ = [
+    "PadListDataCollate",
+]
+
+
+def replace_element(to_replace, batch, idx, key_or_idx):
+    # since tuple is immutable we'll have to recreate
+    if isinstance(batch[idx], tuple):
+        batch_idx_list = list(batch[idx])
+        batch_idx_list[key_or_idx] = to_replace
+        batch[idx] = tuple(batch_idx_list)
+    # else, replace
+    else:
+        batch[idx][key_or_idx] = to_replace
+    return batch
+
+
+class PadListDataCollate(InvertibleTransform):
+    """
+    Same as MONAI's ``list_data_collate``, except any tensors are centrally padded to match the shape of the biggest
+    tensor in each dimension. This transform is useful if some of the applied transforms generate batch data of
+    different sizes.
+
+    This can be used on both list and dictionary data. In the case of the dictionary data, this transform will be added
+    to the list of invertible transforms.
+
+    Note that normally, a user won't explicitly use the `__call__` method. Rather this would be passed to the `DataLoader`.
+    This means that `__call__` handles data as it comes out of a `DataLoader`, containing batch dimension. However, the
+    `inverse` operates on dictionaries containing images of shape `C,H,W,[D]`. This asymmetry is necessary so that we can
+    pass the inverse through multiprocessing.
+
+    Args:
+        batch: batch of data to pad-collate
+        method: padding method (see :py:class:`monai.transforms.SpatialPad`)
+        mode: padding mode (see :py:class:`monai.transforms.SpatialPad`)
+    """
+
+    def __init__(
+        self,
+        method: Union[Method, str] = Method.SYMMETRIC,
+        mode: Union[NumpyPadMode, str] = NumpyPadMode.CONSTANT,
+    ) -> None:
+        self.method = method
+        self.mode = mode
+
+    def __call__(self, batch: Any):
+        # data is either list of dicts or list of lists
+        is_list_of_dicts = isinstance(batch[0], dict)
+        # loop over items inside of each element in a batch
+        for key_or_idx in batch[0].keys() if is_list_of_dicts else range(len(batch[0])):
+            # calculate max size of each dimension
+            max_shapes = []
+            for elem in batch:
+                if not isinstance(elem[key_or_idx], (torch.Tensor, np.ndarray)):
+                    break
+                max_shapes.append(elem[key_or_idx].shape[1:])
+            # len > 0 if objects were arrays, else skip as no padding to be done
+            if len(max_shapes) == 0:
+                continue
+            max_shape = np.array(max_shapes).max(axis=0)
+            # If all same size, skip
+            if np.all(np.array(max_shapes).min(axis=0) == max_shape):
+                continue
+            # Do we need to convert output to Tensor?
+            output_to_tensor = isinstance(batch[0][key_or_idx], torch.Tensor)
+
+            # Use `SpatialPadd` or `SpatialPad` to match sizes
+            # Default params are central padding, padding with 0's
+            # If input is dictionary, use the dictionary version so that the transformation is recorded
+
+            padder = SpatialPad(max_shape, self.method, self.mode)  # type: ignore
+            transform = padder if not output_to_tensor else Compose([padder, ToTensor()])
+
+            for idx in range(len(batch)):
+                im = batch[idx][key_or_idx]
+                orig_size = im.shape[1:]
+                padded = transform(batch[idx][key_or_idx])
+                batch = replace_element(padded, batch, idx, key_or_idx)
+
+                # If we have a dictionary of data, append to list
+                if is_list_of_dicts:
+                    self.push_transform(batch[idx], key_or_idx, orig_size=orig_size)
+
+        # After padding, use default list collator
+        return list_data_collate(batch)
+
+    @staticmethod
+    def inverse(data: dict) -> Dict[Hashable, np.ndarray]:
+        if not isinstance(data, dict):
+            raise RuntimeError("Inverse can only currently be applied on dictionaries.")
+
+        d = deepcopy(data)
+        for key in d.keys():
+            transform_key = str(key) + InverseKeys.KEY_SUFFIX.value
+            if transform_key in d.keys():
+                transform = d[transform_key][-1]
+                if transform[InverseKeys.CLASS_NAME.value] == PadListDataCollate.__name__:
+                    d[key] = CenterSpatialCrop(transform["orig_size"])(d[key])
+                    # remove transform
+                    d[transform_key].pop()
+        return d

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -333,6 +333,7 @@ class Decollated(MapTransform):
     """
 
     def __init__(self, batch_size: Optional[int] = None) -> None:
+        super().__init__(None)
         self.batch_size = batch_size
 
     def __call__(self, data: dict) -> List[dict]:


### PR DESCRIPTION
Addresses https://github.com/Project-MONAI/MONAI/pull/1795#discussion_r597585725.

part of #1515 

### Description
Create transform that in the forward direction takes a batch of data and centrally pads any tensors to the maximum size of each dimension of all images in the batch.

The inverse acts on a dictionary containing the data for 1 dataset. 

I find the asymmetry between the forward and inverse a little ugly, but I can't really see any other way about it. The only reason we need the whole batch in the forward direction is so that we can find out the required padding size. However, in the inverse direction, we want to deal with them individually so that we can take advantage of multiprocessing.

I should note that the asymmetry is mostly hidden from the user who wouldn't call this directly. Instead, they would pass the forward as the `collate_fn` for a `DataLoader`, and then the `inverse` would be called automatically when doing batch inversion.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
