### PR TITLE
3610 review array copy perf

### DIFF
--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -174,7 +174,7 @@ def dense_patch_slices(
             start_idx -= max(start_idx + patch_size[dim] - image_size[dim], 0)
             dim_starts.append(start_idx)
         starts.append(dim_starts)
-    out = np.asarray([x.flatten() for x in np.meshgrid(*starts, indexing="ij")]).T
+    out = np.asarray([x.reshape(-1) for x in np.meshgrid(*starts, indexing="ij")]).T
     return [tuple(slice(s, s + patch_size[d]) for d, s in enumerate(x)) for x in out]
 
 

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -238,7 +238,7 @@ def any_np_pt(x: NdarrayOrTensor, axis: Union[int, Sequence[int]]):
         axis: axis to perform `any` over
 
     Returns:
-        Return a contiguous flattened array/tensor.
+        Return a bool or an array/tensor.
     """
     if isinstance(x, np.ndarray):
         return np.any(x, axis)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

follow-up of #3610

### Description
review and remove unnecessary array flatten copies

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
