### PR TITLE
Improve NVTX Range Naming

### DIFF
--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -1006,6 +1006,7 @@ class TorchVision:
 
         """
         super().__init__()
+        self.name = name
         transform, _ = optional_import("torchvision.transforms", "0.8.0", min_version, name=name)
         self.trans = transform(*args, **kwargs)
 
@@ -1194,6 +1195,7 @@ class CuCIM(Transform):
 
     def __init__(self, name: str, *args, **kwargs) -> None:
         super().__init__()
+        self.name = name
         self.transform, _ = optional_import("cucim.core.operations.expose.transform", name=name)
         self.args = args
         self.kwargs = kwargs

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -1319,6 +1319,7 @@ class TorchVisiond(MapTransform):
 
         """
         super().__init__(keys, allow_missing_keys)
+        self.name = name
         self.trans = TorchVision(name, *args, **kwargs)
 
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
@@ -1358,6 +1359,7 @@ class RandTorchVisiond(Randomizable, MapTransform):
 
         """
         MapTransform.__init__(self, keys, allow_missing_keys)
+        self.name = name
         self.trans = TorchVision(name, *args, **kwargs)
 
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
@@ -1519,6 +1521,7 @@ class CuCIMd(MapTransform):
 
     def __init__(self, keys: KeysCollection, name: str, allow_missing_keys: bool = False, *args, **kwargs) -> None:
         super().__init__(keys=keys, allow_missing_keys=allow_missing_keys)
+        self.name = name
         self.trans = CuCIM(name, *args, **kwargs)
 
     def __call__(self, data):

--- a/monai/utils/nvtx.py
+++ b/monai/utils/nvtx.py
@@ -62,6 +62,26 @@ class Range:
         # Define the name to be associated to the range if not provided
         if self.name is None:
             name = type(obj).__name__
+            # If CuCIM or TorchVision transform wrappers are being used,
+            # append the underlying transform to the name for more clarity
+            if name in [
+                "CuCIM",
+                "CuCIMd",
+                "CuCIMD",
+                "CuCIMDict",
+                "RandCuCIM",
+                "RandCuCIMd",
+                "RandCuCIMD",
+                "RandCuCIMDict",
+                "TorchVision",
+                "TorchVisiond",
+                "TorchVisionD",
+                "TorchVisionDict",
+                "RandTorchVisiond",
+                "RandTorchVisionD",
+                "RandTorchVisionDict",
+            ]:
+                name = f"{name}_{obj.name}"
             self.name_counter[name] += 1
             if self.name_counter[name] > 1:
                 self.name = f"{name}_{self.name_counter[name]}"

--- a/monai/utils/nvtx.py
+++ b/monai/utils/nvtx.py
@@ -63,7 +63,10 @@ class Range:
         if self.name is None:
             name = type(obj).__name__
             self.name_counter[name] += 1
-            self.name = f"{name}_{self.name_counter[name]}"
+            if self.name_counter[name] > 1:
+                self.name = f"{name}_{self.name_counter[name]}"
+            else:
+                self.name = name
 
         # Define the methods to be wrapped if not provided
         if self.methods is None:


### PR DESCRIPTION
### Description
This PR make some improvement in NVTX Range. 
- To not have redundant numbering when a transform is used once, it does not append number to the first call of a transform but will start the numbering for the next ones from two (e.g., Transform, Transform_2, Transform_3, etc) 
- When wrapper transforms are being used (i.e. CuCIM and TorchVision), it extract the underlying transfrom name that are being called and append to the name of the transform for profiling.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
