### PR TITLE
Use reshape to replace view in loss function

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -459,8 +459,8 @@ class GeneralizedWassersteinDiceLoss(_Loss):
 
         """
         # Aggregate spatial dimensions
-        flat_input = input.view(input.size(0), input.size(1), -1)
-        flat_target = target.view(target.size(0), -1).long()
+        flat_input = input.reshape(input.size(0), input.size(1), -1)
+        flat_target = target.reshape(target.size(0), -1).long()
 
         # Apply the softmax to the input scores map
         probs = F.softmax(flat_input, dim=1)

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -113,8 +113,9 @@ class FocalLoss(_Loss):
         t = target
 
         # Change the shape of input and target to B x N x num_voxels.
-        i = i.view(i.size(0), i.size(1), -1)
-        t = t.view(t.size(0), t.size(1), -1)
+        b, n = t.shape[:2]
+        i = i.reshape(b, n, -1)
+        t = t.reshape(b, n, -1)
 
         # Compute the log proba.
         logpt = F.log_softmax(i, dim=1)


### PR DESCRIPTION
Fixes #2296 .

### Description
Use `reshape` to replace `view` in class `FocalLoss` and `GeneralizedWassersteinDiceLoss`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
