### PR TITLE
clear compiler warnings

### DIFF
--- a/monai/csrc/filtering/permutohedral/permutohedral_cpu.cpp
+++ b/monai/csrc/filtering/permutohedral/permutohedral_cpu.cpp
@@ -464,14 +464,14 @@ class PermutohedralLattice {
     // depending where we ended up, we may have to copy data
     if (oldValue != hashTableBase) {
       memcpy(hashTableBase, oldValue, hashTable.size() * vd * sizeof(scalar_t));
-      delete oldValue;
+      delete[] oldValue;
     } else {
-      delete newValue;
+      delete[] newValue;
     }
 
-    delete zero;
-    delete neighbor1;
-    delete neighbor2;
+    delete[] zero;
+    delete[] neighbor1;
+    delete[] neighbor2;
   }
 
  private:


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>


### Description
clear warnings such as
```
/MONAI/monai/csrc/filtering/permutohedral/permutohedral_cpu.cpp:469:7: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
      delete newValue;
      ^
            []
/MONAI/monai/csrc/filtering/permutohedral/permutohedral_cpu.cpp:417:26: note: allocated with 'new[]' here
    scalar_t* newValue = new scalar_t[vd * hashTable.size()];
```

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
