### PR TITLE
fixes logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/Project-MONAI/MONAI/blob/dev/docs/images/MONAI-logo-color.png" width="50%" alt='project-monai'>
+  <img src="https://raw.githubusercontent.com/Project-MONAI/MONAI/dev/docs/images/MONAI-logo-color.png" width="50%" alt='project-monai'>
 </p>
 
 **M**edical **O**pen **N**etwork for **AI**


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

### Description
the logo link in the readme is broken on the pypi page, even though it works fine on github
![Screenshot 2021-05-14 at 22 14 32](https://user-images.githubusercontent.com/831580/118332292-c46cee00-b501-11eb-91ba-7984512071be.png)

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).

