### PR TITLE
Add parameter unpacking for transforms

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -1031,7 +1031,7 @@ class NPZDictItemDataset(Dataset):
         self,
         npzfile: Union[str, IO],
         keys: Dict[str, str],
-        transform: Optional[Callable] = None,
+        transform: Optional[Callable[..., Dict[str, Any]]] = None,
         other_keys: Optional[Sequence[str]] = (),
     ):
         self.npzfile: Union[str, IO] = npzfile if isinstance(npzfile, str) else "STREAM"
@@ -1058,10 +1058,15 @@ class NPZDictItemDataset(Dataset):
     def _transform(self, index: int):
         data = {k: v[index] for k, v in self.arrays.items()}
 
-        if self.transform is not None:
-            data = apply_transform(self.transform, data)
+        if not self.transform:
+            return data
 
-        return data
+        transformed_data = apply_transform(self.transform, data)
+
+        if not isinstance(transformed_data, dict):
+            raise AssertionError("With a dict supplied to apply_transform a single dict return is expected.")
+
+        return transformed_data
 
 
 class CSVDataset(Dataset):

--- a/monai/data/image_dataset.py
+++ b/monai/data/image_dataset.py
@@ -111,20 +111,22 @@ class ImageDataset(Dataset, Randomizable):
         if self.transform is not None:
             if isinstance(self.transform, Randomizable):
                 self.transform.set_random_state(seed=self._seed)
-            img = apply_transform(
-                self.transform, (img, meta_data) if self.transform_with_metadata else img, map_items=False
-            )
+
             if self.transform_with_metadata:
-                img, meta_data = img
+                img, meta_data = apply_transform(self.transform, (img, meta_data), map_items=False, unpack_items=True)
+            else:
+                img = apply_transform(self.transform, img, map_items=False)
 
         if self.seg_transform is not None:
             if isinstance(self.seg_transform, Randomizable):
                 self.seg_transform.set_random_state(seed=self._seed)
-            seg = apply_transform(
-                self.seg_transform, (seg, seg_meta_data) if self.transform_with_metadata else seg, map_items=False
-            )
+
             if self.transform_with_metadata:
-                seg, seg_meta_data = seg
+                seg, seg_meta_data = apply_transform(
+                    self.seg_transform, (seg, seg_meta_data), map_items=False, unpack_items=True
+                )
+            else:
+                seg = apply_transform(self.seg_transform, seg, map_items=False)
 
         if self.labels is not None:
             label = self.labels[index]

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -131,7 +131,7 @@ def default_make_latent(
     return torch.randn(num_latents, latent_size).to(device=device, non_blocking=non_blocking)
 
 
-def engine_apply_transform(batch: Any, output: Any, transform: Callable):
+def engine_apply_transform(batch: Any, output: Any, transform: Callable[..., Dict]):
     """
     Apply transform for the engine.state.batch and engine.state.output.
     If `batch` and `output` are dictionaries, temporarily combine them for the transform,
@@ -141,8 +141,12 @@ def engine_apply_transform(batch: Any, output: Any, transform: Callable):
     if isinstance(batch, dict) and isinstance(output, dict):
         data = dict(batch)
         data.update(output)
-        data = apply_transform(transform, data)
-        for k, v in data.items():
+        transformed_data = apply_transform(transform, data)
+
+        if not isinstance(transformed_data, dict):
+            raise AssertionError("With a dict supplied to apply_transform a single dict return is expected.")
+
+        for k, v in transformed_data.items():
             # split the output data of post transforms into `output` and `batch`,
             # `batch` should be read-only, so save the generated key-value into `output`
             if k in output or k not in batch:

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -102,12 +102,16 @@ class Compose(Randomizable, InvertibleTransform):
     """
 
     def __init__(
-        self, transforms: Optional[Union[Sequence[Callable], Callable]] = None, map_items: bool = True
+        self,
+        transforms: Optional[Union[Sequence[Callable], Callable]] = None,
+        map_items: bool = True,
+        unpack_items: bool = False,
     ) -> None:
         if transforms is None:
             transforms = []
         self.transforms = ensure_tuple(transforms)
         self.map_items = map_items
+        self.unpack_items = unpack_items
         self.set_random_state(seed=get_seed())
 
     def set_random_state(self, seed: Optional[int] = None, state: Optional[np.random.RandomState] = None) -> "Compose":
@@ -152,7 +156,7 @@ class Compose(Randomizable, InvertibleTransform):
 
     def __call__(self, input_):
         for _transform in self.transforms:
-            input_ = apply_transform(_transform, input_, self.map_items)
+            input_ = apply_transform(_transform, input_, self.map_items, self.unpack_items)
         return input_
 
     def inverse(self, data):
@@ -162,5 +166,5 @@ class Compose(Randomizable, InvertibleTransform):
 
         # loop backwards over transforms
         for t in reversed(invertible_transforms):
-            data = apply_transform(t.inverse, data, self.map_items)
+            data = apply_transform(t.inverse, data, self.map_items, self.unpack_items)
         return data

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -79,6 +79,26 @@ class TestCompose(unittest.TestCase):
         for item in value:
             self.assertDictEqual(item, {"a": 2, "b": 1, "c": 2})
 
+    def test_non_dict_compose_with_unpack(self):
+        def a(i, i2):
+            return i + "a", i2 + "a2"
+
+        def b(i, i2):
+            return i + "b", i2 + "b2"
+
+        c = Compose([a, b, a, b], map_items=False, unpack_items=True)
+        self.assertEqual(c(("", "")), ("abab", "a2b2a2b2"))
+
+    def test_list_non_dict_compose_with_unpack(self):
+        def a(i, i2):
+            return i + "a", i2 + "a2"
+
+        def b(i, i2):
+            return i + "b", i2 + "b2"
+
+        c = Compose([a, b, a, b], unpack_items=True)
+        self.assertEqual(c([("", ""), ("t", "t")]), [("abab", "a2b2a2b2"), ("tabab", "ta2b2a2b2")])
+
     def test_list_dict_compose_no_map(self):
         def a(d):  # transform to handle dict data
             d = dict(d)

--- a/tests/test_image_dataset.py
+++ b/tests/test_image_dataset.py
@@ -36,8 +36,7 @@ class RandTest(RandomizableTransform):
 
 
 class _TestCompose(Compose):
-    def __call__(self, input_):
-        data, meta = input_
+    def __call__(self, data, meta):
         data = self.transforms[0](data, meta)  # ensure channel first
         data, _, meta["affine"] = self.transforms[1](data, meta["affine"])  # spacing
         if len(self.transforms) == 3:


### PR DESCRIPTION
Signed-off-by: Sebastian Penhouet <sebastian.penhouet@airamed.de>

Fixes https://github.com/Project-MONAI/MONAI/issues/2426

### Description
Transforms can return any number of values. This pull request enables that these return values are passed into the next transform in a Compose as parameters (unpacked arguments).
This is especially useful in the case where the input and output of transforms always matches like in the case of always passing along the image array and the meta data dict.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
