### PR TITLE
correct panelled example images

### DIFF
--- a/monai/transforms/utils_create_transform_ims.py
+++ b/monai/transforms/utils_create_transform_ims.py
@@ -302,7 +302,7 @@ def save_image(images, labels, filename, transform_name, transform_args, shapes,
             ax.set_yticks([])
             ax.set_frame_on(False)
             if labels is not None:
-                ax.imshow(labels[row][col], cmap="hsv", alpha=0.9)
+                ax.imshow(labels[row][col], cmap="hsv", alpha=0.9, interpolation="nearest")
     # title is e.g., Flipd(keys=keys, spatial_axis=0)
     title = transform_name + "("
     for k, v in transform_args.items():


### PR DESCRIPTION
### Description
Fixes the panelling problem for transform examples. Doc already updated, can be seen here: https://docs.monai.io/en/latest/transforms.html#randspatialcropsamplesd.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).