### PR TITLE
2172 caching grid for randaffine

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -1443,7 +1443,7 @@ class RandAffine(RandomizableTransform):
         if spatial_size != fall_back_tuple(spatial_size, [1] * ndim) or spatial_size != fall_back_tuple(
             spatial_size, [2] * ndim
         ):
-            raise RuntimeError(f"spatial_size should not by dynamic, got {spatial_size}.")
+            raise RuntimeError(f"spatial_size should not be dynamic, got {spatial_size}.")
         return create_grid(spatial_size=spatial_size) if self._cached_grid is None else self._cached_grid
 
     def set_random_state(

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -678,6 +678,7 @@ class RandAffined(RandomizableTransform, MapTransform, InvertibleTransform):
         scale_range: Optional[Union[Sequence[Union[Tuple[float, float], float]], float]] = None,
         mode: GridSampleModeSequence = GridSampleMode.BILINEAR,
         padding_mode: GridSamplePadModeSequence = GridSamplePadMode.REFLECTION,
+        cache_grid: bool = False,
         as_tensor_output: bool = True,
         device: Optional[torch.device] = None,
         allow_missing_keys: bool = False,
@@ -711,6 +712,9 @@ class RandAffined(RandomizableTransform, MapTransform, InvertibleTransform):
                 Padding mode for outside grid values. Defaults to ``"reflection"``.
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
                 It also can be a sequence of string, each element corresponds to a key in ``keys``.
+            cache_grid: whether to cache the identity sampling grid.
+                If the spatial size is not dynamically defined by input image, enabling this option could
+                accelerate the transform.
             as_tensor_output: the computation is implemented using pytorch tensors, this option specifies
                 whether to convert it back to numpy arrays.
             device: device on which the tensor will be allocated.
@@ -729,6 +733,7 @@ class RandAffined(RandomizableTransform, MapTransform, InvertibleTransform):
             translate_range=translate_range,
             scale_range=scale_range,
             spatial_size=spatial_size,
+            cache_grid=cache_grid,
             as_tensor_output=as_tensor_output,
             device=device,
         )
@@ -753,15 +758,17 @@ class RandAffined(RandomizableTransform, MapTransform, InvertibleTransform):
         self.randomize()
 
         sp_size = fall_back_tuple(self.rand_affine.spatial_size, data[self.keys[0]].shape[1:])
-        if self._do_transform:
-            grid = self.rand_affine.rand_affine_grid(spatial_size=sp_size)
-            affine = self.rand_affine.rand_affine_grid.get_transformation_matrix()
-        else:
-            # to be consistent with the self._do_transform case (dtype and device)
-            affine = torch.as_tensor(np.eye(len(sp_size) + 1), device=self.rand_affine.rand_affine_grid.device)
-            # no transform, but a change of size
-            if self.rand_affine.spatial_size is not None:
-                grid = create_grid(spatial_size=sp_size)
+        # change image size or do random transform
+        do_resampling = self.rand_affine.spatial_size is not None or self._do_transform
+
+        # to be consistent with the self._do_transform case (dtype and device)
+        affine = torch.as_tensor(np.eye(len(sp_size) + 1), device=self.rand_affine.rand_affine_grid.device)
+        grid = None
+        if do_resampling:  # need to prepare grid
+            grid = self.rand_affine.get_identity_grid(sp_size)
+            if self._do_transform:  # add some random factors
+                grid = self.rand_affine.rand_affine_grid(grid=grid)
+                affine = self.rand_affine.rand_affine_grid.get_transformation_matrix()  # type: ignore[assignment]
 
         for key, mode, padding_mode in self.key_iterator(d, self.mode, self.padding_mode):
             self.push_transform(
@@ -774,7 +781,7 @@ class RandAffined(RandomizableTransform, MapTransform, InvertibleTransform):
                 },
             )
             # do the transform
-            if self._do_transform or self.rand_affine.spatial_size is not None:
+            if do_resampling:
                 d[key] = self.rand_affine.resampler(d[key], grid, mode=mode, padding_mode=padding_mode)
             # if not doing transform and and spatial size is unchanged, only need to do numpy/torch conversion
             else:

--- a/tests/test_rand_affine.py
+++ b/tests/test_rand_affine.py
@@ -117,6 +117,8 @@ class TestRandAffine(unittest.TestCase):
         g = RandAffine(**input_param)
         g.set_random_state(123)
         result = g(**input_data)
+        if input_param.get("cache_grid", False):
+            self.assertTrue(g._cached_grid is not None)
         self.assertEqual(isinstance(result, torch.Tensor), isinstance(expected_val, torch.Tensor))
         if isinstance(result, torch.Tensor):
             np.testing.assert_allclose(result.cpu().numpy(), expected_val.cpu().numpy(), rtol=1e-4, atol=1e-4)

--- a/tests/test_rand_affined.py
+++ b/tests/test_rand_affined.py
@@ -30,6 +30,11 @@ TEST_CASES = [
         np.ones((3, 2, 2)),
     ],
     [
+        dict(as_tensor_output=False, device=None, spatial_size=(2, 2), cache_grid=True, keys=("img", "seg")),
+        {"img": torch.ones((3, 3, 3)), "seg": torch.ones((3, 3, 3))},
+        np.ones((3, 2, 2)),
+    ],
+    [
         dict(as_tensor_output=True, device=None, spatial_size=(2, 2, 2), keys=("img", "seg")),
         {"img": torch.ones((1, 3, 3, 3)), "seg": torch.ones((1, 3, 3, 3))},
         torch.ones((1, 2, 2, 2)),
@@ -49,6 +54,23 @@ TEST_CASES = [
         ),
         {"img": torch.ones((1, 3, 3, 3)), "seg": torch.ones((1, 3, 3, 3))},
         torch.tensor([[[[0.3658, 1.0000], [1.0000, 1.0000]], [[1.0000, 1.0000], [1.0000, 0.9333]]]]),
+    ],
+    [
+        dict(
+            prob=0.9,
+            rotate_range=(np.pi / 2,),
+            shear_range=[1, 2],
+            translate_range=[2, 1],
+            as_tensor_output=False,
+            spatial_size=(2, 2, 2),
+            padding_mode="zeros",
+            device=None,
+            cache_grid=True,
+            keys=("img", "seg"),
+            mode="bilinear",
+        ),
+        {"img": torch.ones((1, 3, 3, 3)), "seg": torch.ones((1, 3, 3, 3))},
+        np.array([[[[0.3658, 1.0000], [1.0000, 1.0000]], [[1.0000, 1.0000], [1.0000, 0.9333]]]]),
     ],
     [
         dict(
@@ -135,6 +157,34 @@ TEST_CASES = [
             "seg": np.array([[[19.0, 20.0, 12.0], [27.0, 28.0, 20.0], [35.0, 36.0, 29.0]]]),
         },
     ],
+    [
+        dict(
+            prob=0.9,
+            mode=(GridSampleMode.BILINEAR, GridSampleMode.NEAREST),
+            rotate_range=(np.pi / 2,),
+            shear_range=[1, 2],
+            translate_range=[2, 1],
+            scale_range=[0.1, 0.2],
+            as_tensor_output=False,
+            spatial_size=(3, 3),
+            cache_grid=True,
+            keys=("img", "seg"),
+            device=torch.device("cpu:0"),
+        ),
+        {"img": torch.arange(64).reshape((1, 8, 8)), "seg": torch.arange(64).reshape((1, 8, 8))},
+        {
+            "img": np.array(
+                [
+                    [
+                        [18.736153, 15.581954, 12.4277525],
+                        [27.398798, 24.244598, 21.090399],
+                        [36.061443, 32.90724, 29.753046],
+                    ]
+                ]
+            ),
+            "seg": np.array([[[19.0, 20.0, 12.0], [27.0, 28.0, 20.0], [35.0, 36.0, 29.0]]]),
+        },
+    ],
 ]
 
 
@@ -153,6 +203,23 @@ class TestRandAffined(unittest.TestCase):
                 np.testing.assert_allclose(result.cpu().numpy(), expected.cpu().numpy(), rtol=1e-4, atol=1e-4)
             else:
                 np.testing.assert_allclose(result, expected, rtol=1e-4, atol=1e-4)
+
+    def test_ill_cache(self):
+        with self.assertWarns(UserWarning):
+            # spatial size is None
+            RandAffined(
+                as_tensor_output=False, device=None, spatial_size=None, prob=1.0, cache_grid=True, keys=("img", "seg")
+            )
+        with self.assertWarns(UserWarning):
+            # spatial size is dynamic
+            RandAffined(
+                as_tensor_output=False,
+                device=None,
+                spatial_size=(2, -1),
+                prob=1.0,
+                cache_grid=True,
+                keys=("img", "seg"),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_affined.py
+++ b/tests/test_rand_affined.py
@@ -193,6 +193,8 @@ class TestRandAffined(unittest.TestCase):
     def test_rand_affined(self, input_param, input_data, expected_val):
         g = RandAffined(**input_param).set_random_state(123)
         res = g(input_data)
+        if input_param.get("cache_grid", False):
+            self.assertTrue(g.rand_affine._cached_grid is not None)
         for key in res:
             result = res[key]
             if "_transforms" in key:


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #2172

### Description
adds caching for the identity grid when the spatial size is not dynamic

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
