### PR TITLE
1994 - adds pip install tests

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Install the dependencies
         run: |
           which python
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade pip wheel twine
           python -m pip uninstall -y torch torchvision
           python -m pip install -r requirements-dev.txt
           python -m pip list

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -99,6 +99,73 @@ jobs:
         fail_ci_if_error: false
         file: ./coverage.xml
 
+  cron-pip:
+    if: github.repository == 'Project-MONAI/MONAI'
+    strategy:
+      matrix:
+        container: ["pytorch:21.02", "pytorch:21.04"]  # 21.02 for backward comp.
+    container:
+      image: nvcr.io/nvidia/${{ matrix.container }}-py3  # testing with the latest pytorch base image
+      options: "--gpus all"
+    runs-on: [self-hosted, linux, x64, common]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install the dependencies
+        run: |
+          which python
+          python -m pip install --upgrade pip wheel
+          python -m pip uninstall -y torch torchvision
+          python -m pip install -r requirements-dev.txt
+          python -m pip list
+      - name: Run tests report coverage
+        run: |
+          export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
+          echo "Sleep $LAUNCH_DELAY"
+          sleep $LAUNCH_DELAY
+          nvidia-smi
+          export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+          echo $CUDA_VISIBLE_DEVICES
+          trap 'if pgrep python; then pkill python; fi;' ERR
+          python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+          python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+
+          pip uninstall monai
+          pip list | grep -iv monai
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          root_dir=$PWD
+          echo "$root_dir"
+          set -e
+
+          # build tar.gz and wheel
+          python setup.py check -m -s
+          python setup.py sdist bdist_wheel
+          python -m twine check dist/*
+
+          # move packages to a temp dir
+          tmp_dir=$(mktemp -d)
+          cp dist/monai* "$tmp_dir"
+          rm -r build dist monai.egg-info
+          cd "$tmp_dir"
+          ls -al
+
+          # install from tar.gz
+          name=$(ls *.tar.gz | head -n1)
+          echo $name
+          python -m pip install $name[all]
+          python -c 'import monai; monai.config.print_config()' 2>&1 | grep -iv "unknown"
+          python -c 'import monai; print(monai.__file__)'
+
+          # run tests
+          cp $root_dir/requirements*.txt "$tmp_dir"
+          cp -r $root_dir/tests "$tmp_dir"
+          pwd
+          ls -al
+          python -m pip install -r requirements-dev.txt
+          python -m unittest -v
+
+          BUILD_MONAI=1 ./tests/runner.py -p test_((?!integration).)  # unit tests
+          if pgrep python; then pkill python; fi
+
   cron-docker:
     if: github.repository == 'Project-MONAI/MONAI'
     container:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -113,25 +113,16 @@ jobs:
     runs-on: [self-hosted, linux, x64, common]
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install the dependencies
         run: |
           which python
           python -m pip install --upgrade pip wheel twine
           python -m pip uninstall -y torch torchvision
-          python -m pip install -r requirements-dev.txt
           python -m pip list
       - name: Run tests report coverage
         run: |
-          export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
-          echo "Sleep $LAUNCH_DELAY"
-          sleep $LAUNCH_DELAY
-          nvidia-smi
-          export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
-          echo $CUDA_VISIBLE_DEVICES
-          trap 'if pgrep python; then pkill python; fi;' ERR
-          python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
-          python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
-
           pip uninstall monai
           pip list | grep -iv monai
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
@@ -159,14 +150,22 @@ jobs:
           python -c 'import monai; print(monai.__file__)'
 
           # run tests
+          export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
+          echo "Sleep $LAUNCH_DELAY"
+          sleep $LAUNCH_DELAY
+          nvidia-smi
+          export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+          echo $CUDA_VISIBLE_DEVICES
+          trap 'if pgrep python; then pkill python; fi;' ERR
+          python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+          python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+
           cp $root_dir/requirements*.txt "$tmp_dir"
           cp -r $root_dir/tests "$tmp_dir"
           pwd
           ls -al
           python -m pip install -r requirements-dev.txt
-          python -m unittest -v
-
-          BUILD_MONAI=1 ./tests/runner.py -p test_((?!integration).)  # unit tests
+          BUILD_MONAI=1 python ./tests/runner.py -p 'test_((?!integration).)'  # unit tests
           if pgrep python; then pkill python; fi
 
 #  cron-docker:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,102 +5,99 @@ on:
     - cron: "0 2 * * *"  # at 02:00 UTC
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  push:
-    branches:
-      - adds-pypi-tests
 
 jobs:
-#  cron-gpu:
-#    if: github.repository == 'Project-MONAI/MONAI'
-#    container:
-#      image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
-#      options: "--gpus all"
-#    runs-on: [self-hosted, linux, x64, common]
-#    strategy:
-#      matrix:
-#        pytorch-version: [1.5.1, 1.6.0, 1.7.1, latest]
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Install the dependencies
-#      run: |
-#        which python
-#        python -m pip install --upgrade pip wheel
-#        python -m pip uninstall -y torch torchvision
-#        if [ ${{ matrix.pytorch-version }} == "latest" ]; then
-#          python -m pip install torch torchvision
-#        elif [ ${{ matrix.pytorch-version }} == "1.5.1" ]; then
-#          python -m pip install torch==1.5.1 torchvision==0.6.1
-#        elif [ ${{ matrix.pytorch-version }} == "1.6.0" ]; then
-#          python -m pip install torch==1.6.0 torchvision==0.7.0
-#        elif [ ${{ matrix.pytorch-version }} == "1.7.1" ]; then
-#          python -m pip install torch==1.7.1 torchvision==0.8.2
-#        fi
-#        python -m pip install -r requirements-dev.txt
-#        python -m pip list
-#    - name: Run tests report coverage
-#      run: |
-#        export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
-#        echo "Sleep $LAUNCH_DELAY"
-#        sleep $LAUNCH_DELAY
-#        nvidia-smi
-#        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
-#        echo $CUDA_VISIBLE_DEVICES
-#        trap 'if pgrep python; then pkill python; fi;' ERR
-#        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
-#        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
-#        python -c 'import torch; print(torch.rand(5, 3, device=torch.device("cuda:0")))'
-#        BUILD_MONAI=1 ./runtests.sh --coverage --unittests  # unit tests with coverage report
-#        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
-#        coverage xml
-#        if pgrep python; then pkill python; fi
-#    - name: Upload coverage
-#      uses: codecov/codecov-action@v1
-#      with:
-#        fail_ci_if_error: false
-#        file: ./coverage.xml
-#
-#  cron-pt-image:
-#    if: github.repository == 'Project-MONAI/MONAI'
-#    strategy:
-#      matrix:
-#        container: ["pytorch:21.02", "pytorch:21.04"]  # 21.02 for backward comp.
-#    container:
-#      image: nvcr.io/nvidia/${{ matrix.container }}-py3  # testing with the latest pytorch base image
-#      options: "--gpus all"
-#    runs-on: [self-hosted, linux, x64, common]
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Install APT dependencies
-#      run: |
-#        apt-get update
-#        DEBIAN_FRONTEND="noninteractive" apt-get install -y libopenslide0
-#    - name: Install Python dependencies
-#      run: |
-#        which python
-#        python -m pip install --upgrade pip wheel
-#        python -m pip install -r requirements-dev.txt
-#        python -m pip list
-#    - name: Run tests report coverage
-#      run: |
-#        export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
-#        echo "Sleep $LAUNCH_DELAY"
-#        sleep $LAUNCH_DELAY
-#        nvidia-smi
-#        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
-#        echo $CUDA_VISIBLE_DEVICES
-#        trap 'if pgrep python; then pkill python; fi;' ERR
-#        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
-#        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
-#        python -c 'import torch; print(torch.rand(5, 3, device=torch.device("cuda:0")))'
-#        BUILD_MONAI=1 ./runtests.sh --coverage --unittests  # unit tests with coverage report
-#        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
-#        coverage xml
-#        if pgrep python; then pkill python; fi
-#    - name: Upload coverage
-#      uses: codecov/codecov-action@v1
-#      with:
-#        fail_ci_if_error: false
-#        file: ./coverage.xml
+  cron-gpu:
+    if: github.repository == 'Project-MONAI/MONAI'
+    container:
+      image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
+      options: "--gpus all"
+    runs-on: [self-hosted, linux, x64, common]
+    strategy:
+      matrix:
+        pytorch-version: [1.5.1, 1.6.0, 1.7.1, latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install the dependencies
+      run: |
+        which python
+        python -m pip install --upgrade pip wheel
+        python -m pip uninstall -y torch torchvision
+        if [ ${{ matrix.pytorch-version }} == "latest" ]; then
+          python -m pip install torch torchvision
+        elif [ ${{ matrix.pytorch-version }} == "1.5.1" ]; then
+          python -m pip install torch==1.5.1 torchvision==0.6.1
+        elif [ ${{ matrix.pytorch-version }} == "1.6.0" ]; then
+          python -m pip install torch==1.6.0 torchvision==0.7.0
+        elif [ ${{ matrix.pytorch-version }} == "1.7.1" ]; then
+          python -m pip install torch==1.7.1 torchvision==0.8.2
+        fi
+        python -m pip install -r requirements-dev.txt
+        python -m pip list
+    - name: Run tests report coverage
+      run: |
+        export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
+        echo "Sleep $LAUNCH_DELAY"
+        sleep $LAUNCH_DELAY
+        nvidia-smi
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        echo $CUDA_VISIBLE_DEVICES
+        trap 'if pgrep python; then pkill python; fi;' ERR
+        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+        python -c 'import torch; print(torch.rand(5, 3, device=torch.device("cuda:0")))'
+        BUILD_MONAI=1 ./runtests.sh --coverage --unittests  # unit tests with coverage report
+        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
+        coverage xml
+        if pgrep python; then pkill python; fi
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: false
+        file: ./coverage.xml
+
+  cron-pt-image:
+    if: github.repository == 'Project-MONAI/MONAI'
+    strategy:
+      matrix:
+        container: ["pytorch:21.02", "pytorch:21.04"]  # 21.02 for backward comp.
+    container:
+      image: nvcr.io/nvidia/${{ matrix.container }}-py3  # testing with the latest pytorch base image
+      options: "--gpus all"
+    runs-on: [self-hosted, linux, x64, common]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install APT dependencies
+      run: |
+        apt-get update
+        DEBIAN_FRONTEND="noninteractive" apt-get install -y libopenslide0
+    - name: Install Python dependencies
+      run: |
+        which python
+        python -m pip install --upgrade pip wheel
+        python -m pip install -r requirements-dev.txt
+        python -m pip list
+    - name: Run tests report coverage
+      run: |
+        export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
+        echo "Sleep $LAUNCH_DELAY"
+        sleep $LAUNCH_DELAY
+        nvidia-smi
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        echo $CUDA_VISIBLE_DEVICES
+        trap 'if pgrep python; then pkill python; fi;' ERR
+        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+        python -c 'import torch; print(torch.rand(5, 3, device=torch.device("cuda:0")))'
+        BUILD_MONAI=1 ./runtests.sh --coverage --unittests  # unit tests with coverage report
+        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
+        coverage xml
+        if pgrep python; then pkill python; fi
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: false
+        file: ./coverage.xml
 
   cron-pip:
     if: github.repository == 'Project-MONAI/MONAI'
@@ -168,69 +165,69 @@ jobs:
           BUILD_MONAI=1 python ./tests/runner.py -p 'test_((?!integration).)'  # unit tests
           if pgrep python; then pkill python; fi
 
-#  cron-docker:
-#    if: github.repository == 'Project-MONAI/MONAI'
-#    container:
-#      image: localhost:5000/local_monai:dockerhub # use currently latest, locally available dockerhub image
-#      options: "--gpus all"
-#    runs-on: [self-hosted, linux, x64, common]
-#    steps:
-#    - name: Run tests report coverage
-#      # The docker image process has done the compilation.
-#      # BUILD_MONAI=1 is necessary for triggering the USE_COMPILED flag.
-#      run: |
-#        cd /opt/monai
-#        nvidia-smi
-#        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
-#        echo $CUDA_VISIBLE_DEVICES
-#        trap 'if pgrep python; then pkill python; fi;' ERR
-#        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
-#        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
-#        python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
-#        ngc --version
-#        BUILD_MONAI=1 ./runtests.sh --coverage --pytype --unittests  # unit tests with pytype checks, coverage report
-#        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
-#        coverage xml
-#        if pgrep python; then pkill python; fi
-#    - name: Upload coverage
-#      uses: codecov/codecov-action@v1
-#      with:
-#        fail_ci_if_error: false
-#        file: ./coverage.xml
-#
-#  cron-tutorial-notebooks:
-#    if: github.repository == 'Project-MONAI/MONAI'
-#    needs: cron-gpu  # so that monai itself is verified first
-#    container:
-#      image: nvcr.io/nvidia/pytorch:21.04-py3  # testing with the latest pytorch base image
-#      options: "--gpus all --ipc=host"
-#    runs-on: [self-hosted, linux, x64, common]
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Install MONAI
-#      id: monai-install
-#      run: |
-#        which python
-#        python -m pip install --upgrade pip wheel
-#        python -m pip install -r requirements-dev.txt
-#        BUILD_MONAI=0 python setup.py develop  # install monai
-#        nvidia-smi
-#        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
-#        echo $CUDA_VISIBLE_DEVICES
-#        echo "::set-output name=devices::$CUDA_VISIBLE_DEVICES"
-#    - name: Checkout tutorials and install their requirements
-#      run: |
-#        cd /opt
-#        git clone --depth 1 --branch master --single-branch https://github.com/Project-MONAI/tutorials.git  # latest commit of master branch
-#        cd tutorials
-#        python -m pip install -r requirements.txt
-#    - name: Run tutorial notebooks
-#      timeout-minutes: 150
-#      run: |
-#        export CUDA_VISIBLE_DEVICES=${{ steps.monai-install.outputs.devices }}
-#        echo $CUDA_VISIBLE_DEVICES
-#        trap 'if pgrep python; then pkill python; fi;' ERR
-#        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
-#        cd /opt/tutorials
-#        $(pwd)/runner.sh
-#        if pgrep python; then pkill python; fi
+  cron-docker:
+    if: github.repository == 'Project-MONAI/MONAI'
+    container:
+      image: localhost:5000/local_monai:dockerhub # use currently latest, locally available dockerhub image
+      options: "--gpus all"
+    runs-on: [self-hosted, linux, x64, common]
+    steps:
+    - name: Run tests report coverage
+      # The docker image process has done the compilation.
+      # BUILD_MONAI=1 is necessary for triggering the USE_COMPILED flag.
+      run: |
+        cd /opt/monai
+        nvidia-smi
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        echo $CUDA_VISIBLE_DEVICES
+        trap 'if pgrep python; then pkill python; fi;' ERR
+        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+        python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
+        ngc --version
+        BUILD_MONAI=1 ./runtests.sh --coverage --pytype --unittests  # unit tests with pytype checks, coverage report
+        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
+        coverage xml
+        if pgrep python; then pkill python; fi
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: false
+        file: ./coverage.xml
+
+  cron-tutorial-notebooks:
+    if: github.repository == 'Project-MONAI/MONAI'
+    needs: cron-gpu  # so that monai itself is verified first
+    container:
+      image: nvcr.io/nvidia/pytorch:21.04-py3  # testing with the latest pytorch base image
+      options: "--gpus all --ipc=host"
+    runs-on: [self-hosted, linux, x64, common]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install MONAI
+      id: monai-install
+      run: |
+        which python
+        python -m pip install --upgrade pip wheel
+        python -m pip install -r requirements-dev.txt
+        BUILD_MONAI=0 python setup.py develop  # install monai
+        nvidia-smi
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        echo $CUDA_VISIBLE_DEVICES
+        echo "::set-output name=devices::$CUDA_VISIBLE_DEVICES"
+    - name: Checkout tutorials and install their requirements
+      run: |
+        cd /opt
+        git clone --depth 1 --branch master --single-branch https://github.com/Project-MONAI/tutorials.git  # latest commit of master branch
+        cd tutorials
+        python -m pip install -r requirements.txt
+    - name: Run tutorial notebooks
+      timeout-minutes: 150
+      run: |
+        export CUDA_VISIBLE_DEVICES=${{ steps.monai-install.outputs.devices }}
+        echo $CUDA_VISIBLE_DEVICES
+        trap 'if pgrep python; then pkill python; fi;' ERR
+        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+        cd /opt/tutorials
+        $(pwd)/runner.sh
+        if pgrep python; then pkill python; fi

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -100,6 +100,7 @@ jobs:
         file: ./coverage.xml
 
   cron-pip:
+    # pip install monai[all] and use it to run unit tests
     if: github.repository == 'Project-MONAI/MONAI'
     strategy:
       matrix:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,99 +5,102 @@ on:
     - cron: "0 2 * * *"  # at 02:00 UTC
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  push:
+    branches:
+      - adds-pypi-tests
 
 jobs:
-  cron-gpu:
-    if: github.repository == 'Project-MONAI/MONAI'
-    container:
-      image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
-      options: "--gpus all"
-    runs-on: [self-hosted, linux, x64, common]
-    strategy:
-      matrix:
-        pytorch-version: [1.5.1, 1.6.0, 1.7.1, latest]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install the dependencies
-      run: |
-        which python
-        python -m pip install --upgrade pip wheel
-        python -m pip uninstall -y torch torchvision
-        if [ ${{ matrix.pytorch-version }} == "latest" ]; then
-          python -m pip install torch torchvision
-        elif [ ${{ matrix.pytorch-version }} == "1.5.1" ]; then
-          python -m pip install torch==1.5.1 torchvision==0.6.1
-        elif [ ${{ matrix.pytorch-version }} == "1.6.0" ]; then
-          python -m pip install torch==1.6.0 torchvision==0.7.0
-        elif [ ${{ matrix.pytorch-version }} == "1.7.1" ]; then
-          python -m pip install torch==1.7.1 torchvision==0.8.2
-        fi
-        python -m pip install -r requirements-dev.txt
-        python -m pip list
-    - name: Run tests report coverage
-      run: |
-        export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
-        echo "Sleep $LAUNCH_DELAY"
-        sleep $LAUNCH_DELAY
-        nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
-        echo $CUDA_VISIBLE_DEVICES
-        trap 'if pgrep python; then pkill python; fi;' ERR
-        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
-        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
-        python -c 'import torch; print(torch.rand(5, 3, device=torch.device("cuda:0")))'
-        BUILD_MONAI=1 ./runtests.sh --coverage --unittests  # unit tests with coverage report
-        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
-        coverage xml
-        if pgrep python; then pkill python; fi
-    - name: Upload coverage
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: false
-        file: ./coverage.xml
-
-  cron-pt-image:
-    if: github.repository == 'Project-MONAI/MONAI'
-    strategy:
-      matrix:
-        container: ["pytorch:21.02", "pytorch:21.04"]  # 21.02 for backward comp.
-    container:
-      image: nvcr.io/nvidia/${{ matrix.container }}-py3  # testing with the latest pytorch base image
-      options: "--gpus all"
-    runs-on: [self-hosted, linux, x64, common]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install APT dependencies
-      run: |
-        apt-get update
-        DEBIAN_FRONTEND="noninteractive" apt-get install -y libopenslide0
-    - name: Install Python dependencies
-      run: |
-        which python
-        python -m pip install --upgrade pip wheel
-        python -m pip install -r requirements-dev.txt
-        python -m pip list
-    - name: Run tests report coverage
-      run: |
-        export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
-        echo "Sleep $LAUNCH_DELAY"
-        sleep $LAUNCH_DELAY
-        nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
-        echo $CUDA_VISIBLE_DEVICES
-        trap 'if pgrep python; then pkill python; fi;' ERR
-        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
-        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
-        python -c 'import torch; print(torch.rand(5, 3, device=torch.device("cuda:0")))'
-        BUILD_MONAI=1 ./runtests.sh --coverage --unittests  # unit tests with coverage report
-        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
-        coverage xml
-        if pgrep python; then pkill python; fi
-    - name: Upload coverage
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: false
-        file: ./coverage.xml
+#  cron-gpu:
+#    if: github.repository == 'Project-MONAI/MONAI'
+#    container:
+#      image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
+#      options: "--gpus all"
+#    runs-on: [self-hosted, linux, x64, common]
+#    strategy:
+#      matrix:
+#        pytorch-version: [1.5.1, 1.6.0, 1.7.1, latest]
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Install the dependencies
+#      run: |
+#        which python
+#        python -m pip install --upgrade pip wheel
+#        python -m pip uninstall -y torch torchvision
+#        if [ ${{ matrix.pytorch-version }} == "latest" ]; then
+#          python -m pip install torch torchvision
+#        elif [ ${{ matrix.pytorch-version }} == "1.5.1" ]; then
+#          python -m pip install torch==1.5.1 torchvision==0.6.1
+#        elif [ ${{ matrix.pytorch-version }} == "1.6.0" ]; then
+#          python -m pip install torch==1.6.0 torchvision==0.7.0
+#        elif [ ${{ matrix.pytorch-version }} == "1.7.1" ]; then
+#          python -m pip install torch==1.7.1 torchvision==0.8.2
+#        fi
+#        python -m pip install -r requirements-dev.txt
+#        python -m pip list
+#    - name: Run tests report coverage
+#      run: |
+#        export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
+#        echo "Sleep $LAUNCH_DELAY"
+#        sleep $LAUNCH_DELAY
+#        nvidia-smi
+#        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+#        echo $CUDA_VISIBLE_DEVICES
+#        trap 'if pgrep python; then pkill python; fi;' ERR
+#        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+#        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+#        python -c 'import torch; print(torch.rand(5, 3, device=torch.device("cuda:0")))'
+#        BUILD_MONAI=1 ./runtests.sh --coverage --unittests  # unit tests with coverage report
+#        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
+#        coverage xml
+#        if pgrep python; then pkill python; fi
+#    - name: Upload coverage
+#      uses: codecov/codecov-action@v1
+#      with:
+#        fail_ci_if_error: false
+#        file: ./coverage.xml
+#
+#  cron-pt-image:
+#    if: github.repository == 'Project-MONAI/MONAI'
+#    strategy:
+#      matrix:
+#        container: ["pytorch:21.02", "pytorch:21.04"]  # 21.02 for backward comp.
+#    container:
+#      image: nvcr.io/nvidia/${{ matrix.container }}-py3  # testing with the latest pytorch base image
+#      options: "--gpus all"
+#    runs-on: [self-hosted, linux, x64, common]
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Install APT dependencies
+#      run: |
+#        apt-get update
+#        DEBIAN_FRONTEND="noninteractive" apt-get install -y libopenslide0
+#    - name: Install Python dependencies
+#      run: |
+#        which python
+#        python -m pip install --upgrade pip wheel
+#        python -m pip install -r requirements-dev.txt
+#        python -m pip list
+#    - name: Run tests report coverage
+#      run: |
+#        export LAUNCH_DELAY=$[ $RANDOM % 16 * 60 ]
+#        echo "Sleep $LAUNCH_DELAY"
+#        sleep $LAUNCH_DELAY
+#        nvidia-smi
+#        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+#        echo $CUDA_VISIBLE_DEVICES
+#        trap 'if pgrep python; then pkill python; fi;' ERR
+#        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+#        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+#        python -c 'import torch; print(torch.rand(5, 3, device=torch.device("cuda:0")))'
+#        BUILD_MONAI=1 ./runtests.sh --coverage --unittests  # unit tests with coverage report
+#        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
+#        coverage xml
+#        if pgrep python; then pkill python; fi
+#    - name: Upload coverage
+#      uses: codecov/codecov-action@v1
+#      with:
+#        fail_ci_if_error: false
+#        file: ./coverage.xml
 
   cron-pip:
     if: github.repository == 'Project-MONAI/MONAI'
@@ -166,69 +169,69 @@ jobs:
           BUILD_MONAI=1 ./tests/runner.py -p test_((?!integration).)  # unit tests
           if pgrep python; then pkill python; fi
 
-  cron-docker:
-    if: github.repository == 'Project-MONAI/MONAI'
-    container:
-      image: localhost:5000/local_monai:dockerhub # use currently latest, locally available dockerhub image
-      options: "--gpus all"
-    runs-on: [self-hosted, linux, x64, common]
-    steps:
-    - name: Run tests report coverage
-      # The docker image process has done the compilation.
-      # BUILD_MONAI=1 is necessary for triggering the USE_COMPILED flag.
-      run: |
-        cd /opt/monai
-        nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
-        echo $CUDA_VISIBLE_DEVICES
-        trap 'if pgrep python; then pkill python; fi;' ERR
-        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
-        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
-        python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
-        ngc --version
-        BUILD_MONAI=1 ./runtests.sh --coverage --pytype --unittests  # unit tests with pytype checks, coverage report
-        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
-        coverage xml
-        if pgrep python; then pkill python; fi
-    - name: Upload coverage
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: false
-        file: ./coverage.xml
-
-  cron-tutorial-notebooks:
-    if: github.repository == 'Project-MONAI/MONAI'
-    needs: cron-gpu  # so that monai itself is verified first
-    container:
-      image: nvcr.io/nvidia/pytorch:21.04-py3  # testing with the latest pytorch base image
-      options: "--gpus all --ipc=host"
-    runs-on: [self-hosted, linux, x64, common]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install MONAI
-      id: monai-install
-      run: |
-        which python
-        python -m pip install --upgrade pip wheel
-        python -m pip install -r requirements-dev.txt
-        BUILD_MONAI=0 python setup.py develop  # install monai
-        nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
-        echo $CUDA_VISIBLE_DEVICES
-        echo "::set-output name=devices::$CUDA_VISIBLE_DEVICES"
-    - name: Checkout tutorials and install their requirements
-      run: |
-        cd /opt
-        git clone --depth 1 --branch master --single-branch https://github.com/Project-MONAI/tutorials.git  # latest commit of master branch
-        cd tutorials
-        python -m pip install -r requirements.txt
-    - name: Run tutorial notebooks
-      timeout-minutes: 150
-      run: |
-        export CUDA_VISIBLE_DEVICES=${{ steps.monai-install.outputs.devices }}
-        echo $CUDA_VISIBLE_DEVICES
-        trap 'if pgrep python; then pkill python; fi;' ERR
-        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
-        cd /opt/tutorials
-        $(pwd)/runner.sh
-        if pgrep python; then pkill python; fi
+#  cron-docker:
+#    if: github.repository == 'Project-MONAI/MONAI'
+#    container:
+#      image: localhost:5000/local_monai:dockerhub # use currently latest, locally available dockerhub image
+#      options: "--gpus all"
+#    runs-on: [self-hosted, linux, x64, common]
+#    steps:
+#    - name: Run tests report coverage
+#      # The docker image process has done the compilation.
+#      # BUILD_MONAI=1 is necessary for triggering the USE_COMPILED flag.
+#      run: |
+#        cd /opt/monai
+#        nvidia-smi
+#        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+#        echo $CUDA_VISIBLE_DEVICES
+#        trap 'if pgrep python; then pkill python; fi;' ERR
+#        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+#        python -c "import torch; print(torch.__version__); print('{} of GPUs available'.format(torch.cuda.device_count()))"
+#        python -c 'import torch; print(torch.rand(5,3, device=torch.device("cuda:0")))'
+#        ngc --version
+#        BUILD_MONAI=1 ./runtests.sh --coverage --pytype --unittests  # unit tests with pytype checks, coverage report
+#        BUILD_MONAI=1 ./runtests.sh --coverage --net  # integration tests with coverage report
+#        coverage xml
+#        if pgrep python; then pkill python; fi
+#    - name: Upload coverage
+#      uses: codecov/codecov-action@v1
+#      with:
+#        fail_ci_if_error: false
+#        file: ./coverage.xml
+#
+#  cron-tutorial-notebooks:
+#    if: github.repository == 'Project-MONAI/MONAI'
+#    needs: cron-gpu  # so that monai itself is verified first
+#    container:
+#      image: nvcr.io/nvidia/pytorch:21.04-py3  # testing with the latest pytorch base image
+#      options: "--gpus all --ipc=host"
+#    runs-on: [self-hosted, linux, x64, common]
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Install MONAI
+#      id: monai-install
+#      run: |
+#        which python
+#        python -m pip install --upgrade pip wheel
+#        python -m pip install -r requirements-dev.txt
+#        BUILD_MONAI=0 python setup.py develop  # install monai
+#        nvidia-smi
+#        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+#        echo $CUDA_VISIBLE_DEVICES
+#        echo "::set-output name=devices::$CUDA_VISIBLE_DEVICES"
+#    - name: Checkout tutorials and install their requirements
+#      run: |
+#        cd /opt
+#        git clone --depth 1 --branch master --single-branch https://github.com/Project-MONAI/tutorials.git  # latest commit of master branch
+#        cd tutorials
+#        python -m pip install -r requirements.txt
+#    - name: Run tutorial notebooks
+#      timeout-minutes: 150
+#      run: |
+#        export CUDA_VISIBLE_DEVICES=${{ steps.monai-install.outputs.devices }}
+#        echo $CUDA_VISIBLE_DEVICES
+#        trap 'if pgrep python; then pkill python; fi;' ERR
+#        python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
+#        cd /opt/tutorials
+#        $(pwd)/runner.sh
+#        if pgrep python; then pkill python; fi

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,7 +7,6 @@ on:
       - dev
       - main
       - releasing/*
-      - adds-pypi-tests
   pull_request:
 
 jobs:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -342,6 +342,8 @@ jobs:
         python -m pip install torch>=1.5 torchvision
     - name: Test source archive and wheel file
       run: |
+        pip uninstall monai
+        pip list | grep -iv monai
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
         root_dir=$PWD
         echo "$root_dir"
@@ -370,12 +372,15 @@ jobs:
         python -m pip install monai*.tar.gz
         python -c 'import monai; monai.config.print_config()' 2>&1 | grep -iv "unknown"
         python -c 'import monai; print(monai.__file__)'
-        python -m pip uninstall -y monai
-        rm monai*.tar.gz
 
-        # clean up
-        cd "$root_dir"
-        rm -r "$tmp_dir"
+        cp "$root_dir"/requirements-min.txt "$tmp_dir"
+        cp -r "$root_dir"/tests "$temp_dir"
+        pwd
+        ls -al
+        python -m pip install -r requirements-min.txt
+        python -m tests.min_tests
+      env:
+        QUICKTEST: True
 
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,6 +7,7 @@ on:
       - dev
       - main
       - releasing/*
+      - adds-pypi-tests
   pull_request:
 
 jobs:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -370,18 +370,22 @@ jobs:
         rm monai*.whl
 
         # install from tar.gz
-        python -m pip install monai*.tar.gz
+        name=$(ls *.tar.gz | head -n1)
+        echo $name
+        python -m pip install $name[all]
         python -c 'import monai; monai.config.print_config()' 2>&1 | grep -iv "unknown"
         python -c 'import monai; print(monai.__file__)'
 
-        cp "$root_dir"/requirements-min.txt "$tmp_dir"
-        cp -r "$root_dir"/tests "$temp_dir"
+        # run min tests
+        cp $root_dir/requirements*.txt "$tmp_dir"
+        cp -r $root_dir/tests "$tmp_dir"
         pwd
         ls -al
-        python -m pip install -r requirements-min.txt
-        python -m tests.min_tests
+        python -m pip install -r requirements-dev.txt
+        python -m unittest -v
       env:
         QUICKTEST: True
+        shell: bash
 
   build-docs:
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,11 +33,13 @@ all =
     scikit-image>=0.14.2
     pillow
     tensorboard
-    pytorch-ignite==0.4.4
     gdown>=3.6.4
+    pytorch-ignite==0.4.4
     torchvision
     itk>=5.0, <=5.1.2
     tqdm>=4.47.0
+    lmdb
+    psutil
     cucim~=0.19.0
     openslide-python==1.1.2
 nibabel =


### PR DESCRIPTION
Fixes #1994

- adds package min_tests for pre-merge ci/cd
- adds package full unit tests for nightly ci/cd


### Status
**Ready**

tested:
- https://github.com/Project-MONAI/MONAI/runs/2647583616
- https://github.com/Project-MONAI/MONAI/runs/2647355573?check_suite_focus=true

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
