### PR TITLE
senet tests with monai's testing data

### DIFF
--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -128,7 +128,8 @@ def download_url(
 
     Args:
         url: source URL link to download file.
-        filepath: target filepath to save the downloaded file. If undefined, `os.path.basename(url)` will be used.
+        filepath: target filepath to save the downloaded file (including the filename).
+            If undefined, `os.path.basename(url)` will be used.
         hash_val: expected hash value to validate the downloaded file.
             if None, skip hash validation.
         hash_type: 'md5' or 'sha1', defaults to 'md5'.

--- a/monai/networks/nets/__init__.py
+++ b/monai/networks/nets/__init__.py
@@ -71,7 +71,6 @@ from .senet import (
     SEResNeXt101,
     SEresnext101,
     Seresnext101,
-    senet,
     senet154,
     seresnet50,
     seresnet101,


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

The SENet pretrained model tests are not stable due the weight downloading,
this PR modifies the unit tests to use monai's host of testing data.

https://github.com/Project-MONAI/MONAI/blob/ff083340c6aa674b43e36e6da42dcf7bef5c9bdd/monai/networks/nets/senet.py#L258-L259

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
