### PR TITLE
3174 Add support to scale datalist

### DIFF
--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -58,7 +58,7 @@ from .utils import (
     pickle_hashing,
     rectify_header_sform_qform,
     rep_scalar_to_batch,
-    scale_datalist,
+    resample_datalist,
     select_cross_validation_folds,
     set_rnd,
     sorted_dict,

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -66,7 +66,7 @@ __all__ = [
     "is_supported_format",
     "partition_dataset",
     "partition_dataset_classes",
-    "scale_datalist",
+    "resample_datalist",
     "select_cross_validation_folds",
     "json_hashing",
     "pickle_hashing",
@@ -992,9 +992,9 @@ def partition_dataset_classes(
     return datasets
 
 
-def scale_datalist(data: Sequence, factor: float, random_pick: bool = False, seed: int = 0):
+def resample_datalist(data: Sequence, factor: float, random_pick: bool = False, seed: int = 0):
     """
-    Utility function to scale the loaded datalist for training, for example:
+    Utility function to resample the loaded datalist for training, for example:
     If factor < 1.0, randomly pick part of the datalist and set to Dataset, useful to quickly test the program.
     If factor > 1.0, repeat the datalist to enhance the Dataset.
 

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -450,7 +450,7 @@ class TestInverse(unittest.TestCase):
 
         batch_size = 10
         # num workers = 0 for mac
-        num_workers = 2 if sys.platform != "darwin" else 0
+        num_workers = 2 if sys.platform == "linux" else 0
         transforms = Compose([AddChanneld(KEYS), SpatialPadd(KEYS, (150, 153)), extra_transform])
         num_invertible_transforms = sum(1 for i in transforms.transforms if isinstance(i, InvertibleTransform))
 

--- a/tests/test_resample_datalist.py
+++ b/tests/test_resample_datalist.py
@@ -14,7 +14,7 @@ import unittest
 import numpy as np
 from parameterized import parameterized
 
-from monai.data import scale_datalist
+from monai.data import resample_datalist
 
 TEST_CASE_1 = [
     {"data": [1, 2, 3, 4, 5], "factor": 2.5, "random_pick": True, "seed": 123},
@@ -29,10 +29,10 @@ TEST_CASE_2 = [
 TEST_CASE_3 = [{"data": [1, 2, 3, 4, 5], "factor": 0.6, "random_pick": True, "seed": 123}, [2, 4, 5]]
 
 
-class TestScaleDatalist(unittest.TestCase):
+class TestResampleDatalist(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_value_shape(self, input_param, expected):
-        result = scale_datalist(**input_param)
+        result = resample_datalist(**input_param)
         np.testing.assert_allclose(result, expected)
 
 


### PR DESCRIPTION
Fixes #3174 .

### Description
This PR implemented the logic to scale a datalist.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
