### PR TITLE
remove tensor-array conversion in `Orientation`

### DIFF
--- a/monai/networks/nets/regunet.py
+++ b/monai/networks/nets/regunet.py
@@ -21,6 +21,7 @@ from monai.networks.blocks.regunet_block import (
     get_conv_block,
     get_deconv_block,
 )
+from monai.networks.utils import meshgrid_ij
 
 __all__ = ["RegUNet", "AffineHead", "GlobalNet", "LocalNet"]
 
@@ -260,7 +261,7 @@ class AffineHead(nn.Module):
     @staticmethod
     def get_reference_grid(image_size: Union[Tuple[int], List[int]]) -> torch.Tensor:
         mesh_points = [torch.arange(0, dim) for dim in image_size]
-        grid = torch.stack(torch.meshgrid(*mesh_points), dim=0)  # (spatial_dims, ...)
+        grid = torch.stack(meshgrid_ij(*mesh_points), dim=0)  # (spatial_dims, ...)
         return grid.to(dtype=torch.float)
 
     def affine_transform(self, theta: torch.Tensor):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -330,7 +330,7 @@ class Orientation(Transform):
             data_array.permute(full_transpose.tolist()) if _is_tensor else data_array.transpose(full_transpose)  # type: ignore
         )
         new_affine = to_affine_nd(affine_np, new_affine)
-        out = data_array.contiguous() if _is_tensor else np.ascontiguousarray(data_array)
+        out = data_array.contiguous() if _is_tensor else np.ascontiguousarray(data_array)  # type: ignore
         new_affine, *_ = convert_to_dst_type(src=new_affine, dst=affine, dtype=torch.float32)
 
         if self.image_only:

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -322,10 +322,12 @@ class Orientation(Transform):
         spatial_ornt[:, 0] += 1  # skip channel dim
         spatial_ornt = np.concatenate([np.array([[0, 1]]), spatial_ornt])
         axes = [ax for ax, flip in enumerate(spatial_ornt[:, 1]) if flip == -1]
-        data_array = torch.flip(data_array, dims=axes) if _is_tensor else np.flip(data_array, axis=axes)
+        data_array = torch.flip(data_array, dims=axes) if _is_tensor else np.flip(data_array, axis=axes)  # type: ignore
         full_transpose = np.arange(len(data_array.shape))
         full_transpose[: len(spatial_ornt)] = np.argsort(spatial_ornt[:, 0])
-        data_array = data_array.permute(full_transpose.tolist()) if _is_tensor else data_array.transpose(full_transpose)
+        data_array = (
+            data_array.permute(full_transpose.tolist()) if _is_tensor else data_array.transpose(full_transpose)  # type: ignore
+        )
         new_affine = to_affine_nd(affine_np, new_affine)
         out = data_array.contiguous() if _is_tensor else np.ascontiguousarray(data_array)
         new_affine, *_ = convert_to_dst_type(src=new_affine, dst=affine, dtype=torch.float32)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -326,11 +326,12 @@ class Orientation(Transform):
             data_array = torch.flip(data_array, dims=axes) if _is_tensor else np.flip(data_array, axis=axes)  # type: ignore
         full_transpose = np.arange(len(data_array.shape))
         full_transpose[: len(spatial_ornt)] = np.argsort(spatial_ornt[:, 0])
-        data_array = (
-            data_array.permute(full_transpose.tolist()) if _is_tensor else data_array.transpose(full_transpose)  # type: ignore
-        )
+        if not np.all(full_transpose == np.arange(len(data_array.shape))):
+            data_array = (
+                data_array.permute(full_transpose.tolist()) if _is_tensor else data_array.transpose(full_transpose)  # type: ignore
+            )
+        out, *_ = convert_to_dst_type(src=data_array, dst=data_array)  # type: ignore
         new_affine = to_affine_nd(affine_np, new_affine)
-        out = data_array.contiguous() if _is_tensor else np.ascontiguousarray(data_array)  # type: ignore
         new_affine, *_ = convert_to_dst_type(src=new_affine, dst=affine, dtype=torch.float32)
 
         if self.image_only:

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -325,7 +325,7 @@ class Orientation(Transform):
         data_array = torch.flip(data_array, dims=axes) if _is_tensor else np.flip(data_array, axis=axes)
         full_transpose = np.arange(len(data_array.shape))
         full_transpose[: len(spatial_ornt)] = np.argsort(spatial_ornt[:, 0])
-        data_array = data_array.permute(full_transpose) if _is_tensor else data_array.transpose(full_transpose)
+        data_array = data_array.permute(full_transpose.tolist()) if _is_tensor else data_array.transpose(full_transpose)
         new_affine = to_affine_nd(affine_np, new_affine)
         out = data_array.contiguous() if _is_tensor else np.ascontiguousarray(data_array)
         new_affine, *_ = convert_to_dst_type(src=new_affine, dst=affine, dtype=torch.float32)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -237,7 +237,7 @@ class Orientation(Transform):
     Change the input image's orientation into the specified based on `axcodes`.
     """
 
-    backend = [TransformBackends.NUMPY]
+    backend = [TransformBackends.NUMPY, TransformBackends.TORCH]
 
     def __init__(
         self,

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -322,7 +322,8 @@ class Orientation(Transform):
         spatial_ornt[:, 0] += 1  # skip channel dim
         spatial_ornt = np.concatenate([np.array([[0, 1]]), spatial_ornt])
         axes = [ax for ax, flip in enumerate(spatial_ornt[:, 1]) if flip == -1]
-        data_array = torch.flip(data_array, dims=axes) if _is_tensor else np.flip(data_array, axis=axes)  # type: ignore
+        if axes:
+            data_array = torch.flip(data_array, dims=axes) if _is_tensor else np.flip(data_array, axis=axes)  # type: ignore
         full_transpose = np.arange(len(data_array.shape))
         full_transpose[: len(spatial_ornt)] = np.argsort(spatial_ornt[:, 0])
         data_array = (

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -293,8 +293,8 @@ class Orientation(Transform):
             (data_array [reoriented in `self.axcodes`], original axcodes, current axcodes).
 
         """
-        data_array_np, *_ = convert_data_type(data_array, np.ndarray)  # type: ignore
-        sr = data_array_np.ndim - 1
+        spatial_shape = data_array.shape[1:]
+        sr = len(spatial_shape)
         if sr <= 0:
             raise ValueError("data_array must have at least one spatial dimension.")
         if affine is None:
@@ -310,21 +310,24 @@ class Orientation(Transform):
             spatial_ornt = src
         else:
             if self.axcodes is None:
-                raise AssertionError
+                raise ValueError("Incompatible values: axcodes=None and as_closest_canonical=True.")
             dst = nib.orientations.axcodes2ornt(self.axcodes[:sr], labels=self.labels)
             if len(dst) < sr:
                 raise ValueError(
                     f"axcodes must match data_array spatially, got axcodes={len(self.axcodes)}D data_array={sr}D"
                 )
             spatial_ornt = nib.orientations.ornt_transform(src, dst)
-        ornt = spatial_ornt.copy()
-        ornt[:, 0] += 1  # skip channel dim
-        ornt = np.concatenate([np.array([[0, 1]]), ornt])
-        shape = data_array_np.shape[1:]
-        data_array_np = np.ascontiguousarray(nib.orientations.apply_orientation(data_array_np, ornt))
-        new_affine = affine_ @ nib.orientations.inv_ornt_aff(spatial_ornt, shape)
+        new_affine = affine_ @ nib.orientations.inv_ornt_aff(spatial_ornt, spatial_shape)
+        _is_tensor = isinstance(data_array, torch.Tensor)
+        spatial_ornt[:, 0] += 1  # skip channel dim
+        spatial_ornt = np.concatenate([np.array([[0, 1]]), spatial_ornt])
+        axes = [ax for ax, flip in enumerate(spatial_ornt[:, 1]) if flip == -1]
+        data_array = torch.flip(data_array, dims=axes) if _is_tensor else np.flip(data_array, axis=axes)
+        full_transpose = np.arange(len(data_array.shape))
+        full_transpose[: len(spatial_ornt)] = np.argsort(spatial_ornt[:, 0])
+        data_array = data_array.permute(full_transpose) if _is_tensor else data_array.transpose(full_transpose)
         new_affine = to_affine_nd(affine_np, new_affine)
-        out, *_ = convert_to_dst_type(src=data_array_np, dst=data_array)
+        out = data_array.contiguous() if _is_tensor else np.ascontiguousarray(data_array)
         new_affine, *_ = convert_to_dst_type(src=new_affine, dst=affine, dtype=torch.float32)
 
         if self.image_only:

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -23,6 +23,7 @@ import monai
 from monai.config import DtypeLike, IndexSelection
 from monai.config.type_definitions import NdarrayOrTensor
 from monai.networks.layers import GaussianFilter
+from monai.networks.utils import meshgrid_ij
 from monai.transforms.compose import Compose, OneOf
 from monai.transforms.transform import MapTransform, Transform, apply_transform
 from monai.transforms.utils_pytorch_numpy_unification import (
@@ -624,7 +625,7 @@ def _create_grid_torch(
         torch.linspace(-(d - 1.0) / 2.0 * s, (d - 1.0) / 2.0 * s, int(d), device=device, dtype=dtype)
         for d, s in zip(spatial_size, spacing)
     ]
-    coords = torch.meshgrid(*ranges)
+    coords = meshgrid_ij(*ranges)
     if not homogeneous:
         return torch.stack(coords)
     return torch.stack([*coords, torch.ones_like(coords[0])])

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -175,9 +175,9 @@ class TestOrientationCase(unittest.TestCase):
         ornt = Orientation(**init_param)
         res = ornt(img, **data_param)
         if not isinstance(res, tuple):
-            assert_allclose(res, expected_data, type_test=False)
+            assert_allclose(res, in_type(expected_data))
             return
-        assert_allclose(res[0], expected_data, type_test=False)
+        assert_allclose(res[0], in_type(expected_data))
         original_affine = data_param["affine"]
         np.testing.assert_allclose(original_affine, res[1])
         new_code = nib.orientations.aff2axcodes(res[2], labels=ornt.labels)

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -16,90 +16,149 @@ import numpy as np
 from parameterized import parameterized
 
 from monai.transforms import Orientation, create_rotate, create_translate
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
-TEST_CASES = [
-    [
-        {"axcodes": "RAS"},
-        np.arange(12).reshape((2, 1, 2, 3)),
-        {"affine": np.eye(4)},
-        np.arange(12).reshape((2, 1, 2, 3)),
-        "RAS",
-    ],
-    [
-        {"axcodes": "ALS"},
-        np.arange(12).reshape((2, 1, 2, 3)),
-        {"affine": np.diag([-1, -1, 1, 1])},
-        np.array([[[[3, 4, 5]], [[0, 1, 2]]], [[[9, 10, 11]], [[6, 7, 8]]]]),
-        "ALS",
-    ],
-    [
-        {"axcodes": "RAS"},
-        np.arange(12).reshape((2, 1, 2, 3)),
-        {"affine": np.diag([-1, -1, 1, 1])},
-        np.array([[[[3, 4, 5], [0, 1, 2]]], [[[9, 10, 11], [6, 7, 8]]]]),
-        "RAS",
-    ],
-    [
-        {"axcodes": "AL"},
-        np.arange(6).reshape((2, 1, 3)),
-        {"affine": np.eye(3)},
-        np.array([[[0], [1], [2]], [[3], [4], [5]]]),
-        "AL",
-    ],
-    [{"axcodes": "L"}, np.arange(6).reshape((2, 3)), {"affine": np.eye(2)}, np.array([[2, 1, 0], [5, 4, 3]]), "L"],
-    [{"axcodes": "L"}, np.arange(6).reshape((2, 3)), {"affine": np.eye(2)}, np.array([[2, 1, 0], [5, 4, 3]]), "L"],
-    [{"axcodes": "L"}, np.arange(6).reshape((2, 3)), {"affine": np.diag([-1, 1])}, np.arange(6).reshape((2, 3)), "L"],
-    [
-        {"axcodes": "LPS"},
-        np.arange(12).reshape((2, 1, 2, 3)),
-        {
-            "affine": create_translate(3, (10, 20, 30))
-            @ create_rotate(3, (np.pi / 2, np.pi / 2, np.pi / 4))
-            @ np.diag([-1, 1, 1, 1])
-        },
-        np.array([[[[2, 5]], [[1, 4]], [[0, 3]]], [[[8, 11]], [[7, 10]], [[6, 9]]]]),
-        "LPS",
-    ],
-    [
-        {"as_closest_canonical": True},
-        np.arange(12).reshape((2, 1, 2, 3)),
-        {
-            "affine": create_translate(3, (10, 20, 30))
-            @ create_rotate(3, (np.pi / 2, np.pi / 2, np.pi / 4))
-            @ np.diag([-1, 1, 1, 1])
-        },
-        np.array([[[[0, 3]], [[1, 4]], [[2, 5]]], [[[6, 9]], [[7, 10]], [[8, 11]]]]),
-        "RAS",
-    ],
-    [
-        {"as_closest_canonical": True},
-        np.arange(6).reshape((1, 2, 3)),
-        {"affine": create_translate(2, (10, 20)) @ create_rotate(2, (np.pi / 3)) @ np.diag([-1, -0.2, 1])},
-        np.array([[[3, 0], [4, 1], [5, 2]]]),
-        "RA",
-    ],
-    [
-        {"axcodes": "LP"},
-        np.arange(6).reshape((1, 2, 3)),
-        {"affine": create_translate(2, (10, 20)) @ create_rotate(2, (np.pi / 3)) @ np.diag([-1, -0.2, 1])},
-        np.array([[[2, 5], [1, 4], [0, 3]]]),
-        "LP",
-    ],
-    [
-        {"axcodes": "LPID", "labels": tuple(zip("LPIC", "RASD"))},
-        np.zeros((1, 2, 3, 4, 5)),
-        {"affine": np.diag([-1, -0.2, -1, 1, 1])},
-        np.zeros((1, 2, 3, 4, 5)),
-        "LPID",
-    ],
-    [
-        {"as_closest_canonical": True, "labels": tuple(zip("LPIC", "RASD"))},
-        np.zeros((1, 2, 3, 4, 5)),
-        {"affine": np.diag([-1, -0.2, -1, 1, 1])},
-        np.zeros((1, 2, 3, 4, 5)),
-        "RASD",
-    ],
-]
+TESTS = []
+for p in TEST_NDARRAYS:
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "RAS"},
+            np.arange(12).reshape((2, 1, 2, 3)),
+            {"affine": np.eye(4)},
+            np.arange(12).reshape((2, 1, 2, 3)),
+            "RAS",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "ALS"},
+            np.arange(12).reshape((2, 1, 2, 3)),
+            {"affine": np.diag([-1, -1, 1, 1])},
+            np.array([[[[3, 4, 5]], [[0, 1, 2]]], [[[9, 10, 11]], [[6, 7, 8]]]]),
+            "ALS",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "RAS"},
+            np.arange(12).reshape((2, 1, 2, 3)),
+            {"affine": np.diag([-1, -1, 1, 1])},
+            np.array([[[[3, 4, 5], [0, 1, 2]]], [[[9, 10, 11], [6, 7, 8]]]]),
+            "RAS",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "AL"},
+            np.arange(6).reshape((2, 1, 3)),
+            {"affine": np.eye(3)},
+            np.array([[[0], [1], [2]], [[3], [4], [5]]]),
+            "AL",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "L"},
+            np.arange(6).reshape((2, 3)),
+            {"affine": np.eye(2)},
+            np.array([[2, 1, 0], [5, 4, 3]]),
+            "L",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "L"},
+            np.arange(6).reshape((2, 3)),
+            {"affine": np.eye(2)},
+            np.array([[2, 1, 0], [5, 4, 3]]),
+            "L",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "L"},
+            np.arange(6).reshape((2, 3)),
+            {"affine": np.diag([-1, 1])},
+            np.arange(6).reshape((2, 3)),
+            "L",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "LPS"},
+            np.arange(12).reshape((2, 1, 2, 3)),
+            {
+                "affine": create_translate(3, (10, 20, 30))
+                @ create_rotate(3, (np.pi / 2, np.pi / 2, np.pi / 4))
+                @ np.diag([-1, 1, 1, 1])
+            },
+            np.array([[[[2, 5]], [[1, 4]], [[0, 3]]], [[[8, 11]], [[7, 10]], [[6, 9]]]]),
+            "LPS",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"as_closest_canonical": True},
+            np.arange(12).reshape((2, 1, 2, 3)),
+            {
+                "affine": create_translate(3, (10, 20, 30))
+                @ create_rotate(3, (np.pi / 2, np.pi / 2, np.pi / 4))
+                @ np.diag([-1, 1, 1, 1])
+            },
+            np.array([[[[0, 3]], [[1, 4]], [[2, 5]]], [[[6, 9]], [[7, 10]], [[8, 11]]]]),
+            "RAS",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"as_closest_canonical": True},
+            np.arange(6).reshape((1, 2, 3)),
+            {"affine": create_translate(2, (10, 20)) @ create_rotate(2, (np.pi / 3)) @ np.diag([-1, -0.2, 1])},
+            np.array([[[3, 0], [4, 1], [5, 2]]]),
+            "RA",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "LP"},
+            np.arange(6).reshape((1, 2, 3)),
+            {"affine": create_translate(2, (10, 20)) @ create_rotate(2, (np.pi / 3)) @ np.diag([-1, -0.2, 1])},
+            np.array([[[2, 5], [1, 4], [0, 3]]]),
+            "LP",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"axcodes": "LPID", "labels": tuple(zip("LPIC", "RASD"))},
+            np.zeros((1, 2, 3, 4, 5)),
+            {"affine": np.diag([-1, -0.2, -1, 1, 1])},
+            np.zeros((1, 2, 3, 4, 5)),
+            "LPID",
+        ]
+    )
+    TESTS.append(
+        [
+            p,
+            {"as_closest_canonical": True, "labels": tuple(zip("LPIC", "RASD"))},
+            np.zeros((1, 2, 3, 4, 5)),
+            {"affine": np.diag([-1, -0.2, -1, 1, 1])},
+            np.zeros((1, 2, 3, 4, 5)),
+            "RASD",
+        ]
+    )
+
 
 ILL_CASES = [
     # no axcodes or as_cloest_canonical
@@ -110,14 +169,15 @@ ILL_CASES = [
 
 
 class TestOrientationCase(unittest.TestCase):
-    @parameterized.expand(TEST_CASES)
-    def test_ornt(self, init_param, img, data_param, expected_data, expected_code):
+    @parameterized.expand(TESTS)
+    def test_ornt(self, in_type, init_param, img, data_param, expected_data, expected_code):
+        img = in_type(img)
         ornt = Orientation(**init_param)
         res = ornt(img, **data_param)
         if not isinstance(res, tuple):
-            np.testing.assert_allclose(res, expected_data)
+            assert_allclose(res, expected_data, type_test=False)
             return
-        np.testing.assert_allclose(res[0], expected_data)
+        assert_allclose(res[0], expected_data, type_test=False)
         original_affine = data_param["affine"]
         np.testing.assert_allclose(original_affine, res[1])
         new_code = nib.orientations.aff2axcodes(res[2], labels=ornt.labels)

--- a/tests/test_orientationd.py
+++ b/tests/test_orientationd.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from monai.transforms import Orientationd
 from monai.utils.enums import PostFix
-from tests.utils import TEST_NDARRAYS, assert_allclose
+from tests.utils import TEST_NDARRAYS
 
 
 class TestOrientationdCase(unittest.TestCase):

--- a/tests/test_orientationd.py
+++ b/tests/test_orientationd.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from monai.transforms import Orientationd
 from monai.utils.enums import PostFix
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
 
 class TestOrientationdCase(unittest.TestCase):
@@ -28,20 +29,21 @@ class TestOrientationdCase(unittest.TestCase):
         self.assertEqual(code, ("R", "A", "S"))
 
     def test_orntd_3d(self):
-        data = {
-            "seg": np.ones((2, 1, 2, 3)),
-            "img": np.ones((2, 1, 2, 3)),
-            PostFix.meta("seg"): {"affine": np.eye(4)},
-            PostFix.meta("img"): {"affine": np.eye(4)},
-        }
-        ornt = Orientationd(keys=("img", "seg"), axcodes="PLI")
-        res = ornt(data)
-        np.testing.assert_allclose(res["img"].shape, (2, 2, 1, 3))
-        np.testing.assert_allclose(res["seg"].shape, (2, 2, 1, 3))
-        code = nib.aff2axcodes(res[PostFix.meta("seg")]["affine"], ornt.ornt_transform.labels)
-        self.assertEqual(code, ("P", "L", "I"))
-        code = nib.aff2axcodes(res[PostFix.meta("img")]["affine"], ornt.ornt_transform.labels)
-        self.assertEqual(code, ("P", "L", "I"))
+        for p in TEST_NDARRAYS:
+            data = {
+                "seg": p(np.ones((2, 1, 2, 3))),
+                "img": p(np.ones((2, 1, 2, 3))),
+                PostFix.meta("seg"): {"affine": np.eye(4)},
+                PostFix.meta("img"): {"affine": np.eye(4)},
+            }
+            ornt = Orientationd(keys=("img", "seg"), axcodes="PLI")
+            res = ornt(data)
+            np.testing.assert_allclose(res["img"].shape, (2, 2, 1, 3))
+            np.testing.assert_allclose(res["seg"].shape, (2, 2, 1, 3))
+            code = nib.aff2axcodes(res[PostFix.meta("seg")]["affine"], ornt.ornt_transform.labels)
+            self.assertEqual(code, ("P", "L", "I"))
+            code = nib.aff2axcodes(res[PostFix.meta("img")]["affine"], ornt.ornt_transform.labels)
+            self.assertEqual(code, ("P", "L", "I"))
 
     def test_orntd_2d(self):
         data = {


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

### Description
non-breaking update to avoid tensor <-> ndarray conversion for the input image in `Orientation` transform

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
