### PR TITLE
support stack of images with channels

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -131,9 +131,10 @@ def _stack_images(image_list: List, meta_dict: Dict):
     if len(image_list) <= 1:
         return image_list[0]
     if meta_dict.get("original_channel_dim", None) not in ("no_channel", None):
-        raise RuntimeError("can not read a list of images which already have channel dimension.")
+        channel_dim = int(meta_dict["original_channel_dim"])
+        return np.concatenate(image_list, axis=channel_dim)
     meta_dict["original_channel_dim"] = 0
-    return np.stack(image_list, axis=0)
+    return np.stack(image_list, axis=meta_dict["original_channel_dim"])
 
 
 @require_pkg(pkg_name="itk")
@@ -194,8 +195,8 @@ class ITKReader(ImageReader):
 
     def read(self, data: Union[Sequence[PathLike], PathLike], **kwargs):
         """
-        Read image data from specified file or files, it can read a list of `no-channel` images
-        and stack them together as multi-channels data in `get_data()`.
+        Read image data from specified file or files, it can read a list of images
+        and stack them together as multi-channel data in `get_data()`.
         If passing directory path instead of file path, will treat it as DICOM images series and read.
         Note that the returned object is ITK image object or list of ITK image objects.
 
@@ -390,8 +391,8 @@ class NibabelReader(ImageReader):
 
     def read(self, data: Union[Sequence[PathLike], PathLike], **kwargs):
         """
-        Read image data from specified file or files, it can read a list of `no-channel` images
-        and stack them together as multi-channels data in `get_data()`.
+        Read image data from specified file or files, it can read a list of images
+        and stack them together as multi-channel data in `get_data()`.
         Note that the returned object is Nibabel image object or list of Nibabel image objects.
 
         Args:
@@ -544,8 +545,8 @@ class NumpyReader(ImageReader):
 
     def read(self, data: Union[Sequence[PathLike], PathLike], **kwargs):
         """
-        Read image data from specified file or files, it can read a list of `no-channel` data files
-        and stack them together as multi-channels data in `get_data()`.
+        Read image data from specified file or files, it can read a list of data files
+        and stack them together as multi-channel data in `get_data()`.
         Note that the returned object is Numpy array or list of Numpy arrays.
 
         Args:
@@ -634,8 +635,8 @@ class PILReader(ImageReader):
 
     def read(self, data: Union[Sequence[PathLike], PathLike, np.ndarray], **kwargs):
         """
-        Read image data from specified file or files, it can read a list of `no-channel` images
-        and stack them together as multi-channels data in `get_data()`.
+        Read image data from specified file or files, it can read a list of images
+        and stack them together as multi-channel data in `get_data()`.
         Note that the returned object is PIL image or list of PIL image.
 
         Args:

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -133,8 +133,9 @@ def _stack_images(image_list: List, meta_dict: Dict):
     if meta_dict.get("original_channel_dim", None) not in ("no_channel", None):
         channel_dim = int(meta_dict["original_channel_dim"])
         return np.concatenate(image_list, axis=channel_dim)
+    # stack at a new first dim as the channel dim, if `'original_channel_dim'` is unspecified
     meta_dict["original_channel_dim"] = 0
-    return np.stack(image_list, axis=meta_dict["original_channel_dim"])
+    return np.stack(image_list, axis=0)
 
 
 @require_pkg(pkg_name="itk")

--- a/tests/test_load_image.py
+++ b/tests/test_load_image.py
@@ -80,6 +80,13 @@ TEST_CASE_8 = [
     (3, 128, 128, 128),
 ]
 
+TEST_CASE_8_1 = [
+    {"reader": ITKReader(channel_dim=0), "image_only": True},
+    ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"],
+    (384, 128, 128),
+]
+
+
 TEST_CASE_9 = [
     {"reader": ITKReader(), "image_only": False},
     ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"],
@@ -128,7 +135,7 @@ class TestLoadImage(unittest.TestCase):
                 np.testing.assert_allclose(header["original_affine"], np.eye(4))
             self.assertTupleEqual(result.shape, expected_shape)
 
-    @parameterized.expand([TEST_CASE_6, TEST_CASE_7, TEST_CASE_8, TEST_CASE_9])
+    @parameterized.expand([TEST_CASE_6, TEST_CASE_7, TEST_CASE_8, TEST_CASE_8_1, TEST_CASE_9])
     def test_itk_reader(self, input_param, filenames, expected_shape):
         test_image = np.random.rand(128, 128, 128)
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

adding the support of stacking at the channel dimension for image reader.
This could be useful for loading multiple single-channel data with shape
`[(42, 42, 1), (42, 42, 1), (42, 42, 1)]`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
