### PR TITLE
3197 Fix iteration count issue in `StatsHandler`

### DIFF
--- a/monai/handlers/stats_handler.py
+++ b/monai/handlers/stats_handler.py
@@ -237,9 +237,9 @@ class StatsHandler:
             return  # no value to print
 
         num_iterations = engine.state.epoch_length
-        current_iteration = engine.state.iteration - 1
+        current_iteration = engine.state.iteration
         if num_iterations is not None:
-            current_iteration %= num_iterations + 1
+            current_iteration = (current_iteration - 1) % num_iterations + 1
         current_epoch = engine.state.epoch
         num_epochs = engine.state.max_epochs
 


### PR DESCRIPTION
Fixes #3197 .

### Description
This PR fixed the iteration count issue in `StatsHandler` logging.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
