### PR TITLE
2516 Change reference code links of PyTorch and ignite to API docs

### DIFF
--- a/monai/data/dataloader.py
+++ b/monai/data/dataloader.py
@@ -35,7 +35,7 @@ class DataLoader(_TorchDataLoader):
           See: :py:class:`monai.transforms.Compose`.
 
     For more details about :py:class:`torch.utils.data.DataLoader`, please see:
-    https://github.com/pytorch/pytorch/blob/master/torch/utils/data/dataloader.py
+    https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader.
 
     For example, to construct a randomized dataset and iterate with the data loader:
 

--- a/monai/data/samplers.py
+++ b/monai/data/samplers.py
@@ -34,7 +34,7 @@ class DistributedSampler(_TorchDistributedSampler):
         kwargs: additional arguments for `DistributedSampler` super class, can be `seed` and `drop_last`.
 
     More information about DistributedSampler, please check:
-    https://github.com/pytorch/pytorch/blob/master/torch/utils/data/distributed.py
+    https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler.
 
     """
 
@@ -61,7 +61,7 @@ class DistributedWeightedRandomSampler(DistributedSampler):
     """
     Extend the `DistributedSampler` to support weighted sampling.
     Refer to `torch.utils.data.WeightedRandomSampler`, for more details please check:
-    https://github.com/pytorch/pytorch/blob/master/torch/utils/data/sampler.py#L150
+    https://pytorch.org/docs/stable/data.html#torch.utils.data.WeightedRandomSampler.
 
     Args:
         dataset: Dataset used for sampling.

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -817,7 +817,7 @@ def partition_dataset(
     Split the dataset into N partitions. It can support shuffle based on specified random seed.
     Will return a set of datasets, every dataset contains 1 partition of original dataset.
     And it can split the dataset based on specified ratios or evenly split into `num_partitions`.
-    Refer to: https://github.com/pytorch/pytorch/blob/master/torch/utils/data/distributed.py.
+    Refer to: https://pytorch.org/docs/stable/distributed.html#module-torch.distributed.launch.
 
     Note:
         It also can be used to partition dataset for ranks in distributed training.

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -64,7 +64,8 @@ class Evaluator(Workflow):
         event_names: additional custom ignite events that will register to the engine.
             new events can be a list of str or `ignite.engine.events.EventEnum`.
         event_to_attr: a dictionary to map an event to a state attribute, then add to `engine.state`.
-            for more details, check: https://github.com/pytorch/ignite/blob/v0.4.4.post1/ignite/engine/engine.py#L160
+            for more details, check: https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html
+            #ignite.engine.engine.Engine.register_events.
         decollate: whether to decollate the batch-first data to a list of data after model computation,
             default to `True`. if `False`, postprocessing will be ignored as the `monai.transforms` module
             assumes channel-first data.
@@ -166,7 +167,8 @@ class SupervisedEvaluator(Evaluator):
         event_names: additional custom ignite events that will register to the engine.
             new events can be a list of str or `ignite.engine.events.EventEnum`.
         event_to_attr: a dictionary to map an event to a state attribute, then add to `engine.state`.
-            for more details, check: https://github.com/pytorch/ignite/blob/v0.4.4.post1/ignite/engine/engine.py#L160
+            for more details, check: https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html
+            #ignite.engine.engine.Engine.register_events.
         decollate: whether to decollate the batch-first data to a list of data after model computation,
             default to `True`. if `False`, postprocessing will be ignored as the `monai.transforms` module
             assumes channel-first data.
@@ -293,7 +295,8 @@ class EnsembleEvaluator(Evaluator):
         event_names: additional custom ignite events that will register to the engine.
             new events can be a list of str or `ignite.engine.events.EventEnum`.
         event_to_attr: a dictionary to map an event to a state attribute, then add to `engine.state`.
-            for more details, check: https://github.com/pytorch/ignite/blob/v0.4.4.post1/ignite/engine/engine.py#L160
+            for more details, check: https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html
+            #ignite.engine.engine.Engine.register_events.
         decollate: whether to decollate the batch-first data to a list of data after model computation,
             default to `True`. if `False`, postprocessing will be ignored as the `monai.transforms` module
             assumes channel-first data.

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -94,7 +94,8 @@ class SupervisedTrainer(Trainer):
         event_names: additional custom ignite events that will register to the engine.
             new events can be a list of str or `ignite.engine.events.EventEnum`.
         event_to_attr: a dictionary to map an event to a state attribute, then add to `engine.state`.
-            for more details, check: https://github.com/pytorch/ignite/blob/v0.4.4.post1/ignite/engine/engine.py#L160
+            for more details, check: https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html
+            #ignite.engine.engine.Engine.register_events.
         decollate: whether to decollate the batch-first data to a list of data after model computation,
             default to `True`. if `False`, postprocessing will be ignored as the `monai.transforms` module
             assumes channel-first data.

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -37,7 +37,7 @@ __all__ = [
 class IterationEvents(EventEnum):
     """
     Additional Events engine can register and trigger in the iteration process.
-    Refer to the example in ignite: https://github.com/pytorch/ignite/blob/master/ignite/engine/events.py#L146
+    Refer to the example in ignite: https://pytorch.org/ignite/generated/ignite.engine.events.EventEnum.html.
     These Events can be triggered during training iteration:
     `FORWARD_COMPLETED` is the Event when `network(image, label)` completed.
     `LOSS_COMPLETED` is the Event when `loss(pred, label)` completed.
@@ -106,7 +106,8 @@ def default_prepare_batch(
 ) -> Union[Tuple[torch.Tensor, Optional[torch.Tensor]], torch.Tensor]:
     """
     Default function to prepare the data for current iteration.
-    Refer to ignite: https://github.com/pytorch/ignite/blob/v0.4.2/ignite/engine/__init__.py#L28.
+    Refer to ignite: https://pytorch.org/ignite/v0.4.5/generated/ignite.engine.create_supervised_trainer.html
+    #ignite.engine.create_supervised_trainer.
 
     Returns:
         image, label(optional).

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -72,7 +72,8 @@ class Workflow(IgniteEngine):  # type: ignore[valid-type, misc] # due to optiona
         event_names: additional custom ignite events that will register to the engine.
             new events can be a list of str or `ignite.engine.events.EventEnum`.
         event_to_attr: a dictionary to map an event to a state attribute, then add to `engine.state`.
-            for more details, check: https://github.com/pytorch/ignite/blob/v0.4.4.post1/ignite/engine/engine.py#L160
+            for more details, check: https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html
+            #ignite.engine.engine.Engine.register_events.
         decollate: whether to decollate the batch-first data to a list of data after model computation,
             default to `True`. if `False`, postprocessing will be ignored as the `monai.transforms` module
             assumes channel-first data.

--- a/monai/handlers/checkpoint_loader.py
+++ b/monai/handlers/checkpoint_loader.py
@@ -60,8 +60,9 @@ class CheckpointLoader:
         checkpoint, so skip loading checkpoint for optimizer.
 
         For more details about loading checkpoint, please refer to:
-        https://github.com/pytorch/ignite/blob/v0.4.5/ignite/handlers/checkpoint.py#L499.
-        https://github.com/pytorch/pytorch/blob/v1.9.0/torch/nn/modules/module.py#L1354.
+        https://pytorch.org/ignite/v0.4.5/generated/ignite.handlers.checkpoint.Checkpoint.html
+        #ignite.handlers.checkpoint.Checkpoint.load_objects.
+        https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.load_state_dict.
 
     """
 

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -57,8 +57,9 @@ class CheckpointSaver:
         key_metric_filename: set a fixed filename to set the best metric model, if not None,
             `key_metric_n_saved` should be 1 and only keep the best metric model.
         key_metric_save_state: whether to save the tracking list of key metric in the checkpoint file.
-            if `True`, then will save an object in the checkpoint file with key `checkpointer` to be consistent
-            with ignite: https://github.com/pytorch/ignite/blob/master/ignite/handlers/checkpoint.py#L99.
+            if `True`, then will save an object in the checkpoint file with key `checkpointer` to be
+            consistent with the `include_self` arg of `Checkpoint` in ignite:
+            https://pytorch.org/ignite/v0.4.5/generated/ignite.handlers.checkpoint.Checkpoint.html.
             typically, it's used to resume training and compare current metric with previous N values.
         key_metric_greater_or_equal: if `True`, the latest equally scored model is stored. Otherwise,
             save the the first equally scored model. default to `False`.

--- a/monai/handlers/parameter_scheduler.py
+++ b/monai/handlers/parameter_scheduler.py
@@ -123,8 +123,8 @@ class ParamSchedulerHandler:
         """
         Decays the parameter value by gamma every step.
 
-        Based on the closed form of ExponentialLR from Pytorch
-        https://github.com/pytorch/pytorch/blob/master/torch/optim/lr_scheduler.py#L457
+        Based on the closed form of ExponentialLR from Pytorch:
+        https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ExponentialLR.html.
 
         Args:
             initial_value (float): Starting value of the parameter.
@@ -141,8 +141,8 @@ class ParamSchedulerHandler:
         """
         Decays the parameter value by gamma every step_size.
 
-        Based on StepLR from Pytorch.
-        https://github.com/pytorch/pytorch/blob/master/torch/optim/lr_scheduler.py#L377
+        Based on StepLR from Pytorch:
+        https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.StepLR.html.
 
         Args:
             initial_value (float): Starting value of the parameter.
@@ -161,7 +161,7 @@ class ParamSchedulerHandler:
         Decays the parameter value by gamma once the number of steps reaches one of the milestones.
 
         Based on MultiStepLR from Pytorch.
-        https://github.com/pytorch/pytorch/blob/master/torch/optim/lr_scheduler.py#L424
+        https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.MultiStepLR.html.
 
         Args:
             initial_value (float): Starting value of the parameter.

--- a/monai/handlers/utils.py
+++ b/monai/handlers/utils.py
@@ -93,7 +93,7 @@ def string_list_all_gather(strings: List[str]) -> List[str]:
     """
     Utility function for distributed data parallel to all gather a list of strings.
     Note that if the item in `strings` is longer than 1024 chars, it will be truncated to 1024:
-    https://github.com/pytorch/ignite/blob/master/ignite/distributed/comp_models/base.py#L92
+    https://pytorch.org/ignite/v0.4.5/distributed.html#ignite.distributed.utils.all_gather.
 
     Args:
         strings: a list of strings to all gather.

--- a/monai/networks/blocks/upsample.py
+++ b/monai/networks/blocks/upsample.py
@@ -154,9 +154,9 @@ class SubpixelUpsample(nn.Module):
     https://arxiv.org/abs/1609.05158
 
     The pixel shuffle mechanism refers to:
-    https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/PixelShuffle.cpp
+    https://pytorch.org/docs/stable/generated/torch.nn.PixelShuffle.html#torch.nn.PixelShuffle.
     and:
-    https://github.com/pytorch/pytorch/pull/6340/files
+    https://github.com/pytorch/pytorch/pull/6340.
 
     """
 

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -120,7 +120,7 @@ class _Transition(nn.Sequential):
 class DenseNet(nn.Module):
     """
     Densenet based on: `Densely Connected Convolutional Networks <https://arxiv.org/pdf/1608.06993.pdf>`_.
-    Adapted from `PyTorch Hub 2D version: https://pytorch.org/vision/stable/models.html#id16.
+    Adapted from PyTorch Hub 2D version: https://pytorch.org/vision/stable/models.html#id16.
 
     Args:
         spatial_dims: number of spatial dimensions of the input image.
@@ -216,7 +216,7 @@ class DenseNet(nn.Module):
 def _load_state_dict(model, arch, progress):
     """
     This function is used to load pretrained models.
-    Adapted from `PyTorch Hub 2D version: https://pytorch.org/vision/stable/models.html#id16.
+    Adapted from PyTorch Hub 2D version: https://pytorch.org/vision/stable/models.html#id16.
 
     """
     model_urls = {

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -120,8 +120,7 @@ class _Transition(nn.Sequential):
 class DenseNet(nn.Module):
     """
     Densenet based on: `Densely Connected Convolutional Networks <https://arxiv.org/pdf/1608.06993.pdf>`_.
-    Adapted from `PyTorch Hub 2D version
-    <https://github.com/pytorch/vision/blob/master/torchvision/models/densenet.py>`_.
+    Adapted from `PyTorch Hub 2D version: https://pytorch.org/vision/stable/models.html#id16.
 
     Args:
         spatial_dims: number of spatial dimensions of the input image.
@@ -217,8 +216,8 @@ class DenseNet(nn.Module):
 def _load_state_dict(model, arch, progress):
     """
     This function is used to load pretrained models.
-    Adapted from `PyTorch Hub 2D version
-    <https://github.com/pytorch/vision/blob/master/torchvision/models/densenet.py>`_
+    Adapted from `PyTorch Hub 2D version: https://pytorch.org/vision/stable/models.html#id16.
+
     """
     model_urls = {
         "densenet121": "https://download.pytorch.org/models/densenet121-a639ec97.pth",

--- a/monai/utils/dist.py
+++ b/monai/utils/dist.py
@@ -127,7 +127,7 @@ def string_list_all_gather(strings: List[str], delimiter: str = "\t") -> List[st
     """
     Utility function for distributed data parallel to all gather a list of strings.
     Refer to the idea of ignite `all_gather(string)`:
-    https://github.com/pytorch/ignite/blob/master/ignite/distributed/utils.py#L346.
+    https://pytorch.org/ignite/v0.4.5/distributed.html#ignite.distributed.utils.all_gather.
 
     Note: If has ignite installed, will execute based on ignite distributed APIs, otherwise, if the native
     PyTorch distributed group initialized, will execute based on native PyTorch distributed APIs.

--- a/tests/test_optim_novograd.py
+++ b/tests/test_optim_novograd.py
@@ -74,8 +74,9 @@ if torch.cuda.device_count() > 1:
 
 class TestNovograd(unittest.TestCase):
     """
-    This class takes `Pytorch's test_optim function
-    <https://github.com/pytorch/pytorch/blob/master/test/test_optim.py>`_ for reference.
+    This class takes `Pytorch's test_optim function:
+    https://github.com/pytorch/pytorch/blob/v1.9.0/test/test_optim.py for reference.
+
     """
 
     @parameterized.expand(TEST_CASES_ALL)


### PR DESCRIPTION
Fixes #2516 .

### Description
This PR changed the **outdated source code link** of PyTorch and ignite to the formal API docs.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
