### PR TITLE
2179 Add warnings for inf/nan surface distance

### DIFF
--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import Tuple, Union
 
 import numpy as np
@@ -189,9 +190,11 @@ def get_surface_distance(
 
     if not np.any(seg_gt):
         dis = np.inf * np.ones_like(seg_gt)
+        warnings.warn("ground truth is all 0, this may result in nan/inf distance.")
     else:
         if not np.any(seg_pred):
             dis = np.inf * np.ones_like(seg_gt)
+            warnings.warn("prediction is all 0, this may result in nan/inf distance.")
             return np.asarray(dis[seg_gt])
         if distance_metric == "euclidean":
             dis = distance_transform_edt(~seg_gt)


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Related to #2179 .

### Description
In this PR, warnings are added in `get_surface_distance`, this function is called for both hausdorff distance and surface distance metrics.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
