### PR TITLE
get number of data conversions

### DIFF
--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -507,6 +507,7 @@ from .utils import (
     generate_spatial_bounding_box,
     get_extreme_points,
     get_largest_connected_component_mask,
+    get_number_image_type_conversions,
     img_bounds,
     in_bounds,
     is_empty,

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -13,10 +13,9 @@ A collection of generic interfaces for MONAI transforms.
 """
 
 import warnings
-from typing import Any, Callable, Hashable, Mapping, Optional, Sequence, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Union
 
 import numpy as np
-import torch
 
 from monai.transforms.inverse import InvertibleTransform
 

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -173,7 +173,8 @@ class Compose(Randomizable, InvertibleTransform):
 
     def get_number_image_type_conversions(self, test_data, key: Optional[Hashable] = None):
         """
-        Get the number of times that the data need to be converted (e.g., from numpy to torch or vice versa).
+        Get the number of times that the data need to be converted (e.g., numpy to torch).
+        Conversions between different devices are also counted (e.g., CPU to GPU).
 
         Args:
             test_data: data to be used to count the number of conversions

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -171,40 +171,6 @@ class Compose(Randomizable, InvertibleTransform):
             data = apply_transform(t.inverse, data, self.map_items, self.unpack_items)
         return data
 
-    def get_number_image_type_conversions(self, test_data, key: Optional[Hashable] = None):
-        """
-        Get the number of times that the data need to be converted (e.g., numpy to torch).
-        Conversions between different devices are also counted (e.g., CPU to GPU).
-
-        Args:
-            test_data: data to be used to count the number of conversions
-            key: if using dictionary transforms, this key will be used to check the number of conversions.
-        """
-
-        def _get_data(obj, key):
-            return obj if key is None else obj[key]
-
-        # if the starting point is a string (e.g., input to LoadImage), start
-        # at -1 since we don't want to count the string -> image conversion.
-        num_conversions = 0 if not isinstance(_get_data(test_data, key), str) else -1
-
-        tr = self.flatten().transforms
-
-        if isinstance(self, OneOf) or any(isinstance(i, OneOf) for i in tr):
-            raise RuntimeError("Not compatible with `OneOf`, as the applied transform is deterministically chosen.")
-
-        for _transform in tr:
-            prev_data = _get_data(test_data, key)
-            prev_type = type(prev_data)
-            prev_device = prev_data.device if isinstance(prev_data, torch.Tensor) else None
-            test_data = apply_transform(_transform, test_data, self.map_items, self.unpack_items)
-            # every time the type or device changes, increment the counter
-            curr_data = _get_data(test_data, key)
-            curr_device = curr_data.device if isinstance(curr_data, torch.Tensor) else None
-            if not isinstance(curr_data, prev_type) or curr_device != prev_device:
-                num_conversions += 1
-        return num_conversions
-
 
 class OneOf(Compose):
     """

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -13,9 +13,10 @@ A collection of generic interfaces for MONAI transforms.
 """
 
 import warnings
-from typing import Any, Callable, Mapping, Optional, Sequence, Union
+from typing import Any, Callable, Hashable, Mapping, Optional, Sequence, Union
 
 import numpy as np
+import torch
 
 from monai.transforms.inverse import InvertibleTransform
 
@@ -169,6 +170,39 @@ class Compose(Randomizable, InvertibleTransform):
         for t in reversed(invertible_transforms):
             data = apply_transform(t.inverse, data, self.map_items, self.unpack_items)
         return data
+
+    def get_number_image_type_conversions(self, test_data, key: Optional[Hashable] = None):
+        """
+        Get the number of times that the data need to be converted (e.g., from numpy to torch or vice versa).
+
+        Args:
+            test_data: data to be used to count the number of conversions
+            key: if using dictionary transforms, this key will be used to check the number of conversions.
+        """
+
+        def _get_data(obj, key):
+            return obj if key is None else obj[key]
+
+        # if the starting point is a string (e.g., input to LoadImage), start
+        # at -1 since we don't want to count the string -> image conversion.
+        num_conversions = 0 if not isinstance(_get_data(test_data, key), str) else -1
+
+        tr = self.flatten().transforms
+
+        if isinstance(self, OneOf) or any(isinstance(i, OneOf) for i in tr):
+            raise RuntimeError("Not compatible with `OneOf`, as the applied transform is deterministically chosen.")
+
+        for _transform in tr:
+            prev_data = _get_data(test_data, key)
+            prev_type = type(prev_data)
+            prev_device = prev_data.device if isinstance(prev_data, torch.Tensor) else None
+            test_data = apply_transform(_transform, test_data, self.map_items, self.unpack_items)
+            # every time the type or device changes, increment the counter
+            curr_data = _get_data(test_data, key)
+            curr_device = curr_data.device if isinstance(curr_data, torch.Tensor) else None
+            if not isinstance(curr_data, prev_type) or curr_device != prev_device:
+                num_conversions += 1
+        return num_conversions
 
 
 class OneOf(Compose):

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -13,14 +13,15 @@ import itertools
 import random
 import warnings
 from contextlib import contextmanager
-from typing import Callable, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Hashable, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
 
+import monai.transforms.transform
 from monai.config import DtypeLike, IndexSelection
 from monai.networks.layers import GaussianFilter
-from monai.transforms.compose import Compose
+from monai.transforms.compose import Compose, OneOf
 from monai.transforms.transform import MapTransform
 from monai.utils import (
     GridSampleMode,
@@ -75,6 +76,7 @@ __all__ = [
     "weighted_patch_samples",
     "zero_margins",
     "equalize_hist",
+    "get_number_image_type_conversions",
 ]
 
 
@@ -1109,3 +1111,41 @@ class Fourier:
             torch.fft.ifftshift(k, dim=tuple(range(-n_dims, 0))), dim=tuple(range(-n_dims, 0))
         ).real
         return x
+
+
+def get_number_image_type_conversions(transform: Compose, test_data: Any, key: Optional[Hashable] = None) -> int:
+    """
+    Get the number of times that the data need to be converted (e.g., numpy to torch).
+    Conversions between different devices are also counted (e.g., CPU to GPU).
+
+    Args:
+        transform: composed transforms to be tested
+        test_data: data to be used to count the number of conversions
+        key: if using dictionary transforms, this key will be used to check the number of conversions.
+    """
+
+    def _get_data(obj, key):
+        return obj if key is None else obj[key]
+
+    # if the starting point is a string (e.g., input to LoadImage), start
+    # at -1 since we don't want to count the string -> image conversion.
+    num_conversions = 0 if not isinstance(_get_data(test_data, key), str) else -1
+
+    tr = transform.flatten().transforms
+
+    if isinstance(transform, OneOf) or any(isinstance(i, OneOf) for i in tr):
+        raise RuntimeError("Not compatible with `OneOf`, as the applied transform is deterministically chosen.")
+
+    for _transform in tr:
+        prev_data = _get_data(test_data, key)
+        prev_type = type(prev_data)
+        prev_device = prev_data.device if isinstance(prev_data, torch.Tensor) else None
+        test_data = monai.transforms.transform.apply_transform(
+            _transform, test_data, transform.map_items, transform.unpack_items
+        )
+        # every time the type or device changes, increment the counter
+        curr_data = _get_data(test_data, key)
+        curr_device = curr_data.device if isinstance(curr_data, torch.Tensor) else None
+        if not isinstance(curr_data, prev_type) or curr_device != prev_device:
+            num_conversions += 1
+    return num_conversions

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -58,7 +58,7 @@ def get_equivalent_dtype(dtype, data_type):
     """Convert to the `dtype` that corresponds to `data_type`.
     Example:
         im = torch.tensor(1)
-        dtype = dtype_convert(np.float32, type(im))
+        dtype = get_equivalent_dtype(np.float32, type(im))
     """
     if data_type is torch.Tensor:
         if type(dtype) is torch.dtype:

--- a/tests/test_compose_get_number_conversions.py
+++ b/tests/test_compose_get_number_conversions.py
@@ -1,0 +1,118 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from copy import deepcopy
+from typing import List, Tuple
+
+import numpy as np
+import torch
+from parameterized import parameterized
+
+from monai.transforms import Compose
+from monai.transforms.compose import OneOf
+from monai.transforms.transform import Transform
+from monai.utils import convert_to_numpy, convert_to_tensor
+
+NP_ARR = np.ones((10, 10, 10))
+PT_ARR = torch.as_tensor(NP_ARR)
+KEY = "IMAGE"
+
+
+def _apply(x, fn):
+    if isinstance(x, dict):
+        d = deepcopy(x)
+        d[KEY] = fn(d[KEY])
+        return d
+    return fn(x)
+
+
+class Load(Transform):
+    def __init__(self, as_tensor):
+        self.fn = lambda _: PT_ARR if as_tensor else NP_ARR
+
+    def __call__(self, x):
+        return _apply(x, self.fn)
+
+
+class N(Transform):
+    def __call__(self, x):
+        return _apply(x, convert_to_numpy)
+
+
+class T(Transform):
+    def __call__(self, x):
+        return _apply(x, convert_to_tensor)
+
+
+class NT(Transform):
+    def __call__(self, x):
+        return _apply(x, lambda x: x)
+
+
+class TCPU(Transform):
+    def __call__(self, x):
+        return _apply(x, lambda x: convert_to_tensor(x).cpu())
+
+
+class TGPU(Transform):
+    def __call__(self, x):
+        return _apply(x, lambda x: convert_to_tensor(x).cuda())
+
+
+TESTS: List[Tuple] = []
+for is_dict in (False, True):
+    # same type depends on input
+    TESTS.append(((N(), N()), is_dict, NP_ARR, 0))
+    TESTS.append(((N(), N()), is_dict, PT_ARR, 1))
+    TESTS.append(((T(), T()), is_dict, NP_ARR, 1))
+    TESTS.append(((T(), T()), is_dict, PT_ARR, 0))
+
+    # loading depends on loader's output type and following transform
+    TESTS.append(((Load(as_tensor=False), N()), is_dict, "fname.nii", 0))
+    TESTS.append(((Load(as_tensor=True), N()), is_dict, "fname.nii", 1))
+    TESTS.append(((Load(as_tensor=False), T()), is_dict, "fname.nii", 1))
+    TESTS.append(((Load(as_tensor=True), T()), is_dict, "fname.nii", 0))
+    TESTS.append(((Load(as_tensor=True), NT()), is_dict, "fname.nii", 0))
+    TESTS.append(((Load(as_tensor=True), NT()), is_dict, "fname.nii", 0))
+
+    # no changes for ambivalent transforms
+    TESTS.append(((NT(), NT()), is_dict, NP_ARR, 0))
+    TESTS.append(((NT(), NT()), is_dict, PT_ARR, 0))
+
+    # multiple conversions
+    TESTS.append(((N(), T(), N()), is_dict, PT_ARR, 3))
+    TESTS.append(((N(), NT(), T(), T(), NT(), NT(), N()), is_dict, PT_ARR, 3))
+
+    # shouldn't matter that there are nested composes
+    TESTS.append(((N(), NT(), T(), Compose([T(), NT(), NT(), N()])), is_dict, PT_ARR, 3))
+
+    # changing device also counts
+    if torch.cuda.is_available():
+        TESTS.append(((TCPU(), TGPU(), TCPU()), is_dict, PT_ARR, 2))
+
+
+class TestComposeNumConversions(unittest.TestCase):
+    @parameterized.expand(TESTS)
+    def test_get_number_of_conversions(self, transforms, is_dict, input, expected):
+        input = input if not is_dict else {KEY: input, "Other": NP_ARR}
+        tr = Compose(transforms)
+        n = tr.get_number_image_type_conversions(input, key=KEY if is_dict else None)
+        self.assertEqual(n, expected)
+
+    def test_raises(self):
+        tr = Compose([N(), OneOf([T(), T()])])
+        with self.assertRaises(RuntimeError):
+            tr.get_number_image_type_conversions(NP_ARR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_compose_get_number_conversions.py
+++ b/tests/test_compose_get_number_conversions.py
@@ -20,6 +20,7 @@ from parameterized import parameterized
 from monai.transforms import Compose
 from monai.transforms.compose import OneOf
 from monai.transforms.transform import Transform
+from monai.transforms.utils import get_number_image_type_conversions
 from monai.utils import convert_to_numpy, convert_to_tensor
 
 NP_ARR = np.ones((10, 10, 10))
@@ -105,13 +106,13 @@ class TestComposeNumConversions(unittest.TestCase):
     def test_get_number_of_conversions(self, transforms, is_dict, input, expected):
         input = input if not is_dict else {KEY: input, "Other": NP_ARR}
         tr = Compose(transforms)
-        n = tr.get_number_image_type_conversions(input, key=KEY if is_dict else None)
+        n = get_number_image_type_conversions(tr, input, key=KEY if is_dict else None)
         self.assertEqual(n, expected)
 
     def test_raises(self):
         tr = Compose([N(), OneOf([T(), T()])])
         with self.assertRaises(RuntimeError):
-            tr.get_number_image_type_conversions(NP_ARR)
+            get_number_image_type_conversions(tr, NP_ARR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
Get the number of data conversions required for a `Compose` of transforms

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
