### PR TITLE
updates contrib doc for releasing a new version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,11 +279,13 @@ When major features are ready for a milestone, to prepare for a new release:
   [TestPyPI](https://test.pypi.org/project/monai/).  The packages are also available for downloading as
   repository's artifacts (e.g. the file at https://github.com/Project-MONAI/MONAI/actions/runs/66570977).
 - Check the release test at [TestPyPI](https://test.pypi.org/project/monai/), download the artifacts when the CI finishes.
-- Once the release candidate is verified, make PRs from `releasing/[version number]` to`dev` and `main` respectively.
-  Make sure all the test pipelines succeed.
-- Check out the `main` branch, tag and push a milestone, for example, `git push origin 0.1.0`.
+- Optionally run [the cron testing jobs](https://github.com/Project-MONAI/MONAI/blob/dev/.github/workflows/cron.yml) on `releasing/[version number]`.
+- Once the release candidate is verified, tag and push a milestone, for example, `git push origin 0.1.0`.
+  The tag must be with the latest commit of `releasing/[version number]`.
+- Rebase `releasing/[version number]` to `main`, make sure all the test pipelines succeed.
 - Upload the packages to [PyPI](https://pypi.org/project/monai/).
   This could be done manually by ``twine upload dist/*``, given the artifacts are unzipped to the folder ``dist/``.
+- Merge `releasing/[version number]` to `dev`, this step must make sure that the tagging commit unchanged on `dev`.
 - Publish the release note.
 
 Note that the release should be tagged with a [PEP440](https://www.python.org/dev/peps/pep-0440/) compliant


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

follow-up of https://github.com/Project-MONAI/MONAI/issues/2041
fixes #2270 
the new releasing steps are now in use


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).

