### PR TITLE
moveaxis with sequence of dims and typing enhancements

### DIFF
--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -402,7 +402,7 @@ def weighted_patch_samples(
         idx = r_state.randint(0, len(v), size=n_samples)
     else:
         r, *_ = convert_to_dst_type(r_state.random(n_samples), v)  # type: ignore
-        idx = searchsorted(v, r * v[-1], right=True)
+        idx = searchsorted(v, r * v[-1], right=True)  # type: ignore
     idx, *_ = convert_to_dst_type(idx, v, dtype=torch.int)  # type: ignore
     # compensate 'valid' mode
     diff = np.minimum(win_size, img_size) // 2
@@ -411,7 +411,7 @@ def weighted_patch_samples(
 
 
 def correct_crop_centers(
-    centers: List[Union[int, torch.Tensor]],
+    centers: Union[NdarrayOrTensor, List[NdarrayOrTensor]],
     spatial_size: Union[Sequence[int], int],
     label_spatial_shape: Sequence[int],
     allow_smaller: bool = False,


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>


### Description
The pytorch/numpy APIs supports a sequence of ints as `moveaxis` arguments,
this PR enhances the `moveaxis` in `monai/transforms/utils_pytorch_numpy_unification.py` so that it also accepts sequences.

The PR also enhances the typing annotations

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
