### PR TITLE
3643 update meshgrid

### DIFF
--- a/monai/networks/blocks/crf.py
+++ b/monai/networks/blocks/crf.py
@@ -15,6 +15,7 @@ import torch
 from torch.nn.functional import softmax
 
 from monai.networks.layers.filtering import PHLFilter
+from monai.networks.utils import meshgrid_ij
 
 __all__ = ["CRF"]
 
@@ -114,6 +115,6 @@ class CRF(torch.nn.Module):
 # helper methods
 def _create_coordinate_tensor(tensor):
     axes = [torch.arange(tensor.size(i)) for i in range(2, tensor.dim())]
-    grids = torch.meshgrid(axes)
+    grids = meshgrid_ij(axes)
     coords = torch.stack(grids).to(device=tensor.device, dtype=tensor.dtype)
     return torch.stack(tensor.size(0) * [coords], dim=0)

--- a/monai/networks/blocks/warp.py
+++ b/monai/networks/blocks/warp.py
@@ -18,6 +18,7 @@ from torch.nn import functional as F
 
 from monai.config.deviceconfig import USE_COMPILED
 from monai.networks.layers.spatial_transforms import grid_pull
+from monai.networks.utils import meshgrid_ij
 from monai.utils import GridSampleMode, GridSamplePadMode, optional_import
 
 _C, _ = optional_import("monai._C")
@@ -84,7 +85,7 @@ class Warp(nn.Module):
     @staticmethod
     def get_reference_grid(ddf: torch.Tensor) -> torch.Tensor:
         mesh_points = [torch.arange(0, dim) for dim in ddf.shape[2:]]
-        grid = torch.stack(torch.meshgrid(*mesh_points), dim=0)  # (spatial_dims, ...)
+        grid = torch.stack(meshgrid_ij(*mesh_points), dim=0)  # (spatial_dims, ...)
         grid = torch.stack([grid] * ddf.shape[0], dim=0)  # (batch, spatial_dims, ...)
         grid = grid.to(ddf)
         return grid

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -37,6 +37,7 @@ __all__ = [
     "train_mode",
     "copy_model_state",
     "convert_to_torchscript",
+    "meshgrid_ij",
 ]
 
 
@@ -500,3 +501,9 @@ def convert_to_torchscript(
                 torch.testing.assert_allclose(r1, r2, rtol=rtol, atol=atol)
 
     return script_module
+
+
+def meshgrid_ij(*tensors):
+    if pytorch_after(1, 10):
+        return torch.meshgrid(*tensors, indexing="ij")
+    return torch.meshgrid(*tensors)

--- a/monai/transforms/smooth_field/array.py
+++ b/monai/transforms/smooth_field/array.py
@@ -19,11 +19,12 @@ from torch.nn.functional import grid_sample, interpolate
 
 import monai
 from monai.config.type_definitions import NdarrayOrTensor
+from monai.networks.utils import meshgrid_ij
 from monai.transforms.transform import Randomizable, RandomizableTransform
 from monai.transforms.utils_pytorch_numpy_unification import moveaxis
 from monai.utils import GridSampleMode, GridSamplePadMode, InterpolateMode
 from monai.utils.enums import TransformBackends
-from monai.utils.module import look_up_option, pytorch_after
+from monai.utils.module import look_up_option
 from monai.utils.type_conversion import convert_to_dst_type, convert_to_tensor
 
 __all__ = ["SmoothField", "RandSmoothFieldAdjustContrast", "RandSmoothFieldAdjustIntensity", "RandSmoothDeform"]
@@ -404,10 +405,7 @@ class RandSmoothDeform(RandomizableTransform):
         grid_space = spatial_size if spatial_size is not None else self.sfield.field.shape[2:]
         grid_ranges = [torch.linspace(-1, 1, d) for d in grid_space]
 
-        if pytorch_after(1, 10):
-            grid = torch.meshgrid(*grid_ranges, indexing="ij")
-        else:
-            grid = torch.meshgrid(*grid_ranges)
+        grid = meshgrid_ij(*grid_ranges)
 
         self.grid = torch.stack(grid).unsqueeze(0).to(self.device, self.grid_dtype)
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -22,6 +22,7 @@ from monai.config import USE_COMPILED, DtypeLike
 from monai.config.type_definitions import NdarrayOrTensor
 from monai.data.utils import compute_shape_offset, to_affine_nd, zoom_affine
 from monai.networks.layers import AffineTransform, GaussianFilter, grid_pull
+from monai.networks.utils import meshgrid_ij
 from monai.transforms.croppad.array import CenterSpatialCrop, Pad
 from monai.transforms.transform import Randomizable, RandomizableTransform, ThreadUnsafe, Transform
 from monai.transforms.utils import (
@@ -2103,7 +2104,7 @@ class GridDistortion(Transform):
             ranges = ranges - (dim_size - 1.0) / 2.0
             all_ranges.append(ranges)
 
-        coords = torch.meshgrid(*all_ranges)
+        coords = meshgrid_ij(*all_ranges)
         grid = torch.stack([*coords, torch.ones_like(coords[0])])
 
         return self.resampler(img, grid=grid, mode=mode, padding_mode=padding_mode)  # type: ignore

--- a/tests/test_grid_pull.py
+++ b/tests/test_grid_pull.py
@@ -16,6 +16,7 @@ import torch
 from parameterized import parameterized
 
 from monai.networks.layers import grid_pull
+from monai.networks.utils import meshgrid_ij
 from monai.utils import optional_import
 from tests.testing_data.cpp_resample_answers import Expected_1D_GP_bwd, Expected_1D_GP_fwd
 from tests.utils import skip_if_no_cpp_extension
@@ -26,7 +27,7 @@ PType, has_p_type = optional_import("monai._C", name="InterpolationType")
 
 def make_grid(shape, dtype=None, device=None, requires_grad=True):
     ranges = [torch.arange(float(s), dtype=dtype, device=device, requires_grad=requires_grad) for s in shape]
-    grid = torch.stack(torch.meshgrid(*ranges), dim=-1)
+    grid = torch.stack(meshgrid_ij(*ranges), dim=-1)
     return grid[None]
 
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #3643

### Description
meshgrid with the indexing option

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
