### PR TITLE
Update license example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ python -m pip install -U -r requirements-dev.txt
 
 License information: all source code files should start with this paragraph:
 ```
-# Copyright 2020 - 2021 MONAI Consortium
+# Copyright <Year> MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
### Description
Contributors are copying the license boilerplate and adding to all new PRs, which is to be expected. 
For new code, the license shouldn't default to "Copyright 2020-2021" (although this is fine for older code). Removing the defaults ensures this template remains accurate.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
