### PR TITLE
573 masked loss wrapper

### DIFF
--- a/docs/source/losses.rst
+++ b/docs/source/losses.rst
@@ -82,9 +82,14 @@ Registration Losses
     :members:
 
 Loss Wrappers
---------------
+-------------
 
 `MultiScaleLoss`
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 .. autoclass:: MultiScaleLoss
+    :members:
+
+`MaskedLoss`
+~~~~~~~~~~~~
+.. autoclass:: MaskedLoss
     :members:

--- a/monai/losses/__init__.py
+++ b/monai/losses/__init__.py
@@ -27,4 +27,5 @@ from .dice import (
 from .focal_loss import FocalLoss
 from .image_dissimilarity import GlobalMutualInformationLoss, LocalNormalizedCrossCorrelationLoss
 from .multi_scale import MultiScaleLoss
+from .spatial_mask import MaskedLoss
 from .tversky import TverskyLoss

--- a/monai/losses/spatial_mask.py
+++ b/monai/losses/spatial_mask.py
@@ -1,0 +1,67 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import warnings
+from typing import Callable, Optional, Union
+
+import torch
+from torch.nn.modules.loss import _Loss
+
+__all__ = ["MaskedLoss"]
+
+
+class MaskedLoss(_Loss):
+    """
+    This is a wrapper class for the loss functions.  It allows for additional
+    weighting masks to be applied to both input and target.
+
+    See Also:
+        - :py:class:`monai.losses.MaskedDiceLoss`
+    """
+
+    def __init__(self, loss: Union[Callable, _Loss], *loss_args, **loss_kwargs) -> None:
+        """
+        Args:
+            loss: loss function to be wrapped, this could be a loss class or an instance of a loss class.
+            loss_args: arguments to the loss function's constructor if `loss` is a class.
+            loss_kwargs: keyword arguments to the loss function's constructor if `loss` is a class.
+        """
+        super().__init__()
+        if inspect.isclass(loss):  # call the loss function's constructor if it's a class
+            self.loss = loss(*loss_args, **loss_kwargs)
+        else:
+            self.loss = loss  # loss is a callable loss function instance.
+
+        if not callable(self.loss):
+            raise ValueError("The loss function is not callable.")
+
+    def forward(self, input: torch.Tensor, target: torch.Tensor, mask: Optional[torch.Tensor] = None):
+        """
+        Args:
+            input: the shape should be BNH[WD].
+            target: the shape should be BNH[WD].
+            mask: the shape should be B1H[WD] or 11H[WD].
+        """
+        if mask is None:
+            warnings.warn("No mask value specified for the MaskedLoss.")
+            return self.loss(input, target)
+
+        if input.dim() != mask.dim():
+            warnings.warn(f"Dim of input ({input.shape}) is different from mask ({mask.shape}).")
+        if not (input.shape[0] == mask.shape[0] or mask.shape[0] == 1):
+            raise ValueError(f"Batch size of mask ({mask.shape}) must be one or equal to input ({input.shape}).")
+        if target.dim() > 1:
+            if mask.shape[1] != 1:
+                raise ValueError(f"Mask ({mask.shape}) must have only one channel.")
+            if input.shape[2:] != mask.shape[2:]:
+                warnings.warn(f"Spatial size of input ({input.shape}) is different from mask ({mask.shape}).")
+        return self.loss(input * mask, target * mask)

--- a/tests/test_masked_loss.py
+++ b/tests/test_masked_loss.py
@@ -32,7 +32,7 @@ TEST_CASES = [
             "to_onehot_y": True,
             "reduction": "sum",
         },
-        12.105497,
+        [12.105497, 10.636354],
     ],
 ]
 
@@ -51,7 +51,11 @@ class TestMaskedLoss(unittest.TestCase):
         label = torch.argmax(label, dim=1, keepdim=True)
         pred = torch.randn(size)
         result = MaskedLoss(**input_param)(pred, label, None)
-        np.testing.assert_allclose(result.detach().cpu().numpy(), expected_val, rtol=1e-5)
+        np.testing.assert_allclose(result.detach().cpu().numpy(), expected_val[0], rtol=1e-5)
+
+        mask = torch.randint(low=0, high=2, size=label.shape)
+        result = MaskedLoss(**input_param)(pred, label, mask)
+        np.testing.assert_allclose(result.detach().cpu().numpy(), expected_val[1], rtol=1e-5)
 
     def test_ill_opts(self):
         with self.assertRaisesRegex(ValueError, ""):

--- a/tests/test_masked_loss.py
+++ b/tests/test_masked_loss.py
@@ -32,7 +32,7 @@ TEST_CASES = [
             "to_onehot_y": True,
             "reduction": "sum",
         },
-        [(12.105497, 18.805185), (10.636354, 6.3138)],
+        [18.805183, 6.3138],  # w/o mask
     ],
 ]
 
@@ -50,17 +50,14 @@ class TestMaskedLoss(unittest.TestCase):
         label = torch.randint(low=0, high=2, size=size)
         label = torch.argmax(label, dim=1, keepdim=True)
         pred = torch.randn(size)
-        print(label[0, 0, 0])
         result = MaskedLoss(**input_param)(pred, label, None)
         out = result.detach().cpu().numpy()
-        checked = np.allclose(out, expected_val[0][0]) or np.allclose(out, expected_val[0][1])
-        self.assertTrue(checked)
+        np.testing.assert_allclose(out, expected_val[0], rtol=1e-4)
 
         mask = torch.randint(low=0, high=2, size=label.shape)
         result = MaskedLoss(**input_param)(pred, label, mask)
         out = result.detach().cpu().numpy()
-        checked = np.allclose(out, expected_val[1][0]) or np.allclose(out, expected_val[1][1])
-        self.assertTrue(checked)
+        np.testing.assert_allclose(out, expected_val[1], rtol=1e-4)
 
     def test_ill_opts(self):
         with self.assertRaisesRegex(ValueError, ""):
@@ -78,9 +75,9 @@ class TestMaskedLoss(unittest.TestCase):
     def test_script(self):
         input_param, expected_val = TEST_CASES[0]
         size = [3, 3, 5, 5]
-        label = torch.randint(low=0, high=2, size=size)
+        label = torch.ones(size)
         label = torch.argmax(label, dim=1, keepdim=True)
-        pred = torch.randn(size)
+        pred = torch.zeros(size)
         loss = MaskedLoss(**input_param)
         test_script_save(loss, pred, label)
 

--- a/tests/test_masked_loss.py
+++ b/tests/test_masked_loss.py
@@ -1,0 +1,80 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import numpy as np
+import torch
+from parameterized import parameterized
+
+from monai.losses.dice import DiceFocalLoss, DiceLoss
+from monai.losses.spatial_mask import MaskedLoss
+from monai.utils import set_determinism
+from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+TEST_CASES = [
+    [
+        {
+            "loss": DiceFocalLoss,
+            "focal_weight": torch.tensor([1.0, 1.0, 2.0]),
+            "gamma": 0.1,
+            "lambda_focal": 0.5,
+            "include_background": True,
+            "to_onehot_y": True,
+            "reduction": "sum",
+        },
+        12.105497,
+    ],
+]
+
+
+class TestMaskedLoss(unittest.TestCase):
+    def setUp(self):
+        set_determinism(0)
+
+    def tearDown(self):
+        set_determinism(None)
+
+    @parameterized.expand(TEST_CASES)
+    def test_shape(self, input_param, expected_val):
+        size = [3, 3, 5, 5]
+        label = torch.randint(low=0, high=2, size=size)
+        label = torch.argmax(label, dim=1, keepdim=True)
+        pred = torch.randn(size)
+        result = MaskedLoss(**input_param)(pred, label, None)
+        np.testing.assert_allclose(result.detach().cpu().numpy(), expected_val, rtol=1e-5)
+
+    def test_ill_opts(self):
+        with self.assertRaisesRegex(ValueError, ""):
+            MaskedLoss(loss=[])
+
+        dice_loss = DiceLoss(include_background=True, sigmoid=True, smooth_nr=1e-5, smooth_dr=1e-5)
+        with self.assertRaisesRegex(ValueError, ""):
+            masked = MaskedLoss(loss=dice_loss)
+            masked(input=torch.zeros((3, 1, 2, 2)), target=torch.zeros((3, 1, 2, 2)), mask=torch.zeros((3, 3, 2, 2)))
+        with self.assertRaisesRegex(ValueError, ""):
+            masked = MaskedLoss(loss=dice_loss)
+            masked(input=torch.zeros((3, 3, 2, 2)), target=torch.zeros((3, 2, 2, 2)), mask=torch.zeros((3, 3, 2, 2)))
+
+    @SkipIfBeforePyTorchVersion((1, 7, 0))
+    def test_script(self):
+        input_param, expected_val = TEST_CASES[0]
+        size = [3, 3, 5, 5]
+        label = torch.randint(low=0, high=2, size=size)
+        label = torch.argmax(label, dim=1, keepdim=True)
+        pred = torch.randn(size)
+        loss = MaskedLoss(**input_param)
+        test_script_save(loss, pred, label)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_masked_loss.py
+++ b/tests/test_masked_loss.py
@@ -32,7 +32,7 @@ TEST_CASES = [
             "to_onehot_y": True,
             "reduction": "sum",
         },
-        [12.105497, 10.636354],
+        [(12.105497, 18.805185), (10.636354, 6.3138)],
     ],
 ]
 
@@ -50,12 +50,17 @@ class TestMaskedLoss(unittest.TestCase):
         label = torch.randint(low=0, high=2, size=size)
         label = torch.argmax(label, dim=1, keepdim=True)
         pred = torch.randn(size)
+        print(label[0, 0, 0])
         result = MaskedLoss(**input_param)(pred, label, None)
-        np.testing.assert_allclose(result.detach().cpu().numpy(), expected_val[0], rtol=1e-5)
+        out = result.detach().cpu().numpy()
+        checked = np.allclose(out, expected_val[0][0]) or np.allclose(out, expected_val[0][1])
+        self.assertTrue(checked)
 
         mask = torch.randint(low=0, high=2, size=label.shape)
         result = MaskedLoss(**input_param)(pred, label, mask)
-        np.testing.assert_allclose(result.detach().cpu().numpy(), expected_val[1], rtol=1e-5)
+        out = result.detach().cpu().numpy()
+        checked = np.allclose(out, expected_val[1][0]) or np.allclose(out, expected_val[1][1])
+        self.assertTrue(checked)
 
     def test_ill_opts(self):
         with self.assertRaisesRegex(ValueError, ""):

--- a/tests/test_masked_loss.py
+++ b/tests/test_masked_loss.py
@@ -32,7 +32,7 @@ TEST_CASES = [
             "to_onehot_y": True,
             "reduction": "sum",
         },
-        [18.805183, 6.3138],  # w/o mask
+        [(12.105497, 18.805185), (10.636354, 6.3138)],
     ],
 ]
 
@@ -50,14 +50,17 @@ class TestMaskedLoss(unittest.TestCase):
         label = torch.randint(low=0, high=2, size=size)
         label = torch.argmax(label, dim=1, keepdim=True)
         pred = torch.randn(size)
+        print(label[0, 0, 0])
         result = MaskedLoss(**input_param)(pred, label, None)
         out = result.detach().cpu().numpy()
-        np.testing.assert_allclose(out, expected_val[0], rtol=1e-4)
+        checked = np.allclose(out, expected_val[0][0]) or np.allclose(out, expected_val[0][1])
+        self.assertTrue(checked)
 
         mask = torch.randint(low=0, high=2, size=label.shape)
         result = MaskedLoss(**input_param)(pred, label, mask)
         out = result.detach().cpu().numpy()
-        np.testing.assert_allclose(out, expected_val[1], rtol=1e-4)
+        checked = np.allclose(out, expected_val[1][0]) or np.allclose(out, expected_val[1][1])
+        self.assertTrue(checked)
 
     def test_ill_opts(self):
         with self.assertRaisesRegex(ValueError, ""):
@@ -75,9 +78,9 @@ class TestMaskedLoss(unittest.TestCase):
     def test_script(self):
         input_param, expected_val = TEST_CASES[0]
         size = [3, 3, 5, 5]
-        label = torch.ones(size)
+        label = torch.randint(low=0, high=2, size=size)
         label = torch.argmax(label, dim=1, keepdim=True)
-        pred = torch.zeros(size)
+        pred = torch.randn(size)
         loss = MaskedLoss(**input_param)
         test_script_save(loss, pred, label)
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #573

### Description
adds a generic loss masking class

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
