### PR TITLE
optional `strict_check` for EnsureChannelFirst(d)

### DIFF
--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -252,6 +252,7 @@ class EnsureChannelFirstd(MapTransform):
         keys: KeysCollection,
         meta_keys: Optional[KeysCollection] = None,
         meta_key_postfix: str = "meta_dict",
+        strict_check: bool = True,
     ) -> None:
         """
         Args:
@@ -265,10 +266,11 @@ class EnsureChannelFirstd(MapTransform):
             meta_key_postfix: if meta_keys is None and `key_{postfix}` was used to store the metadata in `LoadImaged`.
                 So need the key to extract metadata for channel dim information, default is `meta_dict`.
                 For example, for data with key `image`, metadata by default is in `image_meta_dict`.
+            strict_check: whether to raise an error when the meta information is insufficient.
 
         """
         super().__init__(keys)
-        self.adjuster = EnsureChannelFirst()
+        self.adjuster = EnsureChannelFirst(strict_check=strict_check)
         self.meta_keys = ensure_tuple_rep(meta_keys, len(self.keys))
         self.meta_key_postfix = ensure_tuple_rep(meta_key_postfix, len(self.keys))
 

--- a/tests/test_ensure_channel_first.py
+++ b/tests/test_ensure_channel_first.py
@@ -81,6 +81,14 @@ class TestEnsureChannelFirst(unittest.TestCase):
             result = EnsureChannelFirst()(result, header)
             self.assertEqual(result.shape[0], 3)
 
+    def test_check(self):
+        with self.assertRaises(ValueError):  # no meta
+            EnsureChannelFirst()(np.zeros((1, 2, 3)), None)
+        with self.assertRaises(ValueError):  # no meta channel
+            EnsureChannelFirst()(np.zeros((1, 2, 3)), {"original_channel_dim": None})
+        EnsureChannelFirst(strict_check=False)(np.zeros((1, 2, 3)), None)
+        EnsureChannelFirst(strict_check=False)(np.zeros((1, 2, 3)), {"original_channel_dim": None})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ensure_channel_firstd.py
+++ b/tests/test_ensure_channel_firstd.py
@@ -57,6 +57,16 @@ class TestEnsureChannelFirstd(unittest.TestCase):
             result = EnsureChannelFirstd(keys="img")(result)
             self.assertEqual(result["img"].shape[0], 3)
 
+    def test_exceptions(self):
+        with self.assertRaises(ValueError):  # no meta
+            EnsureChannelFirstd("img")({"img": np.zeros((1, 2, 3)), "img_meta_dict": None})
+        with self.assertRaises(ValueError):  # no meta channel
+            EnsureChannelFirstd("img")({"img": np.zeros((1, 2, 3)), "img_meta_dict": {"original_channel_dim": None}})
+        EnsureChannelFirstd("img", strict_check=False)({"img": np.zeros((1, 2, 3)), "img_meta_dict": None})
+        EnsureChannelFirstd("img", strict_check=False)(
+            {"img": np.zeros((1, 2, 3)), "img_meta_dict": {"original_channel_dim": None}}
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

### Description
adds a boolean flag `strict_check` to the `EnsureChannelFirst`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
