### PR TITLE
`self.centers` not set in `randomize`

### DIFF
--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -167,7 +167,7 @@ class Randomizable(ABC, ThreadUnsafe):
         self.R = np.random.RandomState()
         return self
 
-    def randomize(self, data: Any) -> None:
+    def randomize(self, data: Any) -> Any:
         """
         Within this method, :py:attr:`self.R` should be used, instead of `np.random`, to introduce random factors.
 


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/discussions/3215 (discussion).

### Description
Don't set `self.centers` in `randomize`. Generally speaking, we shouldn't be setting any `self` variables in `randomize` (unless they're marked `ThreadUnsafe`).

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
