### PR TITLE
Make bending energy loss invariant to resolution

### DIFF
--- a/monai/losses/deform.py
+++ b/monai/losses/deform.py
@@ -52,12 +52,12 @@ class BendingEnergyLoss(_Loss):
         DeepReg (https://github.com/DeepRegNet/DeepReg)
     """
 
-    def __init__(self, normalize: bool = True, reduction: Union[LossReduction, str] = LossReduction.MEAN) -> None:
+    def __init__(self, normalize: bool = False, reduction: Union[LossReduction, str] = LossReduction.MEAN) -> None:
         """
         Args:
             normalize:
                 Whether to divide out spatial sizes in order to make the computation roughly
-                invariant to image scale (i.e. vector field sampling resolution). Defaults to True.
+                invariant to image scale (i.e. vector field sampling resolution). Defaults to False.
             reduction: {``"none"``, ``"mean"``, ``"sum"``}
                 Specifies the reduction to apply to the output. Defaults to ``"mean"``.
 

--- a/monai/losses/deform.py
+++ b/monai/losses/deform.py
@@ -52,9 +52,12 @@ class BendingEnergyLoss(_Loss):
         DeepReg (https://github.com/DeepRegNet/DeepReg)
     """
 
-    def __init__(self, reduction: Union[LossReduction, str] = LossReduction.MEAN) -> None:
+    def __init__(self, normalize: bool = True, reduction: Union[LossReduction, str] = LossReduction.MEAN) -> None:
         """
         Args:
+            normalize:
+                Whether to divide out spatial sizes in order to make the computation roughly
+                invariant to image scale (i.e. vector field sampling resolution). Defaults to True.
             reduction: {``"none"``, ``"mean"``, ``"sum"``}
                 Specifies the reduction to apply to the output. Defaults to ``"mean"``.
 
@@ -63,6 +66,7 @@ class BendingEnergyLoss(_Loss):
                 - ``"sum"``: the output will be summed.
         """
         super().__init__(reduction=LossReduction(reduction).value)
+        self.normalize = normalize
 
     def forward(self, pred: torch.Tensor) -> torch.Tensor:
         """
@@ -74,20 +78,35 @@ class BendingEnergyLoss(_Loss):
 
         """
         if pred.ndim not in [3, 4, 5]:
-            raise ValueError(f"expecting 3-d, 4-d or 5-d pred, instead got pred of shape {pred.shape}")
+            raise ValueError(f"Expecting 3-d, 4-d or 5-d pred, instead got pred of shape {pred.shape}")
         for i in range(pred.ndim - 2):
             if pred.shape[-i - 1] <= 4:
-                raise ValueError("all spatial dimensions must > 4, got pred of shape {pred.shape}")
+                raise ValueError(f"All spatial dimensions must be > 4, got spatial dimensions {pred.shape[2:]}")
+        if pred.shape[1] != pred.ndim - 2:
+            raise ValueError(
+                f"Number of vector components, {pred.shape[1]}, does not match number of spatial dimensions, {pred.ndim-2}"
+            )
 
         # first order gradient
         first_order_gradient = [spatial_gradient(pred, dim) for dim in range(2, pred.ndim)]
 
+        # spatial dimensions in a shape suited for broadcasting below
+        if self.normalize:
+            spatial_dims = torch.tensor(pred.shape, device=pred.device)[2:].reshape((1, -1) + (pred.ndim - 2) * (1,))
+
         energy = torch.tensor(0)
         for dim_1, g in enumerate(first_order_gradient):
             dim_1 += 2
-            energy = spatial_gradient(g, dim_1) ** 2 + energy
+            if self.normalize:
+                g *= pred.shape[dim_1] / spatial_dims
+                energy = energy + (spatial_gradient(g, dim_1) * pred.shape[dim_1]) ** 2
+            else:
+                energy = energy + spatial_gradient(g, dim_1) ** 2
             for dim_2 in range(dim_1 + 1, pred.ndim):
-                energy = 2 * spatial_gradient(g, dim_2) ** 2 + energy
+                if self.normalize:
+                    energy = energy + 2 * (spatial_gradient(g, dim_2) * pred.shape[dim_2]) ** 2
+                else:
+                    energy = energy + 2 * spatial_gradient(g, dim_2) ** 2
 
         if self.reduction == LossReduction.MEAN.value:
             energy = torch.mean(energy)  # the batch and channel average

--- a/tests/test_bending_energy.py
+++ b/tests/test_bending_energy.py
@@ -22,9 +22,28 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 TEST_CASES = [
     [{}, {"pred": torch.ones((1, 3, 5, 5, 5), device=device)}, 0.0],
     [{}, {"pred": torch.arange(0, 5, device=device)[None, None, None, None, :].expand(1, 3, 5, 5, 5)}, 0.0],
-    [{}, {"pred": torch.arange(0, 5, device=device)[None, None, None, None, :].expand(1, 3, 5, 5, 5) ** 2}, 4.0],
-    [{}, {"pred": torch.arange(0, 5, device=device)[None, None, None, :].expand(1, 3, 5, 5) ** 2}, 4.0],
-    [{}, {"pred": torch.arange(0, 5, device=device)[None, None, :].expand(1, 3, 5) ** 2}, 4.0],
+    [
+        {"normalize": False},
+        {"pred": torch.arange(0, 5, device=device)[None, None, None, None, :].expand(1, 3, 5, 5, 5) ** 2},
+        4.0,
+    ],
+    [
+        {"normalize": False},
+        {"pred": torch.arange(0, 5, device=device)[None, None, None, :].expand(1, 2, 5, 5) ** 2},
+        4.0,
+    ],
+    [{"normalize": False}, {"pred": torch.arange(0, 5, device=device)[None, None, :].expand(1, 1, 5) ** 2}, 4.0],
+    [
+        {"normalize": True},
+        {"pred": torch.arange(0, 5, device=device)[None, None, None, None, :].expand(1, 3, 5, 5, 5) ** 2},
+        100.0,
+    ],
+    [
+        {"normalize": True},
+        {"pred": torch.arange(0, 5, device=device)[None, None, None, :].expand(1, 2, 5, 5) ** 2},
+        100.0,
+    ],
+    [{"normalize": True}, {"pred": torch.arange(0, 5, device=device)[None, None, :].expand(1, 1, 5) ** 2}, 100.0],
 ]
 
 
@@ -37,17 +56,23 @@ class TestBendingEnergy(unittest.TestCase):
     def test_ill_shape(self):
         loss = BendingEnergyLoss()
         # not in 3-d, 4-d, 5-d
-        with self.assertRaisesRegex(ValueError, ""):
+        with self.assertRaisesRegex(ValueError, "Expecting 3-d, 4-d or 5-d"):
             loss.forward(torch.ones((1, 3), device=device))
-        with self.assertRaisesRegex(ValueError, ""):
-            loss.forward(torch.ones((1, 3, 5, 5, 5, 5), device=device))
+        with self.assertRaisesRegex(ValueError, "Expecting 3-d, 4-d or 5-d"):
+            loss.forward(torch.ones((1, 4, 5, 5, 5, 5), device=device))
         # spatial_dim < 5
-        with self.assertRaisesRegex(ValueError, ""):
+        with self.assertRaisesRegex(ValueError, "All spatial dimensions"):
             loss.forward(torch.ones((1, 3, 4, 5, 5), device=device))
-        with self.assertRaisesRegex(ValueError, ""):
+        with self.assertRaisesRegex(ValueError, "All spatial dimensions"):
             loss.forward(torch.ones((1, 3, 5, 4, 5)))
-        with self.assertRaisesRegex(ValueError, ""):
+        with self.assertRaisesRegex(ValueError, "All spatial dimensions"):
             loss.forward(torch.ones((1, 3, 5, 5, 4)))
+
+        # number of vector components unequal to number of spatial dims
+        with self.assertRaisesRegex(ValueError, "Number of vector components"):
+            loss.forward(torch.ones((1, 2, 5, 5, 5)))
+        with self.assertRaisesRegex(ValueError, "Number of vector components"):
+            loss.forward(torch.ones((1, 2, 5, 5, 5)))
 
     def test_ill_opts(self):
         pred = torch.rand(1, 3, 5, 5, 5).to(device=device)

--- a/tests/test_reg_loss_integration.py
+++ b/tests/test_reg_loss_integration.py
@@ -20,7 +20,7 @@ from monai.losses import BendingEnergyLoss, GlobalMutualInformationLoss, LocalNo
 from tests.utils import SkipIfBeforePyTorchVersion
 
 TEST_CASES = [
-    [BendingEnergyLoss, {}, ["pred"]],
+    [BendingEnergyLoss, {}, ["pred"], 3],
     [LocalNormalizedCrossCorrelationLoss, {"kernel_size": 7, "kernel_type": "rectangular"}, ["pred", "target"]],
     [LocalNormalizedCrossCorrelationLoss, {"kernel_size": 5, "kernel_type": "triangular"}, ["pred", "target"]],
     [LocalNormalizedCrossCorrelationLoss, {"kernel_size": 3, "kernel_type": "gaussian"}, ["pred", "target"]],
@@ -42,7 +42,7 @@ class TestRegLossIntegration(unittest.TestCase):
 
     @parameterized.expand(TEST_CASES)
     @SkipIfBeforePyTorchVersion((1, 9))
-    def test_convergence(self, loss_type, loss_args, forward_args):
+    def test_convergence(self, loss_type, loss_args, forward_args, pred_channels=1):
         """
         The goal of this test is to assess if the gradient of the loss function
         is correct by testing if we can train a one layer neural network
@@ -64,7 +64,7 @@ class TestRegLossIntegration(unittest.TestCase):
                 self.layer = nn.Sequential(
                     nn.Conv3d(in_channels=1, out_channels=1, kernel_size=3, padding=1),
                     nn.ReLU(),
-                    nn.Conv3d(in_channels=1, out_channels=1, kernel_size=3, padding=1),
+                    nn.Conv3d(in_channels=1, out_channels=pred_channels, kernel_size=3, padding=1),
                 )
 
             def forward(self, x):


### PR DESCRIPTION
Fixes #3485

### Description
See #3485 for a complete description.

- Introduce `normalize` parameter to `BendingEnergyLoss` constructor, which defaults to `True`. This makes loss computation robust to different image resolutions. Setting `normalize` to `False` explicitly provides the old behavior, which follows the "bending energy" formula as it appears in publications.
- Raise error when number of vector components does not match the number of spatial dimensions.
- Add test cases for the new error.
- Adjust old test cases to expect the new bending loss behavior, and add test cases to test both behaviors
- Adjust tensor shapes in old test cases so that the number of vector components always matches the number of spatial dimensions.

**Feedback wanted:** Should `normalize=True` be the default? I preferred this because I felt that the default behavior should be resolution-invariant... but this is also the reason it's a breaking change. If `BendingEnergyLoss` is already used in some project, then a revision would be needed in that project. If I set `normalize=False` by default, it's not a breaking change.

### Status
**Ready**

- [x] Run some less trivial tests
- [x] Get feedback to my question above

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
