### PR TITLE
2345 no default mmar home for pytorch < 1.6

### DIFF
--- a/monai/apps/mmars/mmars.py
+++ b/monai/apps/mmars/mmars.py
@@ -69,7 +69,12 @@ def download_mmar(item, mmar_dir=None, progress: bool = True):
     if not isinstance(item, Mapping):
         item = _get_model_spec(item)
     if not mmar_dir:
-        mmar_dir = os.path.join(torch.hub.get_dir(), "mmars")
+        get_dir, has_home = optional_import("torch.hub", name="get_dir")
+        if has_home:
+            mmar_dir = os.path.join(get_dir(), "mmars")
+        else:
+            raise ValueError("mmar_dir=None, but no suitable default directory computed. Upgrade Pytorch to 1.6+ ?")
+
     model_dir = os.path.join(mmar_dir, item[Keys.ID])
     download_and_extract(
         url=item[Keys.URL],

--- a/tests/test_mmar_download.py
+++ b/tests/test_mmar_download.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 
 from monai.apps import download_mmar, load_from_mmar
 from monai.apps.mmars import MODEL_DESC
-from tests.utils import skip_if_quick
+from tests.utils import SkipIfAtLeastPyTorchVersion, SkipIfBeforePyTorchVersion, skip_if_quick
 
 TEST_CASES = [["clara_pt_prostate_mri_segmentation_1"], ["clara_pt_covid19_ct_lesion_segmentation_1"]]
 TEST_EXTRACT_CASES = [
@@ -83,6 +83,7 @@ TEST_EXTRACT_CASES = [
 class TestMMMARDownload(unittest.TestCase):
     @parameterized.expand(TEST_CASES)
     @skip_if_quick
+    @SkipIfBeforePyTorchVersion((1, 6))
     def test_download(self, idx):
         download_mmar(idx)
         download_mmar(idx, progress=False)  # repeated to check caching
@@ -103,6 +104,11 @@ class TestMMMARDownload(unittest.TestCase):
         # model ids are unique
         keys = sorted([m["id"] for m in MODEL_DESC])
         self.assertTrue(keys == sorted(set(keys)))
+
+    @SkipIfAtLeastPyTorchVersion((1, 6))
+    def test_no_default(self):
+        with self.assertRaises(ValueError):
+            download_mmar(0)
 
 
 if __name__ == "__main__":

--- a/tests/test_mmar_download.py
+++ b/tests/test_mmar_download.py
@@ -94,6 +94,7 @@ class TestMMMARDownload(unittest.TestCase):
 
     @parameterized.expand(TEST_EXTRACT_CASES)
     @skip_if_quick
+    @SkipIfBeforePyTorchVersion((1, 6))
     def test_load_ckpt(self, input_args, expected_name, expected_val):
         output = load_from_mmar(**input_args)
         self.assertEqual(output.__class__.__name__, expected_name)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -126,7 +126,7 @@ class SkipIfBeforePyTorchVersion:
 
 class SkipIfAtLeastPyTorchVersion:
     """Decorator to be used if test should be skipped
-    with PyTorch versions newer than that given."""
+    with PyTorch versions newer than or equal to that given."""
 
     def __init__(self, pytorch_version_tuple):
         self.max_version = pytorch_version_tuple


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #2345

### Description
the get_dir API is not available for pytorch < 1.6,
in this case, the user should provide a directory or upgrade pytorch

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
