### PR TITLE
only pip install cucim if on linux

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,5 +30,5 @@ Sphinx==3.5.3
 recommonmark==0.6.0
 sphinx-autodoc-typehints==1.11.1
 sphinx-rtd-theme==0.5.2
-cucim~=0.19.0
+cucim~=0.19.0; platform_system == "Linux"
 openslide-python==1.1.2


### PR DESCRIPTION
### Description

Only pip install cucim if on linux. The requirements-dev.txt, as it currently stands, causes an error on non-linux machines, meaning that following requirements don't get installed.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
