### PR TITLE
fixes version of flake8-bugbear

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ scikit-image>=0.14.2
 tqdm>=4.47.0
 lmdb
 flake8>=3.8.1
-flake8-bugbear
+flake8-bugbear==21.3.2
 flake8-comprehensions
 flake8-executable
 flake8-pyi


### PR DESCRIPTION
### Description
the recent update of flake8-bugbear breaks the premerge checks.
https://github.com/Project-MONAI/MONAI/runs/2248500187?check_suite_focus=true#step:7:157

the previous version worked
https://github.com/Project-MONAI/MONAI/runs/2247959830?check_suite_focus=true#step:6:46

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
