### PR TITLE
`TileOnGrid` support for `Tensor` input

### DIFF
--- a/monai/apps/pathology/transforms/spatial/array.py
+++ b/monai/apps/pathology/transforms/spatial/array.py
@@ -17,6 +17,7 @@ from numpy.lib.stride_tricks import as_strided
 
 from monai.config.type_definitions import NdarrayOrTensor
 from monai.transforms.transform import Randomizable, Transform
+from monai.utils import convert_data_type, convert_to_dst_type
 from monai.utils.enums import TransformBackends
 
 __all__ = ["SplitOnGrid", "TileOnGrid"]
@@ -129,6 +130,8 @@ class TileOnGrid(Randomizable, Transform):
 
     """
 
+    backend = [TransformBackends.NUMPY]
+
     def __init__(
         self,
         tile_count: Optional[int] = None,
@@ -185,21 +188,23 @@ class TileOnGrid(Randomizable, Transform):
         else:
             self.random_idxs = np.array((0,))
 
-    def __call__(self, image: np.ndarray) -> np.ndarray:
+    def __call__(self, image: NdarrayOrTensor) -> NdarrayOrTensor:
+        img_np: np.ndarray
+        img_np, *_ = convert_data_type(image, np.ndarray)  # type: ignore
 
         # add random offset
-        self.randomize(img_size=image.shape)
+        self.randomize(img_size=img_np.shape)
 
         if self.random_offset and (self.offset[0] > 0 or self.offset[1] > 0):
-            image = image[:, self.offset[0] :, self.offset[1] :]
+            img_np = img_np[:, self.offset[0] :, self.offset[1] :]
 
         # pad to full size, divisible by tile_size
         if self.pad_full:
-            c, h, w = image.shape
+            c, h, w = img_np.shape
             pad_h = (self.tile_size - h % self.tile_size) % self.tile_size
             pad_w = (self.tile_size - w % self.tile_size) % self.tile_size
-            image = np.pad(
-                image,
+            img_np = np.pad(
+                img_np,
                 [[0, 0], [pad_h // 2, pad_h - pad_h // 2], [pad_w // 2, pad_w - pad_w // 2]],
                 constant_values=self.background_val,
             )
@@ -207,15 +212,15 @@ class TileOnGrid(Randomizable, Transform):
         # extact tiles
         x_step, y_step = self.step, self.step
         x_size, y_size = self.tile_size, self.tile_size
-        c_len, x_len, y_len = image.shape
-        c_stride, x_stride, y_stride = image.strides
+        c_len, x_len, y_len = img_np.shape
+        c_stride, x_stride, y_stride = img_np.strides
         llw = as_strided(
-            image,
+            img_np,
             shape=((x_len - x_size) // x_step + 1, (y_len - y_size) // y_step + 1, c_len, x_size, y_size),
             strides=(x_stride * x_step, y_stride * y_step, c_stride, x_stride, y_stride),
             writeable=False,
         )
-        image = llw.reshape(-1, c_len, x_size, y_size)
+        img_np = llw.reshape(-1, c_len, x_size, y_size)
 
         # if keeping all patches
         if self.tile_count is None:
@@ -224,32 +229,34 @@ class TileOnGrid(Randomizable, Transform):
             thresh = 0.999 * 3 * self.background_val * self.tile_size * self.tile_size
             if self.filter_mode == "min":
                 # default, keep non-background tiles (small values)
-                idxs = np.argwhere(image.sum(axis=(1, 2, 3)) < thresh)
-                image = image[idxs.reshape(-1)]
+                idxs = np.argwhere(img_np.sum(axis=(1, 2, 3)) < thresh)
+                img_np = img_np[idxs.reshape(-1)]
             elif self.filter_mode == "max":
-                idxs = np.argwhere(image.sum(axis=(1, 2, 3)) >= thresh)
-                image = image[idxs.reshape(-1)]
+                idxs = np.argwhere(img_np.sum(axis=(1, 2, 3)) >= thresh)
+                img_np = img_np[idxs.reshape(-1)]
 
         else:
-            if len(image) > self.tile_count:
+            if len(img_np) > self.tile_count:
 
                 if self.filter_mode == "min":
                     # default, keep non-background tiles (smallest values)
-                    idxs = np.argsort(image.sum(axis=(1, 2, 3)))[: self.tile_count]
-                    image = image[idxs]
+                    idxs = np.argsort(img_np.sum(axis=(1, 2, 3)))[: self.tile_count]
+                    img_np = img_np[idxs]
                 elif self.filter_mode == "max":
-                    idxs = np.argsort(image.sum(axis=(1, 2, 3)))[-self.tile_count :]
-                    image = image[idxs]
+                    idxs = np.argsort(img_np.sum(axis=(1, 2, 3)))[-self.tile_count :]
+                    img_np = img_np[idxs]
                 else:
                     # random subset (more appropriate for WSIs without distinct background)
                     if self.random_idxs is not None:
-                        image = image[self.random_idxs]
+                        img_np = img_np[self.random_idxs]
 
-            elif len(image) < self.tile_count:
-                image = np.pad(
-                    image,
-                    [[0, self.tile_count - len(image)], [0, 0], [0, 0], [0, 0]],
+            elif len(img_np) < self.tile_count:
+                img_np = np.pad(
+                    img_np,
+                    [[0, self.tile_count - len(img_np)], [0, 0], [0, 0], [0, 0]],
                     constant_values=self.background_val,
                 )
+
+        image, *_ = convert_to_dst_type(src=img_np, dst=image, dtype=image.dtype)
 
         return image

--- a/monai/apps/pathology/transforms/spatial/array.py
+++ b/monai/apps/pathology/transforms/spatial/array.py
@@ -210,17 +210,17 @@ class TileOnGrid(Randomizable, Transform):
             )
 
         # extact tiles
-        x_step, y_step = self.step, self.step
-        x_size, y_size = self.tile_size, self.tile_size
-        c_len, x_len, y_len = img_np.shape
-        c_stride, x_stride, y_stride = img_np.strides
+        h_step, w_step = self.step, self.step
+        h_size, w_size = self.tile_size, self.tile_size
+        c_len, h_len, w_len = img_np.shape
+        c_stride, h_stride, w_stride = img_np.strides
         llw = as_strided(
             img_np,
-            shape=((x_len - x_size) // x_step + 1, (y_len - y_size) // y_step + 1, c_len, x_size, y_size),
-            strides=(x_stride * x_step, y_stride * y_step, c_stride, x_stride, y_stride),
+            shape=((h_len - h_size) // h_step + 1, (w_len - w_size) // w_step + 1, c_len, h_size, w_size),
+            strides=(h_stride * h_step, w_stride * w_step, c_stride, h_stride, w_stride),
             writeable=False,
         )
-        img_np = llw.reshape(-1, c_len, x_size, y_size)
+        img_np = llw.reshape(-1, c_len, h_size, w_size)
 
         # if keeping all patches
         if self.tile_count is None:

--- a/monai/apps/pathology/transforms/spatial/dictionary.py
+++ b/monai/apps/pathology/transforms/spatial/dictionary.py
@@ -12,8 +12,6 @@
 import copy
 from typing import Any, Dict, Hashable, List, Mapping, Optional, Tuple, Union
 
-import numpy as np
-
 from monai.config import KeysCollection
 from monai.config.type_definitions import NdarrayOrTensor
 from monai.transforms.transform import MapTransform, Randomizable
@@ -112,7 +110,9 @@ class TileOnGridd(Randomizable, MapTransform):
     def randomize(self, data: Any = None) -> None:
         self.seed = self.R.randint(10000)  # type: ignore
 
-    def __call__(self, data: Mapping[Hashable, np.ndarray]) -> Union[Dict[Hashable, np.ndarray], List[Dict]]:
+    def __call__(
+        self, data: Mapping[Hashable, NdarrayOrTensor]
+    ) -> Union[Dict[Hashable, NdarrayOrTensor], List[Dict[Hashable, NdarrayOrTensor]]]:
 
         self.randomize()
 

--- a/monai/apps/pathology/transforms/spatial/dictionary.py
+++ b/monai/apps/pathology/transforms/spatial/dictionary.py
@@ -79,6 +79,8 @@ class TileOnGridd(Randomizable, MapTransform):
 
     """
 
+    backend = SplitOnGrid.backend
+
     def __init__(
         self,
         keys: KeysCollection,

--- a/tests/test_tile_on_grid.py
+++ b/tests/test_tile_on_grid.py
@@ -16,6 +16,7 @@ import numpy as np
 from parameterized import parameterized
 
 from monai.apps.pathology.transforms import TileOnGrid
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
 TEST_CASES = []
 for tile_count in [16, 64]:
@@ -38,6 +39,10 @@ for tile_size in [8, 16]:
     for step in [4, 8]:
         TEST_CASES.append([{"tile_count": 16, "step": step, "tile_size": tile_size}])
 
+TESTS = []
+for p in TEST_NDARRAYS:
+    for tc in TEST_CASES:
+        TESTS.append([p, *tc])
 
 TEST_CASES2 = []
 for tile_count in [16, 64]:
@@ -55,6 +60,11 @@ for tile_count in [16, 64]:
                         }
                     ]
                 )
+
+TESTS2 = []
+for p in TEST_NDARRAYS:
+    for tc in TEST_CASES2:
+        TESTS2.append([p, *tc])
 
 
 def make_image(
@@ -104,25 +114,27 @@ def make_image(
 
 
 class TestTileOnGrid(unittest.TestCase):
-    @parameterized.expand(TEST_CASES)
-    def test_tile_patch_single_call(self, input_parameters):
+    @parameterized.expand(TESTS)
+    def test_tile_patch_single_call(self, in_type, input_parameters):
 
         img, tiles = make_image(**input_parameters)
+        input_img = in_type(img)
 
         tiler = TileOnGrid(**input_parameters)
-        output = tiler(img)
-        np.testing.assert_equal(output, tiles)
+        output = tiler(input_img)
+        assert_allclose(output, tiles, type_test=False)
 
-    @parameterized.expand(TEST_CASES2)
-    def test_tile_patch_random_call(self, input_parameters):
+    @parameterized.expand(TESTS2)
+    def test_tile_patch_random_call(self, in_type, input_parameters):
 
         img, tiles = make_image(**input_parameters, seed=123)
+        input_img = in_type(img)
 
         tiler = TileOnGrid(**input_parameters)
         tiler.set_random_state(seed=123)
 
-        output = tiler(img)
-        np.testing.assert_equal(output, tiles)
+        output = tiler(input_img)
+        assert_allclose(output, tiles, type_test=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_tile_on_grid_dict.py
+++ b/tests/test_tile_on_grid_dict.py
@@ -13,9 +13,11 @@ import unittest
 from typing import Optional
 
 import numpy as np
+import torch
 from parameterized import parameterized
 
 from monai.apps.pathology.transforms import TileOnGridDict
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
 TEST_CASES = []
 for tile_count in [16, 64]:
@@ -36,11 +38,14 @@ for tile_count in [16, 64]:
                         ]
                     )
 
-
 for tile_size in [8, 16]:
     for step in [4, 8]:
         TEST_CASES.append([{"tile_count": 16, "step": step, "tile_size": tile_size}])
 
+TESTS = []
+for p in TEST_NDARRAYS:
+    for tc in TEST_CASES:
+        TESTS.append([p, *tc])
 
 TEST_CASES2 = []
 for tile_count in [16, 64]:
@@ -61,6 +66,10 @@ for tile_count in [16, 64]:
                         ]
                     )
 
+TESTS2 = []
+for p in TEST_NDARRAYS:
+    for tc in TEST_CASES2:
+        TESTS2.append([p, *tc])
 
 for tile_size in [8, 16]:
     for step in [4, 8]:
@@ -114,27 +123,31 @@ def make_image(
 
 
 class TestTileOnGridDict(unittest.TestCase):
-    @parameterized.expand(TEST_CASES)
-    def test_tile_patch_single_call(self, input_parameters):
+    @parameterized.expand(TESTS)
+    def test_tile_patch_single_call(self, in_type, input_parameters):
 
         key = "image"
         input_parameters["keys"] = key
 
         img, tiles = make_image(**input_parameters)
+        input_img = in_type(img)
 
         splitter = TileOnGridDict(**input_parameters)
 
-        output = splitter({key: img})
+        output = splitter({key: input_img})
 
         if input_parameters.get("return_list_of_dicts", False):
-            output = np.stack([ix[key] for ix in output], axis=0)
+            if isinstance(input_img, torch.Tensor):
+                output = torch.stack([ix[key] for ix in output], axis=0)
+            else:
+                output = np.stack([ix[key] for ix in output], axis=0)
         else:
             output = output[key]
 
-        np.testing.assert_equal(tiles, output)
+        assert_allclose(output, tiles, type_test=False)
 
-    @parameterized.expand(TEST_CASES2)
-    def test_tile_patch_random_call(self, input_parameters):
+    @parameterized.expand(TESTS2)
+    def test_tile_patch_random_call(self, in_type, input_parameters):
 
         key = "image"
         input_parameters["keys"] = key
@@ -142,18 +155,21 @@ class TestTileOnGridDict(unittest.TestCase):
         random_state = np.random.RandomState(123)
         seed = random_state.randint(10000)
         img, tiles = make_image(**input_parameters, seed=seed)
+        input_img = in_type(img)
 
         splitter = TileOnGridDict(**input_parameters)
         splitter.set_random_state(seed=123)
 
-        output = splitter({key: img})
+        output = splitter({key: input_img})
 
         if input_parameters.get("return_list_of_dicts", False):
-            output = np.stack([ix[key] for ix in output], axis=0)
+            if isinstance(input_img, torch.Tensor):
+                output = torch.stack([ix[key] for ix in output], axis=0)
+            else:
+                output = np.stack([ix[key] for ix in output], axis=0)
         else:
             output = output[key]
-
-        np.testing.assert_equal(tiles, output)
+        assert_allclose(output, tiles, type_test=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3379 

### Description
This PR updates `TileOnGrid` to support `torch.Tensor` through type conversion while the backend is `numpy`. It also updates the unittests to include `torch.Tenor` inputs on cpu and cuda device.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.