### PR TITLE
2655-new doc theme

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,2 +1,4 @@
 @import url('https://fonts.googleapis.com/css?family=Lekton:700|Roboto&display=swap');
-body{font-family:'Roboto',sans-serif;}.wy-side-nav-search>div.version{color:#222;}a:visited{color:#0285b0;}.wy-menu-vertical a:visited{color:#d9d9d9;}.wy-menu-vertical p.caption{color:#7cccc7;}
+body{font-family:'Roboto',sans-serif;}.wy-menu-vertical p.caption{color:#7cccc7;}
+*{font-variant-ligatures: none;}.autoclasstoc td {padding:0.2rem;line-height:normal;}
+dl.field-list>dt{word-break: normal}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,8 +9,8 @@ scikit-image>=0.14.2
 tensorboard
 commonmark==0.9.1
 recommonmark==0.6.0
-Sphinx==3.5.3
-sphinx-rtd-theme==0.5.2
+Sphinx
+pydata-sphinx-theme
 sphinxcontrib-applehelp
 sphinxcontrib-devhelp
 sphinxcontrib-htmlhelp

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,20 @@
+:github_url: https://github.com/Project-MONAI/MONAI
+
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 1
+
+   apps
+   transforms
+   losses
+   networks
+   metrics
+   optimizers
+   data
+   engines
+   inferers
+   handlers
+   visualize
+   utils

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,8 +11,8 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sys
 import subprocess
+import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
@@ -68,12 +68,6 @@ def generate_apidocs(*args):
     )
 
 
-def setup(app):
-    # Hook to allow for automatic generation of API docs
-    # before doc deployment begins.
-    app.connect("builder-inited", generate_apidocs)
-
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -94,8 +88,10 @@ extensions = [
 
 autoclass_content = "both"
 add_module_names = True
+source_encoding = "utf-8"
 autosectionlabel_prefix_document = True
 napoleon_use_param = True
+napoleon_include_init_with_doc = True
 set_type_checking_flag = True
 
 # Add any paths that contain templates here, relative to this directory.
@@ -106,29 +102,55 @@ templates_path = ["_templates"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "pydata_sphinx_theme"
 # html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_theme_options = {
+    "external_links": [{"url": "https://github.com/Project-MONAI/tutorials", "name": "Tutorials"}],
     "collapse_navigation": True,
-    "display_version": True,
-    "sticky_navigation": True,  # Set to False to disable the sticky nav while scrolling.
-    "logo_only": True,  # if we have a html_logo below, this shows /only/ the logo with no title text
-    "style_nav_header_background": "#FBFBFB",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/project-monai/monai",
+            "icon": "fab fa-github-square",
+        },
+        {
+            "name": "Twitter",
+            "url": "https://twitter.com/projectmonai",
+            "icon": "fab fa-twitter-square",
+        },
+    ],
+    "collapse_navigation": True,
+    "navigation_depth": 3,
+    "show_toc_level": 1,
+    "footer_items": ["copyright"],
+    "navbar_align": "content",
 }
 html_context = {
-    "display_github": True,
     "github_user": "Project-MONAI",
     "github_repo": "MONAI",
     "github_version": "dev",
+    "doc_path": "docs/",
     "conf_py_path": "/docs/",
+    "VERSION": version,
 }
 html_scaled_image_link = False
 html_show_sourcelink = True
 html_favicon = "../images/favicon.ico"
 html_logo = "../images/MONAI-logo-color.png"
+html_sidebars = {"**": ["search-field", "sidebar-nav-bs"]}
+pygments_style = "sphinx"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["../_static"]
 html_css_files = ["custom.css"]
+html_title = f"{project} {version} Documentation"
+
+# -- Auto-convert markdown pages to demo --------------------------------------
+
+
+def setup(app):
+    # Hook to allow for automatic generation of API docs
+    # before doc deployment begins.
+    app.connect("builder-inited", generate_apidocs)

--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -1,0 +1,7 @@
+:github_url: https://github.com/Project-MONAI/MONAI
+
+Development
+===========
+
+For guidance on making a contribution to MONAI, see the `contributing guidelines
+<https://github.com/Project-MONAI/MONAI/blob/dev/CONTRIBUTING.md>`_.

--- a/docs/source/highlights.md
+++ b/docs/source/highlights.md
@@ -1,4 +1,4 @@
-# Modules overview
+# Modules Overview
 
 MONAI aims at supporting deep learning in medical image analysis at multiple granularities.
 This figure shows a typical example of the end-to-end workflow:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,26 +45,14 @@ Technical documentation is available at `docs.monai.io <https://docs.monai.io>`_
    :maxdepth: 1
    :caption: Feature highlights
 
-   whatsnew_0_6.md
-   whatsnew_0_5.md
+   whatsnew
    highlights.md
 
 .. toctree::
    :maxdepth: 1
-   :caption: APIs
+   :caption: API Reference
 
-   apps
-   transforms
-   losses
-   networks
-   metrics
-   optimizers
-   data
-   engines
-   inferers
-   handlers
-   visualize
-   utils
+   api
 
 .. toctree::
   :maxdepth: 1
@@ -72,12 +60,11 @@ Technical documentation is available at `docs.monai.io <https://docs.monai.io>`_
 
   installation
 
+.. toctree::
+  :maxdepth: 1
+  :caption: Contributing
 
-Contributing
-------------
-
-For guidance on making a contribution to MONAI, see the `contributing guidelines
-<https://github.com/Project-MONAI/MONAI/blob/dev/CONTRIBUTING.md>`_.
+  contrib
 
 
 Links

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,4 +1,4 @@
-# Installation guide
+# Installation Guide
 
 ## Table of Contents
 1. [From PyPI](#from-pypi)

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -1,0 +1,10 @@
+:github_url: https://github.com/Project-MONAI/MONAI
+
+What's New
+==========
+
+.. toctree::
+   :maxdepth: 1
+
+   whatsnew_0_6.md
+   whatsnew_0_5.md

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -131,14 +131,16 @@ class ITKReader(ImageReader):
 
     Args:
         channel_dim: the channel dimension of the input image, default is None.
-            This is used to set `original_channel_dim` in the meta data, `EnsureChannelFirstD` reads this field.
-            If None, `original_channel_dim` will be either `no_channel` or `-1`.
-            - Nifti file is usually "channel last", so there is no need to specify this argument.
-            - PNG file usually has `GetNumberOfComponentsPerPixel()==3`, so there is no need to specify this argument.
+            This is used to set original_channel_dim in the meta data, EnsureChannelFirstD reads this field.
+            If None, original_channel_dim will be either `no_channel` or `-1`.
+
+                - Nifti file is usually "channel last", so there is no need to specify this argument.
+                - PNG file usually has `GetNumberOfComponentsPerPixel()==3`, so there is no need to specify this argument.
+
         series_name: the name of the DICOM series if there are multiple ones.
             used when loading DICOM series.
         kwargs: additional args for `itk.imread` API. more details about available args:
-            https://github.com/InsightSoftwareConsortium/ITK/blob/master/Wrapping/Generators/Python/itkExtras.py
+            https://github.com/InsightSoftwareConsortium/ITK/blob/master/Wrapping/Generators/Python/itk/support/extras.py
 
     """
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #2655

### Description
the current preview is at https://monai-dev.readthedocs.io/en/new-doc-theme/
happy to change it to adopt any other themes

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
