### PR TITLE
 3620  intensity range percentiles

### DIFF
--- a/tests/test_scale_intensity.py
+++ b/tests/test_scale_intensity.py
@@ -58,7 +58,7 @@ class TestScaleIntensity(NumpyImageTestCase2D):
     def test_channel_wise(self):
         for p in TEST_NDARRAYS:
             scaler = ScaleIntensity(minv=1.0, maxv=2.0, channel_wise=True)
-            data = p(self.imt)
+            data = p(np.tile(self.imt, (3, 1, 1, 1)))
             result = scaler(data)
             mina = self.imt.min()
             maxa = self.imt.max()

--- a/tests/test_scale_intensity_range_percentiles.py
+++ b/tests/test_scale_intensity_range_percentiles.py
@@ -66,7 +66,7 @@ class TestScaleIntensityRangePercentiles(NumpyImageTestCase2D):
         self.assertRaises(ValueError, ScaleIntensityRangePercentiles, lower=30, upper=900, b_min=0, b_max=255)
 
     def test_channel_wise(self):
-        img = self.imt[0]
+        img = np.tile(self.imt, (3, 1, 1, 1))
         lower = 10
         upper = 99
         b_min = 0
@@ -78,8 +78,8 @@ class TestScaleIntensityRangePercentiles(NumpyImageTestCase2D):
         for c in img:
             a_min = np.percentile(c, lower)
             a_max = np.percentile(c, upper)
-            expected.append(((c - a_min) / (a_max - a_min)) * (b_max - b_min) + b_min)
-        expected = np.stack(expected).astype(np.uint8)
+            expected.append((((c - a_min) / (a_max - a_min)) * (b_max - b_min) + b_min).astype(np.uint8))
+        expected = np.stack(expected)
 
         for p in TEST_NDARRAYS:
             result = scaler(p(img))

--- a/tests/test_scale_intensity_range_percentilesd.py
+++ b/tests/test_scale_intensity_range_percentilesd.py
@@ -75,7 +75,7 @@ class TestScaleIntensityRangePercentilesd(NumpyImageTestCase2D):
             s(self.imt)
 
     def test_channel_wise(self):
-        img = self.imt
+        img = np.tile(self.imt, (3, 1, 1, 1))
         lower = 10
         upper = 99
         b_min = 0


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #3620

### Description
the previous channel-wise test only covers the single-channel cases

### Status
**ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
