### PR TITLE
match keys in doc code examples

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -106,8 +106,8 @@ class PersistentDataset(Dataset):
     For example, typical input data can be a list of dictionaries::
 
         [{                            {                            {
-             'img': 'image1.nii.gz',      'img': 'image2.nii.gz',      'img': 'image3.nii.gz',
-             'seg': 'label1.nii.gz',      'seg': 'label2.nii.gz',      'seg': 'label3.nii.gz',
+             'image': 'image1.nii.gz',    'image': 'image2.nii.gz',    'image': 'image3.nii.gz',
+             'label': 'label1.nii.gz',    'label': 'label2.nii.gz',    'label': 'label3.nii.gz',
              'extra': 123                 'extra': 456                 'extra': 789
          },                           },                           }]
 


### PR DESCRIPTION
Signed-off-by: Jeff VanOss <jeff.vanoss@bamfhealth.com>

### Description
Docs change so that keys in code blocks match

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
