### PR TITLE
fix type for margin argument in CropForegroundd

### DIFF
--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -693,7 +693,7 @@ class CropForegroundd(MapTransform, InvertibleTransform):
         source_key: str,
         select_fn: Callable = is_positive,
         channel_indices: Optional[IndexSelection] = None,
-        margin: int = 0,
+        margin: Union[Sequence[int], int] = 0,
         k_divisible: Union[Sequence[int], int] = 1,
         mode: Union[NumpyPadMode, str] = NumpyPadMode.CONSTANT,
         start_coord_key: str = "foreground_start_coord",


### PR DESCRIPTION
### Description
This PR changes the type of the `margin` argument of the `CropForegroundd` transformation from `int` to `Union[Sequence[int], int]` to match the array based version and correspond with the docs.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
