### PR TITLE
[1823] allow None for switch endianness

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -47,10 +47,10 @@ def switch_endianness(data, old, new):
         data = [switch_endianness(x, old, new) for x in data]
     elif isinstance(data, dict):
         data = {k: switch_endianness(v, old, new) for k, v in data.items()}
-    elif isinstance(data, (bool, str, float, int)):
+    elif isinstance(data, (bool, str, float, int, type(None))):
         pass
     else:
-        raise AssertionError()
+        raise AssertionError(f"Unknown type: {type(data).__name__}")
     return data
 
 

--- a/monai/utils/jupyter_utils.py
+++ b/monai/utils/jupyter_utils.py
@@ -10,8 +10,8 @@
 # limitations under the License.
 
 """
-This set of utility function is meant to make using Jupyter notebooks easier with MONAI. Plotting functions using 
-Matplotlib produce common plots for metrics and images. 
+This set of utility function is meant to make using Jupyter notebooks easier with MONAI. Plotting functions using
+Matplotlib produce common plots for metrics and images.
 """
 
 from enum import Enum

--- a/tests/test_nifti_endianness.py
+++ b/tests/test_nifti_endianness.py
@@ -1,4 +1,3 @@
-from monai.data.image_reader import PILReader
 import os
 import tempfile
 import unittest
@@ -9,6 +8,7 @@ import numpy as np
 from parameterized import parameterized
 
 from monai.data import DataLoader, Dataset, create_test_image_2d
+from monai.data.image_reader import PILReader
 from monai.transforms import LoadImage, LoadImaged
 from monai.transforms.io.array import switch_endianness
 from monai.utils.module import optional_import

--- a/tests/test_nifti_endianness.py
+++ b/tests/test_nifti_endianness.py
@@ -1,3 +1,5 @@
+from monai.data.image_reader import PILReader
+import os
 import tempfile
 import unittest
 from typing import TYPE_CHECKING, List, Tuple
@@ -13,10 +15,13 @@ from monai.utils.module import optional_import
 
 if TYPE_CHECKING:
     import nibabel as nib
+    from PIL import Image as PILImage
 
     has_nib = True
+    has_pil = True
 else:
     nib, has_nib = optional_import("nibabel")
+    PILImage, has_pil = optional_import("PIL.Image")
 
 TESTS: List[Tuple] = []
 for endianness in ["<", ">"]:
@@ -48,6 +53,15 @@ class TestNiftiEndianness(unittest.TestCase):
         for data in (np.zeros((2, 1)), ("test",), [24, 42], {"foo": "bar"}, True, 42):
             output = switch_endianness(data, ">", "<")
             self.assertEqual(type(data), type(output))
+
+    def test_pil(self):
+        tempdir = tempfile.mkdtemp()
+        test_image = np.random.randint(0, 256, size=[128, 256])
+        filename = os.path.join(tempdir, "test_image.png")
+        PILImage.fromarray(test_image.astype("uint8")).save(filename)
+
+        loader = LoadImage(PILReader(converter=lambda image: image.convert("LA")))
+        _ = loader(filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/1823.

### Description
Allow None as type for switching endianness. Also improve print statement for previously unseen data types.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
