### PR TITLE
update box_start/end for deepgrow

### DIFF
--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -478,8 +478,8 @@ class SpatialCropForegroundd(MapTransform):
 
         if np.all(np.less(current_size, self.spatial_size)):
             cropper = SpatialCrop(roi_center=center, roi_size=self.spatial_size)
-            box_start = cropper.roi_start
-            box_end = cropper.roi_end
+            box_start = np.array([s.start for s in cropper.slices])
+            box_end = np.array([s.stop for s in cropper.slices])
         else:
             cropper = SpatialCrop(roi_start=box_start, roi_end=box_end)
 

--- a/tests/test_deepgrow_transforms.py
+++ b/tests/test_deepgrow_transforms.py
@@ -176,6 +176,19 @@ CROP_TEST_CASE_1 = [
     np.array([[[[1, 2, 1], [2, 3, 2], [1, 2, 1]]]]),
 ]
 
+CROP_TEST_CASE_2 = [
+    {
+        "keys": ["image", "label"],
+        "source_key": "label",
+        "select_fn": lambda x: x > 0,
+        "channel_indices": None,
+        "margin": 0,
+        "spatial_size": [2, 4, 4],
+    },
+    DATA_1,
+    np.array([1, 1, 4, 4]),
+]
+
 ADD_INITIAL_POINT_TEST_CASE_1 = [
     {"label": "label", "guidance": "guidance", "sids": "sids"},
     DATA_1,
@@ -359,6 +372,11 @@ class TestSpatialCropForegroundd(unittest.TestCase):
     def test_correct_results(self, arguments, input_data, expected_result):
         result = SpatialCropForegroundd(**arguments)(input_data)
         np.testing.assert_allclose(result["image"], expected_result)
+
+    @parameterized.expand([CROP_TEST_CASE_2])
+    def test_correct_shape(self, arguments, input_data, expected_shape):
+        result = SpatialCropForegroundd(**arguments)(input_data)
+        np.testing.assert_equal(result["image"].shape, expected_shape)
 
     @parameterized.expand([CROP_TEST_CASE_1])
     def test_foreground_position(self, arguments, input_data, _):


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/2087.

### Description
Update method for getting start and stop of bounding box from `slices`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
