### PR TITLE
Fix blossom-ci - add comma after last user

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     # This job only runs for pull request comments
     if: |
-         contains( 'madil90,Nic-Ma,wyli', format('{0},', github.actor)) &&
+         contains( 'madil90,Nic-Ma,wyli,', format('{0},', github.actor)) &&
          github.event.comment.body == '/build'
     steps:
       - name: Check if comment is issued by authorized person


### PR DESCRIPTION
part of #2381 

### Description
add comma after last user.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
