### PR TITLE
allow sequence for network consistency

### DIFF
--- a/tests/test_network_consistency.py
+++ b/tests/test_network_consistency.py
@@ -13,6 +13,7 @@ import json
 import os
 import unittest
 from glob import glob
+from typing import Sequence
 from unittest.case import skipIf
 
 import torch
@@ -61,7 +62,14 @@ class TestNetworkConsistency(unittest.TestCase):
 
         actual_out_data = model(in_data)
 
-        torch.testing.assert_allclose(actual_out_data, expected_out_data)
+        self.check_output_consistency(actual_out_data, expected_out_data)
+
+    def check_output_consistency(self, actual, expected):
+        if isinstance(actual, Sequence):
+            for a, e in zip(actual, expected):
+                self.check_output_consistency(a, e)
+        else:
+            torch.testing.assert_allclose(actual, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow a sequence of outputs from network to be checked

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
