### PR TITLE
3350 drops pytorch 1.5.x support

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, common]
     strategy:
       matrix:
-        pytorch-version: [1.5.1, 1.6.0, 1.7.1, 1.8.1, latest]
+        pytorch-version: [1.6.0, 1.7.1, 1.8.1, 1.9.1, latest]
     steps:
     - uses: actions/checkout@v2
     - name: Install the dependencies
@@ -25,14 +25,14 @@ jobs:
         python -m pip uninstall -y torch torchvision
         if [ ${{ matrix.pytorch-version }} == "latest" ]; then
           python -m pip install torch torchvision
-        elif [ ${{ matrix.pytorch-version }} == "1.5.1" ]; then
-          python -m pip install torch==1.5.1 torchvision==0.6.1
         elif [ ${{ matrix.pytorch-version }} == "1.6.0" ]; then
           python -m pip install torch==1.6.0 torchvision==0.7.0
         elif [ ${{ matrix.pytorch-version }} == "1.7.1" ]; then
           python -m pip install torch==1.7.1 torchvision==0.8.2
         elif [ ${{ matrix.pytorch-version }} == "1.8.1" ]; then
           python -m pip install torch==1.8.1 torchvision==0.9.1
+        elif [ ${{ matrix.pytorch-version }} == "1.9.1" ]; then
+          python -m pip install torch==1.9.1 torchvision==0.10.1
         fi
         python -m pip install -r requirements-dev.txt
         python -m pip list

--- a/.github/workflows/pythonapp-gpu.yml
+++ b/.github/workflows/pythonapp-gpu.yml
@@ -19,17 +19,13 @@ jobs:
     strategy:
       matrix:
         environment:
-          - "PT16+CUDA110"
           - "PT17+CUDA102"
           - "PT17+CUDA110"
           - "PT18+CUDA102"
+          - "PT18+CUDA110"
           - "PT19+CUDA114"
           - "PT110+CUDA102"
         include:
-          - environment: PT16+CUDA110
-            # we explicitly set pytorch to -h to avoid pip install error
-            pytorch: "-h"
-            base: "nvcr.io/nvidia/pytorch:20.07-py3"
           - environment: PT17+CUDA102
             pytorch: "torch==1.7.1 torchvision==0.8.2"
             base: "nvcr.io/nvidia/cuda:10.2-devel-ubuntu18.04"
@@ -40,6 +36,10 @@ jobs:
           - environment: PT18+CUDA102
             pytorch: "torch==1.8.1 torchvision==0.9.1"
             base: "nvcr.io/nvidia/cuda:10.2-devel-ubuntu18.04"
+          - environment: PT18+CUDA110
+            # we explicitly set pytorch to -h to avoid pip install error
+            pytorch: "-h"
+            base: "nvcr.io/nvidia/pytorch:21.02-py3"
           - environment: PT19+CUDA114
             # we explicitly set pytorch to -h to avoid pip install error
             # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes

--- a/.github/workflows/pythonapp-min.yml
+++ b/.github/workflows/pythonapp-min.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pytorch-version: [1.5.1, 1.6.0, 1.7.1, 1.8.1, latest]
+        pytorch-version: [1.6.0, 1.7.1, 1.8.1, 1.9.1, latest]
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v2
@@ -148,14 +148,14 @@ jobs:
         # min. requirements
         if [ ${{ matrix.pytorch-version }} == "latest" ]; then
           python -m pip install torch
-        elif [ ${{ matrix.pytorch-version }} == "1.5.1" ]; then
-          python -m pip install torch==1.5.1
         elif [ ${{ matrix.pytorch-version }} == "1.6.0" ]; then
           python -m pip install torch==1.6.0
         elif [ ${{ matrix.pytorch-version }} == "1.7.1" ]; then
           python -m pip install torch==1.7.1
         elif [ ${{ matrix.pytorch-version }} == "1.8.1" ]; then
           python -m pip install torch==1.8.1
+        elif [ ${{ matrix.pytorch-version }} == "1.9.1" ]; then
+          python -m pip install torch==1.9.1
         fi
         python -m pip install -r requirements-min.txt
         python -m pip list

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -137,7 +137,7 @@ jobs:
         # install the latest pytorch for testing
         # however, "pip install monai*.tar.gz" will build cpp/cuda with an isolated
         # fresh torch installation according to pyproject.toml
-        python -m pip install torch>=1.5 torchvision
+        python -m pip install torch>=1.6 torchvision
     - name: Check packages
       run: |
         pip uninstall monai

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -f https://download.pytorch.org/whl/cpu/torch-1.6.0%2Bcpu-cp37-cp37m-linux_x86_64.whl
-torch>=1.5
+torch>=1.6
 pytorch-ignite==0.4.6
 numpy>=1.17
 itk>=5.2

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -215,8 +215,7 @@ def separable_filtering(x: torch.Tensor, kernels: List[torch.Tensor], mode: str 
             could be a single kernel (duplicated for all spatial dimensions), or
             a list of `spatial_dims` number of kernels.
         mode (string, optional): padding mode passed to convolution class. ``'zeros'``, ``'reflect'``, ``'replicate'``
-            or ``'circular'``. Default: ``'zeros'``. Modes other than ``'zeros'`` require PyTorch version >= 1.5.1. See
-            torch.nn.Conv1d() for more information.
+            or ``'circular'``. Default: ``'zeros'``. See ``torch.nn.Conv1d()`` for more information.
 
     Raises:
         TypeError: When ``x`` is not a ``torch.Tensor``.

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -297,12 +297,7 @@ def searchsorted(a: NdarrayOrTensor, v: NdarrayOrTensor, right=False, sorter=Non
     side = "right" if right else "left"
     if isinstance(a, np.ndarray):
         return np.searchsorted(a, v, side, sorter)  # type: ignore
-    if hasattr(torch, "searchsorted"):
-        return torch.searchsorted(a, v, right=right)  # type: ignore
-    # if using old PyTorch, will convert to numpy array then compute
-    ret = np.searchsorted(a.cpu().numpy(), v.cpu().numpy(), side, sorter)  # type: ignore
-    ret, *_ = convert_to_dst_type(ret, a)
-    return ret
+    return torch.searchsorted(a, v, right=right)  # type: ignore
 
 
 def repeat(a: NdarrayOrTensor, repeats: int, axis: Optional[int] = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "wheel",
   "setuptools",
-  "torch>=1.5",
+  "torch>=1.6",
   "ninja",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-torch>=1.5
+torch>=1.6
 numpy>=1.17

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ setup_requires =
     torch
     ninja
 install_requires =
-    torch>=1.5
+    torch>=1.6
     numpy>=1.17
 
 [options.extras_require]

--- a/tests/test_cachedataset.py
+++ b/tests/test_cachedataset.py
@@ -20,7 +20,7 @@ from parameterized import parameterized
 
 from monai.data import CacheDataset, DataLoader, PersistentDataset, SmartCacheDataset
 from monai.transforms import Compose, Lambda, LoadImaged, RandLambda, ThreadUnsafe, Transform
-from monai.utils import get_torch_version_tuple
+from monai.utils.module import pytorch_after
 
 TEST_CASE_1 = [Compose([LoadImaged(keys=["image", "label", "extra"])]), (128, 128, 128)]
 
@@ -134,7 +134,7 @@ class TestCacheThread(unittest.TestCase):
     @parameterized.expand(TEST_DS)
     def test_thread_safe(self, persistent_workers, cache_workers, loader_workers):
         expected = [102, 202, 302, 402, 502, 602, 702, 802, 902, 1002]
-        _kwg = {"persistent_workers": persistent_workers} if get_torch_version_tuple() > (1, 7) else {}
+        _kwg = {"persistent_workers": persistent_workers} if pytorch_after(1, 8) else {}
         data_list = list(range(1, 11))
         dataset = CacheDataset(
             data=data_list, transform=_StatefulTransform(), cache_rate=1.0, num_workers=cache_workers, progress=False

--- a/tests/test_integration_workflows.py
+++ b/tests/test_integration_workflows.py
@@ -346,7 +346,7 @@ class IntegrationWorkflows(DistTestCase):
 
     def test_training(self):
         repeated = []
-        test_rounds = 3 if monai.utils.module.get_torch_version_tuple() >= (1, 6) else 2
+        test_rounds = 3
         for i in range(test_rounds):
             results = self.train_and_infer(idx=i)
             repeated.append(results)
@@ -354,8 +354,7 @@ class IntegrationWorkflows(DistTestCase):
 
     @TimedCall(seconds=300, skip_timing=not torch.cuda.is_available(), daemon=False)
     def test_timing(self):
-        if monai.utils.module.get_torch_version_tuple() >= (1, 6):
-            self.train_and_infer(idx=2)
+        self.train_and_infer(idx=2)
 
 
 if __name__ == "__main__":

--- a/tests/test_invertd.py
+++ b/tests/test_invertd.py
@@ -161,9 +161,8 @@ class TestInvertd(unittest.TestCase):
         print("invert diff", reverted.size - n_good)
         # 25300: 2 workers (cpu, non-macos)
         # 1812: 0 workers (gpu or macos)
-        # 1824: torch 1.5.1
         # 1821: windows torch 1.10.0
-        self.assertTrue((reverted.size - n_good) in (34007, 1812, 1824, 1821), f"diff.  {reverted.size - n_good}")
+        self.assertTrue((reverted.size - n_good) in (34007, 1812, 1821), f"diff.  {reverted.size - n_good}")
 
         set_determinism(seed=None)
 

--- a/tests/test_map_label_value.py
+++ b/tests/test_map_label_value.py
@@ -16,7 +16,6 @@ import torch
 from parameterized import parameterized
 
 from monai.transforms import MapLabelValue
-from monai.utils import pytorch_after
 from tests.utils import TEST_NDARRAYS
 
 TESTS = []
@@ -33,15 +32,14 @@ for p in TEST_NDARRAYS:
             [{"orig_labels": [1, 2, 3], "target_labels": [0.5, 1.5, 2.5]}, p([3, 1, 1, 2]), p([2.5, 0.5, 0.5, 1.5])],
         ]
     )
-    # PyTorch 1.5.1 doesn't support rich dtypes
-    if pytorch_after(1, 7):
-        TESTS.append(
-            [
-                {"orig_labels": [1.5, 2.5, 3.5], "target_labels": [0, 1, 2], "dtype": np.int8},
-                p([3.5, 1.5, 1.5, 2.5]),
-                p([2, 0, 0, 1]),
-            ]
-        )
+    # note: PyTorch 1.5.1 doesn't support rich dtypes
+    TESTS.append(
+        [
+            {"orig_labels": [1.5, 2.5, 3.5], "target_labels": [0, 1, 2], "dtype": np.int8},
+            p([3.5, 1.5, 1.5, 2.5]),
+            p([2, 0, 0, 1]),
+        ]
+    )
 TESTS.extend(
     [
         [

--- a/tests/test_mmar_download.py
+++ b/tests/test_mmar_download.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 from monai.apps import RemoteMMARKeys, download_mmar, get_model_spec, load_from_mmar
 from monai.apps.mmars import MODEL_DESC
 from monai.apps.mmars.mmars import _get_val
-from tests.utils import SkipIfAtLeastPyTorchVersion, SkipIfBeforePyTorchVersion, skip_if_quick
+from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick
 
 TEST_CASES = [["clara_pt_prostate_mri_segmentation_1"], ["clara_pt_covid19_ct_lesion_segmentation_1"]]
 TEST_EXTRACT_CASES = [
@@ -125,7 +125,6 @@ class TestMMMARDownload(unittest.TestCase):
 
     @parameterized.expand(TEST_EXTRACT_CASES)
     @skip_if_quick
-    @SkipIfBeforePyTorchVersion((1, 6))
     def test_load_ckpt(self, input_args, expected_name, expected_val):
         try:
             output = load_from_mmar(**input_args)
@@ -142,11 +141,6 @@ class TestMMMARDownload(unittest.TestCase):
         # model ids are unique
         keys = sorted(m["id"] for m in MODEL_DESC)
         self.assertTrue(keys == sorted(set(keys)))
-
-    @SkipIfAtLeastPyTorchVersion((1, 6))
-    def test_no_default(self):
-        with self.assertRaises(ValueError):
-            download_mmar(0)
 
     def test_search(self):
         self.assertEqual(_get_val({"a": 1, "b": 2}, key="b"), 2)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

part of #3350

### Description

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
