### PR TITLE
Add query to NGC to get matched model URL and version.

### DIFF
--- a/monai/apps/mmars/mmars.py
+++ b/monai/apps/mmars/mmars.py
@@ -90,8 +90,8 @@ def _get_all_ngc_models(pattern, page_index=0, page_size=50):
     return model_dict
 
 
-def _get_ngc_url(model_name: str, version: str):
-    return f"https://api.ngc.nvidia.com/v2/models/{model_name}/versions/{version}/zip"
+def _get_ngc_url(model_name: str, version: str, model_prefix=""):
+    return f"https://api.ngc.nvidia.com/v2/models/{model_prefix}{model_name}/versions/{version}/zip"
 
 
 def download_mmar(item, mmar_dir=None, progress: bool = True, api: bool = False, version: int = 1):
@@ -155,7 +155,7 @@ def download_mmar(item, mmar_dir=None, progress: bool = True, api: bool = False,
 
     model_dir = os.path.join(mmar_dir, item[Keys.ID])
     download_and_extract(
-        url=_get_ngc_url(item[Keys.NAME], str(version)),
+        url=_get_ngc_url(item[Keys.NAME], str(version), model_prefix="nvidia/med/"),
         filepath=os.path.join(mmar_dir, f"{item[Keys.ID]}.{item[Keys.FILE_TYPE]}"),
         output_dir=model_dir,
         hash_val=item[Keys.HASH_VAL],

--- a/monai/apps/mmars/mmars.py
+++ b/monai/apps/mmars/mmars.py
@@ -21,7 +21,6 @@ import os
 import warnings
 from typing import Mapping
 
-import requests
 import torch
 
 import monai.networks.nets as monai_nets
@@ -74,16 +73,20 @@ def _get_all_ngc_models(pattern, page_index=0, page_size=50):
     query_dict["filters"] = filter
     query_str = json.dumps(query_dict)
     full_url = f"{url}?q={query_str}"
-    resp = requests.get(full_url)
+    requests_get, has_requests = optional_import("requests", name="get")
+    if has_requests:
+        resp = requests_get(full_url)
+    else:
+        raise ValueError("NGC API requires requests package.  Please install it.")
     model_list = json.loads(resp.text)
     model_dict = dict()
     for result in model_list["results"]:
         for model in result["resources"]:
-            current_resId = model["resourceId"]
-            model_dict[current_resId] = {"name": model["name"]}
+            current_res_id = model["resourceId"]
+            model_dict[current_res_id] = {"name": model["name"]}
             for attribute in model["attributes"]:
                 if attribute["key"] == "latestVersionIdStr":
-                    model_dict[current_resId]["latest"] = attribute["value"]
+                    model_dict[current_res_id]["latest"] = attribute["value"]
     return model_dict
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,3 +34,4 @@ sphinx-rtd-theme==0.5.2
 cucim~=0.19.0; platform_system == "Linux"
 openslide-python==1.1.2
 pandas
+requests


### PR DESCRIPTION
Allow mmar download with latest version or a specific version.

Signed-off-by: Isaac Yang <isaacy@nvidia.com>

Fixes #2365 .

### Description
Add api, version options to current download_mmar method to enable query NGC for list of models, and the version to download.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
