### PR TITLE
Use `pip` to install `black`

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -26,7 +26,6 @@ dependencies:
   - pep8-naming
   - pycodestyle
   - pyflakes
-  - black
   - isort
   - types-pkg_resources
   - mypy>=0.790
@@ -47,6 +46,8 @@ dependencies:
   - pip:
     # pip for itk as conda-forge version only up to v5.1
     - itk>=5.2
+    # black currently at v19 on conda vs v21 on pip
+    - black
     # OS-specific needs to be done via pip:
     #   https://github.com/conda/conda/issues/8089
     - pytype>=2020.6.1; platform_system != "Windows"


### PR DESCRIPTION
### Description
`conda`'s `black` is at v19, `pip` is at v21.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).