### PR TITLE
remove unused in_channels in LNCC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,7 @@ temp/
 # temporary testing data MedNIST
 tests/testing_data/MedNIST*
 tests/testing_data/*Hippocampus*
-tests/testing_data/CMU-1.tiff
+tests/testing_data/*.tiff
 
 # clang format tool
 .clang-format-bin/

--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -61,7 +61,6 @@ class LocalNormalizedCrossCorrelationLoss(_Loss):
 
     def __init__(
         self,
-        in_channels: int,
         ndim: int = 3,
         kernel_size: int = 3,
         kernel_type: str = "rectangular",
@@ -71,7 +70,6 @@ class LocalNormalizedCrossCorrelationLoss(_Loss):
     ) -> None:
         """
         Args:
-            in_channels: number of input channels
             ndim: number of spatial ndimensions, {``1``, ``2``, ``3``}. Defaults to 3.
             kernel_size: kernel spatial size, must be odd.
             kernel_type: {``"rectangular"``, ``"triangular"``, ``"gaussian"``}. Defaults to ``"rectangular"``.
@@ -85,7 +83,6 @@ class LocalNormalizedCrossCorrelationLoss(_Loss):
             smooth_dr: a small constant added to the denominator to avoid nan.
         """
         super(LocalNormalizedCrossCorrelationLoss, self).__init__(reduction=LossReduction(reduction).value)
-        self.in_channels = in_channels
 
         self.ndim = ndim
         if self.ndim not in [1, 2, 3]:
@@ -119,8 +116,6 @@ class LocalNormalizedCrossCorrelationLoss(_Loss):
         Raises:
             ValueError: When ``self.reduction`` is not one of ["mean", "sum", "none"].
         """
-        if pred.shape[1] != self.in_channels:
-            raise ValueError(f"expecting pred with {self.in_channels} channels, got pred of shape {pred.shape}")
         if pred.ndim - 2 != self.ndim:
             raise ValueError(f"expecting pred with {self.ndim} spatial dimensions, got pred of shape {pred.shape}")
         if target.shape != pred.shape:

--- a/monai/networks/blocks/warp.py
+++ b/monai/networks/blocks/warp.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional, Union
+from typing import List, Union
 
 import torch
 from torch import nn
@@ -7,7 +7,9 @@ from torch.nn import functional as F
 
 from monai.config.deviceconfig import USE_COMPILED
 from monai.networks.layers.spatial_transforms import grid_pull
-from monai.utils import GridSampleMode, GridSamplePadMode
+from monai.utils import GridSampleMode, GridSamplePadMode, optional_import
+
+_C, _ = optional_import("monai._C")
 
 __all__ = ["Warp", "DVF2DDF"]
 
@@ -19,51 +21,58 @@ class Warp(nn.Module):
 
     def __init__(
         self,
-        mode=1,
-        padding_mode: Optional[Union[GridSamplePadMode, str]] = GridSamplePadMode.ZEROS,
+        mode: Union[str, int] = GridSampleMode.BILINEAR.value,
+        padding_mode: Union[str, int] = GridSamplePadMode.BORDER.value,
     ):
         """
-        Args:
-            mode: interpolation mode to calculate output values, defaults to 1.
-                Possible values are::
+        For pytorch native APIs, the possible values are:
 
-                    - 0 or 'nearest'    or InterpolationType.nearest
-                    - 1 or 'linear'     or InterpolationType.linear
-                    - 2 or 'quadratic'  or InterpolationType.quadratic
-                    - 3 or 'cubic'      or InterpolationType.cubic
-                    - 4 or 'fourth'     or InterpolationType.fourth
-                    - etc.
-            padding_mode: {``"zeros"``, ``"border"``, ``"reflection"``}
-                Padding mode for outside grid values. Defaults to ``"border"``.
-                See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
+            - mode: ``"nearest"``, ``"bilinear"``, ``"bicubic"``.
+            - padding_mode: ``"zeros"``, ``"border"``, ``"reflection"``
+
+        See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
+
+        For MONAI C++/CUDA extensions, the possible values are:
+
+            - mode: ``"nearest"``, ``"bilinear"``, ``"bicubic"``, 0, 1, ...
+            - padding_mode: ``"zeros"``, ``"border"``, ``"reflection"``, 0, 1, ...
+
+        See also: :py:class:`monai.networks.layers.grid_pull`
         """
         super(Warp, self).__init__()
         # resolves _interp_mode for different methods
+
         if USE_COMPILED:
+            if mode in (inter.value for inter in GridSampleMode):
+                mode = GridSampleMode(mode)
+                if mode == GridSampleMode.BILINEAR:
+                    mode = 1
+                elif mode == GridSampleMode.NEAREST:
+                    mode = 0
+                elif mode == GridSampleMode.BICUBIC:
+                    mode = 3
+                else:
+                    mode = 1  # default to linear
             self._interp_mode = mode
         else:
             warnings.warn("monai.networks.blocks.Warp: Using PyTorch native grid_sample.")
-            self._interp_mode = GridSampleMode.BILINEAR.value  # works for both 4D and 5D tensors
-            if mode == 0:
-                self._interp_mode = GridSampleMode.NEAREST.value
-            elif mode == 1:
-                self._interp_mode = GridSampleMode.BILINEAR.value
-            elif mode == 3:
-                self._interp_mode = GridSampleMode.BICUBIC.value  # torch.functional.grid_sample only supports 4D
-            else:
-                warnings.warn(f"Order-{mode} interpolation is not supported, using linear interpolation.")
+            self._interp_mode = GridSampleMode(mode).value
 
         # resolves _padding_mode for different methods
-        padding_mode = GridSamplePadMode(padding_mode).value
         if USE_COMPILED:
-            if padding_mode == GridSamplePadMode.ZEROS.value:
-                self._padding_mode = 7
-            elif padding_mode == GridSamplePadMode.BORDER.value:
-                self._padding_mode = 0
-            else:
-                self._padding_mode = 1  # reflection
+            if padding_mode in (pad.value for pad in GridSamplePadMode):
+                padding_mode = GridSamplePadMode(padding_mode)
+                if padding_mode == GridSamplePadMode.ZEROS:
+                    padding_mode = 7
+                elif padding_mode == GridSamplePadMode.BORDER:
+                    padding_mode = 0
+                elif padding_mode == GridSamplePadMode.REFLECTION:
+                    padding_mode = 1
+                else:
+                    padding_mode = 0  # default to nearest
+            self._padding_mode = padding_mode
         else:
-            self._padding_mode = padding_mode  # type: ignore
+            self._padding_mode = GridSamplePadMode(padding_mode).value
 
     @staticmethod
     def get_reference_grid(ddf: torch.Tensor) -> torch.Tensor:
@@ -125,8 +134,8 @@ class DVF2DDF(nn.Module):
     def __init__(
         self,
         num_steps: int = 7,
-        mode: int = 1,
-        padding_mode: Optional[Union[GridSamplePadMode, str]] = GridSamplePadMode.ZEROS,
+        mode: Union[str, int] = GridSampleMode.BILINEAR.value,
+        padding_mode: Union[str, int] = GridSamplePadMode.ZEROS.value,
     ):
         super(DVF2DDF, self).__init__()
         if num_steps <= 0:

--- a/monai/networks/blocks/warp.py
+++ b/monai/networks/blocks/warp.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Union
+from typing import List
 
 import torch
 from torch import nn
@@ -21,8 +21,8 @@ class Warp(nn.Module):
 
     def __init__(
         self,
-        mode: Union[str, int] = GridSampleMode.BILINEAR.value,
-        padding_mode: Union[str, int] = GridSamplePadMode.BORDER.value,
+        mode=GridSampleMode.BILINEAR.value,
+        padding_mode=GridSamplePadMode.BORDER.value,
     ):
         """
         For pytorch native APIs, the possible values are:
@@ -134,8 +134,8 @@ class DVF2DDF(nn.Module):
     def __init__(
         self,
         num_steps: int = 7,
-        mode: Union[str, int] = GridSampleMode.BILINEAR.value,
-        padding_mode: Union[str, int] = GridSamplePadMode.ZEROS.value,
+        mode=GridSampleMode.BILINEAR.value,
+        padding_mode=GridSamplePadMode.ZEROS.value,
     ):
         super(DVF2DDF, self).__init__()
         if num_steps <= 0:

--- a/tests/test_local_normalized_cross_correlation_loss.py
+++ b/tests/test_local_normalized_cross_correlation_loss.py
@@ -21,7 +21,7 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 
 TEST_CASES = [
     [
-        {"in_channels": 1, "ndim": 1, "kernel_type": "rectangular", "reduction": "sum"},
+        {"ndim": 1, "kernel_type": "rectangular", "reduction": "sum"},
         {
             "pred": torch.arange(0, 3).reshape(1, 1, -1).to(dtype=torch.float, device=device),
             "target": torch.arange(0, 3).reshape(1, 1, -1).to(dtype=torch.float, device=device),
@@ -29,7 +29,7 @@ TEST_CASES = [
         -1.0 * 3,
     ],
     [
-        {"in_channels": 1, "ndim": 1, "kernel_type": "rectangular"},
+        {"ndim": 1, "kernel_type": "rectangular"},
         {
             "pred": torch.arange(0, 3).reshape(1, 1, -1).to(dtype=torch.float, device=device),
             "target": torch.arange(0, 3).reshape(1, 1, -1).to(dtype=torch.float, device=device),
@@ -37,7 +37,7 @@ TEST_CASES = [
         -1.0,
     ],
     [
-        {"in_channels": 1, "ndim": 2, "kernel_type": "rectangular"},
+        {"ndim": 2, "kernel_type": "rectangular"},
         {
             "pred": torch.arange(0, 3).reshape(1, 1, -1, 1).expand(1, 1, 3, 3).to(dtype=torch.float, device=device),
             "target": torch.arange(0, 3).reshape(1, 1, -1, 1).expand(1, 1, 3, 3).to(dtype=torch.float, device=device),
@@ -45,7 +45,7 @@ TEST_CASES = [
         -1.0,
     ],
     [
-        {"in_channels": 1, "ndim": 3, "kernel_type": "rectangular"},
+        {"ndim": 3, "kernel_type": "rectangular"},
         {
             "pred": torch.arange(0, 3)
             .reshape(1, 1, -1, 1, 1)
@@ -59,7 +59,7 @@ TEST_CASES = [
         -1.0,
     ],
     [
-        {"in_channels": 3, "ndim": 3, "kernel_type": "rectangular"},
+        {"ndim": 3, "kernel_type": "rectangular"},
         {
             "pred": torch.arange(0, 3)
             .reshape(1, 1, -1, 1, 1)
@@ -74,7 +74,7 @@ TEST_CASES = [
         -0.95801723,
     ],
     [
-        {"in_channels": 3, "ndim": 3, "kernel_type": "triangular", "kernel_size": 5},
+        {"ndim": 3, "kernel_type": "triangular", "kernel_size": 5},
         {
             "pred": torch.arange(0, 5)
             .reshape(1, 1, -1, 1, 1)
@@ -89,7 +89,7 @@ TEST_CASES = [
         -0.918672,
     ],
     [
-        {"in_channels": 3, "ndim": 3, "kernel_type": "gaussian"},
+        {"ndim": 3, "kernel_type": "gaussian"},
         {
             "pred": torch.arange(0, 3)
             .reshape(1, 1, -1, 1, 1)
@@ -113,13 +113,7 @@ class TestLocalNormalizedCrossCorrelationLoss(unittest.TestCase):
         np.testing.assert_allclose(result.detach().cpu().numpy(), expected_val, rtol=1e-5)
 
     def test_ill_shape(self):
-        loss = LocalNormalizedCrossCorrelationLoss(in_channels=3, ndim=3)
-        # in_channel unmatch
-        with self.assertRaisesRegex(ValueError, ""):
-            loss.forward(
-                torch.ones((1, 2, 3, 3, 3), dtype=torch.float, device=device),
-                torch.ones((1, 2, 3, 3, 3), dtype=torch.float, device=device),
-            )
+        loss = LocalNormalizedCrossCorrelationLoss(ndim=3)
         # ndim unmatch
         with self.assertRaisesRegex(ValueError, ""):
             loss.forward(
@@ -137,15 +131,15 @@ class TestLocalNormalizedCrossCorrelationLoss(unittest.TestCase):
         pred = torch.ones((1, 3, 3, 3, 3), dtype=torch.float)
         target = torch.ones((1, 3, 3, 3, 3), dtype=torch.float)
         with self.assertRaisesRegex(ValueError, ""):
-            LocalNormalizedCrossCorrelationLoss(in_channels=3, kernel_type="unknown")(pred, target)
+            LocalNormalizedCrossCorrelationLoss(kernel_type="unknown")(pred, target)
         with self.assertRaisesRegex(ValueError, ""):
-            LocalNormalizedCrossCorrelationLoss(in_channels=3, kernel_type=None)(pred, target)
+            LocalNormalizedCrossCorrelationLoss(kernel_type=None)(pred, target)
         with self.assertRaisesRegex(ValueError, ""):
-            LocalNormalizedCrossCorrelationLoss(in_channels=3, kernel_size=4)(pred, target)
+            LocalNormalizedCrossCorrelationLoss(kernel_size=4)(pred, target)
         with self.assertRaisesRegex(ValueError, ""):
-            LocalNormalizedCrossCorrelationLoss(in_channels=3, reduction="unknown")(pred, target)
+            LocalNormalizedCrossCorrelationLoss(reduction="unknown")(pred, target)
         with self.assertRaisesRegex(ValueError, ""):
-            LocalNormalizedCrossCorrelationLoss(in_channels=3, reduction=None)(pred, target)
+            LocalNormalizedCrossCorrelationLoss(reduction=None)(pred, target)
 
 
 #     def test_script(self):

--- a/tests/test_reg_loss_integration.py
+++ b/tests/test_reg_loss_integration.py
@@ -22,17 +22,17 @@ TEST_CASES = [
     [BendingEnergyLoss, {}, ["pred"]],
     [
         LocalNormalizedCrossCorrelationLoss,
-        {"in_channels": 1, "kernel_size": 7, "kernel_type": "rectangular"},
+        {"kernel_size": 7, "kernel_type": "rectangular"},
         ["pred", "target"],
     ],
     [
         LocalNormalizedCrossCorrelationLoss,
-        {"in_channels": 1, "kernel_size": 5, "kernel_type": "triangular"},
+        {"kernel_size": 5, "kernel_type": "triangular"},
         ["pred", "target"],
     ],
     [
         LocalNormalizedCrossCorrelationLoss,
-        {"in_channels": 1, "kernel_size": 3, "kernel_type": "gaussian"},
+        {"kernel_size": 3, "kernel_type": "gaussian"},
         ["pred", "target"],
     ],
     [GlobalMutualInformationLoss, {"num_bins": 10}, ["pred", "target"]],


### PR DESCRIPTION
### Description
`in_channels` is not currently used in the LNCC

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
