### PR TITLE
Update Range decorator

### DIFF
--- a/monai/utils/nvtx.py
+++ b/monai/utils/nvtx.py
@@ -21,7 +21,6 @@ from torch.nn import Module
 from torch.optim import Optimizer
 from torch.utils.data import Dataset
 
-# from monai.transforms.transform import Transform
 from monai.utils import ensure_tuple, optional_import
 
 _nvtx, _ = optional_import("torch._C._nvtx", descriptor="NVTX is not installed. Are you sure you have a CUDA build?")

--- a/monai/utils/nvtx.py
+++ b/monai/utils/nvtx.py
@@ -40,7 +40,7 @@ class Range:
         methods: (only when used as decorator) the name of a method (or a list of the name of the methods)
             to be wrapped by NVTX range.
             If None (default), the method(s) will be inferred based on the object's type for various MONAI components,
-            such as Networks, Losses, Optimizers, Functions, Transforms, Datasets, and Dataloaders.
+            such as Networks, Losses, Functions, Transforms, and Datasets.
             Otherwise, it look up predefined methods: "forward", "__call__", "__next__", "__getitem__"
         append_method_name: if append the name of the methods to be decorated to the range's name
             If None (default), it appends the method's name only if we are annotating more than one method.
@@ -114,15 +114,13 @@ class Range:
 
     def _get_method(self, obj: Any) -> tuple:
         if isinstance(obj, Module):
-            method_list = ["forward", "__call__"]
+            method_list = ["forward"]
         elif isinstance(obj, Optimizer):
             method_list = ["step"]
         elif isinstance(obj, Function):
             method_list = ["forward", "backward"]
         elif isinstance(obj, Dataset):
             method_list = ["__getitem__"]
-        elif isinstance(obj, DataLoader):
-            method_list = ["_next_data"]
         else:
             default_methods = ["forward", "__call__", "__next__", "__getitem__"]
             method_list = []

--- a/monai/utils/nvtx.py
+++ b/monai/utils/nvtx.py
@@ -19,7 +19,7 @@ from typing import Any, Optional, Tuple, Union
 from torch.autograd import Function
 from torch.nn import Module
 from torch.optim import Optimizer
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import Dataset
 
 # from monai.transforms.transform import Transform
 from monai.utils import ensure_tuple, optional_import


### PR DESCRIPTION
### Description
This PR changes the methods for `nn.Module` to `forward` only. The reason is that `__call__` finally calls `forward` and the overhead is insignificant in the tests that I have done, so annotating both create redundancy and make the output less readable.

It also drops the logic to annotate `DataLoaders` since their iterator is being created in the runtime and there is not any obvious way to annotate them. Instead, one can annotate `Dataset`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).