### PR TITLE
3654 remove some  flake8 errors ignore

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,7 +10,7 @@ jobs:
   cron-gpu:
     if: github.repository == 'Project-MONAI/MONAI'
     container:
-      image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
+      image: nvcr.io/nvidia/pytorch:21.06-py3  # CUDA 11.3
       options: "--gpus all"
     runs-on: [self-hosted, linux, x64, common]
     strategy:

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -21,7 +21,7 @@ jobs:
   coverage-py3:
     if: github.repository == 'Project-MONAI/MONAI'
     container:
-      image: nvcr.io/nvidia/pytorch:20.03-py3  # CUDA 10.2
+      image: nvcr.io/nvidia/pytorch:21.06-py3  # CUDA 11.3
       options: --gpus all
     runs-on: [self-hosted, linux, x64, common]
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,20 +100,11 @@ max_line_length = 120
 # E501 is not flexible enough, we're using B950 instead
 ignore =
     E203
-    E305
-    E402
     E501
-    E721
     E741
-    F821
-    F841
-    F999
     W503
     W504
     C408
-    E302
-    W291
-    E303
     N812  # lowercase 'torch.nn.functional' imported as non lowercase 'F'
 per_file_ignores = __init__.py: F401
 exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,.venv,_version.py

--- a/tests/test_adaptors.py
+++ b/tests/test_adaptors.py
@@ -20,7 +20,7 @@ class TestAdaptors(unittest.TestCase):
         def foo(image, label=None, *a, **kw):
             pass
 
-        f = FunctionSignature(foo)
+        _ = FunctionSignature(foo)
 
     def test_single_in_single_out(self):
         def foo(image):

--- a/tests/test_simulatedelay.py
+++ b/tests/test_simulatedelay.py
@@ -24,7 +24,7 @@ class TestSimulateDelay(NumpyImageTestCase2D):
     def test_value(self, delay_test_time: float):
         resize = SimulateDelay(delay_time=delay_test_time)
         start: float = time.time()
-        result = resize(self.imt[0])
+        _ = resize(self.imt[0])
         stop: float = time.time()
         measured_approximate: float = stop - start
         np.testing.assert_allclose(delay_test_time, measured_approximate, rtol=0.5)

--- a/tests/test_unet.py
+++ b/tests/test_unet.py
@@ -198,7 +198,7 @@ class TestUNET(unittest.TestCase):
     @parameterized.expand(ILL_CASES)
     def test_ill_input_hyper_params(self, input_param):
         with self.assertRaises(ValueError):
-            net = UNet(**input_param)
+            _ = UNet(**input_param)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

part of #3654 


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
