### PR TITLE
inverse adjust contrast

### DIFF
--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -623,7 +623,7 @@ class AdjustContrast(Transform):
     """
     Changes image intensity by gamma. Each pixel/voxel intensity is updated as::
 
-        x = ((x - min) / intensity_range) ^ gamma * intensity_range + min
+        x' = ((x - min) / intensity_range) ^ gamma * intensity_range + min
 
     Args:
         gamma: gamma value to adjust the contrast as function.
@@ -642,6 +642,16 @@ class AdjustContrast(Transform):
         img_min = img.min()
         img_range = img.max() - img_min
         return np.power(((img - img_min) / float(img_range + epsilon)), self.gamma) * img_range + img_min
+
+    @staticmethod
+    def inverse(img: Union[np.ndarray, torch.Tensor], old_min: float, old_max: float, gamma: float):
+        """Inverse method. Pass the min and max of the original image, as well as the
+        gamma that was used. Inverse is:
+
+            x = old_min + old_range * ((x' - old_min) / old_range) ** (1/gamma)
+        """
+        _range = old_max - old_min
+        return old_min + _range * ((img - old_min) / _range) ** (1 / gamma)
 
 
 class RandAdjustContrast(RandomizableTransform):

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -16,6 +16,7 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
 from collections.abc import Iterable
+from copy import deepcopy
 from typing import Any, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -38,8 +39,10 @@ from monai.transforms.intensity.array import (
     StdShiftIntensity,
     ThresholdIntensity,
 )
+from monai.transforms.inverse import InvertibleTransform
 from monai.transforms.transform import MapTransform, RandomizableTransform
 from monai.utils import dtype_torch_to_numpy, ensure_tuple_rep, ensure_tuple_size
+from monai.utils.enums import InverseKeys
 
 __all__ = [
     "RandGaussianNoised",
@@ -610,7 +613,7 @@ class ScaleIntensityRanged(MapTransform):
         return d
 
 
-class AdjustContrastd(MapTransform):
+class AdjustContrastd(MapTransform, InvertibleTransform):
     """
     Dictionary-based wrapper of :py:class:`monai.transforms.AdjustContrast`.
     Changes image intensity by gamma. Each pixel/voxel intensity is updated as:
@@ -631,11 +634,24 @@ class AdjustContrastd(MapTransform):
     def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
         d = dict(data)
         for key in self.key_iterator(d):
+            self.push_transform(d, key, extra_info={"min": d[key].min(), "max": d[key].max()})
             d[key] = self.adjuster(d[key])
         return d
 
+    def inverse(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
+        d = deepcopy(dict(data))
 
-class RandAdjustContrastd(RandomizableTransform, MapTransform):
+        for key in self.key_iterator(d):
+            transform = self.get_most_recent_transform(d, key)
+            _min = transform[InverseKeys.EXTRA_INFO]["min"]
+            _max = transform[InverseKeys.EXTRA_INFO]["max"]
+            d[key] = AdjustContrast.inverse(d[key], _min, _max, self.adjuster.gamma)
+            # Remove the applied transform
+            self.pop_transform(d, key)
+        return d
+
+
+class RandAdjustContrastd(RandomizableTransform, MapTransform, InvertibleTransform):
     """
     Dictionary-based version :py:class:`monai.transforms.RandAdjustContrast`.
     Randomly changes image intensity by gamma. Each pixel/voxel intensity is updated as:
@@ -683,11 +699,27 @@ class RandAdjustContrastd(RandomizableTransform, MapTransform):
         self.randomize()
         if self.gamma_value is None:
             raise AssertionError
-        if not self._do_transform:
-            return d
+
         adjuster = AdjustContrast(self.gamma_value)
         for key in self.key_iterator(d):
-            d[key] = adjuster(d[key])
+            self.push_transform(
+                d, key, extra_info={"min": d[key].min(), "max": d[key].max(), "gamma": self.gamma_value}
+            )
+            if self._do_transform:
+                d[key] = adjuster(d[key])
+        return d
+
+    def inverse(self, data: Mapping[Hashable, np.ndarray]) -> Dict[Hashable, np.ndarray]:
+        d = deepcopy(dict(data))
+
+        for key in self.key_iterator(d):
+            transform = self.get_most_recent_transform(d, key)
+            _min = transform[InverseKeys.EXTRA_INFO]["min"]
+            _max = transform[InverseKeys.EXTRA_INFO]["max"]
+            _gamma = transform[InverseKeys.EXTRA_INFO]["gamma"]
+            d[key] = AdjustContrast.inverse(d[key], _min, _max, _gamma)
+            # Remove the applied transform
+            self.pop_transform(d, key)
         return d
 
 

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -25,6 +25,7 @@ from monai.data.utils import decollate_batch
 from monai.networks.nets import UNet
 from monai.transforms import (
     AddChanneld,
+    AdjustContrastd,
     Affined,
     BatchInverseTransform,
     BorderPadd,
@@ -36,6 +37,7 @@ from monai.transforms import (
     InvertibleTransform,
     LoadImaged,
     Orientationd,
+    RandAdjustContrastd,
     RandAffined,
     RandAxisFlipd,
     RandFlipd,
@@ -437,6 +439,24 @@ TESTS.append(
         "3D",
         0,
         RandAffined(KEYS, spatial_size=None, prob=0),
+    )
+)
+
+TESTS.append(
+    (
+        "AdjustContrast 3d",
+        "3D",
+        1e-7,
+        AdjustContrastd(KEYS, gamma=13.4),
+    )
+)
+
+TESTS.append(
+    (
+        "AdjustContrast 3d",
+        "3D",
+        1e-7,
+        RandAdjustContrastd(KEYS, prob=1),
     )
 )
 


### PR DESCRIPTION
Starts to address https://github.com/Project-MONAI/MONAI/issues/2213.

### Description
Add inverse for `AdjustContrastd` and `RandAdjustContrastd`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
