### PR TITLE
RandFlip arbitrary combination of axes

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -773,7 +773,17 @@ class RandFlip(RandomizableTransform):
 
     def __init__(self, prob: float = 0.1, spatial_axis: Optional[Union[Sequence[int], int]] = None) -> None:
         RandomizableTransform.__init__(self, prob)
-        self.flipper = Flip(spatial_axis=spatial_axis)
+        self.spatial_axis = spatial_axis
+        self.sampled_spatial_axis: Optional[Union[Sequence[int], int]] = None
+
+    def randomize(self, _) -> None:
+        super().randomize(None)
+        if isinstance(self.spatial_axis, Sequence):
+            # at least 1 axis to flip
+            num_to_flip = np.random.randint(1, len(self.spatial_axis) + 1)
+            self.sampled_spatial_axis = np.random.choice(self.spatial_axis, size=num_to_flip, replace=False)
+        else:
+            self.sampled_spatial_axis = self.spatial_axis
 
     def __call__(self, img: np.ndarray) -> np.ndarray:
         """
@@ -783,7 +793,7 @@ class RandFlip(RandomizableTransform):
         self.randomize(None)
         if not self._do_transform:
             return img
-        return self.flipper(img)
+        return Flip(self.sampled_spatial_axis)(img)
 
 
 class RandAxisFlip(RandomizableTransform):


### PR DESCRIPTION
Fixes #2245.

**Whilst the API remains the same, the output will be changed, so this is a breaking change.**

### Description
Randomly flip arbitrary combination of axes. 

Previously:

```python
RandFlipd(["image", "label"], prob=0.5, spatial_axis=0),
RandFlipd(["image", "label"], prob=0.5, spatial_axis=1),
```

Now:

```python
RandFlipd(["image", "label"], prob=0.5, spatial_axis=[0,1]),
```

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
