### PR TITLE
[WIP] 2849 Add cupy install as optional package

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,3 +20,4 @@ sphinxcontrib-serializinghtml
 sphinx-autodoc-typehints==1.11.1
 pandas
 einops
+cupy

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -174,9 +174,9 @@ Since MONAI v0.2.0, the extras syntax such as `pip install 'monai[nibabel]'` is 
 
 - The options are
 ```
-[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, cucim, openslide, pandas, einops]
+[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, cucim, openslide, pandas, einops, cupy]
 ```
 which correspond to `nibabel`, `scikit-image`, `pillow`, `tensorboard`,
-`gdown`, `pytorch-ignite`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas` and `einops`, respectively.
+`gdown`, `pytorch-ignite`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas`, `einops` and `cupy`, respectively.
 
 - `pip install 'monai[all]'` installs all the optional dependencies.

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -73,6 +73,7 @@ def get_optional_config_values():
     output["psutil"] = psutil_version
     output["pandas"] = get_package_version("pandas")
     output["einops"] = get_package_version("einops")
+    output["cupy"] = get_package_version("cupy")
 
     return output
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,3 +36,4 @@ openslide-python==1.1.2
 pandas
 requests
 einops
+cupy

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ all =
     openslide-python==1.1.2
     pandas
     einops
+    cupy
 nibabel =
     nibabel
 skimage =
@@ -74,6 +75,8 @@ pandas =
     pandas
 einops =
     einops
+cupy =
+    cupy
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9
 max_line_length = 120


### PR DESCRIPTION
Fixes #2849 .

### Description
This PR added all the necessary info for cupy package.

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
