### PR TITLE
update lmdbdataset

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -428,8 +428,8 @@ class LMDBDataset(PersistentDataset):
 
     def _fill_cache_start_reader(self, show_progress=True):
         """
-        Write the LMDB cache. py-lmdb doesn't have good support of concurrent write
-        this method could be used with multiple processes, but it may have an impact on the performance.
+        Check the LMDB cache and write the cache if needed. py-lmdb doesn't have a good support for concurrent write.
+        This method can be used with multiple processes, but it may have a negative impact on the performance.
 
         Args:
             show_progress: whether to show the progress bar if possible.

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -414,6 +414,8 @@ class LMDBDataset(PersistentDataset):
         if not self.lmdb_kwargs.get("map_size", 0):
             self.lmdb_kwargs["map_size"] = 1024 ** 4  # default map_size
         self._env = None
+        # lmdb is single-writer multi-reader by default
+        # the cache is created without multi-threading
         self._read_env = self._fill_cache_start_reader(show_progress=self.progress)
         print(f"Accessing lmdb file: {self.db_file.absolute()}.")
 

--- a/tests/test_lmdbdataset.py
+++ b/tests/test_lmdbdataset.py
@@ -191,12 +191,15 @@ class TestLMDBDataset(unittest.TestCase):
                     "extra": os.path.join(tempdir, "test_extra2_new.nii.gz"),
                 },
             ]
-            dataset_postcached.set_data(data=test_data_new)
             # test new exchanged cache content
             if transform is None:
+                dataset_postcached.set_data(data=test_data_new)
                 self.assertEqual(dataset_postcached[0]["image"], os.path.join(tempdir, "test_image1_new.nii.gz"))
                 self.assertEqual(dataset_postcached[0]["label"], os.path.join(tempdir, "test_label1_new.nii.gz"))
                 self.assertEqual(dataset_postcached[1]["extra"], os.path.join(tempdir, "test_extra2_new.nii.gz"))
+            else:
+                with self.assertRaises(RuntimeError):
+                    dataset_postcached.set_data(data=test_data_new)  # filename list updated, files do not exist
 
 
 @skip_if_windows


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

this PR moves the lmdb `_fill_cache_start_reader` to the dataset's constructor, otherwise multiprocess lmdb writing may slow down the loading a lot

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
