### PR TITLE
Pathology Masked Inference WSI Dataset

### DIFF
--- a/docs/source/apps.rst
+++ b/docs/source/apps.rst
@@ -71,6 +71,8 @@ Applications
     :members:
 .. autoclass:: SmartCachePatchWSIDataset
     :members:
+.. autoclass:: MaskedInferenceWSIDataset
+    :members:
 
 .. automodule:: monai.apps.pathology.utils
 .. autoclass:: PathologyProbNMS

--- a/monai/apps/pathology/__init__.py
+++ b/monai/apps/pathology/__init__.py
@@ -9,5 +9,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .datasets import PatchWSIDataset, SmartCacheDataset
+from .datasets import PatchWSIDataset, SmartCacheDataset, MaskedInferenceWSIDataset
 from .utils import ProbNMS

--- a/monai/apps/pathology/datasets.py
+++ b/monai/apps/pathology/datasets.py
@@ -204,6 +204,7 @@ class MaskedInferenceWSIDataset(Dataset):
         # calculate cummulative number of patches for all whole slide images
         self.cum_num_patches = np.cumsum([0] + [len(d["image_locations"]) for d in self.data_list])
         self.total_num_patches = self.cum_num_patches[-1]
+        self.cum_num_patches = self.cum_num_patches[:-1]
 
     def _create_data_list(self, data: List[Dict]) -> List[Dict]:
         data_list = []
@@ -276,6 +277,7 @@ class MaskedInferenceWSIDataset(Dataset):
         patch_num = index - self.cum_num_patches[sample_num]
         image_location = sample["image_locations"][patch_num]
         mask_location = sample["mask_locations"][patch_num]
+
         image, _ = self.image_reader.get_data(
             img=sample["image"],
             location=image_location,

--- a/monai/apps/pathology/datasets.py
+++ b/monai/apps/pathology/datasets.py
@@ -9,15 +9,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
-from typing import Callable, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
 from monai.data import Dataset, SmartCacheDataset
 from monai.data.image_reader import WSIReader
 
-__all__ = ["PatchWSIDataset", "SmartCachePatchWSIDataset"]
+__all__ = ["PatchWSIDataset", "SmartCachePatchWSIDataset", "MaskedInferenceWSIDataset"]
 
 
 class PatchWSIDataset(Dataset):
@@ -26,13 +27,13 @@ class PatchWSIDataset(Dataset):
     It also reads labels for each patch and provides each patch with its associated class labels.
 
     Args:
-        data: the list of input samples including image, location, and label (see below for more details).
-        region_size: the region to be extracted from the whole slide image.
+        data: the list of input samples including image, location, and label (see the note below for more details).
+        region_size: the size of regions to be extracted from the whole slide image.
         grid_shape: the grid shape on which the patches should be extracted.
-        patch_size: the patches extracted from the region on the grid.
+        patch_size: the size of patches extracted from the region on the grid.
+        transform: transforms to be executed on input data.
         image_reader_name: the name of library to be used for loading whole slide imaging, either CuCIM or OpenSlide.
             Defaults to CuCIM.
-        transform: transforms to be executed on input data.
 
     Note:
         The input data has the following form as an example:
@@ -52,8 +53,8 @@ class PatchWSIDataset(Dataset):
         region_size: Union[int, Tuple[int, int]],
         grid_shape: Union[int, Tuple[int, int]],
         patch_size: int,
-        image_reader_name: str = "cuCIM",
         transform: Optional[Callable] = None,
+        image_reader_name: str = "cuCIM",
     ):
         super().__init__(data, transform)
 
@@ -71,7 +72,6 @@ class PatchWSIDataset(Dataset):
         self.sub_region_size = (self.region_size[0] / self.grid_shape[0], self.region_size[1] / self.grid_shape[1])
 
         self.image_path_list = list({x["image"] for x in self.data})
-
         self.image_reader_name = image_reader_name
         self.image_reader = WSIReader(image_reader_name)
         self.wsi_object_dict = None
@@ -148,7 +148,13 @@ class SmartCachePatchWSIDataset(SmartCacheDataset):
         num_replace_workers: Optional[int] = None,
         progress: bool = True,
     ):
-        patch_wsi_dataset = PatchWSIDataset(data, region_size, grid_shape, patch_size, image_reader_name)
+        patch_wsi_dataset = PatchWSIDataset(
+            data=data,
+            region_size=region_size,
+            grid_shape=grid_shape,
+            patch_size=patch_size,
+            image_reader_name=image_reader_name,
+        )
         super().__init__(
             data=patch_wsi_dataset,  # type: ignore
             transform=transform,
@@ -159,3 +165,133 @@ class SmartCachePatchWSIDataset(SmartCacheDataset):
             num_replace_workers=num_replace_workers,
             progress=progress,
         )
+
+
+class MaskedInferenceWSIDataset(Dataset):
+    """
+    This dataset load the provided tissue masks at an arbitrary resolution level,
+    and extract patches based on that mask from the associated whole slide image.
+
+    Args:
+        data: a list of sample including path to the mask and path to the whole slide image
+            `[{"image": "path/to/image1.tiff", "label": "path/to/mask.npy}, ...]"`.
+        patch_size: the size of patches to be extracted from the whole slide image for inference.
+        transform: transforms to be executed on extracted patches.
+        image_reader_name: the name of library to be used for loading whole slide imaging, either CuCIM or OpenSlide.
+            Defaults to CuCIM.
+
+    """
+
+    def __init__(
+        self,
+        data: List,
+        patch_size: Union[int, Tuple[int, int]],
+        transform: Optional[Callable] = None,
+        image_reader_name: str = "cuCIM",
+    ) -> None:
+        super().__init__(data, transform)
+
+        if isinstance(patch_size, int):
+            self.patch_size = np.array((patch_size, patch_size))
+        else:
+            self.patch_size = np.array(patch_size)
+        self.image_reader_name = image_reader_name
+        self.image_reader = WSIReader(image_reader_name)
+
+        # process data and create a list of dictionaries containing all required data and metadata
+        self.data_list = self._create_data_list(data)
+
+        # calculate cummulative number of patches for all whole slide images
+        self.cum_num_patches = np.cumsum([0] + [len(d["image_locations"]) for d in self.data_list])
+        self.total_num_patches = self.cum_num_patches[-1]
+
+    def _create_data_list(self, data: List[Dict]) -> List[Dict]:
+        data_list = []
+        print("Number of whole slide images: ", len(data))
+        for sample in data:
+            processed_data = self._preprocess_sample(sample)
+            data_list.append(processed_data)
+        return data_list
+
+    def _preprocess_sample(self, sample: Dict) -> Dict:
+        """
+        Preprocess input data to load WSIReader object and the foreground mask,
+        and define the locations where patches need to be extracted.
+        """
+        image = self.image_reader.read(sample["image"])
+        mask = np.load(sample["label"]).T
+        try:
+            level, ratio = self._calculate_mask_level(image, mask)
+        except ValueError as err:
+            err.args = (sample["label"],) + err.args
+            raise
+        print(f"Mask ({sample['label']}) at level {int(level)}, with ratio {int(ratio)}")
+
+        # get all indices for tissue region from the foreground mask
+        # note: output same size as the foreground mask and not original wsi image size
+        mask_locations = np.vstack(mask.nonzero()).T
+
+        # convert mask locations to image locations to extract patches
+        image_locations = (mask_locations + 0.5) * ratio - self.patch_size // 2
+
+        return {
+            "name": os.path.splitext(os.path.basename(sample["image"]))[0],
+            "image": image,
+            "mask_shape": mask.shape,
+            "mask_locations": mask_locations.astype(int).tolist(),
+            "image_locations": image_locations.astype(int).tolist(),
+            "level": level,
+        }
+
+    def _calculate_mask_level(self, image, mask) -> Tuple[int, int]:
+        """Calculate level of the mask and its ratio with respect to the whole slide image"""
+        dim_y_img, dim_x_img, _ = image.shape
+        dim_y_msk, dim_x_msk = mask.shape
+
+        ratio_x = dim_x_img / dim_x_msk
+        ratio_y = dim_y_img / dim_y_msk
+        level_x = np.log2(ratio_x)
+
+        if ratio_x != ratio_y:
+            raise ValueError(
+                "Image/Mask dimension does not match!"
+                " dim_x_img / dim_x_msk : {} / {},"
+                " dim_y_img / dim_y_msk : {} / {}".format(dim_x_img, dim_x_msk, dim_y_img, dim_y_msk)
+            )
+        elif not level_x.is_integer():
+            raise ValueError(
+                "Mask not at regular level (ratio not power of 2)," " image / mask ratio: {},".format(ratio_x)
+            )
+        return level_x, ratio_x
+
+    def _load_a_sample(self, index: int) -> Dict:
+        """
+        Load sample given the index
+
+        This method first, find the right patch to be extracted from the right whole slide image, and
+        then load this patch and provide it with its image name and the corrsponding mask location.
+        """
+        sample_num = np.argmax(self.cum_num_patches > index) - 1
+        sample = self.data_list[sample_num]
+        patch_num = index - self.cum_num_patches[sample_num]
+        image_location = sample["image_locations"][patch_num]
+        mask_location = sample["mask_locations"][patch_num]
+        image, _ = self.image_reader.get_data(
+            img=sample["image"],
+            location=image_location,
+            size=self.patch_size.tolist(),
+        )
+        processed_sample = {"image": image, "name": sample["name"], "mask_location": mask_location}
+        return processed_sample
+
+    def __len__(self):
+        return self.total_num_patches
+
+    def __getitem__(self, index):
+        try:
+            sample = self._load_a_sample(index)
+        except IndexError:
+            raise
+        if self.transform:
+            sample = self.transform(sample)
+        return sample

--- a/tests/test_masked_inference_wsi_dataset.py
+++ b/tests/test_masked_inference_wsi_dataset.py
@@ -1,0 +1,243 @@
+import os
+import unittest
+from unittest import skipUnless
+from urllib import request
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from parameterized import parameterized
+
+from monai.apps.pathology.datasets import MaskedInferenceWSIDataset
+from monai.utils import optional_import
+from tests.utils import skip_if_quick
+
+_, has_cim = optional_import("cucim")
+_, has_osl = optional_import("openslide")
+
+FILE_URL = "http://openslide.cs.cmu.edu/download/openslide-testdata/Generic-TIFF/CMU-1.tiff"
+
+HEIGHT = 32914
+WIDTH = 46000
+
+mask = np.zeros((WIDTH // 2, HEIGHT // 2))
+mask[100, 100] = 1
+np.save("./tests/testing_data/mask1.npy", mask)
+mask[100, 100:102] = 1
+np.save("./tests/testing_data/mask2.npy", mask)
+mask[100:102, 100:102] = 1
+np.save("./tests/testing_data/mask4.npy", mask)
+
+TEST_CASE_0 = [
+    FILE_URL,
+    {
+        "data": [
+            {"image": "./CMU-1.tiff", "label": "./tests/testing_data/mask1.npy"},
+        ],
+        "patch_size": 1,
+        "image_reader_name": "cuCIM",
+    },
+    [
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [100, 100],
+        },
+    ],
+]
+
+TEST_CASE_1 = [
+    FILE_URL,
+    {
+        "data": [{"image": "./CMU-1.tiff", "label": "./tests/testing_data/mask2.npy"}],
+        "patch_size": 1,
+        "image_reader_name": "cuCIM",
+    },
+    [
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [100, 100],
+        },
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [101, 100],
+        },
+    ],
+]
+
+TEST_CASE_2 = [
+    FILE_URL,
+    {
+        "data": [{"image": "./CMU-1.tiff", "label": "./tests/testing_data/mask4.npy"}],
+        "patch_size": 1,
+        "image_reader_name": "cuCIM",
+    },
+    [
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [100, 100],
+        },
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [100, 101],
+        },
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [101, 100],
+        },
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [101, 101],
+        },
+    ],
+]
+
+TEST_CASE_3 = [
+    FILE_URL,
+    {
+        "data": [
+            {"image": "./CMU-1.tiff", "label": "./tests/testing_data/mask1.npy"},
+        ],
+        "patch_size": 2,
+        "image_reader_name": "cuCIM",
+    },
+    [
+        {
+            "image": np.array(
+                [
+                    [[243, 243], [243, 243]],
+                    [[243, 243], [243, 243]],
+                    [[243, 243], [243, 243]],
+                ],
+                dtype=np.uint8,
+            ),
+            "name": "CMU-1",
+            "mask_location": [100, 100],
+        },
+    ],
+]
+
+TEST_CASE_4 = [
+    FILE_URL,
+    {
+        "data": [
+            {"image": "./CMU-1.tiff", "label": "./tests/testing_data/mask1.npy"},
+            {"image": "./CMU-1.tiff", "label": "./tests/testing_data/mask2.npy"},
+        ],
+        "patch_size": 1,
+        "image_reader_name": "cuCIM",
+    },
+    [
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [100, 100],
+        },
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [100, 100],
+        },
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [101, 100],
+        },
+    ],
+]
+
+
+TEST_CASE_OPENSLIDE_0 = [
+    FILE_URL,
+    {
+        "data": [
+            {"image": "./CMU-1.tiff", "label": "./tests/testing_data/mask1.npy"},
+        ],
+        "patch_size": 1,
+        "image_reader_name": "OpenSlide",
+    },
+    [
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [100, 100],
+        },
+    ],
+]
+
+TEST_CASE_OPENSLIDE_1 = [
+    FILE_URL,
+    {
+        "data": [{"image": "./CMU-1.tiff", "label": "./tests/testing_data/mask2.npy"}],
+        "patch_size": 1,
+        "image_reader_name": "OpenSlide",
+    },
+    [
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [100, 100],
+        },
+        {
+            "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
+            "name": "CMU-1",
+            "mask_location": [101, 100],
+        },
+    ],
+]
+
+
+class TestMaskedInferenceWSIDataset(unittest.TestCase):
+    @parameterized.expand(
+        [
+            TEST_CASE_0,
+            TEST_CASE_1,
+            TEST_CASE_2,
+            TEST_CASE_3,
+            TEST_CASE_4,
+        ]
+    )
+    @skipUnless(has_cim, "Requires CuCIM")
+    @skip_if_quick
+    def test_read_patches_cucim(self, file_url, input_parameters, expected):
+        self.camelyon_data_download(file_url)
+        dataset = MaskedInferenceWSIDataset(**input_parameters)
+        samples = list(dataset)
+        self.compare_samples_expected(samples, expected)
+
+    @parameterized.expand(
+        [
+            TEST_CASE_OPENSLIDE_0,
+            TEST_CASE_OPENSLIDE_1,
+        ]
+    )
+    @skipUnless(has_osl, "Requires OpenSlide")
+    @skip_if_quick
+    def test_read_patches_openslide(self, file_url, input_parameters, expected):
+        self.camelyon_data_download(file_url)
+        dataset = MaskedInferenceWSIDataset(**input_parameters)
+        samples = list(dataset)
+        self.compare_samples_expected(samples, expected)
+
+    def camelyon_data_download(self, file_url):
+        filename = os.path.basename(file_url)
+        if not os.path.exists(filename):
+            print(f"Test image [{filename}] does not exist. Downloading...")
+            request.urlretrieve(file_url, filename)
+        return filename
+
+    def compare_samples_expected(self, samples, expected):
+        for i in range(len(samples)):
+            self.assertTupleEqual(samples[i]["image"].shape, expected[i]["image"].shape)
+            self.assertIsNone(assert_array_equal(samples[i]["image"], expected[i]["image"]))
+            self.assertEqual(samples[i]["name"], expected[i]["name"])
+            self.assertListEqual(samples[i]["mask_location"], expected[i]["mask_location"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description
This PR implements a dataset for pathology inference. It uses tissue foreground masks to extract patches from whole slide images and provide necessary meta data for post-processing of inference results.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
