### PR TITLE
3716 enhance doc-strings of DenseNet

### DIFF
--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -148,7 +148,7 @@ class DenseNet(nn.Module):
     """
     Densenet based on: `Densely Connected Convolutional Networks <https://arxiv.org/pdf/1608.06993.pdf>`_.
     Adapted from PyTorch Hub 2D version: https://pytorch.org/vision/stable/models.html#id16.
-    This network is non-determistic When `in_channels` is 3 and CUDA is enabled. Please check the link below
+    This network is non-determistic When `spatial_dims` is 3 and CUDA is enabled. Please check the link below
     for more details:
     https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms
 

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -148,6 +148,9 @@ class DenseNet(nn.Module):
     """
     Densenet based on: `Densely Connected Convolutional Networks <https://arxiv.org/pdf/1608.06993.pdf>`_.
     Adapted from PyTorch Hub 2D version: https://pytorch.org/vision/stable/models.html#id16.
+    This network is non-determistic When `in_channels` is 3 and CUDA is enabled. Please check the link below
+    for more details:
+    https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms
 
     Args:
         spatial_dims: number of spatial dimensions of the input image.


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Related to #3716  .

### Description
In this PR, I enhanced the doc-strings of DenseNet to explain its non-determinism.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
