### PR TITLE
3293 Remove extra deep supervision modules of DynUNet

### DIFF
--- a/monai/networks/blocks/activation.py
+++ b/monai/networks/blocks/activation.py
@@ -19,7 +19,6 @@ if optional_import("torch.nn.functional", name="mish")[1]:
     def monai_mish(x, inplace: bool = False):
         return torch.nn.functional.mish(x, inplace=inplace)
 
-
 else:
 
     def monai_mish(x, inplace: bool = False):
@@ -30,7 +29,6 @@ if optional_import("torch.nn.functional", name="silu")[1]:
 
     def monai_swish(x, inplace: bool = False):
         return torch.nn.functional.silu(x, inplace=inplace)
-
 
 else:
 

--- a/monai/networks/nets/dynunet.py
+++ b/monai/networks/nets/dynunet.py
@@ -79,6 +79,8 @@ class DynUNet(nn.Module):
     For example, if `strides=((1, 2, 4), 2, 1, 1)`, the minimal spatial size of the input is `(8, 16, 32)`, and
     the spatial size of the output is `(8, 8, 8)`.
 
+    For backwards compatibility with old weights, please set `strict=False` when calling `load_state_dict`.
+
     Usage example with medical segmentation decathlon dataset is available at:
     https://github.com/Project-MONAI/tutorials/tree/master/modules/dynunet_pipeline.
 

--- a/monai/networks/nets/dynunet.py
+++ b/monai/networks/nets/dynunet.py
@@ -58,24 +58,30 @@ class DynUNet(nn.Module):
     `Automated Design of Deep Learning Methods for Biomedical Image Segmentation <https://arxiv.org/abs/1904.08128>`_.
     `nnU-Net: Self-adapting Framework for U-Net-Based Medical Image Segmentation <https://arxiv.org/abs/1809.10486>`_.
     `Optimized U-Net for Brain Tumor Segmentation <https://arxiv.org/pdf/2110.03352.pdf>`_.
+
     This model is more flexible compared with ``monai.networks.nets.UNet`` in three
     places:
+
         - Residual connection is supported in conv blocks.
         - Anisotropic kernel sizes and strides can be used in each layers.
         - Deep supervision heads can be added.
+
     The model supports 2D or 3D inputs and is consisted with four kinds of blocks:
     one input block, `n` downsample blocks, one bottleneck and `n+1` upsample blocks. Where, `n>0`.
     The first and last kernel and stride values of the input sequences are used for input block and
     bottleneck respectively, and the rest value(s) are used for downsample and upsample blocks.
     Therefore, pleasure ensure that the length of input sequences (``kernel_size`` and ``strides``)
     is no less than 3 in order to have at least one downsample and upsample blocks.
+
     To meet the requirements of the structure, the input size for each spatial dimension should be divisible
     by `2 * the product of all strides in the corresponding dimension`. The output size for each spatial dimension
     equals to the input size of the corresponding dimension divided by the stride in strides[0].
     For example, if `strides=((1, 2, 4), 2, 1, 1)`, the minimal spatial size of the input is `(8, 16, 32)`, and
     the spatial size of the output is `(8, 8, 8)`.
+
     Usage example with medical segmentation decathlon dataset is available at:
     https://github.com/Project-MONAI/tutorials/tree/master/modules/dynunet_pipeline.
+
     Args:
         spatial_dims: number of spatial dimensions.
         in_channels: number of input channels.
@@ -210,10 +216,7 @@ class DynUNet(nn.Module):
 
         if not self.deep_supervision:
             self.skip_layers = create_skips(
-                0,
-                [self.input_block] + list(self.downsamples),
-                self.upsamples[::-1],
-                self.bottleneck,
+                0, [self.input_block] + list(self.downsamples), self.upsamples[::-1], self.bottleneck
             )
         else:
             self.skip_layers = create_skips(

--- a/tests/test_network_consistency.py
+++ b/tests/test_network_consistency.py
@@ -22,7 +22,7 @@ from parameterized.parameterized import parameterized
 import monai.networks.nets as nets
 from monai.utils import set_determinism
 
-extra_test_data_dir = os.environ.get("MONAI_EXTRA_TEST_DATA", None)
+extra_test_data_dir = os.environ.get("MONAI_EXTRA_TEST_DATA")
 
 TESTS = []
 if extra_test_data_dir is not None:

--- a/tests/test_network_consistency.py
+++ b/tests/test_network_consistency.py
@@ -60,14 +60,8 @@ class TestNetworkConsistency(unittest.TestCase):
         json_file.close()
 
         # Create model
-        model = nets.__dict__[net_name](**model_params)
-        state_dict = loaded_data["model"]
-        model_dict = model.state_dict()
-        state_dict = {
-            k: v for k, v in state_dict.items() if (k in model_dict) and (model_dict[k].shape == state_dict[k].shape)
-        }
-        model_dict.update(state_dict)
-        model.load_state_dict(model_dict)
+        model = getattr(nets, net_name)(**model_params)
+        model.load_state_dict(loaded_data["model"], strict=False)
         model.eval()
 
         in_data = loaded_data["in_data"]

--- a/tests/test_network_consistency.py
+++ b/tests/test_network_consistency.py
@@ -61,7 +61,13 @@ class TestNetworkConsistency(unittest.TestCase):
 
         # Create model
         model = nets.__dict__[net_name](**model_params)
-        model.load_state_dict(loaded_data["model"])
+        state_dict = loaded_data["model"]
+        model_dict = model.state_dict()
+        state_dict = {
+            k: v for k, v in state_dict.items() if (k in model_dict) and (model_dict[k].shape == state_dict[k].shape)
+        }
+        model_dict.update(state_dict)
+        model.load_state_dict(model_dict)
         model.eval()
 
         in_data = loaded_data["in_data"]


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #3293 

### Description
Our current implementation of DynUNet may have extra modules:

1. When `deep_supervision=False`, `self.deep_supervision_heads` is created but useless.
2. When `deep_supervision=True` and `len(self.upsamples) - 1 > deep_supr_num`, extra heads may be created but they will not be used in `forward`.

With these extra modules, when using `DistributedDataParallel`, `find_unused_parameters=True` must be specified ( see: [here](https://github.com/Project-MONAI/MONAILabel/issues/492)).

This PR enhances the network structure and remove the potential extra modules, and also solve the issue mentioned in https://github.com/Project-MONAI/MONAILabel/issues/492

Whereas,  one thing needs to be considered is that when users want to reuse weights achieved from the old version, they may need to remove the extra key and values in the old state dict ( like what I changed in [test_network_consistency.py](https://github.com/Project-MONAI/MONAI/pull/3427/files#diff-ed0900ba2f36662a1420528a81103add6142c97bc8e963792874cbec40e3522eR67)). Therefore, do you have any suggestions for this breaking changes? should I add a function like `def load_old_version_weights()`? @ericspod @wyli @Nic-Ma 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
