### PR TITLE
Enhance version_leq API and doc-string

### DIFF
--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -367,14 +367,22 @@ def get_torch_version_tuple():
     return tuple(int(x) for x in torch.__version__.split(".")[:2])
 
 
-def version_leq(lhs, rhs):
-    """Returns True if version `lhs` is earlier or equal to `rhs`."""
+def version_leq(lhs: str, rhs: str):
+    """
+    Returns True if version `lhs` is earlier or equal to `rhs`.
 
+    Args:
+        lhs: version name to compare with `rhs`, return True if earlier or equal to `rhs`.
+        rhs: version name to compare with `lhs`, return True if later or equal to `lhs`.
+
+    """
+
+    lhs, rhs = str(lhs), str(rhs)
     ver, has_ver = optional_import("pkg_resources", name="parse_version")
     if has_ver:
         return ver(lhs) <= ver(rhs)
 
-    def _try_cast(val):
+    def _try_cast(val: str):
         val = val.strip()
         try:
             m = match("(\\d+)(.*)", val)
@@ -390,10 +398,10 @@ def version_leq(lhs, rhs):
     rhs = rhs.split("+", 1)[0]
 
     # parse the version strings in this basic way without `packaging` package
-    lhs = map(_try_cast, lhs.split("."))
-    rhs = map(_try_cast, rhs.split("."))
+    lhs_ = map(_try_cast, lhs.split("."))
+    rhs_ = map(_try_cast, rhs.split("."))
 
-    for l, r in zip(lhs, rhs):
+    for l, r in zip(lhs_, rhs_):
         if l != r:
             if isinstance(l, int) and isinstance(r, int):
                 return l < r

--- a/tests/test_version_leq.py
+++ b/tests/test_version_leq.py
@@ -67,6 +67,9 @@ TEST_CASES = (
     ("0post1", "0.4post1"),
     ("2.1.0-rc1", "2.1.0"),
     ("2.1dev", "2.1a0"),
+    (1.6, "1.6.0"),
+    ("1.6.0", 1.6),
+    (1.6, 1.7),
 ) + tuple(_pairwise(reversed(torture.split())))
 
 


### PR DESCRIPTION
### Description
This PR enhanced the `version_leq` API to clearly define the input data type and doc-string.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
