### PR TITLE
2316 load image with big-endian header

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -36,7 +36,7 @@ __all__ = ["LoadImage", "SaveImage"]
 
 def switch_endianness(data, new="<"):
     """
-    Convert the input `data` endianness to `new.
+    Convert the input `data` endianness to `new`.
 
     Args:
         data: input to be converted.

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -13,6 +13,7 @@ A collection of "vanilla" transforms for IO functions
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
+import sys
 from typing import Dict, List, Optional, Sequence, Union
 
 import numpy as np
@@ -33,20 +34,24 @@ Image, _ = optional_import("PIL.Image")
 __all__ = ["LoadImage", "SaveImage"]
 
 
-def switch_endianness(data, old, new):
+def switch_endianness(data, new="<"):
     """
-    If any numpy arrays have `old` (e.g., ">"),
-    replace with `new` (e.g., "<").
+    If any numpy arrays have `new` endianness (e.g., "<").
     """
     if isinstance(data, np.ndarray):
-        if data.dtype.byteorder == old:
-            data = data.newbyteorder(new)
+        # default to system endian
+        sys_native = ((sys.byteorder == "little") and "<") or ">"
+        current_ = sys_native if data.dtype.byteorder not in ("<", ">") else data.dtype.byteorder
+        if new not in ("<", ">"):
+            raise NotImplementedError(f"Not implemented option new={new}.")
+        if current_ != new:
+            data = data.byteswap().newbyteorder(new)
     elif isinstance(data, tuple):
-        data = tuple(switch_endianness(x, old, new) for x in data)
+        data = tuple(switch_endianness(x, new) for x in data)
     elif isinstance(data, list):
-        data = [switch_endianness(x, old, new) for x in data]
+        data = [switch_endianness(x, new) for x in data]
     elif isinstance(data, dict):
-        data = {k: switch_endianness(v, old, new) for k, v in data.items()}
+        data = {k: switch_endianness(v, new) for k, v in data.items()}
     elif isinstance(data, (bool, str, float, int, type(None))):
         pass
     else:
@@ -159,7 +164,7 @@ class LoadImage(Transform):
             return img_array
         meta_data[Key.FILENAME_OR_OBJ] = ensure_tuple(filename)[0]
         # make sure all elements in metadata are little endian
-        meta_data = switch_endianness(meta_data, ">", "<")
+        meta_data = switch_endianness(meta_data, "<")
 
         return img_array, meta_data
 

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -36,7 +36,11 @@ __all__ = ["LoadImage", "SaveImage"]
 
 def switch_endianness(data, new="<"):
     """
-    If any numpy arrays have `new` endianness (e.g., "<").
+    Convert the input `data` endianness to `new.
+
+    Args:
+        data: input to be converted.
+        new: the target endianness, currently support "<" or ">".
     """
     if isinstance(data, np.ndarray):
         # default to system endian

--- a/tests/test_nifti_endianness.py
+++ b/tests/test_nifti_endianness.py
@@ -64,8 +64,22 @@ class TestNiftiEndianness(unittest.TestCase):
 
     def test_switch(self):  # verify data types
         for data in (np.zeros((2, 1)), ("test",), [24, 42], {"foo": "bar"}, True, 42):
-            output = switch_endianness(data, ">", "<")
+            output = switch_endianness(data, "<")
             self.assertEqual(type(data), type(output))
+
+        before = np.array((20, 20), dtype=">i2")
+        expected_float = before.astype(float)
+        after = switch_endianness(before)
+        np.testing.assert_allclose(after.astype(float), expected_float)
+        self.assertEqual(after.dtype.byteorder, "<")
+
+        before = np.array((20, 20), dtype="<i2")
+        expected_float = before.astype(float)
+        after = switch_endianness(before)
+        np.testing.assert_allclose(after.astype(float), expected_float)
+
+        with self.assertRaises(NotImplementedError):
+            switch_endianness(np.zeros((2, 1)), "=")
 
     @skipUnless(has_pil, "Requires PIL")
     def test_pil(self):

--- a/tests/test_nifti_endianness.py
+++ b/tests/test_nifti_endianness.py
@@ -78,6 +78,10 @@ class TestNiftiEndianness(unittest.TestCase):
         after = switch_endianness(before)
         np.testing.assert_allclose(after.astype(float), expected_float)
 
+        before = np.array(["1.12", "-9.2", "42"], dtype=np.string_)
+        after = switch_endianness(before)
+        np.testing.assert_array_equal(before, after)
+
         with self.assertRaises(NotImplementedError):
             switch_endianness(np.zeros((2, 1)), "=")
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #2316

### Description
- from big-endian to little-endian requires swapping the bytes, otherwise the header info are incorrect and may cause OOM

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
