### PR TITLE
fix comprehension error

### DIFF
--- a/monai/networks/nets/efficientnet.py
+++ b/monai/networks/nets/efficientnet.py
@@ -768,7 +768,7 @@ def _calculate_output_image_size(input_image_size: List[int], stride: Union[int,
 
     # checks to extract integer stride in case tuple was received
     if isinstance(stride, tuple):
-        all_strides_equal = all([stride[0] == s for s in stride])
+        all_strides_equal = all(stride[0] == s for s in stride)
         if not all_strides_equal:
             raise ValueError("unequal strides are not possible, got {}".format(stride))
 


### PR DESCRIPTION
Fixes local flake8 error:

```
monai/networks/nets/efficientnet.py:771:29: C407 Unnecessary list comprehension - 'all' can take a generator.
1     C407 Unnecessary list comprehension - 'all' can take a generator.
```

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
