### PR TITLE
Add dtype to ToCupy

### DIFF
--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -393,15 +393,22 @@ class ToNumpy(Transform):
 class ToCupy(Transform):
     """
     Converts the input data to CuPy array, can support list or tuple of numbers, NumPy and PyTorch Tensor.
+
+    Args:
+        dtype: data type specifier. It is inferred from the input by default.
     """
 
     backend = [TransformBackends.TORCH, TransformBackends.NUMPY]
 
-    def __call__(self, img: NdarrayOrTensor) -> NdarrayOrTensor:
+    def __init__(self, dtype=None) -> None:
+        super().__init__()
+        self.dtype = dtype
+
+    def __call__(self, img: NdarrayOrTensor):
         """
-        Apply the transform to `img` and make it contiguous.
+        Create a CuPy array from `img` and make it contiguous
         """
-        return cp.ascontiguousarray(cp.asarray(img))  # type: ignore
+        return cp.ascontiguousarray(cp.asarray(img, dtype=self.dtype))  # type: ignore
 
 
 class ToPIL(Transform):

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -32,7 +32,15 @@ from monai.transforms.utils import (
     map_classes_to_indices,
 )
 from monai.transforms.utils_pytorch_numpy_unification import in1d, moveaxis
-from monai.utils import convert_to_numpy, convert_to_tensor, ensure_tuple, look_up_option, min_version, optional_import
+from monai.utils import (
+    convert_to_cupy,
+    convert_to_numpy,
+    convert_to_tensor,
+    ensure_tuple,
+    look_up_option,
+    min_version,
+    optional_import,
+)
 from monai.utils.enums import TransformBackends
 from monai.utils.misc import is_module_ver_at_least
 from monai.utils.type_conversion import convert_data_type
@@ -404,11 +412,11 @@ class ToCupy(Transform):
         super().__init__()
         self.dtype = dtype
 
-    def __call__(self, img: NdarrayOrTensor):
+    def __call__(self, data: NdarrayOrTensor):
         """
-        Create a CuPy array from `img` and make it contiguous
+        Create a CuPy array from `data` and make it contiguous
         """
-        return cp.ascontiguousarray(cp.asarray(img, dtype=self.dtype))  # type: ignore
+        return convert_to_cupy(data, self.dtype)
 
 
 class ToPIL(Transform):

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -549,17 +549,17 @@ class ToNumpyd(MapTransform):
 class ToCupyd(MapTransform):
     """
     Dictionary-based wrapper of :py:class:`monai.transforms.ToCupy`.
+
+    Args:
+        keys: keys of the corresponding items to be transformed.
+            See also: :py:class:`monai.transforms.compose.MapTransform`
+        allow_missing_keys: don't raise exception if key is missing.
+        dtype: data type specifier. It is inferred from the input by default.
     """
 
     backend = ToCupy.backend
 
     def __init__(self, keys: KeysCollection, allow_missing_keys: bool = False, dtype=None) -> None:
-        """
-        Args:
-            keys: keys of the corresponding items to be transformed.
-                See also: :py:class:`monai.transforms.compose.MapTransform`
-            allow_missing_keys: don't raise exception if key is missing.
-        """
         super().__init__(keys, allow_missing_keys)
         self.converter = ToCupy(dtype=dtype)
 

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -553,7 +553,7 @@ class ToCupyd(MapTransform):
 
     backend = ToCupy.backend
 
-    def __init__(self, keys: KeysCollection, allow_missing_keys: bool = False) -> None:
+    def __init__(self, keys: KeysCollection, allow_missing_keys: bool = False, dtype=None) -> None:
         """
         Args:
             keys: keys of the corresponding items to be transformed.
@@ -561,7 +561,7 @@ class ToCupyd(MapTransform):
             allow_missing_keys: don't raise exception if key is missing.
         """
         super().__init__(keys, allow_missing_keys)
-        self.converter = ToCupy()
+        self.converter = ToCupy(dtype=dtype)
 
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
         d = dict(data)

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -77,6 +77,7 @@ from .profiling import PerfContext, torch_profiler_full, torch_profiler_time_cpu
 from .state_cacher import StateCacher
 from .type_conversion import (
     convert_data_type,
+    convert_to_cupy,
     convert_to_dst_type,
     convert_to_numpy,
     convert_to_tensor,

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -239,10 +239,9 @@ def convert_data_type(
         if data is not None and dtype != data.dtype:
             data = data.astype(dtype)
     elif has_cp and output_type is cp.ndarray:
-        if orig_type is not cp.ndarray:
+        if data is not None:
             data = convert_to_cupy(data, dtype)
-        elif data is not None:
-            data = data.astype(dtype)
+
     else:
         raise ValueError(f"Unsupported output type: {output_type}")
     return data, orig_type, orig_device

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -170,14 +170,7 @@ def convert_to_cupy(data, dtype, wrap_sequence: bool = True):
     """
 
     # direct calls
-    if isinstance(data, cp_ndarray):
-        if dtype is not None:
-            data = data.astype(dtype)
-    elif isinstance(data, np.ndarray):
-        data = cp.asarray(data, dtype)
-    elif isinstance(data, torch.Tensor):
-        data = cp.asarray(data, dtype)
-    elif isinstance(data, (float, int, bool)):
+    if isinstance(data, (cp_ndarray, np.ndarray, torch.Tensor, float, int, bool)):
         data = cp.asarray(data, dtype)
     # recursive calls
     elif isinstance(data, Sequence) and wrap_sequence:
@@ -248,7 +241,7 @@ def convert_data_type(
     elif has_cp and output_type is cp.ndarray:
         if orig_type is not cp.ndarray:
             data = convert_to_cupy(data, dtype)
-        elif data is not None and dtype != data.dtype:
+        elif data is not None:
             data = data.astype(dtype)
     else:
         raise ValueError(f"Unsupported output type: {output_type}")

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -174,7 +174,7 @@ def convert_to_cupy(data, dtype, wrap_sequence: bool = True):
         data = cp.asarray(data, dtype)
     # recursive calls
     elif isinstance(data, Sequence) and wrap_sequence:
-        return cp.asarray(data)
+        return cp.asarray(data, dtype)
     elif isinstance(data, list):
         return [convert_to_cupy(i, dtype) for i in data]
     elif isinstance(data, tuple):

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -16,6 +16,7 @@ __all__ = [
     "get_equivalent_dtype",
     "convert_data_type",
     "get_dtype",
+    "convert_to_cupy",
     "convert_to_numpy",
     "convert_to_tensor",
     "convert_to_dst_type",
@@ -154,6 +155,49 @@ def convert_to_numpy(data, wrap_sequence: bool = False):
     return data
 
 
+def convert_to_cupy(data, dtype, wrap_sequence: bool = True):
+    """
+    Utility to convert the input data to a cupy array. If passing a dictionary, list or tuple,
+    recursively check every item and convert it to cupy array.
+
+    Args:
+        data: input data can be PyTorch Tensor, numpy array, cupy array, list, dictionary, int, float, bool, str, etc.
+            Tensor, numpy array, cupy array, float, int, bool are converted to cupy arrays
+
+            for dictionary, list or tuple, convert every item to a numpy array if applicable.
+        wrap_sequence: if `False`, then lists will recursively call this function. E.g., `[1, 2]` -> `[array(1), array(2)]`.
+            If `True`, then `[1, 2]` -> `array([1, 2])`.
+    """
+
+    # direct calls
+    if isinstance(data, cp_ndarray):
+        if dtype is not None:
+            data = data.astype(dtype)
+    elif isinstance(data, np.ndarray):
+        data = cp.asarray(data, dtype)
+    elif isinstance(data, torch.Tensor):
+        data = cp.asarray(data, dtype)
+    elif isinstance(data, (float, int, bool)):
+        data = cp.asarray(data, dtype)
+    # recursive calls
+    elif isinstance(data, Sequence) and wrap_sequence:
+        return cp.asarray(data)
+    elif isinstance(data, list):
+        return [convert_to_cupy(i, dtype) for i in data]
+    elif isinstance(data, tuple):
+        return tuple(convert_to_cupy(i, dtype) for i in data)
+    elif isinstance(data, dict):
+        return {k: convert_to_cupy(v, dtype) for k, v in data.items()}
+    # make it contiguous
+    if isinstance(data, cp.ndarray):
+        if data.ndim > 0:
+            data = cp.ascontiguousarray(data)
+    else:
+        raise ValueError(f"The input data type [{type(data)}] cannot be converted into cupy arrays!")
+
+    return data
+
+
 def convert_data_type(
     data: Any,
     output_type: Optional[type] = None,
@@ -178,6 +222,8 @@ def convert_data_type(
         orig_type = torch.Tensor
     elif isinstance(data, np.ndarray):
         orig_type = np.ndarray
+    elif has_cp and isinstance(data, cp.ndarray):
+        orig_type = cp.ndarray
     else:
         orig_type = type(data)
 
@@ -198,6 +244,11 @@ def convert_data_type(
         if orig_type is not np.ndarray:
             data = convert_to_numpy(data)
         if data is not None and dtype != data.dtype:
+            data = data.astype(dtype)
+    elif has_cp and output_type is cp.ndarray:
+        if orig_type is not cp.ndarray:
+            data = convert_to_cupy(data, dtype)
+        elif data is not None and dtype != data.dtype:
             data = data.astype(dtype)
     else:
         raise ValueError(f"Unsupported output type: {output_type}")

--- a/tests/test_to_cupy.py
+++ b/tests/test_to_cupy.py
@@ -22,49 +22,81 @@ from tests.utils import skip_if_no_cuda
 cp, has_cp = optional_import("cupy")
 
 
+@skipUnless(has_cp, "CuPy is required.")
 class TestToCupy(unittest.TestCase):
-    @skipUnless(has_cp, "CuPy is required.")
     def test_cupy_input(self):
-        test_data = cp.array([[1, 2], [3, 4]])
+        test_data = cp.array([[1, 2], [3, 4]], dtype=cp.float32)
         test_data = cp.rot90(test_data)
         self.assertFalse(test_data.flags["C_CONTIGUOUS"])
         result = ToCupy()(test_data)
+        self.assertTrue(result.dtype == cp.float32)
         self.assertTrue(isinstance(result, cp.ndarray))
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         cp.testing.assert_allclose(result, test_data)
 
-    @skipUnless(has_cp, "CuPy is required.")
+    def test_cupy_input_dtype(self):
+        test_data = cp.array([[1, 2], [3, 4]], dtype=cp.float32)
+        test_data = cp.rot90(test_data)
+        self.assertFalse(test_data.flags["C_CONTIGUOUS"])
+        result = ToCupy(cp.uint8)(test_data)
+        self.assertTrue(result.dtype == cp.uint8)
+        self.assertTrue(isinstance(result, cp.ndarray))
+        self.assertTrue(result.flags["C_CONTIGUOUS"])
+        cp.testing.assert_allclose(result, test_data)
+
     def test_numpy_input(self):
-        test_data = np.array([[1, 2], [3, 4]])
+        test_data = np.array([[1, 2], [3, 4]], dtype=np.float32)
         test_data = np.rot90(test_data)
         self.assertFalse(test_data.flags["C_CONTIGUOUS"])
         result = ToCupy()(test_data)
+        self.assertTrue(result.dtype == cp.float32)
         self.assertTrue(isinstance(result, cp.ndarray))
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         cp.testing.assert_allclose(result, test_data)
 
-    @skipUnless(has_cp, "CuPy is required.")
+    def test_numpy_input_dtype(self):
+        test_data = np.array([[1, 2], [3, 4]], dtype=np.float32)
+        test_data = np.rot90(test_data)
+        self.assertFalse(test_data.flags["C_CONTIGUOUS"])
+        result = ToCupy(np.uint8)(test_data)
+        self.assertTrue(result.dtype == cp.uint8)
+        self.assertTrue(isinstance(result, cp.ndarray))
+        self.assertTrue(result.flags["C_CONTIGUOUS"])
+        cp.testing.assert_allclose(result, test_data)
+
     def test_tensor_input(self):
-        test_data = torch.tensor([[1, 2], [3, 4]])
+        test_data = torch.tensor([[1, 2], [3, 4]], dtype=torch.float32)
         test_data = test_data.rot90()
         self.assertFalse(test_data.is_contiguous())
         result = ToCupy()(test_data)
+        self.assertTrue(result.dtype == cp.float32)
         self.assertTrue(isinstance(result, cp.ndarray))
         self.assertTrue(result.flags["C_CONTIGUOUS"])
-        cp.testing.assert_allclose(result, test_data.numpy())
+        cp.testing.assert_allclose(result, test_data)
 
-    @skipUnless(has_cp, "CuPy is required.")
     @skip_if_no_cuda
     def test_tensor_cuda_input(self):
-        test_data = torch.tensor([[1, 2], [3, 4]]).cuda()
+        test_data = torch.tensor([[1, 2], [3, 4]], dtype=torch.float32).cuda()
         test_data = test_data.rot90()
         self.assertFalse(test_data.is_contiguous())
         result = ToCupy()(test_data)
+        self.assertTrue(result.dtype == cp.float32)
         self.assertTrue(isinstance(result, cp.ndarray))
         self.assertTrue(result.flags["C_CONTIGUOUS"])
-        cp.testing.assert_allclose(result, test_data.cpu().numpy())
+        cp.testing.assert_allclose(result, test_data)
 
-    @skipUnless(has_cp, "CuPy is required.")
+    @skip_if_no_cuda
+    def test_tensor_cuda_input_dtype(self):
+        test_data = torch.tensor([[1, 2], [3, 4]], dtype=torch.uint8).cuda()
+        test_data = test_data.rot90()
+        self.assertFalse(test_data.is_contiguous())
+
+        result = ToCupy(dtype="float32")(test_data)
+        self.assertTrue(result.dtype == cp.float32)
+        self.assertTrue(isinstance(result, cp.ndarray))
+        self.assertTrue(result.flags["C_CONTIGUOUS"])
+        cp.testing.assert_allclose(result, test_data)
+
     def test_list_tuple(self):
         test_data = [[1, 2], [3, 4]]
         result = ToCupy()(test_data)


### PR DESCRIPTION
### Description
This PR allow `ToCupy` transform define the expected output `dtype`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
