### PR TITLE
2374 multiprocess for non-exist persistent cache dir

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -168,7 +168,7 @@ class PersistentDataset(Dataset):
         self.hash_func = hash_func
         if self.cache_dir is not None:
             if not self.cache_dir.exists():
-                self.cache_dir.mkdir(parents=True)
+                self.cache_dir.mkdir(parents=True, exist_ok=True)
             if not self.cache_dir.is_dir():
                 raise ValueError("cache_dir must be a directory.")
 

--- a/tests/test_persistentdataset.py
+++ b/tests/test_persistentdataset.py
@@ -151,5 +151,24 @@ class TestDistDataset(DistTestCase):
         self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
 
 
+class TestDistCreateDataset(DistTestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    @DistCall(nnodes=1, nproc_per_node=2)
+    def test_mp_dataset(self):
+        print("persistent", dist.get_rank())
+        items = [[list(range(i))] for i in range(5)]
+        cache_dir = os.path.join(self.tempdir, "test")
+        ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=cache_dir)
+        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+        ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=cache_dir)
+        self.assertEqual(list(ds1), list(ds))
+        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_persistentdataset.py
+++ b/tests/test_persistentdataset.py
@@ -10,18 +10,15 @@
 # limitations under the License.
 
 import os
-import shutil
 import tempfile
 import unittest
 
 import nibabel as nib
 import numpy as np
-import torch.distributed as dist
 from parameterized import parameterized
 
 from monai.data import PersistentDataset, json_hashing
 from monai.transforms import Compose, LoadImaged, SimulateDelayd, Transform
-from tests.utils import DistCall, DistTestCase
 
 TEST_CASE_1 = [
     Compose(
@@ -125,49 +122,6 @@ class TestDataset(unittest.TestCase):
                 self.assertTupleEqual(data2_postcached["extra"].shape, expected_shape)
                 for d in data3_postcached:
                     self.assertTupleEqual(d["image"].shape, expected_shape)
-
-
-class TestDistDataset(DistTestCase):
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-
-    @DistCall(nnodes=1, nproc_per_node=2)
-    def test_mp_dataset(self):
-        print("persistent", dist.get_rank())
-        items = [[list(range(i))] for i in range(5)]
-        ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=self.tempdir)
-        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
-        ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=self.tempdir)
-        self.assertEqual(list(ds1), list(ds))
-        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
-
-        ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=self.tempdir, hash_func=json_hashing)
-        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
-        ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=self.tempdir, hash_func=json_hashing)
-        self.assertEqual(list(ds1), list(ds))
-        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
-
-
-class TestDistCreateDataset(DistTestCase):
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-
-    @DistCall(nnodes=1, nproc_per_node=2)
-    def test_mp_dataset(self):
-        print("persistent", dist.get_rank())
-        items = [[list(range(i))] for i in range(5)]
-        cache_dir = os.path.join(self.tempdir, "test")
-        ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=cache_dir)
-        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
-        ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=cache_dir)
-        self.assertEqual(list(ds1), list(ds))
-        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
 
 
 if __name__ == "__main__":

--- a/tests/test_persistentdataset_dist.py
+++ b/tests/test_persistentdataset_dist.py
@@ -1,0 +1,78 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+import torch.distributed as dist
+
+from monai.data import PersistentDataset, json_hashing
+from monai.transforms import Transform
+from tests.utils import DistCall, DistTestCase
+
+
+class _InplaceXform(Transform):
+    def __call__(self, data):
+        if data:
+            data[0] = data[0] + np.pi
+        else:
+            data.append(1)
+        return data
+
+
+class TestDistDataset(DistTestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    @DistCall(nnodes=1, nproc_per_node=2)
+    def test_mp_dataset(self):
+        print("persistent", dist.get_rank())
+        items = [[list(range(i))] for i in range(5)]
+        ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=self.tempdir)
+        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+        ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=self.tempdir)
+        self.assertEqual(list(ds1), list(ds))
+        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+
+        ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=self.tempdir, hash_func=json_hashing)
+        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+        ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=self.tempdir, hash_func=json_hashing)
+        self.assertEqual(list(ds1), list(ds))
+        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+
+
+class TestDistCreateDataset(DistTestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    @DistCall(nnodes=1, nproc_per_node=2)
+    def test_mp_dataset(self):
+        print("persistent", dist.get_rank())
+        items = [[list(range(i))] for i in range(5)]
+        cache_dir = os.path.join(self.tempdir, "test")
+        ds = PersistentDataset(items, transform=_InplaceXform(), cache_dir=cache_dir)
+        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+        ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=cache_dir)
+        self.assertEqual(list(ds1), list(ds))
+        self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #2374

### Description
allows for existing cache dir to avoid race condition

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
