### PR TITLE
fixes issue of typing with py3.6

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -41,7 +41,7 @@ jobs:
         # Git hub actions have 2 cores, so parallize pytype
         $(pwd)/runtests.sh --codeformat -j 2
 
-  quick-py3:  # full dependencies installed
+  quick-py3:  # full dependencies installed tests for different OS
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -105,7 +105,7 @@ jobs:
       env:
         QUICKTEST: True
 
-  min-dep-os:  # min dependencies installed
+  min-dep-os:  # min dependencies installed tests for different OS
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -154,7 +154,7 @@ jobs:
       env:
         QUICKTEST: True
 
-  min-dep-py3:  # min dependencies installed
+  min-dep-py3:  # min dependencies installed tests for different python
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - debug-release-rc
   pull_request:
 
 jobs:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - debug-release-rc
   pull_request:
 
 jobs:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -105,7 +105,7 @@ jobs:
       env:
         QUICKTEST: True
 
-  min-dep-py3:  # min dependencies installed
+  min-dep-os:  # min dependencies installed
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -138,6 +138,51 @@ jobs:
       name: Install torch cpu from pytorch.org (Windows only)
       run: |
         python -m pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    - name: Install the dependencies
+      run: |
+        # min. requirements
+        python -m pip install torch==1.8.1
+        python -m pip install -r requirements-min.txt
+        python -m pip list
+        BUILD_MONAI=0 python setup.py develop  # no compile of extensions
+      shell: bash
+    - name: Run quick tests (CPU ${{ runner.os }})
+      run: |
+        python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
+        python -c "import monai; monai.config.print_config()"
+        python -m tests.min_tests
+      env:
+        QUICKTEST: True
+
+  min-dep-py3:  # min dependencies installed
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7]
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Prepare pip wheel
+      run: |
+        which python
+        python -m pip install --user --upgrade pip setuptools wheel
+    - name: cache weekly timestamp
+      id: pip-cache
+      run: |
+        echo "::set-output name=datew::$(date '+%Y-%V')"
+        echo "::set-output name=dir::$(pip cache dir)"
+      shell: bash
+    - name: cache for pip
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ubuntu-latest-latest-pip-${{ steps.pip-cache.outputs.datew }}
     - name: Install the dependencies
       run: |
         # min. requirements

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'releases/*'
+      - debug-release-rc
     tags:
       - '*'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'releases/*'
-      - debug-release-rc
     tags:
       - '*'
 

--- a/monai/handlers/utils.py
+++ b/monai/handlers/utils.py
@@ -11,7 +11,7 @@
 
 import os
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -33,7 +33,7 @@ __all__ = [
 ]
 
 
-def stopping_fn_from_metric(metric_name: str) -> Callable[[Engine], Any]:
+def stopping_fn_from_metric(metric_name: str):
     """
     Returns a stopping function for ignite.handlers.EarlyStopping using the given metric name.
     """
@@ -44,7 +44,7 @@ def stopping_fn_from_metric(metric_name: str) -> Callable[[Engine], Any]:
     return stopping_fn
 
 
-def stopping_fn_from_loss() -> Callable[[Engine], Any]:
+def stopping_fn_from_loss():
     """
     Returns a stopping function for ignite.handlers.EarlyStopping using the loss value.
     """

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -16,7 +16,7 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 import logging
 import sys
 import time
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -26,14 +26,8 @@ from monai.transforms.transform import RandomizableTransform, Transform
 from monai.transforms.utils import extreme_points_to_image, get_extreme_points, map_binary_to_indices
 from monai.utils import ensure_tuple, min_version, optional_import
 
-if TYPE_CHECKING:
-    from PIL.Image import Image as PILImageImage
-    from PIL.Image import fromarray as pil_image_fromarray
-
-    has_pil = True
-else:
-    PILImageImage, has_pil = optional_import("PIL.Image", name="Image")
-    pil_image_fromarray, _ = optional_import("PIL.Image", name="fromarray")
+PILImageImage, has_pil = optional_import("PIL.Image", name="Image")
+pil_image_fromarray, _ = optional_import("PIL.Image", name="fromarray")
 
 __all__ = [
     "Identity",
@@ -302,7 +296,7 @@ class ToTensor(Transform):
     Converts the input image to a tensor without applying any other transformations.
     """
 
-    def __call__(self, img: Union[np.ndarray, torch.Tensor, PILImageImage]) -> torch.Tensor:
+    def __call__(self, img) -> torch.Tensor:
         """
         Apply the transform to `img` and make it contiguous.
         """
@@ -316,7 +310,7 @@ class ToNumpy(Transform):
     Converts the input data to numpy array, can support list or tuple of numbers and PyTorch Tensor.
     """
 
-    def __call__(self, img: Union[List, Tuple, np.ndarray, torch.Tensor, PILImageImage]) -> np.ndarray:
+    def __call__(self, img) -> np.ndarray:
         """
         Apply the transform to `img` and make it contiguous.
         """
@@ -330,7 +324,7 @@ class ToPIL(Transform):
     Converts the input image (in the form of NumPy array or PyTorch Tensor) to PIL image
     """
 
-    def __call__(self, img: Union[np.ndarray, torch.Tensor, PILImageImage]) -> PILImageImage:
+    def __call__(self, img):
         """
         Apply the transform to `img` and make it contiguous.
         """

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -17,7 +17,7 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 
 import copy
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -49,13 +49,6 @@ from monai.transforms.utility.array import (
 )
 from monai.transforms.utils import extreme_points_to_image, get_extreme_points
 from monai.utils import ensure_tuple, ensure_tuple_rep, optional_import
-
-if TYPE_CHECKING:
-    from PIL.Image import Image as PILImageImage
-
-    has_pil = True
-else:
-    PILImageImage, has_pil = optional_import("PIL.Image", name="Image")
 
 __all__ = [
     "Identityd",
@@ -402,8 +395,8 @@ class ToTensord(MapTransform):
         self.converter = ToTensor()
 
     def __call__(
-        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor, PILImageImage]]
-    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor, PILImageImage]]:
+        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]
+    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor]]:
         d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.converter(d[key])
@@ -425,9 +418,7 @@ class ToNumpyd(MapTransform):
         super().__init__(keys, allow_missing_keys)
         self.converter = ToNumpy()
 
-    def __call__(
-        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor, PILImageImage]]
-    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor, PILImageImage]]:
+    def __call__(self, data: Mapping[Hashable, Any]) -> Dict[Hashable, Any]:
         d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.converter(d[key])
@@ -449,9 +440,7 @@ class ToPILd(MapTransform):
         super().__init__(keys, allow_missing_keys)
         self.converter = ToPIL()
 
-    def __call__(
-        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor, PILImageImage]]
-    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor, PILImageImage]]:
+    def __call__(self, data: Mapping[Hashable, Any]) -> Dict[Hashable, Any]:
         d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.converter(d[key])

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -48,7 +48,7 @@ from monai.transforms.utility.array import (
     ToTensor,
 )
 from monai.transforms.utils import extreme_points_to_image, get_extreme_points
-from monai.utils import ensure_tuple, ensure_tuple_rep, optional_import
+from monai.utils import ensure_tuple, ensure_tuple_rep
 
 __all__ = [
     "Identityd",
@@ -394,9 +394,7 @@ class ToTensord(MapTransform):
         super().__init__(keys, allow_missing_keys)
         self.converter = ToTensor()
 
-    def __call__(
-        self, data: Mapping[Hashable, Union[np.ndarray, torch.Tensor]]
-    ) -> Dict[Hashable, Union[np.ndarray, torch.Tensor]]:
+    def __call__(self, data: Mapping[Hashable, Any]) -> Dict[Hashable, Any]:
         d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.converter(d[key])

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -96,14 +96,14 @@ def min_version(the_module, min_version_str: str = "") -> bool:
     Returns True if the module's version is greater or equal to the 'min_version'.
     When min_version_str is not provided, it always returns True.
     """
+    if not min_version_str:
+        return True  # always valid version
     if not hasattr(the_module, "__version__"):
         warnings.warn(f"{the_module} has no attribute __version__ in min_version check.")
         return True  # min_version is the default, shouldn't be noisy
-    if min_version_str:
-        mod_version = tuple(int(x) for x in the_module.__version__.split(".")[:2])
-        required = tuple(int(x) for x in min_version_str.split(".")[:2])
-        return mod_version >= required
-    return True  # always valid version
+    mod_version = tuple(int(x) for x in the_module.__version__.split(".")[:2])
+    required = tuple(int(x) for x in min_version_str.split(".")[:2])
+    return mod_version >= required
 
 
 def exact_version(the_module, version_str: str = "") -> bool:

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -94,6 +94,7 @@ def run_testsuit():
         "test_smartcachedataset",
         "test_spacing",
         "test_spacingd",
+        "test_senet",
         "test_surface_distance",
         "test_zoom",
         "test_zoom_affine",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -569,13 +569,14 @@ def query_memory(n=2):
     """
     Find best n idle devices and return a string of device ids.
     """
-    bash_string = "nvidia-smi --query-gpu=utilization.gpu,power.draw,memory.used --format=csv,noheader,nounits"
+    bash_string = "nvidia-smi --query-gpu=power.draw,temperature.gpu,memory.used --format=csv,noheader,nounits"
 
     try:
         p1 = Popen(bash_string.split(), stdout=PIPE)
         output, error = p1.communicate()
         free_memory = [x.split(",") for x in output.decode("utf-8").split("\n")[:-1]]
         free_memory = np.asarray(free_memory, dtype=float).T
+        free_memory[1] += free_memory[0]  # combine 0/1 column measures
         ids = np.lexsort(free_memory)[:n]
     except (FileNotFoundError, TypeError, IndexError):
         ids = range(n) if isinstance(n, int) else []


### PR DESCRIPTION
part of #1889 

### Description
- removes incompatible typing for py3.6 e.g. https://github.com/Project-MONAI/MONAI/runs/2266395083?check_suite_focus=true
- adds more quick python tests for python 3.6 3.7 with ubuntu latest
- remove the verbose warning message in get package version
- this will fix the release pipelines, verified: https://github.com/Project-MONAI/MONAI/actions/runs/717758760

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.

