### PR TITLE
2721 - fixes rst format issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ tests/testing_data/*.tiff
 
 # VSCode
 .vscode/
+*.zip

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -386,39 +386,39 @@ Intensity
 """"""""""""""""""""""
 .. image:: https://github.com/Project-MONAI/DocImages/raw/main/transforms/RandKSpaceSpikeNoise.png
     :alt: example of RandKSpaceSpikeNoise
- .. autoclass:: RandKSpaceSpikeNoise
-     :members:
-     :special-members: __call__
+.. autoclass:: RandKSpaceSpikeNoise
+    :members:
+    :special-members: __call__
 
 `RandCoarseTransform`
 """""""""""""""""""""
- .. autoclass:: RandCoarseTransform
-     :members:
-     :special-members: __call__
+.. autoclass:: RandCoarseTransform
+    :members:
+    :special-members: __call__
 
 `RandCoarseDropout`
 """""""""""""""""""
 .. image:: https://github.com/Project-MONAI/DocImages/raw/main/transforms/RandCoarseDropout.png
     :alt: example of RandCoarseDropout
- .. autoclass:: RandCoarseDropout
-     :members:
-     :special-members: __call__
+.. autoclass:: RandCoarseDropout
+    :members:
+    :special-members: __call__
 
 `RandCoarseShuffle`
 """""""""""""""""""
 .. image:: https://github.com/Project-MONAI/DocImages/raw/main/transforms/RandCoarseShuffle.png
     :alt: example of RandCoarseShuffle
- .. autoclass:: RandCoarseShuffle
-     :members:
-     :special-members: __call__
+.. autoclass:: RandCoarseShuffle
+    :members:
+    :special-members: __call__
 
 `HistogramNormalize`
 """"""""""""""""""""
 .. image:: https://github.com/Project-MONAI/DocImages/raw/main/transforms/HistogramNormalize.png
     :alt: example of HistogramNormalize
- .. autoclass:: HistogramNormalize
-     :members:
-     :special-members: __call__
+.. autoclass:: HistogramNormalize
+    :members:
+    :special-members: __call__
 
 IO
 ^^
@@ -843,13 +843,13 @@ Utility
 
 `IntensityStats`
 """"""""""""""""
- .. autoclass:: IntensityStats
-     :members:
-     :special-members: __call__
+.. autoclass:: IntensityStats
+    :members:
+    :special-members: __call__
 
 `ToDevice`
 """"""""""
- .. autoclass:: ToDevice
+.. autoclass:: ToDevice
      :members:
      :special-members: __call__
 
@@ -1205,9 +1205,9 @@ Intensity (Dict)
 """""""""""""""""""""
 .. image:: https://github.com/Project-MONAI/DocImages/raw/main/transforms/HistogramNormalized.png
     :alt: example of HistogramNormalized
- .. autoclass:: HistogramNormalized
-     :members:
-     :special-members: __call__
+.. autoclass:: HistogramNormalized
+    :members:
+    :special-members: __call__
 
 
 IO (Dict)
@@ -1622,9 +1622,9 @@ Utility (Dict)
 
 `ToDeviced`
 """""""""""
- .. autoclass:: ToDeviced
-     :members:
-     :special-members: __call__
+.. autoclass:: ToDeviced
+    :members:
+    :special-members: __call__
 
 `CuCIMd`
 """"""""


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

part of #2721

### Description
fixes some formatting errors that break the transforms figures, e.g.
- https://docs.monai.io/en/latest/transforms.html#randcoarseshuffle

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
