### PR TITLE
create meta data key if necessary

### DIFF
--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -198,6 +198,9 @@ class Spacingd(MapTransform, InvertibleTransform):
             d, self.mode, self.padding_mode, self.align_corners, self.dtype
         ):
             meta_data_key = f"{key}_{self.meta_key_postfix}"
+            # create metadata if necessary
+            if meta_data_key not in d:
+                d[meta_data_key] = {"affine": None}
             meta_data = d[meta_data_key]
             # resample array of each corresponding key
             # using affine fetched from d[affine_key]

--- a/tests/test_spacingd.py
+++ b/tests/test_spacingd.py
@@ -33,6 +33,14 @@ class TestSpacingDCase(unittest.TestCase):
         np.testing.assert_allclose(res["image"].shape, (2, 10, 10))
         np.testing.assert_allclose(res["image_meta_dict"]["affine"], np.diag((1, 2, 1)))
 
+    def test_spacingd_2d_no_spacing(self):
+        data = {"image": np.ones((2, 10, 20))}
+        spacing = Spacingd(keys="image", pixdim=(1, 2, 1.4))
+        res = spacing(data)
+        self.assertEqual(("image", "image_meta_dict", "image_transforms"), tuple(sorted(res)))
+        np.testing.assert_allclose(res["image"].shape, (2, 10, 10))
+        np.testing.assert_allclose(res["image_meta_dict"]["affine"], np.diag((1, 2, 1)))
+
     def test_interp_all(self):
         data = {
             "image": np.arange(20).reshape((2, 1, 10)),


### PR DESCRIPTION
Not all images will have been read from file, meaning `img_meta_data` won't necessarily be present. The user may still want to change voxel spacing, in which case the original affine is assumed to be identity. However, previously an error would be thrown if the meta data wasn't present. Here, we create it if necessary.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
