### PR TITLE
Fix differentiability of generalized Dice loss

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -348,10 +348,10 @@ class GeneralizedDiceLoss(_Loss):
         denominator = ground_o + pred_o
 
         w = self.w_func(ground_o.float())
-        for b in w:
-            infs = torch.isinf(b)
-            b[infs] = 0.0
-            b[infs] = torch.max(b)
+        infs = torch.isinf(w)
+        w[infs] = 0.0
+        max_values = torch.max(w, dim=1)[0].unsqueeze(dim=1)
+        w = w + infs * max_values
 
         final_reduce_dim = 0 if self.batch else 1
         numer = 2.0 * (intersection * w).sum(final_reduce_dim, keepdim=True) + self.smooth_nr

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -349,9 +349,12 @@ class GeneralizedDiceLoss(_Loss):
 
         w = self.w_func(ground_o.float())
         infs = torch.isinf(w)
-        w[infs] = 0.0
-        max_values = torch.max(w, dim=1)[0].unsqueeze(dim=1)
-        w = w + infs * max_values
+        if self.batch:
+            w[infs] = torch.max(w)
+        else:
+            w[infs] = 0.0
+            max_values = torch.max(w, dim=1)[0].unsqueeze(dim=1)
+            w = w + infs * max_values
 
         final_reduce_dim = 0 if self.batch else 1
         numer = 2.0 * (intersection * w).sum(final_reduce_dim, keepdim=True) + self.smooth_nr

--- a/tests/test_generalized_dice_loss.py
+++ b/tests/test_generalized_dice_loss.py
@@ -174,12 +174,23 @@ class TestGeneralizedDiceLoss(unittest.TestCase):
             loss.forward(chn_input, chn_target)
 
     def test_differentiability(self):
-        input = torch.ones((1, 1, 1, 3))
+        prediction = torch.ones((1, 1, 1, 3))
         target = torch.ones((1, 1, 1, 3))
-        input.requires_grad = True
+        prediction.requires_grad = True
         target.requires_grad = True
-        loss_module = GeneralizedDiceLoss()
-        loss = loss_module(input, target)
+
+        generalized_dice_loss = GeneralizedDiceLoss()
+        loss = generalized_dice_loss(prediction, target)
+        self.assertNotEqual(loss.grad_fn, None)
+
+    def test_batch(self):
+        prediction = torch.zeros(2, 3, 3, 3)
+        target = torch.zeros(2, 3, 3, 3)
+        prediction.requires_grad = True
+        target.requires_grad = True
+
+        generalized_dice_loss = GeneralizedDiceLoss(batch=True)
+        loss = generalized_dice_loss(prediction, target)
         self.assertNotEqual(loss.grad_fn, None)
 
     @SkipIfBeforePyTorchVersion((1, 7, 0))

--- a/tests/test_generalized_dice_loss.py
+++ b/tests/test_generalized_dice_loss.py
@@ -173,6 +173,15 @@ class TestGeneralizedDiceLoss(unittest.TestCase):
             loss = GeneralizedDiceLoss(to_onehot_y=True)
             loss.forward(chn_input, chn_target)
 
+    def test_differentiability(self):
+        input = torch.ones((1, 1, 1, 3))
+        target = torch.ones((1, 1, 1, 3))
+        input.requires_grad = True
+        target.requires_grad = True
+        loss_module = GeneralizedDiceLoss()
+        loss = loss_module(input, target)
+        self.assertNotEqual(loss.grad_fn, None)
+
     @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         loss = GeneralizedDiceLoss()


### PR DESCRIPTION
Signed-off-by: Josafat-Mattias Burmeister <josafat-mattias.burmeister@student.hpi.de>

Fixes #3618.

### Description
Replaces the weight clamp code in the forward method of the GeneralizedDiceLoss module with an equivalent differentiable version.

### Status
**Ready**

I was not able to run the tests locally as some tests that do not seem to be related to my changes failed. Since the tests passed in the CI pipeline, I marked this PR as ready.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
