### PR TITLE
fix set visible devices

### DIFF
--- a/monai/data/test_time_augmentation.py
+++ b/monai/data/test_time_augmentation.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Union
 
 import numpy as np
 import torch

--- a/monai/data/test_time_augmentation.py
+++ b/monai/data/test_time_augmentation.py
@@ -89,7 +89,7 @@ class TestTimeAugmentation:
         batch_size: int,
         num_workers: int,
         inferrer_fn: Callable,
-        device: Union[str, torch.device] = torch.device("cpu"),
+        device: Union[str, torch.device] = "cpu",
         image_key=CommonKeys.IMAGE,
         label_key=CommonKeys.LABEL,
         meta_key_postfix="meta_dict",

--- a/monai/data/test_time_augmentation.py
+++ b/monai/data/test_time_augmentation.py
@@ -89,7 +89,7 @@ class TestTimeAugmentation:
         batch_size: int,
         num_workers: int,
         inferrer_fn: Callable,
-        device: Optional[Union[str, torch.device]] = "cuda" if torch.cuda.is_available() else "cpu",
+        device: Optional[Union[str, torch.device]] = None,
         image_key=CommonKeys.IMAGE,
         label_key=CommonKeys.LABEL,
         meta_key_postfix="meta_dict",
@@ -100,7 +100,7 @@ class TestTimeAugmentation:
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.inferrer_fn = inferrer_fn
-        self.device = device
+        self.device = device or "cuda" if torch.cuda.is_available() else "cpu"
         self.image_key = image_key
         self.label_key = label_key
         self.meta_key_postfix = meta_key_postfix

--- a/monai/data/test_time_augmentation.py
+++ b/monai/data/test_time_augmentation.py
@@ -89,7 +89,7 @@ class TestTimeAugmentation:
         batch_size: int,
         num_workers: int,
         inferrer_fn: Callable,
-        device: Optional[Union[str, torch.device]] = None,
+        device: Union[str, torch.device] = torch.device("cpu"),
         image_key=CommonKeys.IMAGE,
         label_key=CommonKeys.LABEL,
         meta_key_postfix="meta_dict",
@@ -100,7 +100,7 @@ class TestTimeAugmentation:
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.inferrer_fn = inferrer_fn
-        self.device = device or "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = device
         self.image_key = image_key
         self.label_key = label_key
         self.meta_key_postfix = meta_key_postfix

--- a/tests/test_set_visible_devices.py
+++ b/tests/test_set_visible_devices.py
@@ -9,10 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from tests.utils import skip_if_no_cuda
 import unittest
-from unittest.case import skipUnless
 import os
-import torch
 
 class TestVisibleDevices(unittest.TestCase):
     @staticmethod
@@ -20,13 +19,13 @@ class TestVisibleDevices(unittest.TestCase):
         value = os.system(code_to_execute)
         return int(bin(value).replace("0b", "").rjust(16, '0')[:8], 2)
 
-    @skipUnless(torch.cuda.device_count() > 1, "Requires at least 2 CUDA devices")
+    @skip_if_no_cuda
     def test_visible_devices(self):
         num_gpus_before = self.run_process_and_get_exit_code(
-            "python -c \"import os; import torch; os.environ['CUDA_VISIBLE_DEVICES'] = '0'; exit(torch.cuda.device_count())\""
+            "python -c \"import os; import torch; os.environ['CUDA_VISIBLE_DEVICES'] = ''; exit(torch.cuda.device_count())\""
         )
         num_gpus_after = self.run_process_and_get_exit_code(
-            "python -c \"import os; import monai; import torch; os.environ['CUDA_VISIBLE_DEVICES'] = '0'; exit(torch.cuda.device_count())\""
+            "python -c \"import os; import monai; import torch; os.environ['CUDA_VISIBLE_DEVICES'] = ''; exit(torch.cuda.device_count())\""
         )
         self.assertEqual(num_gpus_before, num_gpus_after)
 

--- a/tests/test_set_visible_devices.py
+++ b/tests/test_set_visible_devices.py
@@ -9,23 +9,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tests.utils import skip_if_no_cuda
-import unittest
 import os
+import unittest
+
+from tests.utils import skip_if_no_cuda
+
 
 class TestVisibleDevices(unittest.TestCase):
     @staticmethod
     def run_process_and_get_exit_code(code_to_execute):
         value = os.system(code_to_execute)
-        return int(bin(value).replace("0b", "").rjust(16, '0')[:8], 2)
+        return int(bin(value).replace("0b", "").rjust(16, "0")[:8], 2)
 
     @skip_if_no_cuda
     def test_visible_devices(self):
         num_gpus_before = self.run_process_and_get_exit_code(
-            "python -c \"import os; import torch; os.environ['CUDA_VISIBLE_DEVICES'] = ''; exit(torch.cuda.device_count())\""
+            'python -c "import os; import torch; '
+            + "os.environ['CUDA_VISIBLE_DEVICES'] = ''; exit(torch.cuda.device_count())\""
         )
         num_gpus_after = self.run_process_and_get_exit_code(
-            "python -c \"import os; import monai; import torch; os.environ['CUDA_VISIBLE_DEVICES'] = ''; exit(torch.cuda.device_count())\""
+            'python -c "import os; import monai; import torch; '
+            + "os.environ['CUDA_VISIBLE_DEVICES'] = ''; exit(torch.cuda.device_count())\""
         )
         self.assertEqual(num_gpus_before, num_gpus_after)
 

--- a/tests/test_set_visible_devices.py
+++ b/tests/test_set_visible_devices.py
@@ -1,0 +1,35 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.case import skipUnless
+import os
+import torch
+
+class TestVisibleDevices(unittest.TestCase):
+    @staticmethod
+    def run_process_and_get_exit_code(code_to_execute):
+        value = os.system(code_to_execute)
+        return int(bin(value).replace("0b", "").rjust(16, '0')[:8], 2)
+
+    @skipUnless(torch.cuda.device_count() > 1, "Requires at least 2 CUDA devices")
+    def test_visible_devices(self):
+        num_gpus_before = self.run_process_and_get_exit_code(
+            "python -c \"import os; import torch; os.environ['CUDA_VISIBLE_DEVICES'] = '0'; exit(torch.cuda.device_count())\""
+        )
+        num_gpus_after = self.run_process_and_get_exit_code(
+            "python -c \"import os; import monai; import torch; os.environ['CUDA_VISIBLE_DEVICES'] = '0'; exit(torch.cuda.device_count())\""
+        )
+        self.assertEqual(num_gpus_before, num_gpus_after)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/2161.

### Description
In TestTimeAugmentation, I called `torch.cuda` as a default argument to a constructor. This meant that the following code previously worked and now didn't:

```python
import os
import monai
os.environ["CUDA_VISIBLE_DEVICES"] = '0'
```

I fixed the problem and also created a unit test to avoid it happening in the future. The trick is that we shouldn't call `torch.cuda.` during `import monai`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
