### PR TITLE
print backends of all MONAI transforms

### DIFF
--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -514,6 +514,7 @@ from .utils import (
     map_binary_to_indices,
     map_classes_to_indices,
     map_spatial_axes,
+    print_transform_backends,
     rand_choice,
     rescale_array,
     rescale_array_int_max,

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -37,6 +37,7 @@ from monai.utils import (
     ensure_tuple_size,
     fall_back_tuple,
 )
+from monai.utils.enums import TransformBackends
 
 __all__ = [
     "RandGaussianNoise",
@@ -81,7 +82,7 @@ class RandGaussianNoise(RandomizableTransform):
         std: Standard deviation (spread) of distribution.
     """
 
-    backend = ["torch", "numpy"]
+    backend = [TransformBackends.TORCH, TransformBackends.NUMPY]
 
     def __init__(self, prob: float = 0.1, mean: Union[Sequence[float], float] = 0.0, std: float = 0.1) -> None:
         RandomizableTransform.__init__(self, prob)
@@ -852,7 +853,7 @@ class SavitzkyGolaySmooth(Transform):
             or ``'circular'``. Default: ``'zeros'``. See ``torch.nn.Conv1d()`` for more information.
     """
 
-    backend = ["numpy"]
+    backend = [TransformBackends.NUMPY]
 
     def __init__(self, window_length: int, order: int, axis: int = 1, mode: str = "zeros"):
 

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -45,6 +45,7 @@ from monai.transforms.intensity.array import (
 from monai.transforms.transform import MapTransform, RandomizableTransform
 from monai.transforms.utils import is_positive
 from monai.utils import convert_to_dst_type, ensure_tuple, ensure_tuple_rep, ensure_tuple_size, fall_back_tuple
+from monai.utils.enums import TransformBackends
 
 __all__ = [
     "RandGaussianNoised",
@@ -144,7 +145,7 @@ class RandGaussianNoised(RandomizableTransform, MapTransform):
         allow_missing_keys: don't raise exception if key is missing.
     """
 
-    backend = ["torch", "numpy"]
+    backend = [TransformBackends.TORCH, TransformBackends.NUMPY]
 
     def __init__(
         self,

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -22,6 +22,7 @@ import torch
 from monai import transforms
 from monai.config import KeysCollection
 from monai.utils import MAX_SEED, ensure_tuple
+from monai.utils.enums import TransformBackends
 
 __all__ = [
     "ThreadUnsafe",
@@ -212,7 +213,7 @@ class Transform(ABC):
         :py:class:`monai.transforms.Compose`
     """
 
-    backend: List[str] = []
+    backend: List[TransformBackends] = []
     """Transforms should add data types to this list if they are capable of performing a transform without
     modifying the input type. For example, [\"torch.Tensor\", \"np.ndarray\"] means that no copies of the data
     are required if the input is either \"torch.Tensor\" or \"np.ndarray\"."""

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1116,6 +1116,7 @@ class Fourier:
 
 def print_transform_backends():
     """Prints a list of backends of all MONAI transforms."""
+
     class Colours:
         red = "91"
         green = "92"

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -14,7 +14,6 @@ import random
 import warnings
 from contextlib import contextmanager
 from inspect import getmembers, isclass
-from typing import Callable, Iterable, List, Optional, Sequence, Tuple, Union
 from typing import Any, Callable, Hashable, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -13,15 +13,17 @@ import itertools
 import random
 import warnings
 from contextlib import contextmanager
+from inspect import getmembers, isclass
 from typing import Callable, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
 
+import monai
 from monai.config import DtypeLike, IndexSelection
 from monai.networks.layers import GaussianFilter
 from monai.transforms.compose import Compose
-from monai.transforms.transform import MapTransform
+from monai.transforms.transform import MapTransform, Transform
 from monai.utils import (
     GridSampleMode,
     InterpolateMode,
@@ -75,6 +77,7 @@ __all__ = [
     "weighted_patch_samples",
     "zero_margins",
     "equalize_hist",
+    "print_transform_backends",
 ]
 
 
@@ -1109,3 +1112,58 @@ class Fourier:
             torch.fft.ifftshift(k, dim=tuple(range(-n_dims, 0))), dim=tuple(range(-n_dims, 0))
         ).real
         return x
+
+
+def print_transform_backends():
+    """Prints a list of backends of all MONAI transforms."""
+    class Colours:
+        red = "91"
+        green = "92"
+        yellow = "93"
+
+    def print_colour(t, colour):
+        print(f"\033[{colour}m{t}\033[00m")
+
+    tr_total = 0
+    tr_t_or_np = 0
+    tr_t = 0
+    tr_np = 0
+    tr_uncategorised = 0
+    unique_transforms = []
+    for n, obj in getmembers(monai.transforms):
+        # skip aliases
+        if obj in unique_transforms:
+            continue
+        unique_transforms.append(obj)
+
+        if isclass(obj) and issubclass(obj, Transform):
+            if n in [
+                "Transform",
+                "InvertibleTransform",
+                "Lambda",
+                "LambdaD",
+                "Compose",
+                "RandomizableTransform",
+                "OneOf",
+                "BatchInverseTransform",
+                "InverteD",
+            ]:
+                continue
+            tr_total += 1
+            if obj.backend == ["torch", "numpy"]:
+                tr_t_or_np += 1
+                print_colour(f"TorchOrNumpy:  {n}", Colours.green)
+            elif obj.backend == ["torch"]:
+                tr_t += 1
+                print_colour(f"Torch:         {n}", Colours.green)
+            elif obj.backend == ["numpy"]:
+                tr_np += 1
+                print_colour(f"Numpy:         {n}", Colours.yellow)
+            else:
+                tr_uncategorised += 1
+                print_colour(f"Uncategorised: {n}", Colours.red)
+    print("Total number of transforms:", tr_total)
+    print_colour(f"Number transforms allowing both torch and numpy: {tr_t_or_np}", Colours.green)
+    print_colour(f"Number of TorchTransform: {tr_t}", Colours.green)
+    print_colour(f"Number of NumpyTransform: {tr_np}", Colours.yellow)
+    print_colour(f"Number of uncategorised: {tr_uncategorised}", Colours.red)

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -30,6 +30,7 @@ from .enums import (
     NumpyPadMode,
     PytorchPadMode,
     SkipMode,
+    TransformBackends,
     UpsampleMode,
     Weight,
 )

--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -29,6 +29,7 @@ __all__ = [
     "InverseKeys",
     "CommonKeys",
     "ForwardMode",
+    "TransformBackends",
 ]
 
 
@@ -233,3 +234,12 @@ class CommonKeys:
     LABEL = "label"
     PRED = "pred"
     LOSS = "loss"
+
+
+class TransformBackends(Enum):
+    """
+    Transform backends.
+    """
+
+    TORCH = "torch"
+    NUMPY = "numpy"

--- a/tests/test_print_transform_backends.py
+++ b/tests/test_print_transform_backends.py
@@ -1,0 +1,23 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from monai.transforms.utils import print_transform_backends
+
+
+class TestPrintTransformBackends(unittest.TestCase):
+    def test_get_number_of_conversions(self):
+        print_transform_backends()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description
Print backends of all MONAI transforms.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
