### PR TITLE
removes redundant casting -- ensure tuple

### DIFF
--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -89,7 +89,7 @@ def ensure_tuple(vals: Any) -> Tuple[Any, ...]:
     Returns a tuple of `vals`.
     """
     if not issequenceiterable(vals):
-        vals = (vals,)
+        return (vals,)
 
     return tuple(vals)
 
@@ -98,8 +98,8 @@ def ensure_tuple_size(tup: Any, dim: int, pad_val: Any = 0) -> Tuple[Any, ...]:
     """
     Returns a copy of `tup` with `dim` values by either shortened or padded with `pad_val` as necessary.
     """
-    tup = ensure_tuple(tup) + (pad_val,) * dim
-    return tuple(tup[:dim])
+    new_tup = ensure_tuple(tup) + (pad_val,) * dim
+    return new_tup[:dim]
 
 
 def ensure_tuple_rep(tup: Any, dim: int) -> Tuple[Any, ...]:


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

### Description
removes the redundant calls of `tuple()` in `ensure_tuple` and `ensure_tuple_size`,
this is to improve the code readability and performance.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
