### PR TITLE
only push lambdad transform if inverse is given

### DIFF
--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -1003,7 +1003,8 @@ class Lambdad(MapTransform, InvertibleTransform):
             ret = self._transform(data=d[key], func=func)
             if overwrite:
                 d[key] = ret
-            self.push_transform(d, key)
+            if self.inv_func is not None:
+                self.push_transform(d, key)
         return d
 
     def _inverse_transform(self, transform_info: Dict, data: Any, func: Callable):


### PR DESCRIPTION
Only add the lambdad transform to the list of invertible transforms if an inverse function has been supplied.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
