### PR TITLE
pip mypy

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -29,7 +29,6 @@ dependencies:
   - pyflakes
   - isort
   - types-pkg_resources
-  - mypy>=0.790
   - ninja
   - torchvision
   - psutil
@@ -49,6 +48,8 @@ dependencies:
     - itk>=5.2
     # black currently at v19 on conda vs v21 on pip
     - black
+    # conda mypy v. slow
+    - mypy>=0.790
     # OS-specific needs to be done via pip:
     #   https://github.com/conda/conda/issues/8089
     - pytype>=2020.6.1; platform_system != "Windows"


### PR DESCRIPTION
I've found conda mypy to be very slow (~8min) compared to pip (~1min).

Hence, I propose to only use the pip version, even when installing via conda.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).