### PR TITLE
CuPy to Tensor

### DIFF
--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -105,6 +105,8 @@ def convert_to_tensor(data, wrap_sequence: bool = False):
             # numpy array with 0 dims is also sequence iterable,
             # `ascontiguousarray` will add 1 dim if img has no dim, so we only apply on data with dims
             return torch.as_tensor(data if data.ndim == 0 else np.ascontiguousarray(data))
+    elif has_cp and isinstance(data, cp_ndarray):
+        return torch.as_tensor(data)
     elif isinstance(data, (float, int, bool)):
         return torch.as_tensor(data)
     elif isinstance(data, Sequence) and wrap_sequence:


### PR DESCRIPTION
### Description
I realized that due to some changes since v0.5, `ToTensor` is not able to convert from `cupy.ndarray` to `torch.Tensor` . This PR brings back CuPy to Tensor functionality.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
