### PR TITLE
backward compatible as discrete

### DIFF
--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -155,36 +155,42 @@ class AsDiscrete(Transform):
 
     backend = [TransformBackends.TORCH]
 
-    @deprecated_arg("n_classes", since="0.6")
-    @deprecated_arg("num_classes", since="0.7")
-    @deprecated_arg("logit_thresh", since="0.7")
-    @deprecated_arg(name="threshold_values", new_name="threshold", since="0.7")
+    @deprecated_arg(name="n_classes", new_name="num_classes", since="0.6", msg_suffix="please use `to_onehot` instead.")
+    @deprecated_arg("num_classes", since="0.7", msg_suffix="please use `to_onehot` instead.")
+    @deprecated_arg("logit_thresh", since="0.7", msg_suffix="please use `threshold` instead.")
+    @deprecated_arg(
+        name="threshold_values", new_name="threshold", since="0.7", msg_suffix="please use `threshold` instead."
+    )
     def __init__(
         self,
         argmax: bool = False,
         to_onehot: Optional[int] = None,
         threshold: Optional[float] = None,
         rounding: Optional[str] = None,
-        n_classes: Optional[int] = None,
-        num_classes: Optional[int] = None,
-        logit_thresh: float = 0.5,
-        threshold_values: bool = False,
+        n_classes: Optional[int] = None,  # deprecated
+        num_classes: Optional[int] = None,  # deprecated
+        logit_thresh: float = 0.5,  # deprecated
+        threshold_values: Optional[bool] = False,  # deprecated
     ) -> None:
         self.argmax = argmax
-        if isinstance(to_onehot, bool):
-            raise ValueError("`to_onehot=True/False` is deprecated, please use `to_onehot=num_classes` instead.")
+        if isinstance(to_onehot, bool):  # for backward compatibility
+            warnings.warn("`to_onehot=True/False` is deprecated, please use `to_onehot=num_classes` instead.")
+            to_onehot = num_classes if to_onehot else None
         self.to_onehot = to_onehot
 
-        if isinstance(threshold, bool):
-            raise ValueError("`threshold_values=True/False` is deprecated, please use `threashold=value` instead.")
+        if isinstance(threshold, bool):  # for backward compatibility
+            warnings.warn("`threshold_values=True/False` is deprecated, please use `threashold=value` instead.")
+            threshold = logit_thresh if threshold else None
         self.threshold = threshold
 
         self.rounding = rounding
 
-    @deprecated_arg("n_classes", since="0.6")
-    @deprecated_arg("num_classes", since="0.7")
-    @deprecated_arg("logit_thresh", since="0.7")
-    @deprecated_arg(name="threshold_values", new_name="threshold", since="0.7")
+    @deprecated_arg(name="n_classes", new_name="num_classes", since="0.6", msg_suffix="please use `to_onehot` instead.")
+    @deprecated_arg("num_classes", since="0.7", msg_suffix="please use `to_onehot` instead.")
+    @deprecated_arg("logit_thresh", since="0.7", msg_suffix="please use `threshold` instead.")
+    @deprecated_arg(
+        name="threshold_values", new_name="threshold", since="0.7", msg_suffix="please use `threshold` instead."
+    )
     def __call__(
         self,
         img: NdarrayOrTensor,
@@ -192,10 +198,10 @@ class AsDiscrete(Transform):
         to_onehot: Optional[int] = None,
         threshold: Optional[float] = None,
         rounding: Optional[str] = None,
-        n_classes: Optional[int] = None,
-        num_classes: Optional[int] = None,
-        logit_thresh: Optional[float] = None,
-        threshold_values: Optional[bool] = None,
+        n_classes: Optional[int] = None,  # deprecated
+        num_classes: Optional[int] = None,  # deprecated
+        logit_thresh: Optional[float] = None,  # deprecated
+        threshold_values: Optional[bool] = None,  # deprecated
     ) -> NdarrayOrTensor:
         """
         Args:
@@ -220,9 +226,11 @@ class AsDiscrete(Transform):
 
         """
         if isinstance(to_onehot, bool):
-            raise ValueError("`to_onehot=True/False` is deprecated, please use `to_onehot=num_classes` instead.")
+            warnings.warn("`to_onehot=True/False` is deprecated, please use `to_onehot=num_classes` instead.")
+            to_onehot = num_classes if to_onehot else None
         if isinstance(threshold, bool):
-            raise ValueError("`threshold_values=True/False` is deprecated, please use `threashold=value` instead.")
+            warnings.warn("`threshold_values=True/False` is deprecated, please use `threashold=value` instead.")
+            threshold = logit_thresh if threshold else None
 
         img_t: torch.Tensor
         img_t, *_ = convert_data_type(img, torch.Tensor)  # type: ignore


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

follow up of https://github.com/Project-MONAI/MONAI/pull/3352

### Description


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
