### PR TITLE
2099 - enhances dataloader/randomizable docstrings

### DIFF
--- a/monai/transforms/croppad/batch.py
+++ b/monai/transforms/croppad/batch.py
@@ -58,7 +58,6 @@ class PadListDataCollate(InvertibleTransform):
     pass the inverse through multiprocessing.
 
     Args:
-        batch: batch of data to pad-collate
         method: padding method (see :py:class:`monai.transforms.SpatialPad`)
         mode: padding mode (see :py:class:`monai.transforms.SpatialPad`)
     """
@@ -72,6 +71,10 @@ class PadListDataCollate(InvertibleTransform):
         self.mode = mode
 
     def __call__(self, batch: Any):
+        """
+        Args:
+            batch: batch of data to pad-collate
+        """
         # data is either list of dicts or list of lists
         is_list_of_dicts = isinstance(batch[0], dict)
         # loop over items inside of each element in a batch

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -73,8 +73,12 @@ def apply_transform(transform: Callable, data, map_items: bool = True):
 
 class Randomizable(ABC):
     """
-    An interface for handling random state locally, currently based on a class variable `R`,
-    which is an instance of `np.random.RandomState`.
+    An interface for handling random state locally, currently based on a class
+    variable `R`, which is an instance of `np.random.RandomState`.  This
+    provides the flexibility of component-specific determinism without
+    affecting the global states.  It is recommended to use this API with
+    :py:class:`monai.data.DataLoader` for deterministic behaviour of the
+    preprocessing pipelines.
     """
 
     R: np.random.RandomState = np.random.RandomState()


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

### Description
docstring updates with a new test case.
fixes #2099 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
