### PR TITLE
2771 HighResBlock convolution

### DIFF
--- a/monai/networks/nets/highresnet.py
+++ b/monai/networks/nets/highresnet.py
@@ -90,6 +90,7 @@ class HighResBlock(nn.Module):
                     kernel_size=kernel_size,
                     dilation=dilation,
                     bias=bias,
+                    conv_only=True,
                 )
             )
             _in_chns = _out_chns


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #2771

### Description
this removes the redundant activations after the convolution.
it will break the previously trained models.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
