### PR TITLE
2825 add hints for `norm_name` in `dynunet_blocks.py`

### DIFF
--- a/monai/networks/blocks/dynunet_block.py
+++ b/monai/networks/blocks/dynunet_block.py
@@ -32,8 +32,10 @@ class UnetResBlock(nn.Module):
         out_channels: number of output channels.
         kernel_size: convolution kernel size.
         stride: convolution stride.
-        norm_name: feature normalization type and arguments. Defaults to ``("INSTANCE", {"affine": True})``, which is
-            used in the referred papers.
+        norm_name: feature normalization type and arguments. If you need to use `"group"` or `"instance"` and want to
+            maintain the consistency with previous version v0.5.3, please set `affine=True`. For example:
+            `norm_name=("instance", {"affine": True})`.
+
     """
 
     def __init__(
@@ -43,7 +45,7 @@ class UnetResBlock(nn.Module):
         out_channels: int,
         kernel_size: Union[Sequence[int], int],
         stride: Union[Sequence[int], int],
-        norm_name: Union[Tuple, str] = ("INSTANCE", {"affine": True}),
+        norm_name: Union[Tuple, str],
     ):
         super(UnetResBlock, self).__init__()
         self.conv1 = get_conv_layer(
@@ -106,8 +108,9 @@ class UnetBasicBlock(nn.Module):
         out_channels: number of output channels.
         kernel_size: convolution kernel size.
         stride: convolution stride.
-        norm_name: feature normalization type and arguments. Defaults to ``("INSTANCE", {"affine": True})``, which is
-            used in the referred papers.
+        norm_name: feature normalization type and arguments. If you need to use `"group"` or `"instance"` and want to
+            maintain the consistency with previous version v0.5.3, please set `affine=True`. For example:
+            `norm_name=("instance", {"affine": True})`.
 
     """
 
@@ -118,7 +121,7 @@ class UnetBasicBlock(nn.Module):
         out_channels: int,
         kernel_size: Union[Sequence[int], int],
         stride: Union[Sequence[int], int],
-        norm_name: Union[Tuple, str] = ("INSTANCE", {"affine": True}),
+        norm_name: Union[Tuple, str],
     ):
         super(UnetBasicBlock, self).__init__()
         self.conv1 = get_conv_layer(
@@ -164,8 +167,9 @@ class UnetUpBlock(nn.Module):
         kernel_size: convolution kernel size.
         stride: convolution stride.
         upsample_kernel_size: convolution kernel size for transposed convolution layers.
-        norm_name: feature normalization type and arguments. Defaults to ``("INSTANCE", {"affine": True})``, which is
-            used in the referred papers.
+        norm_name: feature normalization type and arguments. If you need to use `"group"` or `"instance"` and want to
+            maintain the consistency with previous version v0.5.3, please set `affine=True`. For example:
+            `norm_name=("instance", {"affine": True})`.
 
     """
 
@@ -177,7 +181,7 @@ class UnetUpBlock(nn.Module):
         kernel_size: Union[Sequence[int], int],
         stride: Union[Sequence[int], int],
         upsample_kernel_size: Union[Sequence[int], int],
-        norm_name: Union[Tuple, str] = ("INSTANCE", {"affine": True}),
+        norm_name: Union[Tuple, str],
     ):
         super(UnetUpBlock, self).__init__()
         upsample_stride = upsample_kernel_size
@@ -215,7 +219,8 @@ class UnetOutBlock(nn.Module):
         )
 
     def forward(self, inp):
-        return self.conv(inp)
+        out = self.conv(inp)
+        return out
 
 
 def get_conv_layer(

--- a/monai/networks/blocks/dynunet_block.py
+++ b/monai/networks/blocks/dynunet_block.py
@@ -32,8 +32,8 @@ class UnetResBlock(nn.Module):
         out_channels: number of output channels.
         kernel_size: convolution kernel size.
         stride: convolution stride.
-        norm_name: feature normalization type and arguments.
-
+        norm_name: feature normalization type and arguments. Defaults to ``("INSTANCE", {"affine": True})``, which is
+            used in the referred papers.
     """
 
     def __init__(
@@ -43,7 +43,7 @@ class UnetResBlock(nn.Module):
         out_channels: int,
         kernel_size: Union[Sequence[int], int],
         stride: Union[Sequence[int], int],
-        norm_name: Union[Tuple, str],
+        norm_name: Union[Tuple, str] = ("INSTANCE", {"affine": True}),
     ):
         super(UnetResBlock, self).__init__()
         self.conv1 = get_conv_layer(
@@ -106,7 +106,8 @@ class UnetBasicBlock(nn.Module):
         out_channels: number of output channels.
         kernel_size: convolution kernel size.
         stride: convolution stride.
-        norm_name: feature normalization type and arguments.
+        norm_name: feature normalization type and arguments. Defaults to ``("INSTANCE", {"affine": True})``, which is
+            used in the referred papers.
 
     """
 
@@ -117,7 +118,7 @@ class UnetBasicBlock(nn.Module):
         out_channels: int,
         kernel_size: Union[Sequence[int], int],
         stride: Union[Sequence[int], int],
-        norm_name: Union[Tuple, str],
+        norm_name: Union[Tuple, str] = ("INSTANCE", {"affine": True}),
     ):
         super(UnetBasicBlock, self).__init__()
         self.conv1 = get_conv_layer(
@@ -163,7 +164,8 @@ class UnetUpBlock(nn.Module):
         kernel_size: convolution kernel size.
         stride: convolution stride.
         upsample_kernel_size: convolution kernel size for transposed convolution layers.
-        norm_name: feature normalization type and arguments.
+        norm_name: feature normalization type and arguments. Defaults to ``("INSTANCE", {"affine": True})``, which is
+            used in the referred papers.
 
     """
 
@@ -175,7 +177,7 @@ class UnetUpBlock(nn.Module):
         kernel_size: Union[Sequence[int], int],
         stride: Union[Sequence[int], int],
         upsample_kernel_size: Union[Sequence[int], int],
-        norm_name: Union[Tuple, str],
+        norm_name: Union[Tuple, str] = ("INSTANCE", {"affine": True}),
     ):
         super(UnetUpBlock, self).__init__()
         upsample_stride = upsample_kernel_size

--- a/monai/networks/nets/dynunet.py
+++ b/monai/networks/nets/dynunet.py
@@ -86,7 +86,7 @@ class DynUNet(nn.Module):
         strides: convolution strides for each blocks.
         upsample_kernel_size: convolution kernel size for transposed convolution layers. The values should
             equal to strides[1:].
-        norm_name: feature normalization type and arguments. Defaults to ``INSTANCE``.
+        norm_name: feature normalization type and arguments. Defaults to ``("INSTANCE", {"affine": True})``.
         deep_supervision: whether to add deep supervision head before output. Defaults to ``False``.
             If ``True``, in training mode, the forward function will output not only the last feature
             map, but also the previous feature maps that come from the intermediate up sample layers.


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #2825 .

### Description
#2166 brings a breaking change for blocks in `dynunet_block.py`, before that commit, when using instance or group norm, `affine=True` is automatically used, but now this default setting is removed.

This PR adds some hints in the corresponding blocks, which is helpful for users to keep the consistency with old versions (0.5.3).

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
