### PR TITLE
oneof doc

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -53,6 +53,11 @@ Generic Interfaces
 .. autoclass:: Decollated
     :members:
 
+`OneOf`
+^^^^^^^
+.. autoclass:: OneOf
+    :members:
+
 Vanilla Transforms
 ------------------
 

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -181,7 +181,7 @@ class OneOf(Compose):
         weights: probabilities corresponding to each callable in transforms.
             Probabilities are normalized to sum to one.
 
-    OneOf inherits from Compose and uses args map_items and unpack_items in
+    ``OneOf`` inherits from ``Compose`` and uses args ``map_items`` and ``unpack_items`` in
     the same way.
     """
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>


### Description
adds some missing documentation

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
