### PR TITLE
KeepLargestConnectedComponent(d) example transforms

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -488,6 +488,8 @@ Post-processing
 
 `KeepLargestConnectedComponent`
 """""""""""""""""""""""""""""""
+.. image:: https://github.com/Project-MONAI/DocImages/raw/main/transforms/KeepLargestConnectedComponent.png
+    :alt: example of KeepLargestConnectedComponent
 .. autoclass:: KeepLargestConnectedComponent
     :members:
     :special-members: __call__
@@ -1249,6 +1251,8 @@ Post-processing (Dict)
 
 `KeepLargestConnectedComponentd`
 """"""""""""""""""""""""""""""""
+.. image:: https://github.com/Project-MONAI/DocImages/raw/main/transforms/KeepLargestConnectedComponentd.png
+    :alt: example of KeepLargestConnectedComponentd
 .. autoclass:: KeepLargestConnectedComponentd
     :members:
     :special-members: __call__

--- a/monai/transforms/utils_create_transform_ims.py
+++ b/monai/transforms/utils_create_transform_ims.py
@@ -139,8 +139,8 @@ from monai.transforms.intensity.dictionary import (
     StdShiftIntensityd,
     ThresholdIntensityd,
 )
-from monai.transforms.post.array import LabelFilter, LabelToContour
-from monai.transforms.post.dictionary import AsDiscreted, LabelFilterd, LabelToContourd
+from monai.transforms.post.array import KeepLargestConnectedComponent, LabelFilter, LabelToContour
+from monai.transforms.post.dictionary import AsDiscreted, KeepLargestConnectedComponentd, LabelFilterd, LabelToContourd
 from monai.transforms.spatial.array import Rand2DElastic, RandAffine, RandAxisFlip, RandRotate90, Resize, Spacing
 from monai.transforms.spatial.dictionary import (
     Rand2DElasticd,
@@ -666,3 +666,9 @@ if __name__ == "__main__":
     create_transform_im(RandAxisFlipd, dict(keys=keys, prob=1), data)
     create_transform_im(Resize, dict(spatial_size=(100, 100, 100)), data)
     create_transform_im(Resized, dict(keys=keys, spatial_size=(100, 100, 100), mode=["area", "nearest"]), data)
+    data_binary = deepcopy(data)
+    data_binary[CommonKeys.LABEL] = (data_binary[CommonKeys.LABEL] > 0).astype(np.float32)
+    create_transform_im(KeepLargestConnectedComponent, dict(applied_labels=1), data_binary, is_post=True, ndim=2)
+    create_transform_im(
+        KeepLargestConnectedComponentd, dict(keys=CommonKeys.LABEL, applied_labels=1), data_binary, is_post=True, ndim=2
+    )


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/pull/3056#issuecomment-932762805. **Requires https://github.com/Project-MONAI/DocImages/pull/5**.

### Description
Example images for `KeepLargestConnectedComponent` and `KeepLargestConnectedComponentd`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).