### PR TITLE
identity init. for global net

### DIFF
--- a/monai/networks/nets/regunet.py
+++ b/monai/networks/nets/regunet.py
@@ -263,14 +263,20 @@ class AffineHead(nn.Module):
         if spatial_dims == 2:
             in_features = in_channels * decode_size[0] * decode_size[1]
             out_features = 6
+            out_init = torch.tensor([1, 0, 0, 0, 1, 0], dtype=torch.float)
         elif spatial_dims == 3:
             in_features = in_channels * decode_size[0] * decode_size[1] * decode_size[2]
             out_features = 12
+            out_init = torch.tensor([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0], dtype=torch.float)
         else:
             raise ValueError(f"only support 2D/3D operation, got spatial_dims={spatial_dims}")
 
         self.fc = nn.Linear(in_features=in_features, out_features=out_features)
         self.grid = self.get_reference_grid(image_size)  # (spatial_dims, ...)
+
+        # init weight/bias
+        self.fc.weight.data.zero_()
+        self.fc.bias.data.copy_(out_init)
 
     @staticmethod
     def get_reference_grid(image_size: Union[Tuple[int], List[int]]) -> torch.Tensor:

--- a/tests/test_globalnet.py
+++ b/tests/test_globalnet.py
@@ -5,6 +5,7 @@ import torch
 from parameterized import parameterized
 
 from monai.networks import eval_mode
+from monai.networks.blocks import Warp
 from monai.networks.nets import GlobalNet
 from monai.networks.nets.regunet import AffineHead
 from tests.utils import test_script_save
@@ -64,9 +65,14 @@ class TestGlobalNet(unittest.TestCase):
     @parameterized.expand(TEST_CASES_GLOBAL_NET)
     def test_shape(self, input_param, input_shape, expected_shape):
         net = GlobalNet(**input_param).to(device)
+        warp_layer = Warp(spatial_dims=input_param.get("spatial_dims", 2))
         with eval_mode(net):
-            result = net(torch.randn(input_shape).to(device))
+            img = torch.randn(input_shape)
+            result = net(img.to(device))
+            warped = warp_layer(img, result)
             self.assertEqual(result.shape, expected_shape)
+            # testing initial pred identity
+            np.testing.assert_allclose(warped.detach().cpu().numpy(), img.detach().cpu().numpy(), rtol=1e-4, atol=1e-4)
 
     def test_script(self):
         input_param, input_shape, _ = TEST_CASES_GLOBAL_NET[0]

--- a/tests/test_globalnet.py
+++ b/tests/test_globalnet.py
@@ -69,7 +69,7 @@ class TestGlobalNet(unittest.TestCase):
         with eval_mode(net):
             img = torch.randn(input_shape)
             result = net(img.to(device))
-            warped = warp_layer(img, result)
+            warped = warp_layer(img.to(device), result)
             self.assertEqual(result.shape, expected_shape)
             # testing initial pred identity
             np.testing.assert_allclose(warped.detach().cpu().numpy(), img.detach().cpu().numpy(), rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
### Description
initialise the AffineHead with an identity transformation

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.


cc @kate-sann5100 