### PR TITLE
blend images

### DIFF
--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -553,6 +553,7 @@ from .utils_pytorch_numpy_unification import (
     nonzero,
     percentile,
     ravel,
+    repeat,
     unravel_index,
     where,
 )

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, Union
+from typing import Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -35,6 +35,7 @@ __all__ = [
     "cumsum",
     "isfinite",
     "searchsorted",
+    "repeat",
 ]
 
 
@@ -301,3 +302,10 @@ def searchsorted(a: NdarrayOrTensor, v: NdarrayOrTensor, right=False, sorter=Non
     ret = np.searchsorted(a.cpu().numpy(), v.cpu().numpy(), side, sorter)  # type: ignore
     ret, *_ = convert_to_dst_type(ret, a)
     return ret
+
+
+def repeat(a: NdarrayOrTensor, repeats: int, axis: Optional[int] = None):
+    """`np.repeat` with equivalent implementation for torch (`repeat_interleave`)."""
+    if isinstance(a, np.ndarray):
+        return np.repeat(a, repeats, axis)
+    return torch.repeat_interleave(a, repeats, dim=axis)

--- a/monai/visualize/__init__.py
+++ b/monai/visualize/__init__.py
@@ -17,5 +17,5 @@ from .img2tensorboard import (
     plot_2d_or_3d_image,
 )
 from .occlusion_sensitivity import OcclusionSensitivity
-from .utils import matshow3d
+from .utils import blend_images, matshow3d
 from .visualizer import default_upsampler

--- a/tests/test_blend_images.py
+++ b/tests/test_blend_images.py
@@ -1,0 +1,53 @@
+# Copyright 2020 - 2021 MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.case import skipUnless
+
+import torch
+from parameterized import parameterized
+
+from monai.data.synthetic import create_test_image_2d, create_test_image_3d
+from monai.transforms.utils_pytorch_numpy_unification import moveaxis
+from monai.utils.module import optional_import
+from monai.visualize.utils import blend_images
+from tests.utils import TEST_NDARRAYS
+
+plt, has_matplotlib = optional_import("matplotlib.pyplot")
+
+TESTS = []
+for p in TEST_NDARRAYS:
+    image, label = create_test_image_2d(100, 101)
+    TESTS.append((p(image), p(label)))
+
+    image, label = create_test_image_3d(100, 101, 102)
+    TESTS.append((p(image), p(label)))
+
+
+@skipUnless(has_matplotlib, "Matplotlib required")
+class TestBlendImages(unittest.TestCase):
+    @parameterized.expand(TESTS)
+    def test_blend(self, image, label):
+        blended = blend_images(image[None], label[None])
+        self.assertEqual(type(image), type(blended))
+        if isinstance(blended, torch.Tensor):
+            self.assertEqual(blended.device, image.device)
+            blended = blended.cpu().numpy()
+        self.assertEqual((3,) + image.shape, blended.shape)
+
+        blended = moveaxis(blended, 0, -1)  # move RGB component to end
+        if blended.ndim > 3:
+            blended = blended[blended.shape[0] // 2]
+        plt.imshow(blended)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description
Utility function for superposing a segmentation on top of an image. Image can be single channel or RGB, label is converted to RGB and superposed.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.

![image](https://user-images.githubusercontent.com/33289025/139871211-d61b6caf-1332-4002-9a98-8cd8c910172c.png)
