### PR TITLE
no need for default orig_size stored for invertible transforms

### DIFF
--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -76,7 +76,7 @@ class InvertibleTransform(Transform):
         info = {
             InverseKeys.CLASS_NAME: self.__class__.__name__,
             InverseKeys.ID: id(self),
-            InverseKeys.ORIG_SIZE: orig_size or (data[key].shape[1:] if hasattr(data[key], "shape") else None),
+            InverseKeys.ORIG_SIZE: orig_size or (data[key].shape[1:] if hasattr(data[key], "shape") else -1),
         }
         if extra_info is not None:
             info[InverseKeys.EXTRA_INFO] = extra_info

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -78,9 +78,9 @@ class InvertibleTransform(Transform):
             InverseKeys.ID: id(self),
         }
         if orig_size is not None:
-            InverseKeys.ORIG_SIZE = orig_size
+            info[InverseKeys.ORIG_SIZE] = orig_size
         elif hasattr(data[key], "shape"):
-            InverseKeys.ORIG_SIZE = data[key].shape[1:]
+            info[InverseKeys.ORIG_SIZE] = data[key].shape[1:]
         if extra_info is not None:
             info[InverseKeys.EXTRA_INFO] = extra_info
         # If class is randomizable transform, store whether the transform was actually performed (based on `prob`)

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -76,8 +76,11 @@ class InvertibleTransform(Transform):
         info = {
             InverseKeys.CLASS_NAME: self.__class__.__name__,
             InverseKeys.ID: id(self),
-            InverseKeys.ORIG_SIZE: orig_size or (data[key].shape[1:] if hasattr(data[key], "shape") else -1),
         }
+        if orig_size is not None:
+            InverseKeys.ORIG_SIZE = orig_size
+        elif hasattr(data[key], "shape"):
+            InverseKeys.ORIG_SIZE = data[key].shape[1:]
         if extra_info is not None:
             info[InverseKeys.EXTRA_INFO] = extra_info
         # If class is randomizable transform, store whether the transform was actually performed (based on `prob`)


### PR DESCRIPTION
### Description
If an object didn't have the attribute `shape`, we stored `orig_size` as `None`. However, `None` can't be collated into a batch, so if the object doesn't have the attribute `shape`, then don't store that information.

Fixes https://github.com/Project-MONAI/MONAI/discussions/2414.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
