### PR TITLE
2317 Preserve ordering of input dict's keys in transforms 

### DIFF
--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -855,7 +855,8 @@ class RandWeightedCropd(Randomizable, MapTransform, InvertibleTransform):
         self.randomize(d[self.w_key])
         _spatial_size = fall_back_tuple(self.spatial_size, d[self.w_key].shape[1:])
 
-        results: List[Dict[Hashable, np.ndarray]] = [{} for _ in range(self.num_samples)]
+        # initialize returned list with shallow copy to preserve key ordering
+        results: List[Dict[Hashable, np.ndarray]] = [dict(data) for _ in range(self.num_samples)]
         # fill in the extra keys with unmodified data
         for i in range(self.num_samples):
             for key in set(data.keys()).difference(set(self.keys)):
@@ -1021,7 +1022,9 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform, InvertibleTransform):
             raise AssertionError
         if self.centers is None:
             raise AssertionError
-        results: List[Dict[Hashable, np.ndarray]] = [{} for _ in range(self.num_samples)]
+
+        # initialize returned list with shallow copy to preserve key ordering
+        results: List[Dict[Hashable, np.ndarray]] = [dict(data) for _ in range(self.num_samples)]
 
         for i, center in enumerate(self.centers):
             # fill in the extra keys with unmodified data

--- a/tests/test_rand_crop_by_pos_neg_labeld.py
+++ b/tests/test_rand_crop_by_pos_neg_labeld.py
@@ -88,6 +88,8 @@ class TestRandCropByPosNegLabeld(unittest.TestCase):
         self.assertTupleEqual(result[0]["image"].shape, expected_shape)
         self.assertTupleEqual(result[0]["extra"].shape, expected_shape)
         self.assertTupleEqual(result[0]["label"].shape, expected_shape)
+        _len = len(tuple(input_data.keys()))
+        self.assertTupleEqual(tuple(result[0].keys())[:_len], tuple(input_data.keys()))
         for i, item in enumerate(result):
             self.assertEqual(item["image_meta_dict"]["patch_index"], i)
             self.assertEqual(item["label_meta_dict"]["patch_index"], i)


### PR DESCRIPTION
Fixes #2317 .

### Description
Initializes the return list of dicts with a shallow copy of `data` (the input dict) in `RandWeightedCropd` and `RandCropByPosNegLabeld`.

### Status
**ready**

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
