### PR TITLE
Fix 2129 - CUDA required dependencies

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -77,6 +77,9 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ matrix.os }}-latest-pip-${{ steps.pip-cache.outputs.datew }}
+    - name: Remove CUDA-required dependencies
+      run: |
+        python -c "f=open('requirements-dev.txt', 'r'); txt=f.readlines(); f.close(); print(txt); f=open('requirements-dev.txt', 'w'); f.writelines([t for t in txt if not t.startswith('cupy')]); f.close()"
     - if: runner.os == 'windows'
       name: Install torch cpu from pytorch.org (Windows only)
       run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,3 +32,4 @@ sphinx-autodoc-typehints==1.11.1
 sphinx-rtd-theme==0.5.2
 cucim~=0.19.0; platform_system == "Linux"
 openslide-python==1.1.2
+cupy==8.6.0


### PR DESCRIPTION
Fixes #2129 

### Description
This PR adds cupy dependency (which requires CUDA), and modifies CI/CD workflow to exclude the dependencies that requires CUDA for non-CUDA instances with full dependency installation (quick-py3).

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
