### PR TITLE
Fix stdshift type error

### DIFF
--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -150,12 +150,20 @@ class StdShiftIntensity(Transform):
         nonzero: whether only count non-zero values.
         channel_wise: if True, calculate on each channel separately. Please ensure
             that the first dimension represents the channel of the image if True.
+        dtype: output data type, defaults to float32.
     """
 
-    def __init__(self, factor: float, nonzero: bool = False, channel_wise: bool = False) -> None:
+    def __init__(
+        self,
+        factor: float,
+        nonzero: bool = False,
+        channel_wise: bool = False,
+        dtype: DtypeLike = np.float32,
+    ) -> None:
         self.factor = factor
         self.nonzero = nonzero
         self.channel_wise = channel_wise
+        self.dtype = dtype
 
     def _stdshift(self, img: np.ndarray) -> np.ndarray:
         slices = (img != 0) if self.nonzero else np.ones(img.shape, dtype=bool)
@@ -169,8 +177,7 @@ class StdShiftIntensity(Transform):
         """
         Apply the transform to `img`.
         """
-        if img.dtype != float:
-            img = img.astype(float)
+        img = img.astype(self.dtype)
         if self.channel_wise:
             for i, d in enumerate(img):
                 img[i] = self._stdshift(d)
@@ -191,6 +198,7 @@ class RandStdShiftIntensity(RandomizableTransform):
         prob: float = 0.1,
         nonzero: bool = False,
         channel_wise: bool = False,
+        dtype: DtypeLike = np.float32,
     ) -> None:
         """
         Args:
@@ -199,6 +207,7 @@ class RandStdShiftIntensity(RandomizableTransform):
             prob: probability of std shift.
             nonzero: whether only count non-zero values.
             channel_wise: if True, calculate on each channel separately.
+            dtype: output data type, defaults to float32.
 
         """
         RandomizableTransform.__init__(self, prob)
@@ -210,6 +219,7 @@ class RandStdShiftIntensity(RandomizableTransform):
             self.factors = (min(factors), max(factors))
         self.nonzero = nonzero
         self.channel_wise = channel_wise
+        self.dtype = dtype
 
     def randomize(self, data: Optional[Any] = None) -> None:
         self.factor = self.R.uniform(low=self.factors[0], high=self.factors[1])
@@ -222,7 +232,9 @@ class RandStdShiftIntensity(RandomizableTransform):
         self.randomize()
         if not self._do_transform:
             return img
-        shifter = StdShiftIntensity(factor=self.factor, nonzero=self.nonzero, channel_wise=self.channel_wise)
+        shifter = StdShiftIntensity(
+            factor=self.factor, nonzero=self.nonzero, channel_wise=self.channel_wise, dtype=self.dtype
+        )
         return shifter(img)
 
 
@@ -313,7 +325,7 @@ class RandBiasField(RandomizableTransform):
         degree: degree of freedom of the polynomials. The value should be no less than 1.
             Defaults to 3.
         coeff_range: range of the random coefficients. Defaults to (0.0, 0.1).
-        dtype: output data type, defaut to float32.
+        dtype: output data type, defaults to float32.
         prob: probability to do random bias field.
 
     """
@@ -403,7 +415,7 @@ class NormalizeIntensity(Transform):
         nonzero: whether only normalize non-zero values.
         channel_wise: if using calculated mean and std, calculate on each channel separately
             or calculate on the entire image directly.
-        dtype: output data type, defaut to float32.
+        dtype: output data type, defaults to float32.
     """
 
     def __init__(

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -233,6 +233,7 @@ class StdShiftIntensityd(MapTransform):
         factor: float,
         nonzero: bool = False,
         channel_wise: bool = False,
+        dtype: DtypeLike = np.float32,
         allow_missing_keys: bool = False,
     ) -> None:
         """
@@ -243,10 +244,11 @@ class StdShiftIntensityd(MapTransform):
             nonzero: whether only count non-zero values.
             channel_wise: if True, calculate on each channel separately. Please ensure
                 that the first dimension represents the channel of the image if True.
+            dtype: output data type, defaults to float32.
             allow_missing_keys: don't raise exception if key is missing.
         """
         super().__init__(keys, allow_missing_keys)
-        self.shifter = StdShiftIntensity(factor, nonzero, channel_wise)
+        self.shifter = StdShiftIntensity(factor, nonzero, channel_wise, dtype)
 
     def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
         d = dict(data)
@@ -267,6 +269,7 @@ class RandStdShiftIntensityd(RandomizableTransform, MapTransform):
         prob: float = 0.1,
         nonzero: bool = False,
         channel_wise: bool = False,
+        dtype: DtypeLike = np.float32,
         allow_missing_keys: bool = False,
     ) -> None:
         """
@@ -278,6 +281,7 @@ class RandStdShiftIntensityd(RandomizableTransform, MapTransform):
             prob: probability of std shift.
             nonzero: whether only count non-zero values.
             channel_wise: if True, calculate on each channel separately.
+            dtype: output data type, defaults to float32.
             allow_missing_keys: don't raise exception if key is missing.
         """
         MapTransform.__init__(self, keys, allow_missing_keys)
@@ -291,6 +295,7 @@ class RandStdShiftIntensityd(RandomizableTransform, MapTransform):
             self.factors = (min(factors), max(factors))
         self.nonzero = nonzero
         self.channel_wise = channel_wise
+        self.dtype = dtype
 
     def randomize(self, data: Optional[Any] = None) -> None:
         self.factor = self.R.uniform(low=self.factors[0], high=self.factors[1])
@@ -301,7 +306,7 @@ class RandStdShiftIntensityd(RandomizableTransform, MapTransform):
         self.randomize()
         if not self._do_transform:
             return d
-        shifter = StdShiftIntensity(self.factor, self.nonzero, self.channel_wise)
+        shifter = StdShiftIntensity(self.factor, self.nonzero, self.channel_wise, self.dtype)
         for key in self.key_iterator(d):
             d[key] = shifter(d[key])
         return d
@@ -412,7 +417,7 @@ class RandBiasFieldd(RandomizableTransform, MapTransform):
             degree: degree of freedom of the polynomials. The value should be no less than 1.
                 Defaults to 3.
             coeff_range: range of the random coefficients. Defaults to (0.0, 0.1).
-            dtype: output data type, defaut to float32.
+            dtype: output data type, defaults to float32.
             prob: probability to do random bias field.
             allow_missing_keys: don't raise exception if key is missing.
 
@@ -449,7 +454,7 @@ class NormalizeIntensityd(MapTransform):
         nonzero: whether only normalize non-zero values.
         channel_wise: if using calculated mean and std, calculate on each channel separately
             or calculate on the entire image directly.
-        dtype: output data type, defaut to float32.
+        dtype: output data type, defaults to float32.
         allow_missing_keys: don't raise exception if key is missing.
     """
 

--- a/tests/test_std_shift_intensity.py
+++ b/tests/test_std_shift_intensity.py
@@ -34,7 +34,7 @@ class TestStdShiftIntensity(NumpyImageTestCase2D):
                 factor = np.random.rand()
                 std_shifter = StdShiftIntensity(factor=factor, nonzero=nonzero, channel_wise=channel_wise)
                 result = std_shifter(image)
-                np.testing.assert_equal(result, image)
+                np.testing.assert_allclose(result, image, rtol=1e-5)
 
     def test_nonzero(self):
         image = np.asarray([[4.0, 0.0, 2.0], [0, 2, 4]])  # std = 1
@@ -42,7 +42,7 @@ class TestStdShiftIntensity(NumpyImageTestCase2D):
         std_shifter = StdShiftIntensity(factor=factor, nonzero=True)
         result = std_shifter(image)
         expected = np.asarray([[4 + factor, 0, 2 + factor], [0, 2 + factor, 4 + factor]])
-        np.testing.assert_equal(result, expected)
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
 
     def test_channel_wise(self):
         image = np.stack((np.asarray([1.0, 2.0]), np.asarray([1.0, 1.0])))  # std: 0.5, 0
@@ -50,7 +50,7 @@ class TestStdShiftIntensity(NumpyImageTestCase2D):
         std_shifter = StdShiftIntensity(factor=factor, channel_wise=True)
         result = std_shifter(image)
         expected = np.stack((np.asarray([1 + 0.5 * factor, 2 + 0.5 * factor]), np.asarray([1, 1])))
-        np.testing.assert_equal(result, expected)
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
 
 
 if __name__ == "__main__":

--- a/tests/test_std_shift_intensityd.py
+++ b/tests/test_std_shift_intensityd.py
@@ -36,7 +36,7 @@ class TestStdShiftIntensityd(NumpyImageTestCase2D):
                 factor = np.random.rand()
                 std_shifter = StdShiftIntensityd(keys=[key], factor=factor, nonzero=nonzero, channel_wise=channel_wise)
                 result = std_shifter({key: image})
-                np.testing.assert_equal(result[key], image)
+                np.testing.assert_allclose(result[key], image, rtol=1e-5)
 
     def test_nonzero(self):
         key = "img"
@@ -45,7 +45,7 @@ class TestStdShiftIntensityd(NumpyImageTestCase2D):
         std_shifter = StdShiftIntensityd(keys=[key], factor=factor, nonzero=True)
         result = std_shifter({key: image})
         expected = np.asarray([[4 + factor, 0, 2 + factor], [0, 2 + factor, 4 + factor]])
-        np.testing.assert_equal(result[key], expected)
+        np.testing.assert_allclose(result[key], expected, rtol=1e-5)
 
     def test_channel_wise(self):
         key = "img"
@@ -54,7 +54,7 @@ class TestStdShiftIntensityd(NumpyImageTestCase2D):
         std_shifter = StdShiftIntensityd(keys=[key], factor=factor, channel_wise=True)
         result = std_shifter({key: image})
         expected = np.stack((np.asarray([1 + 0.5 * factor, 2 + 0.5 * factor]), np.asarray([1, 1])))
-        np.testing.assert_equal(result[key], expected)
+        np.testing.assert_allclose(result[key], expected, rtol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

### Description
This PR fixes the type error in StdShiftIntensity transform.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
