### PR TITLE
Issue #3315 Pickling Error in DeepGrow

### DIFF
--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -18,7 +18,7 @@ from monai.config import IndexSelection, KeysCollection
 from monai.networks.layers import GaussianFilter
 from monai.transforms import Resize, SpatialCrop
 from monai.transforms.transform import MapTransform, Randomizable, Transform
-from monai.transforms.utils import generate_spatial_bounding_box
+from monai.transforms.utils import generate_spatial_bounding_box, is_positive
 from monai.utils import (
     InterpolateMode,
     deprecated_arg,
@@ -395,7 +395,7 @@ class SpatialCropForegroundd(MapTransform):
         keys: KeysCollection,
         source_key: str,
         spatial_size: Union[Sequence[int], np.ndarray],
-        select_fn: Callable = lambda x: x > 0,
+        select_fn: Callable = is_positive,
         channel_indices: Optional[IndexSelection] = None,
         margin: int = 0,
         meta_keys: Optional[KeysCollection] = None,


### PR DESCRIPTION
Fixes #3315

### Description
Fix for 
`Pickling Error: Can't pickle <function SpatialCropForegroundd.<lambda> on monai.apps.deepgrow.transforms`

The problem is similar to Issue: Unable to Train Model in PyTorch Subprocess #2122
Following fix 2128 need to be added in
/monai/apps/deepgrow/transforms.py b/monai/apps/deepgrow/transforms.py
Line 398 has to be changed from
`select_fn: Callable = lambda x: x > 0`
to
`select_fn: Callable = is_positive`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
