### PR TITLE
refactor CommonKeys

### DIFF
--- a/monai/apps/deepgrow/interaction.py
+++ b/monai/apps/deepgrow/interaction.py
@@ -13,9 +13,9 @@ from typing import Callable, Dict, Sequence, Union
 import torch
 
 from monai.engines import SupervisedEvaluator, SupervisedTrainer
-from monai.engines.utils import CommonKeys
 from monai.engines.workflow import Events
 from monai.transforms import Compose
+from monai.utils.enums import CommonKeys
 
 
 class Interaction:

--- a/monai/engines/__init__.py
+++ b/monai/engines/__init__.py
@@ -12,4 +12,4 @@
 from .evaluator import EnsembleEvaluator, Evaluator, SupervisedEvaluator
 from .multi_gpu_supervised_trainer import create_multigpu_supervised_evaluator, create_multigpu_supervised_trainer
 from .trainer import GanTrainer, SupervisedTrainer, Trainer
-from .utils import CommonKeys, GanKeys, IterationEvents, default_make_latent, default_prepare_batch, get_devices_spec
+from .utils import GanKeys, IterationEvents, default_make_latent, default_prepare_batch, get_devices_spec

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -14,13 +14,13 @@ from typing import TYPE_CHECKING, Callable, Dict, Iterable, Optional, Sequence, 
 import torch
 from torch.utils.data import DataLoader
 
-from monai.engines.utils import CommonKeys as Keys
 from monai.engines.utils import IterationEvents, default_prepare_batch
 from monai.engines.workflow import Workflow
 from monai.inferers import Inferer, SimpleInferer
 from monai.networks.utils import eval_mode
 from monai.transforms import Transform
 from monai.utils import ensure_tuple, exact_version, optional_import
+from monai.utils.enums import CommonKeys as Keys
 
 if TYPE_CHECKING:
     from ignite.engine import Engine

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -15,12 +15,12 @@ import torch
 from torch.optim.optimizer import Optimizer
 from torch.utils.data import DataLoader
 
-from monai.engines.utils import CommonKeys as Keys
 from monai.engines.utils import GanKeys, IterationEvents, default_make_latent, default_prepare_batch
 from monai.engines.workflow import Workflow
 from monai.inferers import Inferer, SimpleInferer
 from monai.transforms import Transform
 from monai.utils import exact_version, optional_import
+from monai.utils.enums import CommonKeys as Keys
 
 if TYPE_CHECKING:
     from ignite.engine import Engine

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple, Union
 import torch
 
 from monai.utils import exact_version, optional_import
+from monai.utils.enums import CommonKeys
 
 if TYPE_CHECKING:
     from ignite.engine import EventEnum
@@ -22,7 +23,6 @@ else:
 
 __all__ = [
     "IterationEvents",
-    "CommonKeys",
     "GanKeys",
     "get_devices_spec",
     "default_prepare_batch",
@@ -45,23 +45,6 @@ class IterationEvents(EventEnum):
     LOSS_COMPLETED = "loss_completed"
     BACKWARD_COMPLETED = "backward_completed"
     OPTIMIZER_COMPLETED = "optimizer_completed"
-
-
-class CommonKeys:
-    """
-    A set of common keys for dictionary based supervised training process.
-    `IMAGE` is the input image data.
-    `LABEL` is the training or evaluation label of segmentation or classification task.
-    `PRED` is the prediction data of model output.
-    `LOSS` is the loss value of current iteration.
-    `INFO` is some useful information during training or evaluation, like loss value, etc.
-
-    """
-
-    IMAGE = "image"
-    LABEL = "label"
-    PRED = "pred"
-    LOSS = "loss"
 
 
 class GanKeys:

--- a/monai/handlers/metric_logger.py
+++ b/monai/handlers/metric_logger.py
@@ -14,8 +14,8 @@ from enum import Enum
 from threading import RLock
 from typing import TYPE_CHECKING, Callable, DefaultDict, List, Optional
 
-from monai.engines.utils import CommonKeys
 from monai.utils import exact_version, optional_import
+from monai.utils.enums import CommonKeys
 
 Events, _ = optional_import("ignite.engine", "0.4.4", exact_version, "Events")
 if TYPE_CHECKING:

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -17,6 +17,7 @@ from .enums import (
     Average,
     BlendMode,
     ChannelMatching,
+    CommonKeys,
     GridSampleMode,
     GridSamplePadMode,
     InterpolateMode,

--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -29,6 +29,7 @@ __all__ = [
     "SkipMode",
     "Method",
     "InverseKeys",
+    "CommonKeys",
 ]
 
 
@@ -226,3 +227,20 @@ class InverseKeys:
     EXTRA_INFO = "extra_info"
     DO_TRANSFORM = "do_transforms"
     KEY_SUFFIX = "_transforms"
+
+
+class CommonKeys:
+    """
+    A set of common keys for dictionary based supervised training process.
+    `IMAGE` is the input image data.
+    `LABEL` is the training or evaluation label of segmentation or classification task.
+    `PRED` is the prediction data of model output.
+    `LOSS` is the loss value of current iteration.
+    `INFO` is some useful information during training or evaluation, like loss value, etc.
+
+    """
+
+    IMAGE = "image"
+    LABEL = "label"
+    PRED = "pred"
+    LOSS = "loss"

--- a/tests/test_threadcontainer.py
+++ b/tests/test_threadcontainer.py
@@ -15,11 +15,12 @@ import unittest
 import torch
 
 from monai.utils import optional_import
+from monai.utils.enums import CommonKeys
 
 try:
     _, has_ignite = optional_import("ignite")
 
-    from monai.engines import CommonKeys, SupervisedTrainer
+    from monai.engines import SupervisedTrainer
     from monai.utils import ThreadContainer
 except ImportError:
     has_ignite = False


### PR DESCRIPTION
Move `CommonKeys` to `enums.py` so that it can be used by the whole MONAI codebase. Addresses problem in this PR: https://github.com/Project-MONAI/MONAI/pull/1794#issuecomment-804013257.