### PR TITLE
removes duplicated docstring rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+_build/
 
 # PyBuilder
 target/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,7 @@ extensions = [
     "sphinx_autodoc_typehints",
 ]
 
-autoclass_content = "both"
+autoclass_content = "class"
 add_module_names = True
 source_encoding = "utf-8"
 autosectionlabel_prefix_document = True


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>
![Screenshot 2022-01-12 at 23 00 46](https://user-images.githubusercontent.com/831580/149236747-17a8bf3a-a655-45d1-b37b-a69641f0a120.png)



### Description
for example https://docs.monai.io/en/stable/data.html#iterabledataset
`__init__` arguments are rendered twice as the class docstring and `__init__` method docstring, this PR removes the duplicated ones

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
