### PR TITLE
Update TiffFile backend in WSIReader

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -852,13 +852,12 @@ class WSIReader(ImageReader):
                 )
             region = img_obj.asarray(level=level)
         else:
+            # Get region size to be extracted
+            region_size = self._get_image_size(img_obj, size, level, location)
+            # reverse the order of location's dimensions to become WxH (for cuCIM and OpenSlide)
+            region_location = location[::-1]
             # Extract a region (or the entire image)
-            if size is None:
-                region_size = self._get_image_size(img_obj, size, level, location)
-            else:
-                region_size = size[::-1]
-            # reverse the order of dimensions for size and location to become WxH
-            region = img_obj.read_region(location=location[::-1], size=region_size, level=level)
+            region = img_obj.read_region(location=region_location, size=region_size, level=level)
 
         region = self.convert_to_rgb_array(region, dtype)
         return region

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -119,26 +119,31 @@ class WSIReaderTests:
 
         @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_5])
         def test_read_region(self, file_path, patch_info, expected_img):
-            # Due to CPU memory limitation ignore tifffile at level 0.
-            if self.backend == "tifffile" and patch_info["level"] == 0:
-                return
             reader = WSIReader(self.backend)
-            # Read twice to check multiple calls
             with reader.read(file_path) as img_obj:
-                img = reader.get_data(img_obj, **patch_info)[0]
-                img2 = reader.get_data(img_obj, **patch_info)[0]
-            self.assertTupleEqual(img.shape, img2.shape)
-            self.assertIsNone(assert_array_equal(img, img2))
-            self.assertTupleEqual(img.shape, expected_img.shape)
-            self.assertIsNone(assert_array_equal(img, expected_img))
+                if self.backend == "tifffile":
+                    with self.assertRaises(ValueError):
+                        reader.get_data(img_obj, **patch_info)[0]
+                else:
+                    # Read twice to check multiple calls
+                    img = reader.get_data(img_obj, **patch_info)[0]
+                    img2 = reader.get_data(img_obj, **patch_info)[0]
+                    self.assertTupleEqual(img.shape, img2.shape)
+                    self.assertIsNone(assert_array_equal(img, img2))
+                    self.assertTupleEqual(img.shape, expected_img.shape)
+                    self.assertIsNone(assert_array_equal(img, expected_img))
 
         @parameterized.expand([TEST_CASE_3, TEST_CASE_4])
         def test_read_patches(self, file_path, patch_info, expected_img):
             reader = WSIReader(self.backend)
             with reader.read(file_path) as img_obj:
-                img = reader.get_data(img_obj, **patch_info)[0]
-            self.assertTupleEqual(img.shape, expected_img.shape)
-            self.assertIsNone(assert_array_equal(img, expected_img))
+                if self.backend == "tifffile":
+                    with self.assertRaises(ValueError):
+                        reader.get_data(img_obj, **patch_info)[0]
+                else:
+                    img = reader.get_data(img_obj, **patch_info)[0]
+                    self.assertTupleEqual(img.shape, expected_img.shape)
+                    self.assertIsNone(assert_array_equal(img, expected_img))
 
         @parameterized.expand([TEST_CASE_RGB_0, TEST_CASE_RGB_1])
         @skipUnless(has_tiff, "Requires tifffile.")


### PR DESCRIPTION
Fixes #3434 

### Description
This PR update TiffFile backend in WSIReader to only read the entire image and not a subregion, which is the intended functionality of TiffFile. Loading subregion with TiffFile backend was not efficient and was just adding unnecessary complication in the code logic. Now, when reading a subregion, it raises value error and suggest to use "cuCIM" or "OpenSlide" backend. This should resolve the raised issue in #3434 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
