### PR TITLE
Transpose tissue masks for pathology inference

### DIFF
--- a/monai/apps/pathology/datasets.py
+++ b/monai/apps/pathology/datasets.py
@@ -228,7 +228,7 @@ class MaskedInferenceWSIDataset(Dataset):
         }
         """
         image = self.image_reader.read(sample["image"])
-        mask = np.load(sample["mask"]).T
+        mask = np.load(sample["mask"])
         try:
             level, ratio = self._calculate_mask_level(image, mask)
         except ValueError as err:

--- a/tests/test_masked_inference_wsi_dataset.py
+++ b/tests/test_masked_inference_wsi_dataset.py
@@ -40,10 +40,10 @@ WIDTH = 46000
 
 def prepare_data():
 
-    mask = np.zeros((WIDTH // 2, HEIGHT // 2))
+    mask = np.zeros((HEIGHT // 2, WIDTH // 2))
     mask[100, 100] = 1
     np.save(MASK1, mask)
-    mask[100, 100:102] = 1
+    mask[100, 101] = 1
     np.save(MASK2, mask)
     mask[100:102, 100:102] = 1
     np.save(MASK4, mask)
@@ -81,7 +81,7 @@ TEST_CASE_1 = [
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
             "name": FILE_NAME,
-            "mask_location": [101, 100],
+            "mask_location": [100, 101],
         },
     ],
 ]
@@ -163,7 +163,7 @@ TEST_CASE_4 = [
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
             "name": FILE_NAME,
-            "mask_location": [101, 100],
+            "mask_location": [100, 101],
         },
     ],
 ]
@@ -201,7 +201,7 @@ TEST_CASE_OPENSLIDE_1 = [
         {
             "image": np.array([[[243]], [[243]], [[243]]], dtype=np.uint8),
             "name": FILE_NAME,
-            "mask_location": [101, 100],
+            "mask_location": [100, 101],
         },
     ],
 ]


### PR DESCRIPTION
### Description
This PR modify the pathology inference dataset to assume the tissue masks have the shape of HxW as the  whole slide images at different levels.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
