### PR TITLE
initial network consistency test

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -281,7 +281,7 @@ jobs:
         python -m pip list
     - name: Run quick tests (GPU)
       run: |
-        git clone --depth 1 --branch master --single-branch \
+        git clone --depth 1 \
           https://github.com/Project-MONAI/MONAI-extra-test-data.git /MONAI-extra-test-data
         export MONAI_EXTRA_TEST_DATA="/MONAI-extra-test-data"
         nvidia-smi

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -260,7 +260,8 @@ jobs:
           libboost-test-dev \
           libgoogle-glog-dev \
           libjsoncpp-dev \
-          cmake && \
+          cmake \
+          git && \
         rm -rf /var/lib/apt/lists/* && \
         export PYTHONIOENCODING=utf-8 LC_ALL=C.UTF-8 && \
         rm -f /usr/bin/python && \
@@ -280,6 +281,9 @@ jobs:
         python -m pip list
     - name: Run quick tests (GPU)
       run: |
+        git clone --depth 1 --branch master --single-branch \
+          https://github.com/Project-MONAI/MONAI-extra-test-data.git /MONAI-extra-test-data
+        export MONAI_EXTRA_TEST_DATA="/MONAI-extra-test-data"
         nvidia-smi
         export LAUNCH_DELAY=$(python -c "import numpy; print(numpy.random.randint(30) * 10)")
         echo "Sleep $LAUNCH_DELAY"

--- a/tests/test_network_consistency.py
+++ b/tests/test_network_consistency.py
@@ -1,0 +1,68 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import unittest
+from glob import glob
+from unittest.case import skipIf
+
+import torch
+from parameterized.parameterized import parameterized
+
+import monai.networks.nets as nets
+
+extra_test_data_dir = os.environ.get("MONAI_EXTRA_TEST_DATA", None)
+
+TESTS = []
+if extra_test_data_dir is not None:
+    for data_path in glob(os.path.join(extra_test_data_dir, "**", "*.pt")):
+        json_path = data_path[:-3] + ".json"
+        # net_name is filename until first underscore (e.g., unet_0.pt is unet)
+        net_name = os.path.basename(data_path).split("_")[0]
+        TESTS.append((net_name, data_path, json_path))
+
+
+class TestNetworkConsistency(unittest.TestCase):
+    @skipIf(
+        len(TESTS) == 0,
+        "To run these tests, clone https://github.com/Project-MONAI/MONAI-extra-test-data and set MONAI_EXTRA_TEST_DATA",
+    )
+    @parameterized.expand(TESTS, skip_on_empty=True)
+    def test_network_consistency(self, net_name, data_path, json_path):
+
+        print("Net name: " + net_name)
+        print("Data path: " + data_path)
+        print("JSON path: " + json_path)
+
+        # Load data
+        loaded_data = torch.load(data_path)
+
+        # Load json from file
+        json_file = open(json_path)
+        model_params = json.load(json_file)
+        json_file.close()
+
+        # Create model
+        model = nets.__dict__[net_name](**model_params)
+        model.load_state_dict(loaded_data["model"])
+        model.eval()
+
+        in_data = loaded_data["in_data"]
+        expected_out_data = loaded_data["out_data"]
+
+        actual_out_data = model(in_data)
+
+        torch.testing.assert_allclose(actual_out_data, expected_out_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Suggested format of testing network consistency. Uses a git submodule to store the data so as not to clog up the main repository. Currently this submodule sits in my user area, but this would obviously be migrated to Project-MONAI.

The idea would be that if the submodule is present, it'll loop over each of the folders in the submodule, load the network (required creating a network factory), and checking consistency of forward pass.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
