### PR TITLE
infer spatial dims from input -- warp

### DIFF
--- a/tests/test_dvf2ddf.py
+++ b/tests/test_dvf2ddf.py
@@ -10,16 +10,16 @@ from monai.networks.blocks.warp import DVF2DDF
 from monai.utils import set_determinism
 
 TEST_CASES = [
-    [{"spatial_dims": 2, "num_steps": 1}, {"dvf": torch.zeros(1, 2, 2, 2)}, torch.zeros(1, 2, 2, 2)],
+    [{"num_steps": 1}, {"dvf": torch.zeros(1, 2, 2, 2)}, torch.zeros(1, 2, 2, 2)],
     [
-        {"spatial_dims": 3, "num_steps": 1},
+        {"num_steps": 1},
         {"dvf": torch.ones(1, 3, 2, 2, 2)},
         torch.tensor([[[1.0000, 0.7500], [0.7500, 0.6250]], [[0.7500, 0.6250], [0.6250, 0.5625]]])
         .reshape(1, 1, 2, 2, 2)
         .expand(-1, 3, -1, -1, -1),
     ],
     [
-        {"spatial_dims": 3, "num_steps": 2},
+        {"num_steps": 2},
         {"dvf": torch.ones(1, 3, 2, 2, 2)},
         torch.tensor([[[0.9175, 0.6618], [0.6618, 0.5306]], [[0.6618, 0.5306], [0.5306, 0.4506]]])
         .reshape(1, 1, 2, 2, 2)
@@ -43,7 +43,7 @@ class TestDVF2DDF(unittest.TestCase):
 
     def test_gradient(self):
         network = nn.Conv2d(in_channels=1, out_channels=2, kernel_size=1)
-        dvf2ddf = DVF2DDF(spatial_dims=2, num_steps=1)
+        dvf2ddf = DVF2DDF(num_steps=1)
         optimizer = SGD(network.parameters(), lr=0.01)
         x = torch.ones((1, 1, 5, 5))
         x = network(x)

--- a/tests/test_globalnet.py
+++ b/tests/test_globalnet.py
@@ -65,7 +65,7 @@ class TestGlobalNet(unittest.TestCase):
     @parameterized.expand(TEST_CASES_GLOBAL_NET)
     def test_shape(self, input_param, input_shape, expected_shape):
         net = GlobalNet(**input_param).to(device)
-        warp_layer = Warp(spatial_dims=input_param.get("spatial_dims", 2))
+        warp_layer = Warp()
         with eval_mode(net):
             img = torch.randn(input_shape)
             result = net(img.to(device))

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -8,12 +8,12 @@ from monai.networks.blocks.warp import Warp
 
 LOW_POWER_TEST_CASES = [
     [
-        {"spatial_dims": 2, "mode": 0, "padding_mode": "zeros"},
+        {"mode": 0, "padding_mode": "zeros"},
         {"image": torch.arange(4).reshape((1, 1, 2, 2)).to(dtype=torch.float), "ddf": torch.zeros(1, 2, 2, 2)},
         torch.arange(4).reshape((1, 1, 2, 2)),
     ],
     [
-        {"spatial_dims": 2, "mode": 1, "padding_mode": "zeros"},
+        {"mode": 1, "padding_mode": "zeros"},
         {"image": torch.arange(4).reshape((1, 1, 2, 2)).to(dtype=torch.float), "ddf": torch.ones(1, 2, 2, 2)},
         torch.tensor([[[[3, 0], [0, 0]]]]),
     ],
@@ -21,7 +21,7 @@ LOW_POWER_TEST_CASES = [
 
 HIGH_POWER_TEST_CASES = [
     [
-        {"spatial_dims": 3, "mode": 2, "padding_mode": "border"},
+        {"mode": 2, "padding_mode": "border"},
         {
             "image": torch.arange(8).reshape((1, 1, 2, 2, 2)).to(dtype=torch.float),
             "ddf": torch.ones(1, 3, 2, 2, 2) * -1,
@@ -29,7 +29,7 @@ HIGH_POWER_TEST_CASES = [
         torch.tensor([[[[[0, 0], [0, 0]], [[0, 0], [0, 0]]]]]),
     ],
     [
-        {"spatial_dims": 3, "mode": 3, "padding_mode": "reflection"},
+        {"mode": 3, "padding_mode": "reflection"},
         {"image": torch.arange(8).reshape((1, 1, 2, 2, 2)).to(dtype=torch.float), "ddf": torch.ones(1, 3, 2, 2, 2)},
         torch.tensor([[[[[7, 6], [5, 4]], [[3, 2], [1, 0]]]]]),
     ],
@@ -48,7 +48,7 @@ class TestWarp(unittest.TestCase):
         np.testing.assert_allclose(result.cpu().numpy(), expected_val.cpu().numpy(), rtol=1e-4, atol=1e-4)
 
     def test_ill_shape(self):
-        warp_layer = Warp(spatial_dims=2)
+        warp_layer = Warp()
         with self.assertRaisesRegex(ValueError, ""):
             warp_layer(
                 image=torch.arange(4).reshape((1, 1, 1, 2, 2)).to(dtype=torch.float), ddf=torch.zeros(1, 2, 2, 2)
@@ -59,10 +59,6 @@ class TestWarp(unittest.TestCase):
             )
         with self.assertRaisesRegex(ValueError, ""):
             warp_layer(image=torch.arange(4).reshape((1, 1, 2, 2)).to(dtype=torch.float), ddf=torch.zeros(1, 2, 3, 3))
-
-    def test_ill_opts(self):
-        with self.assertRaisesRegex(ValueError, ""):
-            Warp(spatial_dims=4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
remove `spatial_dims` from the `Warp` and `DVF2DDF` constructor,
infer the `spatial_dims` automatically in `forward`.
these will simplify the usages.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
