### PR TITLE
Invert some keys

### DIFF
--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -243,6 +243,7 @@ class InverseKeys:
     EXTRA_INFO = "extra_info"
     DO_TRANSFORM = "do_transforms"
     KEY_SUFFIX = "_transforms"
+    KEY_SUFFIX_SKIPPED = "_skipped_inverses"
 
 
 class CommonKeys:

--- a/tests/test_inverse_subset.py
+++ b/tests/test_inverse_subset.py
@@ -1,0 +1,87 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from typing import Callable, List, Optional, Sequence, Tuple
+
+from parameterized import parameterized
+
+from monai.data import create_test_image_2d
+from monai.transforms import AddChanneld, Compose, LoadImaged, RandAdjustContrastd, RandAxisFlipd, RandFlipd
+from monai.transforms.inverse import InvertibleTransform
+from monai.utils import set_determinism
+from monai.utils.enums import InverseKeys
+from tests.utils import make_nifti_image
+
+KEYS = ["image", "label"]
+
+TESTS: List[Tuple] = []
+
+
+class ErrorRandAxisFlipd(RandAxisFlipd):
+    def inverse(self, _):
+        raise NotImplementedError
+
+
+# Remove any applied "RandAdjustContrastd" (only "label")
+TESTS.append(
+    (
+        Compose(
+            [
+                LoadImaged(KEYS),
+                AddChanneld(KEYS),
+                RandAxisFlipd("image"),
+                ErrorRandAxisFlipd("label"),
+                ErrorRandAxisFlipd(KEYS),
+                RandFlipd(KEYS),
+            ]
+        ),
+        "ErrorRandAxisFlipd",
+        False,
+    )
+)
+
+TESTS.append(
+    (
+        Compose([LoadImaged(KEYS), AddChanneld(KEYS), ErrorRandAxisFlipd("label")]),
+        "",
+        True,
+    )
+)
+
+
+class TestInverseSubset(unittest.TestCase):
+    def setUp(self):
+        set_determinism(seed=0)
+
+        im_fnames = [make_nifti_image(i) for i in create_test_image_2d(101, 100)]
+        self.data = {k: v for k, v in zip(KEYS, im_fnames)}
+
+    def tearDown(self):
+        set_determinism(seed=None)
+
+    @parameterized.expand(TESTS)
+    def test_inverse_subset(
+        self,
+        transforms: Compose,
+        to_skip: Sequence[str],
+        expected_exception: bool,
+    ) -> None:
+        d = transforms(self.data)
+        if not expected_exception:
+            transforms.inverse_with_omissions(d, to_skip)
+        else:
+            with self.assertRaises(RuntimeError):
+                transforms.inverse_with_omissions(d, to_skip)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_inverse_subset.py
+++ b/tests/test_inverse_subset.py
@@ -17,7 +17,7 @@ from parameterized import parameterized
 
 from monai.data import create_test_image_2d
 from monai.transforms import AddChanneld, Compose, LoadImaged, RandAxisFlipd, RandFlipd
-from monai.utils import set_determinism, optional_import
+from monai.utils import optional_import, set_determinism
 from monai.utils.enums import InverseKeys
 from tests.utils import make_nifti_image
 

--- a/tests/test_inverse_subset.py
+++ b/tests/test_inverse_subset.py
@@ -10,15 +10,13 @@
 # limitations under the License.
 
 import unittest
-from typing import Callable, List, Optional, Sequence, Tuple
+from typing import List, Sequence, Tuple
 
 from parameterized import parameterized
 
 from monai.data import create_test_image_2d
-from monai.transforms import AddChanneld, Compose, LoadImaged, RandAdjustContrastd, RandAxisFlipd, RandFlipd
-from monai.transforms.inverse import InvertibleTransform
+from monai.transforms import AddChanneld, Compose, LoadImaged, RandAxisFlipd, RandFlipd
 from monai.utils import set_determinism
-from monai.utils.enums import InverseKeys
 from tests.utils import make_nifti_image
 
 KEYS = ["image", "label"]
@@ -28,10 +26,11 @@ TESTS: List[Tuple] = []
 
 class ErrorRandAxisFlipd(RandAxisFlipd):
     def inverse(self, _):
-        raise NotImplementedError
+        raise RuntimeError
 
 
-# Remove any applied "RandAdjustContrastd" (only "label")
+# remove the ErrorRandAxisFlipd transform. Since its inverse
+# raises an exception, we'll know if this wasn't successful
 TESTS.append(
     (
         Compose(
@@ -49,6 +48,7 @@ TESTS.append(
     )
 )
 
+# Nothing is removed, so exception is expected
 TESTS.append(
     (
         Compose([LoadImaged(KEYS), AddChanneld(KEYS), ErrorRandAxisFlipd("label")]),

--- a/tests/test_inverse_subset.py
+++ b/tests/test_inverse_subset.py
@@ -17,7 +17,7 @@ from parameterized import parameterized
 
 from monai.data import create_test_image_2d
 from monai.transforms import AddChanneld, Compose, LoadImaged, RandAxisFlipd, RandFlipd
-from monai.utils import set_determinism
+from monai.utils import set_determinism, optional_import
 from monai.utils.enums import InverseKeys
 from tests.utils import make_nifti_image
 


### PR DESCRIPTION
Invert some but not all transforms.

To skip the inverse of `RandAdjustContrastd`, for example, this can be done with:

```python
d_fwd = transforms(d)
d_fwd_inv = transforms.inverse_with_omissions(d, "RandAdjustContrastd")
```

Skipped transforms will be added to a list in the dictionary e.g., `image_skipped_inverses`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
