### PR TITLE
2768 Add parameter bias for conv blocks

### DIFF
--- a/monai/networks/blocks/aspp.py
+++ b/monai/networks/blocks/aspp.py
@@ -39,6 +39,7 @@ class SimpleASPP(nn.Module):
         dilations: Sequence[int] = (1, 2, 4, 6),
         norm_type: Optional[Union[Tuple, str]] = "BATCH",
         acti_type: Optional[Union[Tuple, str]] = "LEAKYRELU",
+        bias: bool = False,
     ) -> None:
         """
         Args:
@@ -54,6 +55,9 @@ class SimpleASPP(nn.Module):
                 Defaults to batch norm.
             acti_type: final kernel-size-one convolution activation type.
                 Defaults to leaky ReLU.
+            bias: whether to have a bias term in convolution blocks. Defaults to False.
+                According to `Performance Tuning Guide <https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html>`_,
+                if a conv layer is directly followed by a batch norm layer, bias should be False.
 
         Raises:
             ValueError: When ``kernel_sizes`` length differs from ``dilations``.
@@ -88,6 +92,7 @@ class SimpleASPP(nn.Module):
             kernel_size=1,
             act=acti_type,
             norm=norm_type,
+            bias=bias,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/monai/networks/nets/autoencoder.py
+++ b/monai/networks/nets/autoencoder.py
@@ -37,6 +37,7 @@ class AutoEncoder(nn.Module):
         act: Optional[Union[Tuple, str]] = Act.PRELU,
         norm: Union[Tuple, str] = Norm.INSTANCE,
         dropout: Optional[Union[Tuple, str, float]] = None,
+        bias: bool = True,
     ) -> None:
 
         super().__init__()
@@ -51,6 +52,7 @@ class AutoEncoder(nn.Module):
         self.act = act
         self.norm = norm
         self.dropout = dropout
+        self.bias = bias
         self.num_inter_units = num_inter_units
         self.inter_channels = inter_channels if inter_channels is not None else []
         self.inter_dilations = list(inter_dilations or [1] * len(self.inter_channels))
@@ -103,6 +105,7 @@ class AutoEncoder(nn.Module):
                         norm=self.norm,
                         dropout=self.dropout,
                         dilation=di,
+                        bias=self.bias,
                     )
                 else:
                     unit = Convolution(
@@ -115,6 +118,7 @@ class AutoEncoder(nn.Module):
                         norm=self.norm,
                         dropout=self.dropout,
                         dilation=di,
+                        bias=self.bias,
                     )
 
                 intermediate.add_module("inter_%i" % i, unit)
@@ -148,6 +152,7 @@ class AutoEncoder(nn.Module):
                 act=self.act,
                 norm=self.norm,
                 dropout=self.dropout,
+                bias=self.bias,
                 last_conv_only=is_last,
             )
         return Convolution(
@@ -159,6 +164,7 @@ class AutoEncoder(nn.Module):
             act=self.act,
             norm=self.norm,
             dropout=self.dropout,
+            bias=self.bias,
             conv_only=is_last,
         )
 
@@ -175,6 +181,7 @@ class AutoEncoder(nn.Module):
             act=self.act,
             norm=self.norm,
             dropout=self.dropout,
+            bias=self.bias,
             conv_only=is_last and self.num_res_units == 0,
             is_transposed=True,
         )
@@ -192,6 +199,7 @@ class AutoEncoder(nn.Module):
                 act=self.act,
                 norm=self.norm,
                 dropout=self.dropout,
+                bias=self.bias,
                 last_conv_only=is_last,
             )
 

--- a/monai/networks/nets/highresnet.py
+++ b/monai/networks/nets/highresnet.py
@@ -43,6 +43,7 @@ class HighResBlock(nn.Module):
         dilation: Union[Sequence[int], int] = 1,
         norm_type: Union[Tuple, str] = ("batch", {"affine": True}),
         acti_type: Union[Tuple, str] = ("relu", {"inplace": True}),
+        bias: bool = False,
         channel_matching: Union[ChannelMatching, str] = ChannelMatching.PAD,
     ) -> None:
         """
@@ -56,6 +57,9 @@ class HighResBlock(nn.Module):
                 Defaults to ``("batch", {"affine": True})``.
             acti_type: {``"relu"``, ``"prelu"``, ``"relu6"``}
                 Non-linear activation using ReLU or PReLU. Defaults to ``"relu"``.
+            bias: whether to have a bias term in convolution blocks. Defaults to False.
+                According to `Performance Tuning Guide <https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html>`_,
+                if a conv layer is directly followed by a batch norm layer, bias should be False.
             channel_matching: {``"pad"``, ``"project"``}
                 Specifies handling residual branch and conv branch channel mismatches. Defaults to ``"pad"``.
 
@@ -85,6 +89,7 @@ class HighResBlock(nn.Module):
                     out_channels=_out_chns,
                     kernel_size=kernel_size,
                     dilation=dilation,
+                    bias=bias,
                 )
             )
             _in_chns = _out_chns
@@ -116,6 +121,9 @@ class HighResNet(nn.Module):
             Defaults to ``("relu", {"inplace": True})``.
         dropout_prob: probability of the feature map to be zeroed
             (only applies to the penultimate conv layer).
+        bias: whether to have a bias term in convolution blocks. Defaults to False.
+            According to `Performance Tuning Guide <https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html>`_,
+            if a conv layer is directly followed by a batch norm layer, bias should be False.
         layer_params: specifying key parameters of each layer/block.
         channel_matching: {``"pad"``, ``"project"``}
             Specifies handling residual branch and conv branch channel mismatches. Defaults to ``"pad"``.
@@ -132,6 +140,7 @@ class HighResNet(nn.Module):
         norm_type: Union[str, tuple] = ("batch", {"affine": True}),
         acti_type: Union[str, tuple] = ("relu", {"inplace": True}),
         dropout_prob: Optional[Union[Tuple, str, float]] = 0.0,
+        bias: bool = False,
         layer_params: Sequence[Dict] = DEFAULT_LAYER_PARAMS_3D,
         channel_matching: Union[ChannelMatching, str] = ChannelMatching.PAD,
     ) -> None:
@@ -151,6 +160,7 @@ class HighResNet(nn.Module):
                 adn_ordering="NA",
                 act=acti_type,
                 norm=norm_type,
+                bias=bias,
             )
         )
 
@@ -168,6 +178,7 @@ class HighResNet(nn.Module):
                         dilation=_dilation,
                         norm_type=norm_type,
                         acti_type=acti_type,
+                        bias=bias,
                         channel_matching=channel_matching,
                     )
                 )
@@ -185,6 +196,7 @@ class HighResNet(nn.Module):
                 adn_ordering="NAD",
                 act=acti_type,
                 norm=norm_type,
+                bias=bias,
                 dropout=dropout_prob,
             )
         )
@@ -200,6 +212,7 @@ class HighResNet(nn.Module):
                 adn_ordering="NAD",
                 act=acti_type,
                 norm=norm_type,
+                bias=bias,
                 dropout=dropout_prob,
             )
         )

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -38,7 +38,8 @@ class UNet(nn.Module):
         num_res_units: int = 0,
         act: Union[Tuple, str] = Act.PRELU,
         norm: Union[Tuple, str] = Norm.INSTANCE,
-        dropout=0.0,
+        dropout: float = 0.0,
+        bias: bool = True,
     ) -> None:
         """
         Enhanced version of UNet which has residual units implemented with the ResidualUnit class.
@@ -60,6 +61,9 @@ class UNet(nn.Module):
             act: activation type and arguments. Defaults to PReLU.
             norm: feature normalization type and arguments. Defaults to instance norm.
             dropout: dropout ratio. Defaults to no dropout.
+            bias: whether to have a bias term in convolution blocks. Defaults to True.
+                According to `Performance Tuning Guide <https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html>`_,
+                if a conv layer is directly followed by a batch norm layer, bias should be False.
 
         Note: The acceptable spatial size of input data depends on the parameters of the network,
             to set appropriate spatial size, please check the tutorial for more details:
@@ -97,6 +101,7 @@ class UNet(nn.Module):
         self.act = act
         self.norm = norm
         self.dropout = dropout
+        self.bias = bias
 
         def _create_block(
             inc: int, outc: int, channels: Sequence[int], strides: Sequence[int], is_top: bool
@@ -151,6 +156,7 @@ class UNet(nn.Module):
                 act=self.act,
                 norm=self.norm,
                 dropout=self.dropout,
+                bias=self.bias,
             )
         return Convolution(
             self.dimensions,
@@ -161,6 +167,7 @@ class UNet(nn.Module):
             act=self.act,
             norm=self.norm,
             dropout=self.dropout,
+            bias=self.bias,
         )
 
     def _get_bottom_layer(self, in_channels: int, out_channels: int) -> nn.Module:
@@ -190,6 +197,7 @@ class UNet(nn.Module):
             act=self.act,
             norm=self.norm,
             dropout=self.dropout,
+            bias=self.bias,
             conv_only=is_top and self.num_res_units == 0,
             is_transposed=True,
         )
@@ -205,6 +213,7 @@ class UNet(nn.Module):
                 act=self.act,
                 norm=self.norm,
                 dropout=self.dropout,
+                bias=self.bias,
                 last_conv_only=is_top,
             )
             conv = nn.Sequential(conv, ru)

--- a/monai/networks/nets/varautoencoder.py
+++ b/monai/networks/nets/varautoencoder.py
@@ -43,6 +43,7 @@ class VarAutoEncoder(AutoEncoder):
         act: Optional[Union[Tuple, str]] = Act.PRELU,
         norm: Union[Tuple, str] = Norm.INSTANCE,
         dropout: Optional[Union[Tuple, str, float]] = None,
+        bias: bool = True,
     ) -> None:
 
         self.in_channels, *self.in_shape = in_shape
@@ -65,6 +66,7 @@ class VarAutoEncoder(AutoEncoder):
             act,
             norm,
             dropout,
+            bias,
         )
 
         padding = same_padding(self.kernel_size)

--- a/monai/networks/nets/vnet.py
+++ b/monai/networks/nets/vnet.py
@@ -57,7 +57,14 @@ def _make_nconv(spatial_dims: int, nchan: int, depth: int, act: Union[Tuple[str,
 
 
 class InputTransition(nn.Module):
-    def __init__(self, spatial_dims: int, in_channels: int, out_channels: int, act: Union[Tuple[str, Dict], str], bias: bool = False):
+    def __init__(
+        self,
+        spatial_dims: int,
+        in_channels: int,
+        out_channels: int,
+        act: Union[Tuple[str, Dict], str],
+        bias: bool = False,
+    ):
         super(InputTransition, self).__init__()
 
         if 16 % in_channels != 0:
@@ -159,7 +166,14 @@ class UpTransition(nn.Module):
 
 
 class OutputTransition(nn.Module):
-    def __init__(self, spatial_dims: int, in_channels: int, out_channels: int, act: Union[Tuple[str, Dict], str], bias: bool = False):
+    def __init__(
+        self,
+        spatial_dims: int,
+        in_channels: int,
+        out_channels: int,
+        act: Union[Tuple[str, Dict], str],
+        bias: bool = False,
+    ):
         super(OutputTransition, self).__init__()
 
         conv_type: Type[Union[nn.Conv2d, nn.Conv3d]] = Conv[Conv.CONV, spatial_dims]

--- a/monai/networks/nets/vnet.py
+++ b/monai/networks/nets/vnet.py
@@ -29,7 +29,7 @@ def get_acti_layer(act: Union[Tuple[str, Dict], str], nchan: int = 0):
 
 
 class LUConv(nn.Module):
-    def __init__(self, spatial_dims: int, nchan: int, act: Union[Tuple[str, Dict], str]):
+    def __init__(self, spatial_dims: int, nchan: int, act: Union[Tuple[str, Dict], str], bias: bool = False):
         super(LUConv, self).__init__()
 
         self.act_function = get_acti_layer(act, nchan)
@@ -40,6 +40,7 @@ class LUConv(nn.Module):
             kernel_size=5,
             act=None,
             norm=Norm.BATCH,
+            bias=bias,
         )
 
     def forward(self, x):
@@ -48,15 +49,15 @@ class LUConv(nn.Module):
         return out
 
 
-def _make_nconv(spatial_dims: int, nchan: int, depth: int, act: Union[Tuple[str, Dict], str]):
+def _make_nconv(spatial_dims: int, nchan: int, depth: int, act: Union[Tuple[str, Dict], str], bias: bool = False):
     layers = []
     for _ in range(depth):
-        layers.append(LUConv(spatial_dims, nchan, act))
+        layers.append(LUConv(spatial_dims, nchan, act, bias))
     return nn.Sequential(*layers)
 
 
 class InputTransition(nn.Module):
-    def __init__(self, spatial_dims: int, in_channels: int, out_channels: int, act: Union[Tuple[str, Dict], str]):
+    def __init__(self, spatial_dims: int, in_channels: int, out_channels: int, act: Union[Tuple[str, Dict], str], bias: bool = False):
         super(InputTransition, self).__init__()
 
         if 16 % in_channels != 0:
@@ -72,6 +73,7 @@ class InputTransition(nn.Module):
             kernel_size=5,
             act=None,
             norm=Norm.BATCH,
+            bias=bias,
         )
 
     def forward(self, x):
@@ -91,6 +93,7 @@ class DownTransition(nn.Module):
         act: Union[Tuple[str, Dict], str],
         dropout_prob: Optional[float] = None,
         dropout_dim: int = 3,
+        bias: bool = False,
     ):
         super(DownTransition, self).__init__()
 
@@ -99,11 +102,11 @@ class DownTransition(nn.Module):
         dropout_type: Type[Union[nn.Dropout, nn.Dropout2d, nn.Dropout3d]] = Dropout[Dropout.DROPOUT, dropout_dim]
 
         out_channels = 2 * in_channels
-        self.down_conv = conv_type(in_channels, out_channels, kernel_size=2, stride=2)
+        self.down_conv = conv_type(in_channels, out_channels, kernel_size=2, stride=2, bias=bias)
         self.bn1 = norm_type(out_channels)
         self.act_function1 = get_acti_layer(act, out_channels)
         self.act_function2 = get_acti_layer(act, out_channels)
-        self.ops = _make_nconv(spatial_dims, out_channels, nconvs, act)
+        self.ops = _make_nconv(spatial_dims, out_channels, nconvs, act, bias)
         self.dropout = dropout_type(dropout_prob) if dropout_prob is not None else None
 
     def forward(self, x):
@@ -156,7 +159,7 @@ class UpTransition(nn.Module):
 
 
 class OutputTransition(nn.Module):
-    def __init__(self, spatial_dims: int, in_channels: int, out_channels: int, act: Union[Tuple[str, Dict], str]):
+    def __init__(self, spatial_dims: int, in_channels: int, out_channels: int, act: Union[Tuple[str, Dict], str], bias: bool = False):
         super(OutputTransition, self).__init__()
 
         conv_type: Type[Union[nn.Conv2d, nn.Conv3d]] = Conv[Conv.CONV, spatial_dims]
@@ -169,6 +172,7 @@ class OutputTransition(nn.Module):
             kernel_size=5,
             act=None,
             norm=Norm.BATCH,
+            bias=bias,
         )
         self.conv2 = conv_type(out_channels, out_channels, kernel_size=1)
 
@@ -201,6 +205,10 @@ class VNet(nn.Module):
             - ``dropout_dim = 1``, randomly zeroes some of the elements for each channel.
             - ``dropout_dim = 2``, Randomly zeroes out entire channels (a channel is a 2D feature map).
             - ``dropout_dim = 3``, Randomly zeroes out entire channels (a channel is a 3D feature map).
+        bias: whether to have a bias term in convolution blocks. Defaults to False.
+            According to `Performance Tuning Guide <https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html>`_,
+            if a conv layer is directly followed by a batch norm layer, bias should be False.
+
     """
 
     def __init__(
@@ -211,22 +219,23 @@ class VNet(nn.Module):
         act: Union[Tuple[str, Dict], str] = ("elu", {"inplace": True}),
         dropout_prob: float = 0.5,
         dropout_dim: int = 3,
+        bias: bool = False,
     ):
         super().__init__()
 
         if spatial_dims not in (2, 3):
             raise AssertionError("spatial_dims can only be 2 or 3.")
 
-        self.in_tr = InputTransition(spatial_dims, in_channels, 16, act)
-        self.down_tr32 = DownTransition(spatial_dims, 16, 1, act)
-        self.down_tr64 = DownTransition(spatial_dims, 32, 2, act)
-        self.down_tr128 = DownTransition(spatial_dims, 64, 3, act, dropout_prob=dropout_prob)
-        self.down_tr256 = DownTransition(spatial_dims, 128, 2, act, dropout_prob=dropout_prob)
+        self.in_tr = InputTransition(spatial_dims, in_channels, 16, act, bias=bias)
+        self.down_tr32 = DownTransition(spatial_dims, 16, 1, act, bias=bias)
+        self.down_tr64 = DownTransition(spatial_dims, 32, 2, act, bias=bias)
+        self.down_tr128 = DownTransition(spatial_dims, 64, 3, act, dropout_prob=dropout_prob, bias=bias)
+        self.down_tr256 = DownTransition(spatial_dims, 128, 2, act, dropout_prob=dropout_prob, bias=bias)
         self.up_tr256 = UpTransition(spatial_dims, 256, 256, 2, act, dropout_prob=dropout_prob)
         self.up_tr128 = UpTransition(spatial_dims, 256, 128, 2, act, dropout_prob=dropout_prob)
         self.up_tr64 = UpTransition(spatial_dims, 128, 64, 1, act)
         self.up_tr32 = UpTransition(spatial_dims, 64, 32, 1, act)
-        self.out_tr = OutputTransition(spatial_dims, 32, out_channels, act)
+        self.out_tr = OutputTransition(spatial_dims, 32, out_channels, act, bias=bias)
 
     def forward(self, x):
         out16 = self.in_tr(x)

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -73,3 +73,7 @@ class TestVNet(unittest.TestCase):
         net = VNet(spatial_dims=3, in_channels=1, out_channels=3, dropout_dim=3)
         test_data = torch.randn(1, 1, 32, 32, 32)
         test_script_save(net, test_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #2768 .

### Description
Except for add parameter bias, this PR also changes `UpCat` to support optional `x_e` in forward function to support encoders that have different number of feature maps .

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
