### PR TITLE
471- fixes deprecated args

### DIFF
--- a/monai/utils/deprecate_utils.py
+++ b/monai/utils/deprecate_utils.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import inspect
+import sys
 import warnings
 from functools import wraps
 from types import FunctionType
@@ -62,7 +63,7 @@ def deprecated(
 
     # if version_val.startswith("0+"):
     #     # version unknown, set version_val to a large value (assuming the latest version)
-    #     version_val = "100"
+    #     version_val = f"{sys.maxsize}"
     if since is not None and removed is not None and not version_leq(since, removed):
         raise ValueError(f"since must be less or equal to removed, got since={since}, removed={removed}.")
     is_not_yet_deprecated = since is not None and version_val != since and version_leq(version_val, since)
@@ -153,7 +154,7 @@ def deprecated_arg(
 
     if version_val.startswith("0+") or not f"{version_val}".strip()[0].isdigit():
         # version unknown, set version_val to a large value (assuming the latest version)
-        version_val = "100"
+        version_val = f"{sys.maxsize}"
     if since is not None and removed is not None and not version_leq(since, removed):
         raise ValueError(f"since must be less or equal to removed, got since={since}, removed={removed}.")
     is_not_yet_deprecated = since is not None and version_val != since and version_leq(version_val, since)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -29,7 +29,7 @@ class TestDeprecatedRC(unittest.TestCase):
         def foo2():
             pass
 
-        print(foo2())
+        foo2()  # should not raise any warnings
 
     def test_warning_milestone(self):
         """Test deprecated decorator with `since` and `removed` set for a milestone version"""
@@ -172,7 +172,7 @@ class TestDeprecated(unittest.TestCase):
         """Test deprecated_arg decorator with just `since` set."""
 
         @deprecated_arg("b", since=self.prev_version, version_val=self.test_version)
-        def afoo2(a, **kwargs):
+        def afoo2(a, **kw):
             pass
 
         afoo2(1)  # ok when no b provided
@@ -235,6 +235,19 @@ class TestDeprecated(unittest.TestCase):
 
         self.assertRaises(DeprecatedError, lambda: afoo4(1, b=2))
 
+    def test_arg_except3_unknown(self):
+        """
+        Test deprecated_arg decorator raises exception with `removed` set in the past.
+        with unknown version and kwargs
+        """
+
+        @deprecated_arg("b", removed=self.prev_version, version_val="0+untagged.1.g3131155")
+        def afoo4(a, b=None, **kwargs):
+            pass
+
+        self.assertRaises(DeprecatedError, lambda: afoo4(1, b=2))
+        self.assertRaises(DeprecatedError, lambda: afoo4(1, b=2, c=3))
+
     def test_replacement_arg(self):
         """
         Test deprecated arg being replaced.
@@ -245,9 +258,35 @@ class TestDeprecated(unittest.TestCase):
             return a
 
         self.assertEqual(afoo4(b=2), 2)
-        # self.assertRaises(DeprecatedError, lambda: afoo4(1, b=2))
         self.assertEqual(afoo4(1, b=2), 1)  # new name is in use
         self.assertEqual(afoo4(a=1, b=2), 1)  # prefers the new arg
+
+    def test_replacement_arg1(self):
+        """
+        Test deprecated arg being replaced with kwargs.
+        """
+
+        @deprecated_arg("b", new_name="a", since=self.prev_version, version_val=self.test_version)
+        def afoo4(a, *args, **kwargs):
+            return a
+
+        self.assertEqual(afoo4(b=2), 2)
+        self.assertEqual(afoo4(1, b=2, c=3), 1)  # new name is in use
+        self.assertEqual(afoo4(a=1, b=2, c=3), 1)  # prefers the new arg
+
+    def test_replacement_arg2(self):
+        """
+        Test deprecated arg (with a default value) being replaced.
+        """
+
+        @deprecated_arg("b", new_name="a", since=self.prev_version, version_val=self.test_version)
+        def afoo4(a, b=None, **kwargs):
+            return a, kwargs
+
+        self.assertEqual(afoo4(b=2, c=3), (2, {"c": 3}))
+        self.assertEqual(afoo4(1, b=2, c=3), (1, {"c": 3}))  # new name is in use
+        self.assertEqual(afoo4(a=1, b=2, c=3), (1, {"c": 3}))  # prefers the new arg
+        self.assertEqual(afoo4(1, 2, c=3), (1, {"c": 3}))  # prefers the new positional arg
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

follow-up of https://github.com/Project-MONAI/tutorials/issues/471

### Description
addresses the issues when `deprecated_args` decorates a function with `**kwargs`
- remove the hard-coded requirement of variable name `kwargs`
- remove the binding for any unwanted binding to the deprecated args. 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
