### PR TITLE
improve error message if reader not available

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -204,6 +204,8 @@ class LoadImage(Transform):
                         break
 
         if img is None or reader is None:
+            if isinstance(filename, tuple) and len(filename) == 0:
+                filename = filename[0]
             raise RuntimeError(
                 f"can not find a suitable reader for file: {filename}.\n"
                 "    Please install the reader libraries, see also the installation instructions:\n"

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -204,10 +204,10 @@ class LoadImage(Transform):
                         break
 
         if img is None or reader is None:
-            if isinstance(filename, tuple) and len(filename) == 0:
+            if isinstance(filename, tuple) and len(filename) == 1:
                 filename = filename[0]
             raise RuntimeError(
-                f"can not find a suitable reader for file: {filename}.\n"
+                f"cannot find a suitable reader for file: {filename}.\n"
                 "    Please install the reader libraries, see also the installation instructions:\n"
                 "    https://docs.monai.io/en/latest/installation.html#installing-the-recommended-dependencies.\n"
                 f"   The current registered: {self.readers}.\n"


### PR DESCRIPTION
When a valid reader is not present, I get the following error:

```
RuntimeError: can not find a suitable reader for file: ('rawdata/sub-verse752/sub-verse752_dir-ax_ct.nii.gz',).
    Please install the reader libraries, see also the installation instructions:
    https://docs.monai.io/en/latest/installation.html#installing-the-recommended-dependencies.
   The current registered: [<monai.data.image_reader.NumpyReader object at 0x7f703531f160>, <monai.data.image_reader.PILReader object at 0x7f703531f220>].
```

I found this confusing since I gave the filename as a string but the error was being printed as a tuple. This PR improves the error message by converting back to string if instance is a tuple and length is 1.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
