### PR TITLE
3432 remove einops and let vit support torchscript

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,7 +19,6 @@ sphinxcontrib-qthelp
 sphinxcontrib-serializinghtml
 sphinx-autodoc-typehints==1.11.1
 pandas
-einops
 transformers
 mlflow
 tensorboardX

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -174,10 +174,10 @@ Since MONAI v0.2.0, the extras syntax such as `pip install 'monai[nibabel]'` is 
 
 - The options are
 ```
-[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, cucim, openslide, pandas, einops, transformers, mlflow, matplotlib, tensorboardX, tifffile, imagecodecs]
+[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, cucim, openslide, pandas, transformers, mlflow, matplotlib, tensorboardX, tifffile, imagecodecs]
 ```
 which correspond to `nibabel`, `scikit-image`, `pillow`, `tensorboard`,
-`gdown`, `pytorch-ignite`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas`, `einops`, `transformers`, `mlflow`, `matplotlib`, `tensorboardX`,
+`gdown`, `pytorch-ignite`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas`, `transformers`, `mlflow`, `matplotlib`, `tensorboardX`,
 `tifffile`, `imagecodecs`, respectively.
 
 - `pip install 'monai[all]'` installs all the optional dependencies.

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -72,7 +72,6 @@ def get_optional_config_values():
     output["lmdb"] = get_package_version("lmdb")
     output["psutil"] = psutil_version
     output["pandas"] = get_package_version("pandas")
-    output["einops"] = get_package_version("einops")
     output["transformers"] = get_package_version("transformers")
     output["mlflow"] = get_package_version("mlflow")
 

--- a/monai/networks/nets/vit.py
+++ b/monai/networks/nets/vit.py
@@ -99,7 +99,7 @@ class ViT(nn.Module):
 
     def forward(self, x):
         x = self.patch_embedding(x)
-        if self.classification:
+        if hasattr(self, "cls_token"):
             cls_token = self.cls_token.expand(x.shape[0], -1, -1)
             x = torch.cat((cls_token, x), dim=1)
         hidden_states_out = []
@@ -107,6 +107,6 @@ class ViT(nn.Module):
             x = blk(x)
             hidden_states_out.append(x)
         x = self.norm(x)
-        if self.classification:
+        if hasattr(self, "classification_head"):
             x = self.classification_head(x[:, 0])
         return x, hidden_states_out

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,7 +37,6 @@ imagecodecs; platform_system == "Linux"
 tifffile; platform_system == "Linux"
 pandas
 requests
-einops
 transformers
 mlflow
 matplotlib!=3.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,6 @@ all =
     tifffile
     imagecodecs
     pandas
-    einops
     transformers
     mlflow
     matplotlib
@@ -82,8 +81,6 @@ imagecodecs =
     imagecodecs
 pandas =
     pandas
-einops =
-    einops
 transformers =
     transformers
 mlflow =

--- a/tests/test_patchembedding.py
+++ b/tests/test_patchembedding.py
@@ -10,16 +10,12 @@
 # limitations under the License.
 
 import unittest
-from unittest import skipUnless
 
 import torch
 from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.blocks.patchembedding import PatchEmbeddingBlock
-from monai.utils import optional_import
-
-einops, has_einops = optional_import("einops")
 
 TEST_CASE_PATCHEMBEDDINGBLOCK = []
 for dropout_rate in (0.5,):
@@ -51,7 +47,6 @@ for dropout_rate in (0.5,):
 
 class TestPatchEmbeddingBlock(unittest.TestCase):
     @parameterized.expand(TEST_CASE_PATCHEMBEDDINGBLOCK)
-    @skipUnless(has_einops, "Requires einops")
     def test_shape(self, input_param, input_shape, expected_shape):
         net = PatchEmbeddingBlock(**input_param)
         with eval_mode(net):

--- a/tests/test_selfattention.py
+++ b/tests/test_selfattention.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import unittest
-from unittest import skipUnless
 
 import numpy as np
 import torch
@@ -18,9 +17,6 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.blocks.selfattention import SABlock
-from monai.utils import optional_import
-
-einops, has_einops = optional_import("einops")
 
 TEST_CASE_SABLOCK = []
 for dropout_rate in np.linspace(0, 1, 4):
@@ -37,7 +33,6 @@ for dropout_rate in np.linspace(0, 1, 4):
 
 class TestResBlock(unittest.TestCase):
     @parameterized.expand(TEST_CASE_SABLOCK)
-    @skipUnless(has_einops, "Requires einops")
     def test_shape(self, input_param, input_shape, expected_shape):
         net = SABlock(**input_param)
         with eval_mode(net):

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -16,6 +16,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets.vit import ViT
+from tests.utils import test_script_save
 
 TEST_CASE_Vit = []
 for dropout_rate in [0.6]:
@@ -132,6 +133,18 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
                 classification=False,
                 dropout_rate=0.3,
             )
+
+    @parameterized.expand(TEST_CASE_Vit)
+    def test_script(self, input_param, input_shape, _):
+        net = ViT(**(input_param))
+        net.eval()
+        with torch.no_grad():
+            torch.jit.script(net)
+
+        input_param_ = dict(input_param)
+        net = ViT(**(input_param_))
+        test_data = torch.randn(input_shape)
+        test_script_save(net, test_data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #3432 .

### Description
This PR makes ViT supports torchscript via:

1. remove einops
2. make other necessary changes

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
