### PR TITLE
`EnsureChannelFirst`: avoid re-creation of `AddChannel`

### DIFF
--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -30,7 +30,8 @@ class Inferer(ABC):
     Example code::
 
         device = torch.device("cuda:0")
-        data = ToTensor()(LoadImage()(filename=img_path)).to(device)
+        transform = Compose([ToTensor(), LoadImage(image_only=True)])
+        data = transform(img_path).to(device)
         model = UNet(...).to(device)
         inferer = SlidingWindowInferer(...)
 

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -202,6 +202,8 @@ class EnsureChannelFirst(Transform):
             strict_check: whether to raise an error when the meta information is insufficient.
         """
         self.strict_check = strict_check
+        self.add_channel = AddChannel()
+        self.as_channel_first = AsChannelFirst()
 
     def __call__(self, img: NdarrayOrTensor, meta_dict: Optional[Mapping] = None) -> NdarrayOrTensor:
         """
@@ -223,8 +225,8 @@ class EnsureChannelFirst(Transform):
             warnings.warn(msg)
             return img
         if channel_dim == "no_channel":
-            return AddChannel()(img)
-        return AsChannelFirst(channel_dim=channel_dim)(img)
+            return self.add_channel(img)
+        return self.as_channel_first(channel_dim=channel_dim)(img)
 
 
 class RepeatChannel(Transform):

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -203,7 +203,6 @@ class EnsureChannelFirst(Transform):
         """
         self.strict_check = strict_check
         self.add_channel = AddChannel()
-        self.as_channel_first = AsChannelFirst()
 
     def __call__(self, img: NdarrayOrTensor, meta_dict: Optional[Mapping] = None) -> NdarrayOrTensor:
         """
@@ -226,7 +225,7 @@ class EnsureChannelFirst(Transform):
             return img
         if channel_dim == "no_channel":
             return self.add_channel(img)
-        return self.as_channel_first(channel_dim=channel_dim)(img)
+        return AsChannelFirst(channel_dim=channel_dim)(img)
 
 
 class RepeatChannel(Transform):


### PR DESCRIPTION
### Description
Each time `EnsureChannelFirst.__call__` is called, `AddChannel` or `AsChannelFirst` is created and then immediately destroyed. Better to create both during the `__init__` and then reuse.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.