### PR TITLE
3557 - skip test when pretrained weights downloading errors

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -97,6 +97,10 @@ def test_pretrained_networks(network, input_param, device):
         return network(**input_param).to(device)
     except (URLError, HTTPError) as e:
         raise unittest.SkipTest(e) from e
+    except RuntimeError as r_error:
+        if "unexpected EOF" in f"{r_error}":  # The file might be corrupted.
+            raise unittest.SkipTest(f"{r_error}") from r_error
+        raise
 
 
 def test_is_quick():


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #3557

### Description
skip the unit tests when the pre-trained weight files are corrupted due to downloading issues

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
