### PR TITLE
torch `SpatialCrop`, `SpatialCropd`

### DIFF
--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -537,6 +537,7 @@ from .utils_pytorch_numpy_unification import (
     clip,
     floor_divide,
     in1d,
+    maximum,
     moveaxis,
     nonzero,
     percentile,

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -618,7 +618,7 @@ class Zoom(Transform):
         img_t, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float32)  # type: ignore
 
         _zoom = ensure_tuple_rep(self.zoom, img.ndim - 1)  # match the spatial image dim
-        zoomed: torch.Tensor = torch.nn.functional.interpolate(  # type: ignore
+        zoomed: NdarrayOrTensor = torch.nn.functional.interpolate(  # type: ignore
             recompute_scale_factor=True,
             input=img_t.unsqueeze(0),
             scale_factor=list(_zoom),

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -22,7 +22,7 @@ import torch
 import monai
 import monai.transforms.transform
 from monai.config import DtypeLike, IndexSelection
-from monai.config.type_definitions import NdarrayOrTensor, NdarrayTensor
+from monai.config.type_definitions import NdarrayOrTensor
 from monai.networks.layers import GaussianFilter
 from monai.transforms.compose import Compose, OneOf
 from monai.transforms.transform import MapTransform, Transform
@@ -1271,7 +1271,7 @@ def print_transform_backends():
     print_color(f"Number of uncategorised: {n_uncategorized}", Colors.red)
 
 
-def convert_pad_mode(dst: NdarrayTensor, mode: Union[NumpyPadMode, PytorchPadMode, str]):
+def convert_pad_mode(dst: NdarrayOrTensor, mode: Union[NumpyPadMode, PytorchPadMode, str]):
     """
     Utility to convert padding mode between numpy array and PyTorch Tensor.
 

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -28,6 +28,7 @@ __all__ = [
     "unravel_index",
     "ravel",
     "any_np_pt",
+    "maximum",
 ]
 
 
@@ -216,3 +217,23 @@ def any_np_pt(x: NdarrayOrTensor, axis: int):
             # older versions of pytorch require the input to be cast to boolean
             return torch.any(x.bool(), axis)
     return np.any(x, axis)
+
+
+def maximum(a: NdarrayOrTensor, b: NdarrayOrTensor) -> NdarrayOrTensor:
+    """`np.maximum` with equivalent implementation for torch.
+
+    `torch.maximum` only available from pt>1.6, else use `torch.stack` and `torch.max`.
+
+    Args:
+        a: first array/tensor
+        b: second array/tensor
+
+    Returns:
+        Element-wise maximum between two arrays/tensors.
+    """
+    if isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor):
+        # is torch and has torch.maximum (pt>1.6)
+        if hasattr(torch, "maximum"):
+            return torch.maximum(a, b)
+        return torch.stack((a, b)).max(dim=0)[0]
+    return np.maximum(a, b)

--- a/tests/test_spatial_crop.py
+++ b/tests/test_spatial_crop.py
@@ -16,8 +16,9 @@ import torch
 from parameterized import parameterized
 
 from monai.transforms import SpatialCrop
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
-TEST_CASES = [
+TESTS = [
     [
         {"roi_center": [1, 1, 1], "roi_size": [2, 2, 2]},
         (3, 3, 3, 3),
@@ -53,17 +54,24 @@ TEST_ERRORS = [
 
 
 class TestSpatialCrop(unittest.TestCase):
-    @parameterized.expand(TEST_CASES)
+    @parameterized.expand(TESTS)
     def test_shape(self, input_param, input_shape, expected_shape):
         input_data = np.random.randint(0, 2, size=input_shape)
-        result = SpatialCrop(**input_param)(input_data)
-        self.assertTupleEqual(result.shape, expected_shape)
-
-    @parameterized.expand(TEST_CASES)
-    def test_tensor_shape(self, input_param, input_shape, expected_shape):
-        input_data = torch.randint(0, 2, size=input_shape, device="cuda" if torch.cuda.is_available() else "cpu")
-        result = SpatialCrop(**input_param)(input_data)
-        self.assertTupleEqual(result.shape, expected_shape)
+        results = []
+        for p in TEST_NDARRAYS:
+            for q in TEST_NDARRAYS + (None,):
+                input_param_mod = {
+                    k: q(v) if k != "roi_slices" and q is not None else v for k, v in input_param.items()
+                }
+                im = p(input_data)
+                result = SpatialCrop(**input_param_mod)(im)
+                self.assertEqual(type(im), type(result))
+                if isinstance(result, torch.Tensor):
+                    self.assertEqual(result.device, im.device)
+                self.assertTupleEqual(result.shape, expected_shape)
+                results.append(result)
+                if len(results) > 1:
+                    assert_allclose(results[0], results[-1], type_test=False)
 
     @parameterized.expand(TEST_ERRORS)
     def test_error(self, input_param):

--- a/tests/test_spatial_cropd.py
+++ b/tests/test_spatial_cropd.py
@@ -15,38 +15,49 @@ import numpy as np
 from parameterized import parameterized
 
 from monai.transforms import SpatialCropd
+from tests.utils import TEST_NDARRAYS
 
-TEST_CASES = [
-    [
-        {"keys": ["img"], "roi_center": [1, 1, 1], "roi_size": [2, 2, 2]},
-        {"img": np.random.randint(0, 2, size=[3, 3, 3, 3])},
-        (3, 2, 2, 2),
-    ],
-    [
-        {"keys": ["img"], "roi_start": [0, 0, 0], "roi_end": [2, 2, 2]},
-        {"img": np.random.randint(0, 2, size=[3, 3, 3, 3])},
-        (3, 2, 2, 2),
-    ],
-    [
-        {"keys": ["img"], "roi_start": [0, 0], "roi_end": [2, 2]},
-        {"img": np.random.randint(0, 2, size=[3, 3, 3, 3])},
-        (3, 2, 2, 3),
-    ],
-    [
-        {"keys": ["img"], "roi_start": [0, 0, 0, 0, 0], "roi_end": [2, 2, 2, 2, 2]},
-        {"img": np.random.randint(0, 2, size=[3, 3, 3, 3])},
-        (3, 2, 2, 2),
-    ],
-    [
-        {"keys": ["img"], "roi_slices": [slice(s, e) for s, e in zip([-1, -2, 0], [None, None, 2])]},
-        {"img": np.random.randint(0, 2, size=[3, 3, 3, 3])},
-        (3, 1, 2, 2),
-    ],
-]
+TESTS = []
+for p in TEST_NDARRAYS:
+    TESTS.append(
+        [
+            {"keys": ["img"], "roi_center": [1, 1, 1], "roi_size": [2, 2, 2]},
+            {"img": p(np.random.randint(0, 2, size=[3, 3, 3, 3]))},
+            (3, 2, 2, 2),
+        ]
+    )
+    TESTS.append(
+        [
+            {"keys": ["img"], "roi_start": [0, 0, 0], "roi_end": [2, 2, 2]},
+            {"img": p(np.random.randint(0, 2, size=[3, 3, 3, 3]))},
+            (3, 2, 2, 2),
+        ]
+    )
+    TESTS.append(
+        [
+            {"keys": ["img"], "roi_start": [0, 0], "roi_end": [2, 2]},
+            {"img": p(np.random.randint(0, 2, size=[3, 3, 3, 3]))},
+            (3, 2, 2, 3),
+        ]
+    )
+    TESTS.append(
+        [
+            {"keys": ["img"], "roi_start": [0, 0, 0, 0, 0], "roi_end": [2, 2, 2, 2, 2]},
+            {"img": p(np.random.randint(0, 2, size=[3, 3, 3, 3]))},
+            (3, 2, 2, 2),
+        ]
+    )
+    TESTS.append(
+        [
+            {"keys": ["img"], "roi_slices": [slice(s, e) for s, e in zip([-1, -2, 0], [None, None, 2])]},
+            {"img": p(np.random.randint(0, 2, size=[3, 3, 3, 3]))},
+            (3, 1, 2, 2),
+        ]
+    )
 
 
 class TestSpatialCropd(unittest.TestCase):
-    @parameterized.expand(TEST_CASES)
+    @parameterized.expand(TESTS)
     def test_shape(self, input_param, input_data, expected_shape):
         result = SpatialCropd(**input_param)(input_data)
         self.assertTupleEqual(result["img"].shape, expected_shape)


### PR DESCRIPTION
### Description
Torch `SpatialCrop` and `SpatialCropd`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
