### PR TITLE
3670 itk reader channel dim

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -324,7 +324,7 @@ class ITKReader(ImageReader):
         if self.channel_dim is not None:
             # channel_dim is given in the numpy convention, which is different from ITK
             # size is reversed
-            _size.pop(-self.channel_dim)
+            _size.pop(self.channel_dim)
         return np.asarray(_size[:sr])
 
     def _get_array_data(self, img):


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

partly address #3670, correct the indexing


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
