### PR TITLE
2512 Make get_model_spec API

### DIFF
--- a/monai/apps/__init__.py
+++ b/monai/apps/__init__.py
@@ -10,5 +10,5 @@
 # limitations under the License.
 
 from .datasets import CrossValidation, DecathlonDataset, MedNISTDataset
-from .mmars import MODEL_DESC, RemoteMMARKeys, download_mmar, load_from_mmar
+from .mmars import MODEL_DESC, RemoteMMARKeys, download_mmar, get_model_spec, load_from_mmar
 from .utils import check_hash, download_and_extract, download_url, extractall

--- a/monai/apps/mmars/__init__.py
+++ b/monai/apps/mmars/__init__.py
@@ -9,5 +9,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .mmars import download_mmar, load_from_mmar
+from .mmars import download_mmar, get_model_spec, load_from_mmar
 from .model_desc import MODEL_DESC, RemoteMMARKeys

--- a/monai/apps/mmars/mmars.py
+++ b/monai/apps/mmars/mmars.py
@@ -19,7 +19,7 @@ See Also:
 import json
 import os
 import warnings
-from typing import Mapping
+from typing import Mapping, Union
 
 import torch
 
@@ -33,14 +33,14 @@ from .model_desc import RemoteMMARKeys as Keys
 __all__ = ["get_model_spec", "download_mmar", "load_from_mmar"]
 
 
-def get_model_spec(idx):
+def get_model_spec(idx: Union[int, str]):
     """get model specification by `idx`. `idx` could be index of the constant tuple of dict or the actual model ID."""
     if isinstance(idx, int):
         return MODEL_DESC[idx]
     if isinstance(idx, str):
         key = idx.strip().lower()
         for cand in MODEL_DESC:
-            if cand[Keys.ID].strip().lower() == key:
+            if str(cand[Keys.ID]).strip().lower() == key:
                 return cand
     print(f"Available specs are: {MODEL_DESC}.")
     raise ValueError(f"Unknown MODEL_DESC request: {idx}")

--- a/monai/apps/mmars/mmars.py
+++ b/monai/apps/mmars/mmars.py
@@ -30,10 +30,10 @@ from monai.utils.module import optional_import
 from .model_desc import MODEL_DESC
 from .model_desc import RemoteMMARKeys as Keys
 
-__all__ = ["download_mmar", "load_from_mmar"]
+__all__ = ["get_model_spec", "download_mmar", "load_from_mmar"]
 
 
-def _get_model_spec(idx):
+def get_model_spec(idx):
     """get model specification by `idx`. `idx` could be index of the constant tuple of dict or the actual model ID."""
     if isinstance(idx, int):
         return MODEL_DESC[idx]
@@ -155,7 +155,7 @@ def download_mmar(item, mmar_dir=None, progress: bool = True, api: bool = False,
         return model_dir_list
 
     if not isinstance(item, Mapping):
-        item = _get_model_spec(item)
+        item = get_model_spec(item)
 
     ver = item.get(Keys.VERSION, 1)
     if version > 0:
@@ -210,7 +210,7 @@ def load_from_mmar(
         https://docs.nvidia.com/clara/
     """
     if not isinstance(item, Mapping):
-        item = _get_model_spec(item)
+        item = get_model_spec(item)
     model_dir = download_mmar(item=item, mmar_dir=mmar_dir, progress=progress, version=version)
     model_file = os.path.join(model_dir, item[Keys.MODEL_FILE])
     print(f'\n*** "{item[Keys.ID]}" available at {model_dir}.')

--- a/tests/test_mmar_download.py
+++ b/tests/test_mmar_download.py
@@ -18,7 +18,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.apps import download_mmar, load_from_mmar
+from monai.apps import download_mmar, get_model_spec, load_from_mmar, RemoteMMARKeys
 from monai.apps.mmars import MODEL_DESC
 from monai.apps.mmars.mmars import _get_val
 from tests.utils import SkipIfAtLeastPyTorchVersion, SkipIfBeforePyTorchVersion, skip_if_quick
@@ -106,6 +106,9 @@ class TestMMMARDownload(unittest.TestCase):
     @SkipIfBeforePyTorchVersion((1, 6))
     def test_download(self, idx):
         try:
+            # test model specification
+            cand = get_model_spec(idx)
+            self.assertEqual(cand[RemoteMMARKeys.ID], idx)
             download_mmar(idx)
             download_mmar(idx, progress=False)  # repeated to check caching
             with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_mmar_download.py
+++ b/tests/test_mmar_download.py
@@ -18,7 +18,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.apps import download_mmar, get_model_spec, load_from_mmar, RemoteMMARKeys
+from monai.apps import RemoteMMARKeys, download_mmar, get_model_spec, load_from_mmar
 from monai.apps.mmars import MODEL_DESC
 from monai.apps.mmars.mmars import _get_val
 from tests.utils import SkipIfAtLeastPyTorchVersion, SkipIfBeforePyTorchVersion, skip_if_quick


### PR DESCRIPTION
Fixes #2512 .

### Description
This PR makes `get_model_spec` as API according to the feature reuqest.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
