### PR TITLE
fixes pickle mod

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -182,7 +182,7 @@ class PersistentDataset(Dataset):
         super().__init__(data=data, transform=transform)
         self.cache_dir = Path(cache_dir) if cache_dir is not None else None
         self.hash_func = hash_func
-        self.pickle_module = look_up_option(pickle_module, SUPPORTED_PICKLE_MOD)
+        self.pickle_module = pickle_module
         self.pickle_protocol = pickle_protocol
         if self.cache_dir is not None:
             if not self.cache_dir.exists():
@@ -287,7 +287,7 @@ class PersistentDataset(Dataset):
                 torch.save(
                     obj=_item_transformed,
                     f=temp_hash_file,
-                    pickle_module=self.pickle_module,
+                    pickle_module=look_up_option(self.pickle_module, SUPPORTED_PICKLE_MOD),
                     pickle_protocol=self.pickle_protocol,
                 )
                 if temp_hash_file.is_file() and not hashfile.is_file():

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -169,9 +169,10 @@ class PersistentDataset(Dataset):
                 If `cache_dir` is `None`, there is effectively no caching.
             hash_func: a callable to compute hash from data items to be cached.
                 defaults to `monai.data.utils.pickle_hashing`.
-            pickle_module: module used for pickling metadata and objects, default to `"pickle"`.
+            pickle_module: string representing the module used for pickling metadata and objects, default to `"pickle"`.
                 this arg is used by `torch.save`, for more details, please check:
-                https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
+                https://pytorch.org/docs/stable/generated/torch.save.html#torch.save,
+                and ``monai.data.utils.SUPPORTED_PICKLE_MOD``.
             pickle_protocol: can be specified to override the default protocol, default to `2`.
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
@@ -335,9 +336,10 @@ class CacheNTransDataset(PersistentDataset):
                 If `cache_dir` is `None`, there is effectively no caching.
             hash_func: a callable to compute hash from data items to be cached.
                 defaults to `monai.data.utils.pickle_hashing`.
-            pickle_module: module used for pickling metadata and objects, default to `"pickle"`.
+            pickle_module: string representing the module used for pickling metadata and objects, default to `"pickle"`.
                 this arg is used by `torch.save`, for more details, please check:
-                https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
+                https://pytorch.org/docs/stable/generated/torch.save.html#torch.save,
+                and ``monai.data.utils.SUPPORTED_PICKLE_MOD``.
             pickle_protocol: can be specified to override the default protocol, default to `2`.
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -29,9 +29,9 @@ import torch
 from torch.utils.data import Dataset as _TorchDataset
 from torch.utils.data import Subset
 
-from monai.data.utils import convert_tables_to_dicts, pickle_hashing
+from monai.data.utils import SUPPORTED_PICKLE_MOD, convert_tables_to_dicts, pickle_hashing
 from monai.transforms import Compose, Randomizable, ThreadUnsafe, Transform, apply_transform
-from monai.utils import MAX_SEED, ensure_tuple, get_seed, min_version, optional_import
+from monai.utils import MAX_SEED, ensure_tuple, get_seed, look_up_option, min_version, optional_import
 from monai.utils.misc import first
 
 if TYPE_CHECKING:
@@ -152,7 +152,7 @@ class PersistentDataset(Dataset):
         transform: Union[Sequence[Callable], Callable],
         cache_dir: Optional[Union[Path, str]],
         hash_func: Callable[..., bytes] = pickle_hashing,
-        pickle_module=pickle,
+        pickle_module: str = "pickle",
         pickle_protocol=pickle.DEFAULT_PROTOCOL,
     ) -> None:
         """
@@ -169,7 +169,7 @@ class PersistentDataset(Dataset):
                 If `cache_dir` is `None`, there is effectively no caching.
             hash_func: a callable to compute hash from data items to be cached.
                 defaults to `monai.data.utils.pickle_hashing`.
-            pickle_module: module used for pickling metadata and objects, default to `pickle`.
+            pickle_module: module used for pickling metadata and objects, default to `"pickle"`.
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             pickle_protocol: can be specified to override the default protocol, default to `2`.
@@ -182,7 +182,7 @@ class PersistentDataset(Dataset):
         super().__init__(data=data, transform=transform)
         self.cache_dir = Path(cache_dir) if cache_dir is not None else None
         self.hash_func = hash_func
-        self.pickle_module = pickle_module
+        self.pickle_module = look_up_option(pickle_module, SUPPORTED_PICKLE_MOD)
         self.pickle_protocol = pickle_protocol
         if self.cache_dir is not None:
             if not self.cache_dir.exists():
@@ -317,7 +317,7 @@ class CacheNTransDataset(PersistentDataset):
         cache_n_trans: int,
         cache_dir: Optional[Union[Path, str]],
         hash_func: Callable[..., bytes] = pickle_hashing,
-        pickle_module=pickle,
+        pickle_module: str = "pickle",
         pickle_protocol=pickle.DEFAULT_PROTOCOL,
     ) -> None:
         """
@@ -335,7 +335,7 @@ class CacheNTransDataset(PersistentDataset):
                 If `cache_dir` is `None`, there is effectively no caching.
             hash_func: a callable to compute hash from data items to be cached.
                 defaults to `monai.data.utils.pickle_hashing`.
-            pickle_module: module used for pickling metadata and objects, default to `pickle`.
+            pickle_module: module used for pickling metadata and objects, default to `"pickle"`.
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             pickle_protocol: can be specified to override the default protocol, default to `2`.

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -79,6 +79,7 @@ __all__ = [
     "SUPPORTED_PICKLE_MOD",
 ]
 
+# module to be used by `torch.save`
 SUPPORTED_PICKLE_MOD = {"pickle": pickle}
 
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -76,7 +76,10 @@ __all__ = [
     "pad_list_data_collate",
     "no_collation",
     "convert_tables_to_dicts",
+    "SUPPORTED_PICKLE_MOD",
 ]
+
+SUPPORTED_PICKLE_MOD = {"pickle": pickle}
 
 
 def get_random_patch(

--- a/tests/test_persistentdataset.py
+++ b/tests/test_persistentdataset.py
@@ -61,7 +61,7 @@ class TestDataset(unittest.TestCase):
                 data=items,
                 transform=_InplaceXform(),
                 cache_dir=tempdir,
-                pickle_module=pickle,
+                pickle_module="pickle",
                 pickle_protocol=pickle.HIGHEST_PROTOCOL,
             )
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

follow up of #3412 

### Description
```
======================================================================
ERROR: test_timing (__main__.IntegrationSegmentation3D)
----------------------------------------------------------------------
TypeError: can't pickle module objects

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/jenkins/agent/workspace/MONAI-postmerge/monai_github/tests/utils.py", line 497, in _wrapper
    raise RuntimeError(res.traceback) from res
RuntimeError: Traceback (most recent call last):
  File "/home/jenkins/agent/workspace/MONAI-postmerge/monai_github/tests/utils.py", line 449, in run_process
    output = func(*args, **kwargs)
  File "/home/jenkins/agent/workspace/MONAI-postmerge/monai_github/tests/utils.py", line 522, in _call_original_func
    return f(*args, **kwargs)
  File "/home/jenkins/agent/workspace/MONAI-postmerge/monai_github/tests/test_integration_segmentation_3d.py", line 296, in test_timing
    self.train_and_infer(idx=3)
  File "/home/jenkins/agent/workspace/MONAI-postmerge/monai_github/tests/test_integration_segmentation_3d.py", line 258, in train_and_infer
    self.data_dir, device=self.device, cachedataset=idx, readers=_readers
  File "/home/jenkins/agent/workspace/MONAI-postmerge/monai_github/tests/test_integration_segmentation_3d.py", line 126, in run_training_test
    for batch_data in train_loader:
  File "/opt/conda/lib/python3.6/site-packages/torch/utils/data/dataloader.py", line 359, in __iter__
    return self._get_iterator()
  File "/opt/conda/lib/python3.6/site-packages/torch/utils/data/dataloader.py", line 305, in _get_iterator
    return _MultiProcessingDataLoaderIter(self)
  File "/opt/conda/lib/python3.6/site-packages/torch/utils/data/dataloader.py", line 918, in __init__
    w.start()
  File "/opt/conda/lib/python3.6/multiprocessing/process.py", line 105, in start
    self._popen = self._Popen(self)
  File "/opt/conda/lib/python3.6/multiprocessing/context.py", line 223, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "/opt/conda/lib/python3.6/multiprocessing/context.py", line 284, in _Popen
    return Popen(process_obj)
  File "/opt/conda/lib/python3.6/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/opt/conda/lib/python3.6/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/opt/conda/lib/python3.6/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)
  File "/opt/conda/lib/python3.6/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
TypeError: can't pickle module objects



```
### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
