### PR TITLE
TTA progress bar, use torch for mode, add label meta_data

### DIFF
--- a/monai/data/test_time_augmentation.py
+++ b/monai/data/test_time_augmentation.py
@@ -9,8 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from monai.utils.module import optional_import
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -24,6 +23,7 @@ from monai.transforms.inverse import InvertibleTransform
 from monai.transforms.transform import Randomizable
 from monai.transforms.utils import allow_missing_keys_mode
 from monai.utils.enums import CommonKeys, InverseKeys
+from monai.utils.module import optional_import
 
 if TYPE_CHECKING:
     from tqdm import tqdm

--- a/monai/data/test_time_augmentation.py
+++ b/monai/data/test_time_augmentation.py
@@ -9,7 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from monai.utils.module import optional_import
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Tuple, Union
 
 import numpy as np
 import torch
@@ -23,6 +24,13 @@ from monai.transforms.inverse import InvertibleTransform
 from monai.transforms.transform import Randomizable
 from monai.transforms.utils import allow_missing_keys_mode
 from monai.utils.enums import CommonKeys, InverseKeys
+
+if TYPE_CHECKING:
+    from tqdm import tqdm
+
+    has_tqdm = True
+else:
+    tqdm, has_tqdm = optional_import("tqdm", name="tqdm")
 
 __all__ = ["TestTimeAugmentation"]
 
@@ -57,6 +65,7 @@ class TestTimeAugmentation:
         return_full_data: normally, metrics are returned (mode, mean, std, vvc). Setting this flag to `True` will return the
             full data. Dimensions will be same size as when passing a single image through `inferrer_fn`, with a dimension appended
             equal in size to `num_examples` (N), i.e., `[N,C,H,W,[D]]`.
+        progress: whether to display a progress bar.
 
     Example:
         .. code-block:: python
@@ -80,6 +89,7 @@ class TestTimeAugmentation:
         image_key=CommonKeys.IMAGE,
         label_key=CommonKeys.LABEL,
         return_full_data: bool = False,
+        progress: bool = True,
     ) -> None:
         self.transform = transform
         self.batch_size = batch_size
@@ -89,6 +99,7 @@ class TestTimeAugmentation:
         self.image_key = image_key
         self.label_key = label_key
         self.return_full_data = return_full_data
+        self.progress = progress
 
         # check that the transform has at least one random component, and that all random transforms are invertible
         self._check_transforms()
@@ -143,7 +154,7 @@ class TestTimeAugmentation:
 
         outputs: List[np.ndarray] = []
 
-        for batch_data in dl:
+        for batch_data in tqdm(dl) if has_tqdm and self.progress else dl:
 
             batch_images = batch_data[self.image_key].to(self.device)
 
@@ -156,6 +167,10 @@ class TestTimeAugmentation:
 
             # create a dictionary containing the inferred batch and their transforms
             inferred_dict = {self.label_key: batch_output, label_transform_key: batch_data[label_transform_key]}
+            # if meta dict is present, add that too (required for some inverse transforms)
+            label_meta_dict_key = self.label_key + "_meta_dict"
+            if label_meta_dict_key in batch_data:
+                inferred_dict[label_meta_dict_key] = batch_data[label_meta_dict_key]
 
             # do inverse transformation (allow missing keys as only inverting label)
             with allow_missing_keys_mode(self.transform):  # type: ignore
@@ -171,7 +186,7 @@ class TestTimeAugmentation:
             return output
 
         # calculate metrics
-        mode: np.ndarray = np.apply_along_axis(lambda x: np.bincount(x).argmax(), axis=0, arr=output.astype(np.int64))
+        mode = np.array(torch.mode(torch.Tensor(output.astype(np.int64)), dim=0).values)
         mean: np.ndarray = np.mean(output, axis=0)  # type: ignore
         std: np.ndarray = np.std(output, axis=0)  # type: ignore
         vvc: float = (np.std(output) / np.mean(output)).item()

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -118,6 +118,7 @@ def run_testsuit():
         "test_ensure_channel_firstd",
         "test_handler_early_stop",
         "test_handler_transform_inverter",
+        "test_testtimeaugmentation",
     ]
     assert sorted(exclude_cases) == sorted(set(exclude_cases)), f"Duplicated items in {exclude_cases}"
 

--- a/tests/test_testtimeaugmentation.py
+++ b/tests/test_testtimeaugmentation.py
@@ -151,7 +151,7 @@ class TestTestTimeAugmentation(unittest.TestCase):
         tta = TestTimeAugmentation(transforms, batch_size=5, num_workers=0, inferrer_fn=lambda x: x, label_key="image")
         tta(self.get_data(1, (20, 20), include_label=False))
 
-    @unittest.skipUnless(has_nib)
+    @unittest.skipUnless(has_nib, "Requires nibabel")
     def test_requires_meta_dict(self):
         transforms = Compose([RandFlipd("image"), Spacingd("image", (1, 1))])
         tta = TestTimeAugmentation(transforms, batch_size=5, num_workers=0, inferrer_fn=lambda x: x, label_key="image")

--- a/tests/test_testtimeaugmentation.py
+++ b/tests/test_testtimeaugmentation.py
@@ -30,8 +30,10 @@ if TYPE_CHECKING:
     import tqdm
 
     has_tqdm = True
+    has_nib = True
 else:
     tqdm, has_tqdm = optional_import("tqdm")
+    _, has_nib = optional_import("nibabel")
 
 trange = partial(tqdm.trange, desc="training") if has_tqdm else range
 
@@ -149,6 +151,7 @@ class TestTestTimeAugmentation(unittest.TestCase):
         tta = TestTimeAugmentation(transforms, batch_size=5, num_workers=0, inferrer_fn=lambda x: x, label_key="image")
         tta(self.get_data(1, (20, 20), include_label=False))
 
+    @unittest.skipUnless(has_nib)
     def test_requires_meta_dict(self):
         transforms = Compose([RandFlipd("image"), Spacingd("image", (1, 1))])
         tta = TestTimeAugmentation(transforms, batch_size=5, num_workers=0, inferrer_fn=lambda x: x, label_key="image")


### PR DESCRIPTION
### Description
A few updates to TTA:

- Progress bar
- Use torch for computing mode (quicker than numpy)
- Include the `meta_dict` as this is required for the inverse of `Orientationd`, `Spacingd`, etc.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
