### PR TITLE
Update pathology unittests

### DIFF
--- a/tests/test_cuimage_reader.py
+++ b/tests/test_cuimage_reader.py
@@ -14,7 +14,7 @@ _, has_cim = optional_import("cucim")
 PILImage, has_pil = optional_import("PIL.Image")
 
 FILE_URL = "http://openslide.cs.cmu.edu/download/openslide-testdata/Generic-TIFF/CMU-1.tiff"
-FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", os.path.basename(FILE_URL))
+FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", "temp_" + os.path.basename(FILE_URL))
 
 HEIGHT = 32914
 WIDTH = 46000
@@ -105,7 +105,7 @@ class TestCuCIMReader(unittest.TestCase):
         image = {}
         reader = WSIReader("cuCIM")
         for mode in ["RGB", "RGBA"]:
-            file_path = self.create_rgba_image(img_expected, "test_cu_tiff_image", mode=mode)
+            file_path = self.create_rgba_image(img_expected, "temp_cu_tiff_image", mode=mode)
             img_obj = reader.read(file_path)
             image[mode], _ = reader.get_data(img_obj)
 

--- a/tests/test_masked_inference_wsi_dataset.py
+++ b/tests/test_masked_inference_wsi_dataset.py
@@ -15,11 +15,13 @@ _, has_cim = optional_import("cucim")
 _, has_osl = optional_import("openslide")
 
 FILE_URL = "http://openslide.cs.cmu.edu/download/openslide-testdata/Generic-TIFF/CMU-1.tiff"
-FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", os.path.basename(FILE_URL))
+base_name, extension = os.path.splitext(os.path.basename(FILE_URL))
+FILE_NAME = "temp_" + base_name
+FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", FILE_NAME + extension)
 
-MASK1 = os.path.join(os.path.dirname(__file__), "testing_data", "tissue_mask1.npy")
-MASK2 = os.path.join(os.path.dirname(__file__), "testing_data", "tissue_mask2.npy")
-MASK4 = os.path.join(os.path.dirname(__file__), "testing_data", "tissue_mask4.npy")
+MASK1 = os.path.join(os.path.dirname(__file__), "testing_data", "temp_tissue_mask1.npy")
+MASK2 = os.path.join(os.path.dirname(__file__), "testing_data", "temp_tissue_mask2.npy")
+MASK4 = os.path.join(os.path.dirname(__file__), "testing_data", "temp_tissue_mask4.npy")
 
 HEIGHT = 32914
 WIDTH = 46000
@@ -47,7 +49,7 @@ TEST_CASE_0 = [
     [
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [100, 100],
         },
     ],
@@ -62,12 +64,12 @@ TEST_CASE_1 = [
     [
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [100, 100],
         },
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [101, 100],
         },
     ],
@@ -82,22 +84,22 @@ TEST_CASE_2 = [
     [
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [100, 100],
         },
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [100, 101],
         },
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [101, 100],
         },
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [101, 101],
         },
     ],
@@ -121,7 +123,7 @@ TEST_CASE_3 = [
                 ],
                 dtype=np.uint8,
             ),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [100, 100],
         },
     ],
@@ -139,17 +141,17 @@ TEST_CASE_4 = [
     [
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [100, 100],
         },
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [100, 100],
         },
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [101, 100],
         },
     ],
@@ -167,7 +169,7 @@ TEST_CASE_OPENSLIDE_0 = [
     [
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [100, 100],
         },
     ],
@@ -182,12 +184,12 @@ TEST_CASE_OPENSLIDE_1 = [
     [
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [100, 100],
         },
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
-            "name": "CMU-1",
+            "name": FILE_NAME,
             "mask_location": [101, 100],
         },
     ],

--- a/tests/test_openslide_reader.py
+++ b/tests/test_openslide_reader.py
@@ -14,7 +14,7 @@ _, has_osl = optional_import("openslide")
 
 
 FILE_URL = "http://openslide.cs.cmu.edu/download/openslide-testdata/Generic-TIFF/CMU-1.tiff"
-FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", os.path.basename(FILE_URL))
+FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", "temp_" + os.path.basename(FILE_URL))
 
 HEIGHT = 32914
 WIDTH = 46000

--- a/tests/test_patch_wsi_dataset.py
+++ b/tests/test_patch_wsi_dataset.py
@@ -14,7 +14,7 @@ _, has_cim = optional_import("cucim")
 _, has_osl = optional_import("openslide")
 
 FILE_URL = "http://openslide.cs.cmu.edu/download/openslide-testdata/Generic-TIFF/CMU-1.tiff"
-FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", os.path.basename(FILE_URL))
+FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", "temp_" + os.path.basename(FILE_URL))
 
 TEST_CASE_0 = [
     {

--- a/tests/test_smartcache_patch_wsi_dataset.py
+++ b/tests/test_smartcache_patch_wsi_dataset.py
@@ -13,7 +13,7 @@ from monai.utils import optional_import
 _, has_cim = optional_import("cucim")
 
 FILE_URL = "http://openslide.cs.cmu.edu/download/openslide-testdata/Generic-TIFF/CMU-1.tiff"
-FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", os.path.basename(FILE_URL))
+FILE_PATH = os.path.join(os.path.dirname(__file__), "testing_data", "temp_" + os.path.basename(FILE_URL))
 
 TEST_CASE_0 = [
     {


### PR DESCRIPTION
### Description
This PR prepend "temp_" to all the pathology related test artifacts, including images, tissue masks, probability maps, in order to be easily recognized and ignored in `.gitignore`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
