### PR TITLE
2823 enhance convert_data/dst_type typing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ jobs:
         which python
         python -m pip install --upgrade pip wheel
         python -m pip uninstall -y torch torchvision
-        python -m pip install torch==1.10.1+cu111 torchvision==0.11.2+cu111 -f https://download.pytorch.org/whl/torch_stable.html
+        python -m pip install --use-deprecated=html5lib torch==1.10.1+cu111 torchvision==0.11.2+cu111 -f https://download.pytorch.org/whl/torch_stable.html
         python -m pip install -r requirements-dev.txt
     - name: Run integration tests
       run: |

--- a/.github/workflows/pythonapp-min.yml
+++ b/.github/workflows/pythonapp-min.yml
@@ -51,7 +51,7 @@ jobs:
     - if: runner.os == 'windows'
       name: Install torch cpu from pytorch.org (Windows only)
       run: |
-        python -m pip install torch==1.10.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+        python -m pip install --use-deprecated=html5lib torch==1.10.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install the dependencies
       run: |
         # min. requirements

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -87,7 +87,7 @@ jobs:
     - if: runner.os == 'windows'
       name: Install torch cpu from pytorch.org (Windows only)
       run: |
-        python -m pip install torch==1.10.1+cpu torchvision==0.11.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
+        python -m pip install --use-deprecated=html5lib torch==1.10.1+cpu torchvision==0.11.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install the dependencies
       run: |
         python -m pip install torch==1.10.1 torchvision==0.11.2

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,7 +7,6 @@ on:
       - dev
       - main
       - releasing/*
-      - enhance-convert-typing
   pull_request:
 
 concurrency:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,6 +7,7 @@ on:
       - dev
       - main
       - releasing/*
+      - enhance-convert-typing
   pull_request:
 
 concurrency:

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -557,6 +557,12 @@ Post-processing
 Spatial
 ^^^^^^^
 
+`SpatialResample`
+"""""""""""""""""
+.. autoclass:: SpatialResample
+    :members:
+    :special-members: __call__
+
 `Spacing`
 """""""""
 .. image:: https://github.com/Project-MONAI/DocImages/raw/main/transforms/Spacing.png
@@ -1397,6 +1403,12 @@ Post-processing (Dict)
 
 Spatial (Dict)
 ^^^^^^^^^^^^^^
+
+`SpatialResampled`
+""""""""""""""""""
+.. autoclass:: SpatialResampled
+    :members:
+    :special-members: __call__
 
 `Spacingd`
 """"""""""

--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -374,7 +374,7 @@ class SpatialCropForegroundd(MapTransform):
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `{key}_{meta_key_postfix}` to to fetch/store the meta data according
+        meta_key_postfix: if meta_keys is None, use `{key}_{meta_key_postfix}` to fetch/store the meta data according
             to the key data, default is `meta_dict`, the meta data is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
@@ -474,7 +474,7 @@ class AddGuidanceFromPointsd(Transform):
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             if None, will try to construct meta_keys by `{ref_image}_{meta_key_postfix}`.
-        meta_key_postfix: if meta_key is None, use `{ref_image}_{meta_key_postfix}` to to fetch the meta data according
+        meta_key_postfix: if meta_key is None, use `{ref_image}_{meta_key_postfix}` to fetch the meta data according
             to the key data, default is `meta_dict`, the meta data is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
@@ -589,7 +589,7 @@ class SpatialCropGuidanced(MapTransform):
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to to fetch the meta data according
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
             to the key data, default is `meta_dict`, the meta data is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
@@ -787,7 +787,7 @@ class RestoreLabeld(MapTransform):
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_key is None, use `key_{meta_key_postfix} to to fetch the meta data according
+        meta_key_postfix: if meta_key is None, use `key_{meta_key_postfix} to fetch the meta data according
             to the key data, default is `meta_dict`, the meta data is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
@@ -897,7 +897,7 @@ class Fetch2DSliced(MapTransform):
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: use `key_{meta_key_postfix}` to to fetch the meta data according to the key data,
+        meta_key_postfix: use `key_{meta_key_postfix}` to fetch the meta data according to the key data,
             default is `meta_dict`, the meta data is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.

--- a/monai/apps/pathology/transforms/spatial/array.py
+++ b/monai/apps/pathology/transforms/spatial/array.py
@@ -190,8 +190,7 @@ class TileOnGrid(Randomizable, Transform):
             self.random_idxs = np.array((0,))
 
     def __call__(self, image: NdarrayOrTensor) -> NdarrayOrTensor:
-        img_np: np.ndarray
-        img_np, *_ = convert_data_type(image, np.ndarray)  # type: ignore
+        img_np, *_ = convert_data_type(image, np.ndarray)
 
         # add random offset
         self.randomize(img_size=img_np.shape)

--- a/monai/config/type_definitions.py
+++ b/monai/config/type_definitions.py
@@ -67,7 +67,7 @@ DtypeLike = Union[np.dtype, type, str, None]
 #
 # Generic type which can represent either a numpy.ndarray or a torch.Tensor
 # Unlike Union can create a dependence between parameter(s) / return(s)
-NdarrayTensor = TypeVar("NdarrayTensor", np.ndarray, torch.Tensor)
+NdarrayTensor = TypeVar("NdarrayTensor", bound=Union[np.ndarray, torch.Tensor])
 
 
 #: NdarrayOrTensor: Union of numpy.ndarray and torch.Tensor to be used for typing

--- a/monai/config/type_definitions.py
+++ b/monai/config/type_definitions.py
@@ -69,7 +69,6 @@ DtypeLike = Union[np.dtype, type, str, None]
 # Unlike Union can create a dependence between parameter(s) / return(s)
 NdarrayTensor = TypeVar("NdarrayTensor", bound=Union[np.ndarray, torch.Tensor])
 
-
 #: NdarrayOrTensor: Union of numpy.ndarray and torch.Tensor to be used for typing
 NdarrayOrTensor = Union[np.ndarray, torch.Tensor]
 

--- a/monai/csrc/ext.cpp
+++ b/monai/csrc/ext.cpp
@@ -31,6 +31,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   py::enum_<monai::BoundType>(m, "BoundType")
       .value("replicate", monai::BoundType::Replicate, "a a a | a b c d | d d d")
       .value("nearest", monai::BoundType::Replicate, "a a a | a b c d | d d d")
+      .value("border", monai::BoundType::Replicate, "a a a | a b c d | d d d")
       .value("dct1", monai::BoundType::DCT1, "d c b | a b c d | c b a")
       .value("mirror", monai::BoundType::DCT1, "d c b | a b c d | c b a")
       .value("dct2", monai::BoundType::DCT2, "c b a | a b c d | d c b")
@@ -43,6 +44,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .value("wrap", monai::BoundType::DFT, "b c d | a b c d | a b c")
       //   .value("sliding", monai::BoundType::Sliding)
       .value("zero", monai::BoundType::Zero, "0 0 0 | a b c d | 0 0 0")
+      .value("zeros", monai::BoundType::Zero, "0 0 0 | a b c d | 0 0 0")
       .export_values();
 
   // resample interpolation mode

--- a/monai/csrc/resample/pushpull_cpu.cpp
+++ b/monai/csrc/resample/pushpull_cpu.cpp
@@ -1527,10 +1527,10 @@ MONAI_NAMESPACE_DEVICE { // cpu
     iy0 = bound::index(bound1, iy0, src_Y);
     iz0 = bound::index(bound2, iz0, src_Z);
 
-    // Offsets into source volume
     offset_t o000, o100, o010, o001, o110, o011, o101, o111;
 
     if (do_pull || do_grad || do_sgrad) {
+      // Offsets into source volume
       o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
       o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
       o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
@@ -1539,18 +1539,20 @@ MONAI_NAMESPACE_DEVICE { // cpu
       o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
       o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
       o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+    } else {
+      // Offsets into 'push' volume
+      o000 = ix0 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o100 = ix1 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o010 = ix0 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o001 = ix0 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o110 = ix1 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o011 = ix0 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+      o101 = ix1 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o111 = ix1 * out_sX + iy1 * out_sY + iz1 * out_sZ;
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_grad) {
-      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
-      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
       scalar_t gx = static_cast<scalar_t>(0);
       scalar_t gy = static_cast<scalar_t>(0);
       scalar_t gz = static_cast<scalar_t>(0);
@@ -1659,14 +1661,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_pull) {
-      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
-      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
       scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
       for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC) {
@@ -1678,14 +1672,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~
     else if (do_sgrad) {
-      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
-      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
       scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
 
@@ -1758,16 +1744,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_count) {
-      // Offsets into 'push' volume
-      o000 = ix0 * out_sX + iy0 * out_sY + iz0 * out_sZ;
-      o100 = ix1 * out_sX + iy0 * out_sY + iz0 * out_sZ;
-      o010 = ix0 * out_sX + iy1 * out_sY + iz0 * out_sZ;
-      o001 = ix0 * out_sX + iy0 * out_sY + iz1 * out_sZ;
-      o110 = ix1 * out_sX + iy1 * out_sY + iz0 * out_sZ;
-      o011 = ix0 * out_sX + iy1 * out_sY + iz1 * out_sZ;
-      o101 = ix1 * out_sX + iy0 * out_sY + iz1 * out_sZ;
-      o111 = ix1 * out_sX + iy1 * out_sY + iz1 * out_sZ;
-
       scalar_t* out_ptr_N = out_ptr + n * out_sN;
       bound::add(out_ptr_N, o000, w000, s000);
       bound::add(out_ptr_N, o100, w100, s100);
@@ -1822,21 +1798,23 @@ MONAI_NAMESPACE_DEVICE { // cpu
     ix0 = bound::index(bound0, ix0, src_X);
     iy0 = bound::index(bound1, iy0, src_Y);
 
-    // Offsets into source volume
     offset_t o00, o10, o01, o11;
     if (do_pull || do_grad || do_sgrad) {
+      // Offsets into source volume
       o00 = ix0 * src_sX + iy0 * src_sY;
       o10 = ix1 * src_sX + iy0 * src_sY;
       o01 = ix0 * src_sX + iy1 * src_sY;
       o11 = ix1 * src_sX + iy1 * src_sY;
+    } else {
+      // Offsets into 'push' volume
+      o00 = ix0 * out_sX + iy0 * out_sY;
+      o10 = ix1 * out_sX + iy0 * out_sY;
+      o01 = ix0 * out_sX + iy1 * out_sY;
+      o11 = ix1 * out_sX + iy1 * out_sY;
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_grad) {
-      o00 = ix0 * src_sX + iy0 * src_sY;
-      o10 = ix1 * src_sX + iy0 * src_sY;
-      o01 = ix0 * src_sX + iy1 * src_sY;
-      o11 = ix1 * src_sX + iy1 * src_sY;
       scalar_t gx = static_cast<scalar_t>(0);
       scalar_t gy = static_cast<scalar_t>(0);
       scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
@@ -1895,10 +1873,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_pull) {
-      o00 = ix0 * src_sX + iy0 * src_sY;
-      o10 = ix1 * src_sX + iy0 * src_sY;
-      o01 = ix0 * src_sX + iy1 * src_sY;
-      o11 = ix1 * src_sX + iy1 * src_sY;
       scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
       for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC) {
@@ -1908,10 +1882,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_sgrad) {
-      o00 = ix0 * src_sX + iy0 * src_sY;
-      o10 = ix1 * src_sX + iy0 * src_sY;
-      o01 = ix0 * src_sX + iy1 * src_sY;
-      o11 = ix1 * src_sX + iy1 * src_sY;
       scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
 
@@ -1926,11 +1896,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_push) {
-      // Offsets into 'push' volume
-      o00 = ix0 * out_sX + iy0 * out_sY;
-      o10 = ix1 * out_sX + iy0 * out_sY;
-      o01 = ix0 * out_sX + iy1 * out_sY;
-      o11 = ix1 * out_sX + iy1 * out_sY;
       scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
       scalar_t* out_ptr_NC = out_ptr + n * out_sN;
       if (trgt_K == 0) {
@@ -1960,12 +1925,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_count) {
-      // Offsets into 'push' volume
-      o00 = ix0 * out_sX + iy0 * out_sY;
-      o10 = ix1 * out_sX + iy0 * out_sY;
-      o01 = ix0 * out_sX + iy1 * out_sY;
-      o11 = ix1 * out_sX + iy1 * out_sY;
-
       scalar_t* out_ptr_N = out_ptr + n * out_sN;
       bound::add(out_ptr_N, o00, w00, s00);
       bound::add(out_ptr_N, o10, w10, s10);
@@ -1996,20 +1955,21 @@ MONAI_NAMESPACE_DEVICE { // cpu
     ix1 = bound::index(bound0, ix0 + 1, src_X);
     ix0 = bound::index(bound0, ix0, src_X);
 
-    // Offsets into source volume
     offset_t o0, o1;
     if (do_pull || do_grad || do_sgrad) {
+      // Offsets into source volume
       o0 = ix0 * src_sX;
       o1 = ix1 * src_sX;
+    } else {
+      // Offsets into 'push' volume
+      o0 = ix0 * out_sX;
+      o1 = ix1 * out_sX;
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_grad) {
       if (trgt_K == 0) {
         // backward w.r.t. push/pull
-
-        o0 = ix0 * src_sX;
-        o1 = ix1 * src_sX;
         scalar_t gx = static_cast<scalar_t>(0);
         scalar_t* trgt_ptr_NCX = trgt_ptr + n * trgt_sN + w * trgt_sX;
         scalar_t* src_ptr_NC = src_ptr + n * src_sN;
@@ -2037,8 +1997,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_pull) {
-      o0 = ix0 * src_sX;
-      o1 = ix1 * src_sX;
       scalar_t* out_ptr_NCX = out_ptr + n * out_sN + w * out_sX;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
       for (offset_t c = 0; c < C; ++c, out_ptr_NCX += out_sC, src_ptr_NC += src_sC) {
@@ -2047,8 +2005,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_sgrad) {
-      o0 = ix0 * src_sX;
-      o1 = ix1 * src_sX;
       scalar_t* out_ptr_NCX = out_ptr + n * out_sN + w * out_sX;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
 
@@ -2058,9 +2014,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_push) {
-      // Offsets into 'push' volume
-      o0 = ix0 * out_sX;
-      o1 = ix1 * out_sX;
       scalar_t* trgt_ptr_NCX = trgt_ptr + n * trgt_sN + w * trgt_sX;
       scalar_t* out_ptr_NC = out_ptr + n * out_sN;
       if (trgt_K == 0) {
@@ -2081,10 +2034,6 @@ MONAI_NAMESPACE_DEVICE { // cpu
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_count) {
-      // Offsets into 'push' volume
-      o0 = ix0 * out_sX;
-      o1 = ix1 * out_sX;
-
       scalar_t* out_ptr_N = out_ptr + n * out_sN;
       bound::add(out_ptr_N, o0, w0, s0);
       bound::add(out_ptr_N, o1, w1, s1);

--- a/monai/csrc/resample/pushpull_cuda.cu
+++ b/monai/csrc/resample/pushpull_cuda.cu
@@ -1491,10 +1491,10 @@ MONAI_NAMESPACE_DEVICE { // cuda
     iy0 = bound::index(bound1, iy0, src_Y);
     iz0 = bound::index(bound2, iz0, src_Z);
 
-    // Offsets into source volume
     offset_t o000, o100, o010, o001, o110, o011, o101, o111;
 
     if (do_pull || do_grad || do_sgrad) {
+      // Offsets into source volume
       o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
       o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
       o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
@@ -1503,18 +1503,20 @@ MONAI_NAMESPACE_DEVICE { // cuda
       o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
       o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
       o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
+    } else {
+      // Offsets into 'push' volume
+      o000 = ix0 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o100 = ix1 * out_sX + iy0 * out_sY + iz0 * out_sZ;
+      o010 = ix0 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o001 = ix0 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o110 = ix1 * out_sX + iy1 * out_sY + iz0 * out_sZ;
+      o011 = ix0 * out_sX + iy1 * out_sY + iz1 * out_sZ;
+      o101 = ix1 * out_sX + iy0 * out_sY + iz1 * out_sZ;
+      o111 = ix1 * out_sX + iy1 * out_sY + iz1 * out_sZ;
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_grad) {
-      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
-      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
       scalar_t gx = static_cast<scalar_t>(0);
       scalar_t gy = static_cast<scalar_t>(0);
       scalar_t gz = static_cast<scalar_t>(0);
@@ -1623,14 +1625,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_pull) {
-      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
-      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
       scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
       for (offset_t c = 0; c < C; ++c, out_ptr_NCXYZ += out_sC, src_ptr_NC += src_sC) {
@@ -1642,14 +1636,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~
     else if (do_sgrad) {
-      o000 = ix0 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o100 = ix1 * src_sX + iy0 * src_sY + iz0 * src_sZ;
-      o010 = ix0 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o001 = ix0 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o110 = ix1 * src_sX + iy1 * src_sY + iz0 * src_sZ;
-      o011 = ix0 * src_sX + iy1 * src_sY + iz1 * src_sZ;
-      o101 = ix1 * src_sX + iy0 * src_sY + iz1 * src_sZ;
-      o111 = ix1 * src_sX + iy1 * src_sY + iz1 * src_sZ;
       scalar_t* out_ptr_NCXYZ = out_ptr + n * out_sN + w * out_sX + h * out_sY + d * out_sZ;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
 
@@ -1672,15 +1658,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_push) {
-      // Offsets into 'push' volume
-      o000 = ix0 * out_sX + iy0 * out_sY + iz0 * out_sZ;
-      o100 = ix1 * out_sX + iy0 * out_sY + iz0 * out_sZ;
-      o010 = ix0 * out_sX + iy1 * out_sY + iz0 * out_sZ;
-      o001 = ix0 * out_sX + iy0 * out_sY + iz1 * out_sZ;
-      o110 = ix1 * out_sX + iy1 * out_sY + iz0 * out_sZ;
-      o011 = ix0 * out_sX + iy1 * out_sY + iz1 * out_sZ;
-      o101 = ix1 * out_sX + iy0 * out_sY + iz1 * out_sZ;
-      o111 = ix1 * out_sX + iy1 * out_sY + iz1 * out_sZ;
       scalar_t* trgt_ptr_NCXYZ = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY + d * trgt_sZ;
       scalar_t* out_ptr_NC = out_ptr + n * out_sN;
       if (trgt_K == 0) {
@@ -1722,16 +1699,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_count) {
-      // Offsets into 'push' volume
-      o000 = ix0 * out_sX + iy0 * out_sY + iz0 * out_sZ;
-      o100 = ix1 * out_sX + iy0 * out_sY + iz0 * out_sZ;
-      o010 = ix0 * out_sX + iy1 * out_sY + iz0 * out_sZ;
-      o001 = ix0 * out_sX + iy0 * out_sY + iz1 * out_sZ;
-      o110 = ix1 * out_sX + iy1 * out_sY + iz0 * out_sZ;
-      o011 = ix0 * out_sX + iy1 * out_sY + iz1 * out_sZ;
-      o101 = ix1 * out_sX + iy0 * out_sY + iz1 * out_sZ;
-      o111 = ix1 * out_sX + iy1 * out_sY + iz1 * out_sZ;
-
       scalar_t* out_ptr_N = out_ptr + n * out_sN;
       bound::add(out_ptr_N, o000, w000, s000);
       bound::add(out_ptr_N, o100, w100, s100);
@@ -1786,21 +1753,23 @@ MONAI_NAMESPACE_DEVICE { // cuda
     ix0 = bound::index(bound0, ix0, src_X);
     iy0 = bound::index(bound1, iy0, src_Y);
 
-    // Offsets into source volume
     offset_t o00, o10, o01, o11;
     if (do_pull || do_grad || do_sgrad) {
+      // Offsets into source volume
       o00 = ix0 * src_sX + iy0 * src_sY;
       o10 = ix1 * src_sX + iy0 * src_sY;
       o01 = ix0 * src_sX + iy1 * src_sY;
       o11 = ix1 * src_sX + iy1 * src_sY;
+    } else {
+      // Offsets into 'push' volume
+      o00 = ix0 * out_sX + iy0 * out_sY;
+      o10 = ix1 * out_sX + iy0 * out_sY;
+      o01 = ix0 * out_sX + iy1 * out_sY;
+      o11 = ix1 * out_sX + iy1 * out_sY;
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_grad) {
-      o00 = ix0 * src_sX + iy0 * src_sY;
-      o10 = ix1 * src_sX + iy0 * src_sY;
-      o01 = ix0 * src_sX + iy1 * src_sY;
-      o11 = ix1 * src_sX + iy1 * src_sY;
       scalar_t gx = static_cast<scalar_t>(0);
       scalar_t gy = static_cast<scalar_t>(0);
       scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
@@ -1859,10 +1828,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_pull) {
-      o00 = ix0 * src_sX + iy0 * src_sY;
-      o10 = ix1 * src_sX + iy0 * src_sY;
-      o01 = ix0 * src_sX + iy1 * src_sY;
-      o11 = ix1 * src_sX + iy1 * src_sY;
       scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
       for (offset_t c = 0; c < C; ++c, out_ptr_NCXY += out_sC, src_ptr_NC += src_sC) {
@@ -1872,10 +1837,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_sgrad) {
-      o00 = ix0 * src_sX + iy0 * src_sY;
-      o10 = ix1 * src_sX + iy0 * src_sY;
-      o01 = ix0 * src_sX + iy1 * src_sY;
-      o11 = ix1 * src_sX + iy1 * src_sY;
       scalar_t* out_ptr_NCXY = out_ptr + n * out_sN + w * out_sX + h * out_sY;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
 
@@ -1890,11 +1851,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_push) {
-      // Offsets into 'push' volume
-      o00 = ix0 * out_sX + iy0 * out_sY;
-      o10 = ix1 * out_sX + iy0 * out_sY;
-      o01 = ix0 * out_sX + iy1 * out_sY;
-      o11 = ix1 * out_sX + iy1 * out_sY;
       scalar_t* trgt_ptr_NCXY = trgt_ptr + n * trgt_sN + w * trgt_sX + h * trgt_sY;
       scalar_t* out_ptr_NC = out_ptr + n * out_sN;
       if (trgt_K == 0) {
@@ -1924,12 +1880,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_count) {
-      // Offsets into 'push' volume
-      o00 = ix0 * out_sX + iy0 * out_sY;
-      o10 = ix1 * out_sX + iy0 * out_sY;
-      o01 = ix0 * out_sX + iy1 * out_sY;
-      o11 = ix1 * out_sX + iy1 * out_sY;
-
       scalar_t* out_ptr_N = out_ptr + n * out_sN;
       bound::add(out_ptr_N, o00, w00, s00);
       bound::add(out_ptr_N, o10, w10, s10);
@@ -1965,15 +1915,16 @@ MONAI_NAMESPACE_DEVICE { // cuda
     if (do_pull || do_grad || do_sgrad) {
       o0 = ix0 * src_sX;
       o1 = ix1 * src_sX;
+    } else {
+      // Offsets into 'push' volume
+      o0 = ix0 * out_sX;
+      o1 = ix1 * out_sX;
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~ Grid gradient ~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_grad) {
       if (trgt_K == 0) {
         // backward w.r.t. push/pull
-
-        o0 = ix0 * src_sX;
-        o1 = ix1 * src_sX;
         scalar_t gx = static_cast<scalar_t>(0);
         scalar_t* trgt_ptr_NCX = trgt_ptr + n * trgt_sN + w * trgt_sX;
         scalar_t* src_ptr_NC = src_ptr + n * src_sN;
@@ -2001,8 +1952,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Pull ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     if (do_pull) {
-      o0 = ix0 * src_sX;
-      o1 = ix1 * src_sX;
       scalar_t* out_ptr_NCX = out_ptr + n * out_sN + w * out_sX;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
       for (offset_t c = 0; c < C; ++c, out_ptr_NCX += out_sC, src_ptr_NC += src_sC) {
@@ -2011,8 +1960,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SGrad ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_sgrad) {
-      o0 = ix0 * src_sX;
-      o1 = ix1 * src_sX;
       scalar_t* out_ptr_NCX = out_ptr + n * out_sN + w * out_sX;
       scalar_t* src_ptr_NC = src_ptr + n * src_sN;
 
@@ -2022,9 +1969,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_push) {
-      // Offsets into 'push' volume
-      o0 = ix0 * out_sX;
-      o1 = ix1 * out_sX;
       scalar_t* trgt_ptr_NCX = trgt_ptr + n * trgt_sN + w * trgt_sX;
       scalar_t* out_ptr_NC = out_ptr + n * out_sN;
       if (trgt_K == 0) {
@@ -2045,10 +1989,6 @@ MONAI_NAMESPACE_DEVICE { // cuda
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Push ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     else if (do_count) {
-      // Offsets into 'push' volume
-      o0 = ix0 * out_sX;
-      o1 = ix1 * out_sX;
-
       scalar_t* out_ptr_N = out_ptr + n * out_sN;
       bound::add(out_ptr_N, o0, w0, s0);
       bound::add(out_ptr_N, o1, w1, s1);

--- a/monai/data/test_time_augmentation.py
+++ b/monai/data/test_time_augmentation.py
@@ -75,7 +75,7 @@ class TestTimeAugmentation:
         orig_meta_keys: the key of the meta data of original input data, will get the `affine`, `data_shape`, etc.
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             if None, will try to construct meta_keys by `{orig_key}_{meta_key_postfix}`.
-        meta_key_postfix: use `key_{postfix}` to to fetch the meta data according to the key data,
+        meta_key_postfix: use `key_{postfix}` to fetch the meta data according to the key data,
             default is `meta_dict`, the meta data is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -715,11 +715,14 @@ def to_affine_nd(r: Union[np.ndarray, int], affine, dtype=np.float64) -> np.ndar
         r (int or matrix): number of spatial dimensions or an output affine to be filled.
         affine (matrix): 2D affine matrix
         dtype: data type of the output array.
+
     Raises:
         ValueError: When ``affine`` dimensions is not 2.
         ValueError: When ``r`` is nonpositive.
+
     Returns:
         an (r+1) x (r+1) matrix
+
     """
     affine_np: np.ndarray
     affine_np = convert_data_type(affine, output_type=np.ndarray, dtype=dtype, wrap_sequence=True)[0]  # type: ignore

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -27,7 +27,7 @@ import numpy as np
 import torch
 from torch.utils.data._utils.collate import default_collate
 
-from monai.config.type_definitions import NdarrayOrTensor, PathLike
+from monai.config.type_definitions import NdarrayOrTensor, NdarrayTensor, PathLike
 from monai.networks.layers.simplelayers import GaussianFilter
 from monai.utils import (
     MAX_SEED,
@@ -676,8 +676,8 @@ def compute_shape_offset(
     """
     shape = np.array(spatial_shape, copy=True, dtype=float)
     sr = len(shape)
-    in_affine_: np.ndarray = convert_data_type(to_affine_nd(sr, in_affine), np.ndarray)[0]
-    out_affine_: np.ndarray = convert_data_type(to_affine_nd(sr, out_affine), np.ndarray)[0]
+    in_affine_ = convert_data_type(to_affine_nd(sr, in_affine), np.ndarray)[0]
+    out_affine_ = convert_data_type(to_affine_nd(sr, out_affine), np.ndarray)[0]
     in_coords = [(0.0, dim - 1.0) for dim in shape]
     corners: np.ndarray = np.asarray(np.meshgrid(*in_coords, indexing="ij")).reshape((len(shape), -1))
     corners = np.concatenate((corners, np.ones_like(corners[:1])))
@@ -700,7 +700,7 @@ def compute_shape_offset(
     return out_shape.astype(int, copy=False), offset
 
 
-def to_affine_nd(r: Union[np.ndarray, int], affine: NdarrayOrTensor, dtype=np.float64) -> NdarrayOrTensor:
+def to_affine_nd(r: Union[np.ndarray, int], affine: NdarrayTensor, dtype=np.float64) -> NdarrayTensor:
     """
     Using elements from affine, to create a new affine matrix by
     assigning the rotation/zoom/scaling matrix and the translation vector.
@@ -742,8 +742,8 @@ def to_affine_nd(r: Union[np.ndarray, int], affine: NdarrayOrTensor, dtype=np.fl
     new_affine[:d, :d] = affine_np[:d, :d]
     if d > 1:
         new_affine[:d, -1] = affine_np[:d, -1]
-    new_affine, *_ = convert_to_dst_type(new_affine, affine, dtype=dtype)  # type: ignore
-    return new_affine
+    output, *_ = convert_to_dst_type(new_affine, affine, dtype=dtype)
+    return output
 
 
 def reorient_spatial_axes(

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -676,16 +676,16 @@ def compute_shape_offset(
     """
     shape = np.array(spatial_shape, copy=True, dtype=float)
     sr = len(shape)
-    in_affine = convert_data_type(to_affine_nd(sr, in_affine), np.ndarray)[0]  # type: ignore
-    out_affine = convert_data_type(to_affine_nd(sr, out_affine), np.ndarray)[0]  # type: ignore
+    in_affine_: np.ndarray = convert_data_type(to_affine_nd(sr, in_affine), np.ndarray)[0]
+    out_affine_: np.ndarray = convert_data_type(to_affine_nd(sr, out_affine), np.ndarray)[0]
     in_coords = [(0.0, dim - 1.0) for dim in shape]
     corners: np.ndarray = np.asarray(np.meshgrid(*in_coords, indexing="ij")).reshape((len(shape), -1))
     corners = np.concatenate((corners, np.ones_like(corners[:1])))
-    corners = in_affine @ corners  # type: ignore
+    corners = in_affine_ @ corners  # type: ignore
     try:
-        inv_mat = np.linalg.inv(out_affine)
+        inv_mat = np.linalg.inv(out_affine_)
     except np.linalg.LinAlgError as e:
-        raise ValueError(f"Affine {out_affine} is not invertible") from e
+        raise ValueError(f"Affine {out_affine_} is not invertible") from e
     corners_out = inv_mat @ corners
     corners_out = corners_out[:-1] / corners_out[-1]
     out_shape = np.round(corners_out.ptp(axis=1) + 1.0)
@@ -728,8 +728,7 @@ def to_affine_nd(r: Union[np.ndarray, int], affine: NdarrayOrTensor, dtype=np.fl
         an (r+1) x (r+1) matrix (tensor or ndarray depends on the input ``affine`` data type)
 
     """
-    affine_np: np.ndarray
-    affine_np = convert_data_type(affine, output_type=np.ndarray, dtype=dtype, wrap_sequence=True)[0]  # type: ignore
+    affine_np = convert_data_type(affine, output_type=np.ndarray, dtype=dtype, wrap_sequence=True)[0]
     affine_np = affine_np.copy()
     if affine_np.ndim != 2:
         raise ValueError(f"affine must have 2 dimensions, got {affine_np.ndim}.")

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -27,7 +27,7 @@ import numpy as np
 import torch
 from torch.utils.data._utils.collate import default_collate
 
-from monai.config.type_definitions import PathLike
+from monai.config.type_definitions import NdarrayOrTensor, PathLike
 from monai.networks.layers.simplelayers import GaussianFilter
 from monai.utils import (
     MAX_SEED,
@@ -740,7 +740,7 @@ def to_affine_nd(r: Union[np.ndarray, int], affine, dtype=np.float64) -> np.ndar
 
 
 def reorient_spatial_axes(
-    data_shape: Sequence[int], init_affine: np.ndarray, target_affine: np.ndarray
+    data_shape: Sequence[int], init_affine: NdarrayOrTensor, target_affine: NdarrayOrTensor
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
     Given the input ``data_array`` and its corresponding coordinate ``init_affine``,
@@ -748,10 +748,12 @@ def reorient_spatial_axes(
     Returns the transformed array and the updated affine.
     Note that this function requires external module ``nibabel.orientations``.
     """
-    start_ornt = nib.orientations.io_orientation(init_affine)
-    target_ornt = nib.orientations.io_orientation(target_affine)
+    init_affine_, *_ = convert_data_type(init_affine, np.ndarray)
+    target_affine_, *_ = convert_data_type(target_affine, np.ndarray)
+    start_ornt = nib.orientations.io_orientation(init_affine_)
+    target_ornt = nib.orientations.io_orientation(target_affine_)
     ornt_transform = nib.orientations.ornt_transform(start_ornt, target_ornt)
-    new_affine = init_affine @ nib.orientations.inv_ornt_aff(ornt_transform, data_shape)
+    new_affine = init_affine_ @ nib.orientations.inv_ornt_aff(ornt_transform, data_shape)
     return ornt_transform, new_affine
 
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -700,14 +700,17 @@ def to_affine_nd(r: Union[np.ndarray, int], affine, dtype=np.float64) -> np.ndar
     """
     Using elements from affine, to create a new affine matrix by
     assigning the rotation/zoom/scaling matrix and the translation vector.
-    when ``r`` is an integer, output is an (r+1)x(r+1) matrix,
+
+    When ``r`` is an integer, output is an (r+1)x(r+1) matrix,
     where the top left kxk elements are copied from ``affine``,
     the last column of the output affine is copied from ``affine``'s last column.
     `k` is determined by `min(r, len(affine) - 1)`.
-    when ``r`` is an affine matrix, the output has the same shape as ``r``,
+
+    When ``r`` is an affine matrix, the output has the same shape as ``r``,
     and the top left kxk elements are copied from ``affine``,
     the last column of the output affine is copied from ``affine``'s last column.
     `k` is determined by `min(len(r) - 1, len(affine) - 1)`.
+
     Args:
         r (int or matrix): number of spatial dimensions or an output affine to be filled.
         affine (matrix): 2D affine matrix

--- a/monai/metrics/metric.py
+++ b/monai/metrics/metric.py
@@ -201,8 +201,7 @@ class Cumulative:
             self._buffers = [[] for _ in data]
         for b, d in zip(self._buffers, data):
             # converting to pytorch tensors so that we can use the distributed API
-            d_t: torch.Tensor
-            d_t, *_ = convert_data_type(d, output_type=torch.Tensor, wrap_sequence=True)  # type: ignore
+            d_t, *_ = convert_data_type(d, output_type=torch.Tensor, wrap_sequence=True)
             try:
                 b.extend([x[0] for x in torch.split(d_t, 1, dim=0)])
             except (AttributeError, IndexError, RuntimeError) as e:
@@ -228,8 +227,7 @@ class Cumulative:
             self._buffers = [[] for _ in data]
         for b, d in zip(self._buffers, data):
             # converting to pytorch tensors so that we can use the distributed API
-            d_t: torch.Tensor
-            d_t, *_ = convert_data_type(d, output_type=torch.Tensor, wrap_sequence=True)  # type: ignore
+            d_t, *_ = convert_data_type(d, output_type=torch.Tensor, wrap_sequence=True)
             b.append(d_t)
         self._synced = False
 

--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -116,7 +116,7 @@ def get_mask_edges(
     The input images can be binary or labelfield images. If labelfield images
     are supplied, they are converted to binary images using `label_idx`.
 
-    `scipy`'s binary erosion is used to to calculate the edges of the binary
+    `scipy`'s binary erosion is used to calculate the edges of the binary
     labelfield.
 
     In order to improve the computing efficiency, before getting the edges,

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -70,13 +70,13 @@ def grid_pull(
     `bound` can be an int, a string or a BoundType.
     Possible values are::
 
-        - 0 or 'replicate' or 'nearest'      or BoundType.replicate
+        - 0 or 'replicate' or 'nearest'      or BoundType.replicate or 'border'
         - 1 or 'dct1'      or 'mirror'       or BoundType.dct1
         - 2 or 'dct2'      or 'reflect'      or BoundType.dct2
         - 3 or 'dst1'      or 'antimirror'   or BoundType.dst1
         - 4 or 'dst2'      or 'antireflect'  or BoundType.dst2
         - 5 or 'dft'       or 'wrap'         or BoundType.dft
-        - 7 or 'zero'                        or BoundType.zero
+        - 7 or 'zero'      or 'zeros'        or BoundType.zero
 
     A list of values can be provided, in the order [W, H, D],
     to specify dimension-specific boundary conditions.

--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -556,6 +556,7 @@ from .utils import (
     zero_margins,
 )
 from .utils_pytorch_numpy_unification import (
+    allclose,
     any_np_pt,
     ascontiguousarray,
     clip,

--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -306,6 +306,7 @@ from .spatial.array import (
     Rotate,
     Rotate90,
     Spacing,
+    SpatialResample,
     Zoom,
 )
 from .spatial.dictionary import (
@@ -360,6 +361,9 @@ from .spatial.dictionary import (
     Spacingd,
     SpacingD,
     SpacingDict,
+    SpatialResampled,
+    SpatialResampleD,
+    SpatialResampleDict,
     Zoomd,
     ZoomD,
     ZoomDict,

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -400,7 +400,7 @@ class SpatialCrop(Transform):
             else:
                 if roi_start is None or roi_end is None:
                     raise ValueError("Please specify either roi_center, roi_size or roi_start, roi_end.")
-                roi_start_torch, *_ = convert_data_type(  # type: ignore
+                roi_start_torch, *_ = convert_data_type(
                     data=roi_start, output_type=torch.Tensor, dtype=torch.int16, wrap_sequence=True
                 )
                 roi_start_torch = maximum(roi_start_torch, torch.zeros_like(roi_start_torch))  # type: ignore

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -735,7 +735,7 @@ class RandSpatialCropSamplesd(Randomizable, MapTransform, InvertibleTransform):
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to to fetch the meta data according
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
             to the key data, default is `meta_dict`, the meta data is a dictionary object.
             used to add `patch_index` to the meta dict.
         allow_missing_keys: don't raise exception if key is missing.
@@ -933,7 +933,7 @@ class RandWeightedCropd(Randomizable, MapTransform, InvertibleTransform):
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to to fetch the meta data according
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
             to the key data, default is `meta_dict`, the meta data is a dictionary object.
             used to add `patch_index` to the meta dict.
         allow_missing_keys: don't raise exception if key is missing.
@@ -1075,7 +1075,7 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform, InvertibleTransform):
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to to fetch the meta data according
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
             to the key data, default is `meta_dict`, the meta data is a dictionary object.
             used to add `patch_index` to the meta dict.
         allow_smaller: if `False`, an exception will be raised if the image is smaller than
@@ -1279,7 +1279,7 @@ class RandCropByLabelClassesd(Randomizable, MapTransform, InvertibleTransform):
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to to fetch the meta data according
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
             to the key data, default is `meta_dict`, the meta data is a dictionary object.
             used to add `patch_index` to the meta dict.
         allow_smaller: if `False`, an exception will be raised if the image is smaller than

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1115,8 +1115,7 @@ class DetectEnvelope(Transform):
             np.ndarray containing envelope of data in img along the specified axis.
 
         """
-        img_t: torch.Tensor
-        img_t, *_ = convert_data_type(img, torch.Tensor)  # type: ignore
+        img_t, *_ = convert_data_type(img, torch.Tensor)
         # add one to transform axis because a batch axis will be added at dimension 0
         hilbert_transform = HilbertTransform(self.axis + 1, self.n)
         # convert to Tensor and add Batch axis expected by HilbertTransform
@@ -1255,8 +1254,7 @@ class GaussianSharpen(Transform):
         self.approx = approx
 
     def __call__(self, img: NdarrayTensor) -> NdarrayTensor:
-        img_t: torch.Tensor
-        img_t, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float32)  # type: ignore
+        img_t, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float32)
 
         gf1, gf2 = (
             GaussianFilter(img_t.ndim - 1, sigma, approx=self.approx).to(img_t.device)
@@ -1401,8 +1399,7 @@ class RandHistogramShift(RandomizableTransform):
 
         if self.reference_control_points is None or self.floating_control_points is None:
             raise RuntimeError("please call the `randomize()` function first.")
-        img_np: np.ndarray
-        img_np, *_ = convert_data_type(img, np.ndarray)  # type: ignore
+        img_np, *_ = convert_data_type(img, np.ndarray)
         img_min, img_max = img_np.min(), img_np.max()
         reference_control_points_scaled = self.reference_control_points * (img_max - img_min) + img_min
         floating_control_points_scaled = self.floating_control_points * (img_max - img_min) + img_min
@@ -1891,8 +1888,7 @@ class RandCoarseTransform(RandomizableTransform):
         if not self._do_transform:
             return img
 
-        img_np: np.ndarray
-        img_np, *_ = convert_data_type(img, np.ndarray)  # type: ignore
+        img_np, *_ = convert_data_type(img, np.ndarray)
         out = self._transform_holes(img=img_np)
         ret, *_ = convert_to_dst_type(src=out, dst=img)
         return ret
@@ -2047,12 +2043,11 @@ class HistogramNormalize(Transform):
         self.dtype = dtype
 
     def __call__(self, img: NdarrayOrTensor, mask: Optional[NdarrayOrTensor] = None) -> NdarrayOrTensor:
-        img_np: np.ndarray
-        img_np, *_ = convert_data_type(img, np.ndarray)  # type: ignore
+        img_np, *_ = convert_data_type(img, np.ndarray)
         mask = mask if mask is not None else self.mask
         mask_np: Optional[np.ndarray] = None
         if mask is not None:
-            mask_np, *_ = convert_data_type(mask, np.ndarray)  # type: ignore
+            mask_np, *_ = convert_data_type(mask, np.ndarray)
 
         ret = equalize_hist(img=img_np, mask=mask_np, num_bins=self.num_bins, min=self.min, max=self.max)
         out, *_ = convert_to_dst_type(src=ret, dst=img, dtype=self.dtype or img.dtype)

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -307,7 +307,7 @@ class ShiftIntensityd(MapTransform):
                 the meta data is a dictionary object which contains: filename, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to to fetch the meta data according
+            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
                 to the key data, default is `meta_dict`, the meta data is a dictionary object.
                 used to extract the factor value is `factor_key` is not None.
             allow_missing_keys: don't raise exception if key is missing.
@@ -366,7 +366,7 @@ class RandShiftIntensityd(RandomizableTransform, MapTransform):
                 the meta data is a dictionary object which contains: filename, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to to fetch the meta data according
+            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
                 to the key data, default is `meta_dict`, the meta data is a dictionary object.
                 used to extract the factor value is `factor_key` is not None.
             prob: probability of rotating.

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -95,8 +95,7 @@ class Activations(Transform):
             raise TypeError(f"other must be None or callable but is {type(other).__name__}.")
 
         # convert to float as activation must operate on float tensor
-        img_t: torch.Tensor
-        img_t, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float)  # type: ignore
+        img_t, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float)
         if sigmoid or self.sigmoid:
             img_t = torch.sigmoid(img_t)
         if softmax or self.softmax:
@@ -232,8 +231,7 @@ class AsDiscrete(Transform):
             warnings.warn("`threshold_values=True/False` is deprecated, please use `threshold=value` instead.")
             threshold = logit_thresh if threshold else None
 
-        img_t: torch.Tensor
-        img_t, *_ = convert_data_type(img, torch.Tensor)  # type: ignore
+        img_t, *_ = convert_data_type(img, torch.Tensor)
         if argmax or self.argmax:
             img_t = torch.argmax(img_t, dim=0, keepdim=True)
 
@@ -496,8 +494,7 @@ class FillHoles(Transform):
         """
         if not isinstance(img, (np.ndarray, torch.Tensor)):
             raise NotImplementedError(f"{self.__class__} can not handle data of type {type(img)}.")
-        img_np: np.ndarray
-        img_np, *_ = convert_data_type(img, np.ndarray)  # type: ignore
+        img_np, *_ = convert_data_type(img, np.ndarray)
         out_np: np.ndarray = fill_holes(img_np, self.applied_labels, self.connectivity)
         out, *_ = convert_to_dst_type(out_np, img)
         return out
@@ -539,7 +536,7 @@ class LabelToContour(Transform):
                    ideally the edge should be thin enough, but now it has a thickness.
 
         """
-        img_: torch.Tensor = convert_data_type(img, torch.Tensor)[0]  # type: ignore
+        img_: torch.Tensor = convert_data_type(img, torch.Tensor)[0]
         spatial_dims = len(img_.shape) - 1
         img_ = img_.unsqueeze(0)  # adds a batch dim
         if spatial_dims == 2:

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -571,7 +571,7 @@ class Invertd(MapTransform):
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `{orig_key}_{meta_key_postfix}`.
                 meta data will also be inverted and stored in `meta_keys`.
-            meta_key_postfix: if `orig_meta_keys` is None, use `{orig_key}_{meta_key_postfix}` to to fetch the
+            meta_key_postfix: if `orig_meta_keys` is None, use `{orig_key}_{meta_key_postfix}` to fetch the
                 meta data from dict, if `meta_keys` is None, use `{key}_{meta_key_postfix}`.
                 default is `meta_dict`, the meta data is a dictionary object.
                 For example, to handle orig_key `image`,  read/write `affine` matrices from the

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -231,12 +231,12 @@ class SpatialResample(Transform):
             xform_shape = [-1] + in_spatial_size
             img_ = img_.reshape(xform_shape)
         if align_corners:
-            _t_r = torch.diag(torch.ones(len(xform), dtype=xform.dtype, device=xform.device))
+            _t_r = torch.diag(torch.ones(len(xform), dtype=xform.dtype, device=xform.device))  # type: ignore
             for idx, d_dst in enumerate(spatial_size[:spatial_rank]):
                 _t_r[idx, -1] = (max(d_dst, 2) - 1.0) / 2.0
             xform = xform @ _t_r
             if not USE_COMPILED:
-                _t_l = normalize_transform(in_spatial_size, xform.device, xform.dtype, align_corners=True)
+                _t_l = normalize_transform(in_spatial_size, xform.device, xform.dtype, align_corners=True)  # type: ignore
                 xform = _t_l @ xform  # type: ignore
             affine_xform = Affine(
                 affine=xform, spatial_size=spatial_size, norm_coords=False, image_only=True, dtype=_dtype

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -191,7 +191,10 @@ class SpatialResample(Transform):
                 output_data, *_ = convert_to_dst_type(img_, img, dtype=torch.float32)
                 return output_data, dst
 
-        xform = np.linalg.inv(src) @ dst
+        try:
+            xform = np.linalg.inv(src) @ dst
+        except np.linalg.LinAlgError as e:
+            raise ValueError(f"src affine is not invertible: {src}") from e
         xform = to_affine_nd(spatial_rank, xform)
         # no resampling if it's identity transform
         if np.allclose(xform, np.diag(np.ones(len(xform))), atol=AFFINE_TOL):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -34,6 +34,7 @@ from monai.transforms.utils import (
     create_translate,
     map_spatial_axes,
 )
+from monai.transforms.utils_pytorch_numpy_unification import moveaxis
 from monai.utils import (
     GridSampleMode,
     GridSamplePadMode,
@@ -1575,9 +1576,7 @@ class Resample(Transform):
             if self.norm_coords:
                 for i, dim in enumerate(img_t.shape[1 : 1 + sr]):
                     grid_t[i] = (max(dim, 2) / 2.0 - 0.5 + grid_t[i]) / grid_t[-1:]
-            else:
-                grid_t = grid_t[:sr]
-            grid_t = torch.movedim(grid_t, 0, -1)
+            grid_t = moveaxis(grid_t[:sr], 0, -1)
             _padding_mode = look_up_option(
                 self.padding_mode if padding_mode is None else padding_mode, GridSamplePadMode
             ).value
@@ -1602,7 +1601,7 @@ class Resample(Transform):
                 for i, dim in enumerate(img_t.shape[1 : 1 + sr]):
                     grid_t[i] = 2.0 / (max(2, dim) - 1.0) * grid_t[i] / grid_t[-1:]
             index_ordering: List[int] = list(range(sr - 1, -1, -1))
-            grid_t = torch.moveaxis(grid_t[index_ordering], 0, -1)
+            grid_t = moveaxis(grid_t[index_ordering], 0, -1)  # type: ignore
             out = torch.nn.functional.grid_sample(
                 img_t.unsqueeze(0),
                 grid_t.unsqueeze(0),

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -87,7 +87,11 @@ RandRange = Optional[Union[Sequence[Union[Tuple[float, float], float]], float]]
 
 class SpatialResample(Transform):
     """
-    Resample input image from the orientation/spacing defined by ``src`` affine into the ones specified by `dst`.
+    Resample input image from the orientation/spacing defined by ``src`` affine matrix into
+    the ones specified by ``dst`` affine matrix.
+
+    Internally this transform computes the affine transform matrix from ``src`` to ``dst``,
+    by ``xform = np.linalg.inv(src) @ dst``, and call ``monai.transforms.Affine`` with ``xform``.
     """
 
     backend = [TransformBackends.TORCH]

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -166,6 +166,8 @@ class SpatialResample(Transform):
                 If ``None``, use the data type of input data. To be compatible with other modules,
                 the output data type is always `float32`.
 
+        The spatial rank is determined by the smallest among ``img.ndim -1``, ``len(src) - 1``, and ``3``.
+
         When both ``monai.config.USE_COMPILED`` and ``align_corners`` are set to ``True``,
         MONAI's resampling implementation will be used.
         """

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -1566,7 +1566,7 @@ class Resample(Transform):
         grid_t = convert_to_dst_type(grid, img_t)[0]  # type: ignore
         if grid_t is grid:  # copy if needed
             grid_t = grid_t.clone()
-        sr = max(len(img_t.shape[1:]), 3)
+        sr = min(len(img_t.shape[1:]), 3)
 
         if USE_COMPILED:
             if self.norm_coords:

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -90,6 +90,8 @@ class SpatialResample(Transform):
     Resample input image from the orientation/spacing defined by ``src`` affine into the ones specified by `dst`.
     """
 
+    backend = [TransformBackends.TORCH]
+
     def __init__(
         self,
         mode: Union[GridSampleMode, str] = GridSampleMode.BILINEAR,
@@ -221,7 +223,7 @@ class SpatialResample(Transform):
             )
             output_data = affine_xform(img_.unsqueeze(0), theta=transform, spatial_size=spatial_size).squeeze(0)
         if additional_dims:
-            full_shape = tuple([chns, *spatial_size, *additional_dims])
+            full_shape = (chns, *spatial_size, *additional_dims)
             output_data = output_data.reshape(full_shape)
         # output dtype float
         output_data, *_ = convert_to_dst_type(output_data, img, dtype=torch.float32)
@@ -233,7 +235,7 @@ class Spacing(Transform):
     Resample input image into the specified `pixdim`.
     """
 
-    backend = [TransformBackends.TORCH]
+    backend = SpatialResample.backend
 
     def __init__(
         self,

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -216,7 +216,9 @@ class SpatialResample(Transform):
                 _t_r[idx, -1] = (max(d_dst, 2) - 1.0) / 2.0
             transform = transform @ _t_r
             if not USE_COMPILED:
-                _t_l = normalize_transform(img.shape[1 : spatial_rank + 1], device=transform.device, dtype=transform.dtype, align_corners=True)
+                _t_l = normalize_transform(
+                    img.shape[1 : spatial_rank + 1], device=transform.device, dtype=transform.dtype, align_corners=True
+                )
                 transform = _t_l @ transform
             affine_xform = Affine(
                 affine=transform, spatial_size=spatial_size, norm_coords=False, image_only=True, dtype=_dtype

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -1563,7 +1563,7 @@ class Resample(Transform):
             elif _padding_mode == "border":
                 bound = 0
             else:
-                bound = 2  # dct2 is reflection with align_corners=True
+                bound = 1  # "relection"
             _interp_mode = look_up_option(self.mode if mode is None else mode, GridSampleMode).value
             if _interp_mode == "nearest":
                 _interp = 0

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -1546,7 +1546,9 @@ class Resample(Transform):
         img_t: torch.Tensor
         grid_t: torch.Tensor
         img_t, *_ = convert_data_type(img, torch.Tensor, device=_device, dtype=dtype)  # type: ignore
-        grid_t, *_ = convert_to_dst_type(grid, img_t)  # type: ignore
+        grid_t = convert_to_dst_type(grid, img_t)[0]  # type: ignore
+        if grid_t is grid:  # copy if needed
+            grid_t = grid_t.clone()
 
         if USE_COMPILED:
             for i, dim in enumerate(img_t.shape[1:]):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -127,11 +127,11 @@ class SpatialResample(Transform):
         src: Optional[NdarrayOrTensor] = None,
         dst: Optional[NdarrayOrTensor] = None,
         spatial_size: Optional[Union[Sequence[int], int]] = None,
-        mode: Union[GridSampleMode, str] = GridSampleMode.BILINEAR,
-        padding_mode: Union[GridSamplePadMode, str] = GridSamplePadMode.BORDER,
-        align_corners: bool = False,
+        mode: Union[GridSampleMode, str, None] = GridSampleMode.BILINEAR,
+        padding_mode: Union[GridSamplePadMode, str, None] = GridSamplePadMode.BORDER,
+        align_corners: Optional[bool] = False,
         dtype: DtypeLike = np.float64,
-    ):
+    ) -> Tuple[NdarrayOrTensor, NdarrayOrTensor]:
         """
         Args:
             img: input image to be resampled. It currently supports channel-first arrays with
@@ -216,8 +216,8 @@ class SpatialResample(Transform):
         else:
             affine_xform = AffineTransform(
                 normalized=False,
-                mode=mode,
-                padding_mode=padding_mode,
+                mode=mode,  # type: ignore
+                padding_mode=padding_mode,  # type: ignore
                 align_corners=align_corners,
                 reverse_indexing=True,
             )
@@ -303,7 +303,7 @@ class Spacing(Transform):
         padding_mode: Optional[Union[GridSamplePadMode, str]] = None,
         align_corners: Optional[bool] = None,
         dtype: DtypeLike = None,
-        output_spatial_shape: Optional[np.ndarray] = None,
+        output_spatial_shape: Optional[Union[Sequence[int], int]] = None,
     ) -> Union[NdarrayOrTensor, Tuple[NdarrayOrTensor, NdarrayOrTensor, NdarrayOrTensor]]:
         """
         Args:
@@ -358,7 +358,7 @@ class Spacing(Transform):
             data_array,
             src=affine,
             dst=new_affine,
-            spatial_size=output_shape if output_spatial_shape is None else output_spatial_shape,
+            spatial_size=list(output_shape) if output_spatial_shape is None else output_spatial_shape,
             mode=mode,
             padding_mode=padding_mode,
             align_corners=align_corners,

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -372,7 +372,7 @@ class Spacing(Transform):
             affine_np = affine = np.eye(sr + 1, dtype=np.float64)
             affine_ = np.eye(sr + 1, dtype=np.float64)
         else:
-            affine_np, *_ = convert_data_type(affine, np.ndarray)  # type: ignore
+            affine_np, *_ = convert_data_type(affine, np.ndarray)
             affine_ = to_affine_nd(sr, affine_np)  # type: ignore
 
         out_d = self.pixdim[:sr]
@@ -599,7 +599,7 @@ class Resize(Transform):
             ValueError: When ``self.spatial_size`` length is less than ``img`` spatial dimensions.
 
         """
-        img_, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float)  # type: ignore
+        img_, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float)
         if self.size_mode == "all":
             input_ndim = img_.ndim - 1  # spatial ndim
             output_ndim = len(ensure_tuple(self.spatial_size))
@@ -817,8 +817,7 @@ class Zoom(Transform):
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.interpolate.html
 
         """
-        img_t: torch.Tensor
-        img_t, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float32)  # type: ignore
+        img_t, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float32)
 
         _zoom = ensure_tuple_rep(self.zoom, img.ndim - 1)  # match the spatial image dim
         zoomed: NdarrayOrTensor = torch.nn.functional.interpolate(  # type: ignore
@@ -1577,9 +1576,7 @@ class Resample(Transform):
         if grid is None:
             raise ValueError("Unknown grid.")
         _device = img.device if isinstance(img, torch.Tensor) else self.device
-        img_t: torch.Tensor
-        grid_t: torch.Tensor
-        img_t, *_ = convert_data_type(img, torch.Tensor, device=_device, dtype=dtype)  # type: ignore
+        img_t, *_ = convert_data_type(img, torch.Tensor, device=_device, dtype=dtype)
         grid_t = convert_to_dst_type(grid, img_t)[0]
         if grid_t is grid:  # copy if needed (convert_data_type converts to contiguous)
             grid_t = grid_t.clone(memory_format=torch.contiguous_format)

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -222,8 +222,8 @@ class SpatialResample(Transform):
         spatial_size = spatial_size[:spatial_rank]
         chns, additional_dims = img.shape[0], img.shape[spatial_rank + 1 :]  # beyond three spatial dims
         # resample
-        img_ = convert_data_type(img, torch.Tensor, dtype=_dtype)[0]  # type: ignore
-        xform = convert_to_dst_type(xform, img_)[0]  # type: ignore
+        img_ = convert_data_type(img, torch.Tensor, dtype=_dtype)[0]
+        xform = convert_to_dst_type(xform, img_)[0]
         align_corners = self.align_corners if align_corners is None else align_corners
         mode = mode or self.mode
         padding_mode = padding_mode or self.padding_mode
@@ -231,12 +231,12 @@ class SpatialResample(Transform):
             xform_shape = [-1] + in_spatial_size
             img_ = img_.reshape(xform_shape)
         if align_corners:
-            _t_r = torch.diag(torch.ones(len(xform), dtype=xform.dtype, device=xform.device))  # type: ignore
+            _t_r = torch.diag(torch.ones(len(xform), dtype=xform.dtype, device=xform.device))
             for idx, d_dst in enumerate(spatial_size[:spatial_rank]):
                 _t_r[idx, -1] = (max(d_dst, 2) - 1.0) / 2.0
             xform = xform @ _t_r
             if not USE_COMPILED:
-                _t_l = normalize_transform(in_spatial_size, xform.device, xform.dtype, align_corners=True)  # type: ignore
+                _t_l = normalize_transform(in_spatial_size, xform.device, xform.dtype, align_corners=True)
                 xform = _t_l @ xform  # type: ignore
             affine_xform = Affine(
                 affine=xform, spatial_size=spatial_size, norm_coords=False, image_only=True, dtype=_dtype
@@ -503,7 +503,7 @@ class Orientation(Transform):
                 data_array = data_array.permute(full_transpose.tolist())  # type: ignore
             else:
                 data_array = data_array.transpose(full_transpose)  # type: ignore
-        out, *_ = convert_to_dst_type(src=data_array, dst=data_array)  # type: ignore
+        out, *_ = convert_to_dst_type(src=data_array, dst=data_array)
         new_affine = to_affine_nd(affine_np, new_affine)
         new_affine, *_ = convert_to_dst_type(src=new_affine, dst=affine, dtype=torch.float32)
 
@@ -700,8 +700,7 @@ class Rotate(Transform, ThreadUnsafe):
         """
         _dtype = dtype or self.dtype or img.dtype
 
-        img_t: torch.Tensor
-        img_t, *_ = convert_data_type(img, torch.Tensor, dtype=_dtype)  # type: ignore
+        img_t, *_ = convert_data_type(img, torch.Tensor, dtype=_dtype)
 
         im_shape = np.asarray(img_t.shape[1:])  # spatial dimensions
         input_ndim = len(im_shape)
@@ -721,8 +720,7 @@ class Rotate(Transform, ThreadUnsafe):
         shift_1 = create_translate(input_ndim, (-(output_shape - 1) / 2).tolist())
         transform = shift @ transform @ shift_1
 
-        transform_t: torch.Tensor
-        transform_t, *_ = convert_to_dst_type(transform, img_t)  # type: ignore
+        transform_t, *_ = convert_to_dst_type(transform, img_t)
 
         xform = AffineTransform(
             normalized=False,
@@ -1582,7 +1580,7 @@ class Resample(Transform):
         img_t: torch.Tensor
         grid_t: torch.Tensor
         img_t, *_ = convert_data_type(img, torch.Tensor, device=_device, dtype=dtype)  # type: ignore
-        grid_t = convert_to_dst_type(grid, img_t)[0]  # type: ignore
+        grid_t = convert_to_dst_type(grid, img_t)[0]
         if grid_t is grid:  # copy if needed (convert_data_type converts to contiguous)
             grid_t = grid_t.clone(memory_format=torch.contiguous_format)
         sr = min(len(img_t.shape[1:]), 3)

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -140,10 +140,10 @@ class SpatialResampled(MapTransform, InvertibleTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.SpatialResample`.
 
     This transform assumes the ``data`` dictionary has a key for the input
-    data's metadata and contains ``src`` and ``dst`` affine required by
+    data's metadata and contains ``src_affine`` and ``dst_affine`` required by
     `SpatialResample`. The key is formed by ``key_{meta_key_postfix}``.  The
-    transform will swap ``src`` and ``dst`` affine (with potential data type
-    changes) in the dictionary so that ``src`` always refers to the current
+    transform will swap ``src_affine`` and ``dst_affine`` affine (with potential data type
+    changes) in the dictionary so that ``src_affine`` always refers to the current
     status of affine.
 
     See also:
@@ -188,12 +188,12 @@ class SpatialResampled(MapTransform, InvertibleTransform):
                 the meta data is a dictionary object which contains: filename, affine, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys=None, use `key_{postfix}` to to fetch the meta data according
+            meta_key_postfix: if meta_keys=None, use `key_{postfix}` to fetch the meta data according
                 to the key data, default is `meta_dict`, the meta data is a dictionary object.
                 For example, to handle key `image`,  read/write affine matrices from the
                 metadata `image_meta_dict` dictionary's `affine` field.
-            meta_src_keys: the key of the corresponding ``src`` affine in the meta data dictionary.
-            meta_dst_keys: the key of the corresponding ``dst`` affine in the meta data dictionary.
+            meta_src_keys: the key of the corresponding ``src_affine`` in the metadata dictionary.
+            meta_dst_keys: the key of the corresponding ``dst_affine`` in the metadata dictionary.
             allow_missing_keys: don't raise exception if key is missing.
         """
         super().__init__(keys, allow_missing_keys)
@@ -233,8 +233,8 @@ class SpatialResampled(MapTransform, InvertibleTransform):
             original_spatial_shape = d[key].shape[1:]
             d[key], meta_data[meta_dst_key] = self.sp_transform(  # write dst affine because the dtype might change
                 img=d[key],
-                src=meta_data[meta_src_key],
-                dst=meta_data[meta_dst_key],
+                src_affine=meta_data[meta_src_key],
+                dst_affine=meta_data[meta_dst_key],
                 spatial_size=None,  # None means shape auto inferred
                 mode=mode,
                 padding_mode=padding_mode,
@@ -275,8 +275,8 @@ class SpatialResampled(MapTransform, InvertibleTransform):
             # Apply inverse
             d[key], dst_affine = inverse_transform(
                 img=d[key],
-                src=src_affine,
-                dst=dst_affine,
+                src_affine=src_affine,
+                dst_affine=dst_affine,
                 mode=mode,
                 padding_mode=padding_mode,
                 align_corners=False if align_corners == TraceKeys.NONE else align_corners,
@@ -359,7 +359,7 @@ class Spacingd(MapTransform, InvertibleTransform):
                 the meta data is a dictionary object which contains: filename, affine, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys=None, use `key_{postfix}` to to fetch the meta data according
+            meta_key_postfix: if meta_keys=None, use `key_{postfix}` to fetch the meta data according
                 to the key data, default is `meta_dict`, the meta data is a dictionary object.
                 For example, to handle key `image`,  read/write affine matrices from the
                 metadata `image_meta_dict` dictionary's `affine` field.
@@ -493,7 +493,7 @@ class Orientationd(MapTransform, InvertibleTransform):
                 the meta data is a dictionary object which contains: filename, affine, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to to fetch the meta data according
+            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
                 to the key data, default is `meta_dict`, the meta data is a dictionary object.
                 For example, to handle key `image`,  read/write affine matrices from the
                 metadata `image_meta_dict` dictionary's `affine` field.

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -251,6 +251,7 @@ class SpatialResampled(MapTransform, InvertibleTransform):
                 },
                 orig_size=original_spatial_shape,
             )
+        return d
 
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
         d = deepcopy(dict(data))
@@ -258,8 +259,8 @@ class SpatialResampled(MapTransform, InvertibleTransform):
             transform = self.get_most_recent_transform(d, key)
             # Create inverse transform
             meta_data = d[transform[TraceKeys.EXTRA_INFO]["meta_key"]]
-            src_affine = meta_data[d[transform[TraceKeys.EXTRA_INFO]["meta_src_key"]]]
-            dst_affine = meta_data[d[transform[TraceKeys.EXTRA_INFO]["meta_dst_key"]]]
+            src_affine = meta_data[d[transform[TraceKeys.EXTRA_INFO]["meta_src_key"]]]  # type: ignore
+            dst_affine = meta_data[d[transform[TraceKeys.EXTRA_INFO]["meta_dst_key"]]]  # type: ignore
             mode = transform[TraceKeys.EXTRA_INFO]["mode"]
             padding_mode = transform[TraceKeys.EXTRA_INFO]["padding_mode"]
             align_corners = transform[TraceKeys.EXTRA_INFO]["align_corners"]
@@ -278,7 +279,6 @@ class SpatialResampled(MapTransform, InvertibleTransform):
             )
             # Remove the applied transform
             self.pop_transform(d, key)
-
         return d
 
 

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -136,7 +136,7 @@ DEFAULT_POST_FIX = PostFix.meta()
 
 
 class SpatialResampled(MapTransform, InvertibleTransform):
-    pass
+    backend = SpatialResample.backend
 
 
 class Spacingd(MapTransform, InvertibleTransform):
@@ -615,6 +615,7 @@ class Affined(MapTransform, InvertibleTransform):
         padding_mode: GridSamplePadModeSequence = GridSamplePadMode.REFLECTION,
         as_tensor_output: bool = True,
         device: Optional[torch.device] = None,
+        dtype: Union[DtypeLike, torch.dtype] = np.float32,
         allow_missing_keys: bool = False,
     ) -> None:
         """
@@ -654,6 +655,9 @@ class Affined(MapTransform, InvertibleTransform):
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
                 It also can be a sequence of string, each element corresponds to a key in ``keys``.
             device: device on which the tensor will be allocated.
+            dtype: data type for resampling computation. Defaults to ``np.float32``.
+                If ``None``, use the data type of input data. To be compatible with other modules,
+                the output data type is always `float32`.
             allow_missing_keys: don't raise exception if key is missing.
 
         See also:
@@ -673,6 +677,7 @@ class Affined(MapTransform, InvertibleTransform):
             affine=affine,
             spatial_size=spatial_size,
             device=device,
+            dtype=dtype,
         )
         self.mode = ensure_tuple_rep(mode, len(self.keys))
         self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
@@ -1345,7 +1350,7 @@ class Rotated(MapTransform, InvertibleTransform):
         mode: GridSampleModeSequence = GridSampleMode.BILINEAR,
         padding_mode: GridSamplePadModeSequence = GridSamplePadMode.BORDER,
         align_corners: Union[Sequence[bool], bool] = False,
-        dtype: Union[Sequence[Union[DtypeLike, torch.dtype]], Union[DtypeLike, torch.dtype]] = np.float64,
+        dtype: Union[Sequence[Union[DtypeLike, torch.dtype]], DtypeLike, torch.dtype] = np.float64,
         allow_missing_keys: bool = False,
     ) -> None:
         super().__init__(keys, allow_missing_keys)
@@ -1459,7 +1464,7 @@ class RandRotated(RandomizableTransform, MapTransform, InvertibleTransform):
         mode: GridSampleModeSequence = GridSampleMode.BILINEAR,
         padding_mode: GridSamplePadModeSequence = GridSamplePadMode.BORDER,
         align_corners: Union[Sequence[bool], bool] = False,
-        dtype: Union[Sequence[Union[DtypeLike, torch.dtype]], Union[DtypeLike, torch.dtype]] = np.float64,
+        dtype: Union[Sequence[Union[DtypeLike, torch.dtype]], DtypeLike, torch.dtype] = np.float64,
         allow_missing_keys: bool = False,
     ) -> None:
         MapTransform.__init__(self, keys, allow_missing_keys)

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -46,6 +46,7 @@ from monai.transforms.spatial.array import (
     Rotate,
     Rotate90,
     Spacing,
+    SpatialResample,
     Zoom,
 )
 from monai.transforms.transform import MapTransform, RandomizableTransform
@@ -68,6 +69,7 @@ from monai.utils.type_conversion import convert_data_type, convert_to_dst_type
 nib, _ = optional_import("nibabel")
 
 __all__ = [
+    "SpatialResampled",
     "Spacingd",
     "Orientationd",
     "Rotate90d",
@@ -86,6 +88,8 @@ __all__ = [
     "RandRotated",
     "Zoomd",
     "RandZoomd",
+    "SpatialResampleD",
+    "SpatialResampleDict",
     "SpacingD",
     "SpacingDict",
     "OrientationD",
@@ -129,6 +133,10 @@ GridSamplePadModeSequence = Union[Sequence[Union[GridSamplePadMode, str]], GridS
 InterpolateModeSequence = Union[Sequence[Union[InterpolateMode, str]], InterpolateMode, str]
 PadModeSequence = Union[Sequence[Union[NumpyPadMode, PytorchPadMode, str]], NumpyPadMode, PytorchPadMode, str]
 DEFAULT_POST_FIX = PostFix.meta()
+
+
+class SpatialResampled(MapTransform, InvertibleTransform):
+    pass
 
 
 class Spacingd(MapTransform, InvertibleTransform):
@@ -1870,6 +1878,7 @@ class RandGridDistortiond(RandomizableTransform, MapTransform):
         return d
 
 
+SpatialResampleD = SpatialResampleDict = SpatialResampled
 SpacingD = SpacingDict = Spacingd
 OrientationD = OrientationDict = Orientationd
 Rotate90D = Rotate90Dict = Rotate90d

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -1552,10 +1552,8 @@ class Rotated(MapTransform, InvertibleTransform):
                 align_corners=False if align_corners == TraceKeys.NONE else align_corners,
                 reverse_indexing=True,
             )
-            img_t: torch.Tensor
-            img_t, *_ = convert_data_type(d[key], torch.Tensor, dtype=dtype)  # type: ignore
-            transform_t: torch.Tensor
-            transform_t, *_ = convert_to_dst_type(inv_rot_mat, img_t)  # type: ignore
+            img_t, *_ = convert_data_type(d[key], torch.Tensor, dtype=dtype)
+            transform_t, *_ = convert_to_dst_type(inv_rot_mat, img_t)
 
             out = xform(img_t.unsqueeze(0), transform_t, spatial_size=transform[TraceKeys.ORIG_SIZE]).squeeze(0)
             out, *_ = convert_to_dst_type(out, dst=d[key], dtype=out.dtype)
@@ -1686,10 +1684,8 @@ class RandRotated(RandomizableTransform, MapTransform, InvertibleTransform):
                     align_corners=False if align_corners == TraceKeys.NONE else align_corners,
                     reverse_indexing=True,
                 )
-                img_t: torch.Tensor
-                img_t, *_ = convert_data_type(d[key], torch.Tensor, dtype=dtype)  # type: ignore
-                transform_t: torch.Tensor
-                transform_t, *_ = convert_to_dst_type(inv_rot_mat, img_t)  # type: ignore
+                img_t, *_ = convert_data_type(d[key], torch.Tensor, dtype=dtype)
+                transform_t, *_ = convert_to_dst_type(inv_rot_mat, img_t)
                 output: torch.Tensor
                 out = xform(img_t.unsqueeze(0), transform_t, spatial_size=transform[TraceKeys.ORIG_SIZE]).squeeze(0)
                 out, *_ = convert_to_dst_type(out, dst=d[key], dtype=out.dtype)

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -336,8 +336,7 @@ class CastToType(Transform):
             TypeError: When ``img`` type is not in ``Union[numpy.ndarray, torch.Tensor]``.
 
         """
-        img_out, *_ = convert_data_type(img, output_type=type(img), dtype=dtype or self.dtype)
-        return img_out
+        return convert_data_type(img, output_type=type(img), dtype=dtype or self.dtype)[0]  # type: ignore
 
 
 class ToTensor(Transform):
@@ -412,11 +411,9 @@ class EnsureType(Transform):
 
         """
         output_type = torch.Tensor if self.data_type == "tensor" else np.ndarray
-        out, *_ = convert_data_type(
+        return convert_data_type(
             data=data, output_type=output_type, dtype=self.dtype, device=self.device, wrap_sequence=self.wrap_sequence
-        )
-        return out
-
+        )[0]  # type: ignore
 
 class ToNumpy(Transform):
     """

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -413,7 +413,10 @@ class EnsureType(Transform):
         output_type = torch.Tensor if self.data_type == "tensor" else np.ndarray
         return convert_data_type(
             data=data, output_type=output_type, dtype=self.dtype, device=self.device, wrap_sequence=self.wrap_sequence
-        )[0]  # type: ignore
+        )[
+            0
+        ]  # type: ignore
+
 
 class ToNumpy(Transform):
     """
@@ -1018,7 +1021,7 @@ class TorchVision:
             img: PyTorch Tensor data for the TorchVision transform.
 
         """
-        img_t, *_ = convert_data_type(img, torch.Tensor)  # type: ignore
+        img_t, *_ = convert_data_type(img, torch.Tensor)
         out = self.trans(img_t)
         out, *_ = convert_to_dst_type(src=out, dst=img)
         return out
@@ -1110,8 +1113,7 @@ class IntensityStats(Transform):
                 mask must have the same shape as input `img`.
 
         """
-        img_np: np.ndarray
-        img_np, *_ = convert_data_type(img, np.ndarray)  # type: ignore
+        img_np, *_ = convert_data_type(img, np.ndarray)
         if meta_data is None:
             meta_data = {}
 

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -1449,7 +1449,7 @@ class IntensityStatsd(MapTransform):
             the meta data is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to to fetch the meta data according
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
             to the key data, default is `meta_dict`, the meta data is a dictionary object.
             used to store the computed statistics to the meta dict.
         allow_missing_keys: don't raise exception if key is missing.

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -940,7 +940,7 @@ def get_largest_connected_component_mask(img: NdarrayTensor, connectivity: Optio
             connectivity of ``input.ndim`` is used. for more details:
             https://scikit-image.org/docs/dev/api/skimage.measure.html#skimage.measure.label.
     """
-    img_arr: np.ndarray = convert_data_type(img, np.ndarray)[0]  # type: ignore
+    img_arr = convert_data_type(img, np.ndarray)[0]
     largest_cc: np.ndarray = np.zeros(shape=img_arr.shape, dtype=img_arr.dtype)
     img_arr = measure.label(img_arr, connectivity=connectivity)
     if img_arr.max() != 0:

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -21,7 +21,7 @@ import torch
 
 import monai
 from monai.config import DtypeLike, IndexSelection
-from monai.config.type_definitions import NdarrayOrTensor
+from monai.config.type_definitions import NdarrayOrTensor, NdarrayTensor
 from monai.networks.layers import GaussianFilter
 from monai.networks.utils import meshgrid_ij
 from monai.transforms.compose import Compose, OneOf
@@ -359,7 +359,7 @@ def map_classes_to_indices(
         label_flat = ravel(any_np_pt(label[c : c + 1] if channels > 1 else label == c, 0))
         label_flat = img_flat & label_flat if img_flat is not None else label_flat
         # no need to save the indices in GPU, otherwise, still need to move to CPU at runtime when crop by indices
-        cls_indices, *_ = convert_data_type(nonzero(label_flat), device=torch.device("cpu"))
+        cls_indices: NdarrayOrTensor = convert_data_type(nonzero(label_flat), device=torch.device("cpu"))[0]
         indices.append(cls_indices)
 
     return indices
@@ -929,7 +929,7 @@ def generate_spatial_bounding_box(
     return box_start, box_end
 
 
-def get_largest_connected_component_mask(img: NdarrayOrTensor, connectivity: Optional[int] = None) -> NdarrayOrTensor:
+def get_largest_connected_component_mask(img: NdarrayTensor, connectivity: Optional[int] = None) -> NdarrayTensor:
     """
     Gets the largest connected component mask of an image.
 
@@ -945,8 +945,7 @@ def get_largest_connected_component_mask(img: NdarrayOrTensor, connectivity: Opt
     img_arr = measure.label(img_arr, connectivity=connectivity)
     if img_arr.max() != 0:
         largest_cc[...] = img_arr == (np.argmax(np.bincount(img_arr.flat)[1:]) + 1)
-    largest_cc = convert_to_dst_type(largest_cc, dst=img, dtype=largest_cc.dtype)[0]  # type: ignore
-    return largest_cc
+    return convert_to_dst_type(largest_cc, dst=img, dtype=largest_cc.dtype)[0]
 
 
 def fill_holes(

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -48,6 +48,7 @@ from monai.utils import (
     ensure_tuple_rep,
     ensure_tuple_size,
     fall_back_tuple,
+    get_equivalent_dtype,
     issequenceiterable,
     look_up_option,
     min_version,
@@ -604,7 +605,7 @@ def _create_grid_numpy(
     """
     spacing = spacing or tuple(1.0 for _ in spatial_size)
     ranges = [np.linspace(-(d - 1.0) / 2.0 * s, (d - 1.0) / 2.0 * s, int(d)) for d, s in zip(spatial_size, spacing)]
-    coords = np.asarray(np.meshgrid(*ranges, indexing="ij"), dtype=dtype)
+    coords = np.asarray(np.meshgrid(*ranges, indexing="ij"), dtype=get_equivalent_dtype(dtype, np.ndarray))
     if not homogeneous:
         return coords
     return np.concatenate([coords, np.ones_like(coords[:1])])
@@ -622,7 +623,13 @@ def _create_grid_torch(
     """
     spacing = spacing or tuple(1.0 for _ in spatial_size)
     ranges = [
-        torch.linspace(-(d - 1.0) / 2.0 * s, (d - 1.0) / 2.0 * s, int(d), device=device, dtype=dtype)
+        torch.linspace(
+            -(d - 1.0) / 2.0 * s,
+            (d - 1.0) / 2.0 * s,
+            int(d),
+            device=device,
+            dtype=get_equivalent_dtype(dtype, torch.Tensor),
+        )
         for d, s in zip(spatial_size, spacing)
     ]
     coords = meshgrid_ij(*ranges)

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -16,8 +16,10 @@ import torch
 
 from monai.config.type_definitions import NdarrayOrTensor
 from monai.utils.misc import ensure_tuple, is_module_ver_at_least
+from monai.utils.type_conversion import convert_to_dst_type
 
 __all__ = [
+    "allclose",
     "moveaxis",
     "in1d",
     "clip",
@@ -38,6 +40,14 @@ __all__ = [
     "isnan",
     "ascontiguousarray",
 ]
+
+
+def allclose(a: NdarrayOrTensor, b: NdarrayOrTensor, rtol=1e-5, atol=1e-8, equal_nan=False) -> bool:
+    """`np.allclose` with equivalent implementation for torch."""
+    b, *_ = convert_to_dst_type(b, a)
+    if isinstance(a, np.ndarray):
+        return np.allclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
+    return torch.allclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)  # type: ignore
 
 
 def moveaxis(x: NdarrayOrTensor, src: Union[int, Sequence[int]], dst: Union[int, Sequence[int]]) -> NdarrayOrTensor:

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -14,7 +14,7 @@ from typing import Optional, Sequence, Union
 import numpy as np
 import torch
 
-from monai.config.type_definitions import NdarrayOrTensor
+from monai.config.type_definitions import NdarrayOrTensor, NdarrayTensor
 from monai.utils.misc import ensure_tuple, is_module_ver_at_least
 from monai.utils.type_conversion import convert_to_dst_type
 
@@ -324,7 +324,7 @@ def isfinite(x: NdarrayOrTensor) -> NdarrayOrTensor:
     return torch.isfinite(x)
 
 
-def searchsorted(a: NdarrayOrTensor, v: NdarrayOrTensor, right=False, sorter=None, **kwargs) -> NdarrayOrTensor:
+def searchsorted(a: NdarrayTensor, v: NdarrayOrTensor, right=False, sorter=None, **kwargs) -> NdarrayTensor:
     """
     `np.searchsorted` with equivalent implementation for torch.
 

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -42,7 +42,7 @@ __all__ = [
 ]
 
 
-def allclose(a: NdarrayOrTensor, b: NdarrayOrTensor, rtol=1e-5, atol=1e-8, equal_nan=False) -> bool:
+def allclose(a: NdarrayTensor, b: NdarrayOrTensor, rtol=1e-5, atol=1e-8, equal_nan=False) -> bool:
     """`np.allclose` with equivalent implementation for torch."""
     b, *_ = convert_to_dst_type(b, a)
     if isinstance(a, np.ndarray):

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -19,7 +19,7 @@ from importlib import import_module
 from pkgutil import walk_packages
 from re import match
 from types import FunctionType
-from typing import Any, Callable, Collection, Hashable, Iterable, List, Mapping, Tuple, cast
+from typing import Any, Callable, Collection, Hashable, Iterable, List, Mapping, Tuple, Union, cast
 
 import torch
 
@@ -44,7 +44,7 @@ __all__ = [
 ]
 
 
-def look_up_option(opt_str, supported: Collection, default="no_default"):
+def look_up_option(opt_str, supported: Union[Collection, enum.EnumMeta], default="no_default"):
     """
     Look up the option in the supported collection and return the matched item.
     Raise a value error possibly with a guess of the closest match.

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import re
-from typing import Any, Optional, Sequence, Tuple, Type, Union, overload
+from typing import Any, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 import torch
@@ -241,7 +241,7 @@ def convert_data_type(
             (1.0, <class 'torch.Tensor'>, None)
 
     """
-    orig_type: Any
+    orig_type: type
     if isinstance(data, torch.Tensor):
         orig_type = torch.Tensor
     elif isinstance(data, np.ndarray):
@@ -260,13 +260,14 @@ def convert_data_type(
     data_: NdarrayTensor
     if issubclass(output_type, torch.Tensor):
         data_ = convert_to_tensor(data, dtype=dtype_, device=device, wrap_sequence=wrap_sequence)
-    elif issubclass(output_type, np.ndarray):
+        return data_, orig_type, orig_device
+    if issubclass(output_type, np.ndarray):
         data_ = convert_to_numpy(data, dtype=dtype_, wrap_sequence=wrap_sequence)
+        return data_, orig_type, orig_device
     elif has_cp and issubclass(output_type, cp.ndarray):
         data_ = convert_to_cupy(data, dtype=dtype_, wrap_sequence=wrap_sequence)
-    else:
-        raise ValueError(f"Unsupported output type: {output_type}")
-    return data_, orig_type, orig_device
+        return data_, orig_type, orig_device
+    raise ValueError(f"Unsupported output type: {output_type}")
 
 
 def convert_to_dst_type(

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -10,12 +10,12 @@
 # limitations under the License.
 
 import re
-from typing import Any, Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Tuple, Union, Type
 
 import numpy as np
 import torch
 
-from monai.config.type_definitions import DtypeLike, NdarrayOrTensor
+from monai.config.type_definitions import DtypeLike, NdarrayOrTensor, NdarrayTensor
 from monai.utils import optional_import
 from monai.utils.module import look_up_option
 
@@ -212,18 +212,18 @@ def convert_to_cupy(data, dtype: Optional[np.dtype] = None, wrap_sequence: bool 
 
 def convert_data_type(
     data: Any,
-    output_type: Optional[type] = None,
+    output_type: Optional[Type[NdarrayTensor]] = None,
     device: Optional[torch.device] = None,
     dtype: Optional[Union[DtypeLike, torch.dtype]] = None,
     wrap_sequence: bool = False,
-) -> Tuple[NdarrayOrTensor, type, Optional[torch.device]]:
+) -> Tuple[NdarrayTensor, type, Optional[torch.device]]:
     """
     Convert to `torch.Tensor`/`np.ndarray` from `torch.Tensor`/`np.ndarray`/`float`/`int` etc.
 
     Args:
         data: data to be converted
-        output_type: `torch.Tensor` or `np.ndarray` (if blank, unchanged)
-        device: if output is `torch.Tensor`, select device (if blank, unchanged)
+        output_type: `torch.Tensor` or `np.ndarray` (if `None`, unchanged)
+        device: if output is `torch.Tensor`, select device (if `None`, unchanged)
         dtype: dtype of output data. Converted to correct library type (e.g.,
             `np.float32` is converted to `torch.float32` if output type is `torch.Tensor`).
             If left blank, it remains unchanged.
@@ -269,8 +269,8 @@ def convert_data_type(
 
 
 def convert_to_dst_type(
-    src: Any, dst: NdarrayOrTensor, dtype: Optional[Union[DtypeLike, torch.dtype]] = None, wrap_sequence: bool = False
-) -> Tuple[NdarrayOrTensor, type, Optional[torch.device]]:
+    src: Any, dst: NdarrayTensor, dtype: Optional[Union[DtypeLike, torch.dtype]] = None, wrap_sequence: bool = False
+) -> Tuple[NdarrayTensor, type, Optional[torch.device]]:
     """
     Convert source data to the same data type and device as the destination data.
     If `dst` is an instance of `torch.Tensor` or its subclass, convert `src` to `torch.Tensor` with the same data type as `dst`,

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -15,7 +15,7 @@ from typing import Any, Optional, Sequence, Tuple, Union
 import numpy as np
 import torch
 
-from monai.config.type_definitions import DtypeLike, NdarrayOrTensor
+from monai.config.type_definitions import DtypeLike, NdarrayOrTensor, NdarrayTensor
 from monai.utils import optional_import
 from monai.utils.module import look_up_option
 

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -15,7 +15,7 @@ from typing import Any, Optional, Sequence, Tuple, Union
 import numpy as np
 import torch
 
-from monai.config.type_definitions import DtypeLike, NdarrayOrTensor, NdarrayTensor
+from monai.config.type_definitions import DtypeLike, NdarrayOrTensor
 from monai.utils import optional_import
 from monai.utils.module import look_up_option
 

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -10,12 +10,12 @@
 # limitations under the License.
 
 import re
-from typing import Any, Optional, Sequence, Tuple, Union, Type
+from typing import Any, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 import torch
 
-from monai.config.type_definitions import DtypeLike, NdarrayOrTensor, NdarrayTensor
+from monai.config.type_definitions import DtypeLike, NdarrayTensor
 from monai.utils import optional_import
 from monai.utils.module import look_up_option
 

--- a/monai/visualize/class_activation_maps.py
+++ b/monai/visualize/class_activation_maps.py
@@ -39,9 +39,9 @@ def default_normalizer(x: NdarrayTensor) -> NdarrayTensor:
         return np.stack([scaler(i) for i in data], axis=0)
 
     if isinstance(x, torch.Tensor):
-        return torch.as_tensor(_compute(x.detach().cpu().numpy()), device=x.device)
+        return torch.as_tensor(_compute(x.detach().cpu().numpy()), device=x.device)  # type: ignore
 
-    return _compute(x)
+    return _compute(x)  # type: ignore
 
 
 class ModelWithHooks:

--- a/monai/visualize/img2tensorboard.py
+++ b/monai/visualize/img2tensorboard.py
@@ -49,8 +49,7 @@ def _image3_animated_gif(
     if len(image.shape) != 3:
         raise AssertionError("3D image tensors expected to be in `HWD` format, len(image.shape) != 3")
 
-    image_np: np.ndarray
-    image_np, *_ = convert_data_type(image, output_type=np.ndarray)  # type: ignore
+    image_np, *_ = convert_data_type(image, output_type=np.ndarray)
     ims = [(i * scale_factor).astype(np.uint8, copy=False) for i in np.moveaxis(image_np, frame_dim, 0)]
     ims = [GifImage.fromarray(im) for im in ims]
     img_str = b""

--- a/monai/visualize/utils.py
+++ b/monai/visualize/utils.py
@@ -109,11 +109,11 @@ def matshow3d(
         while len(vol.shape) < 3:
             vol = np.expand_dims(vol, 0)  # so that we display 2d as well
 
-    if channel_dim is not None:
-        vol = np.moveaxis(vol, frame_dim, -4)  # move the expected dim to construct frames with `B` dim
+    if channel_dim is not None:  # move the expected dim to construct frames with `B` dim
+        vol = np.moveaxis(vol, frame_dim, -4)  # type: ignore
         vol = vol.reshape((-1, vol.shape[-3], vol.shape[-2], vol.shape[-1]))
     else:
-        vol = np.moveaxis(vol, frame_dim, -3)
+        vol = np.moveaxis(vol, frame_dim, -3)  # type: ignore
         vol = vol.reshape((-1, vol.shape[-2], vol.shape[-1]))
     vmin = np.nanmin(vol) if vmin is None else vmin
     vmax = np.nanmax(vol) if vmax is None else vmax
@@ -129,7 +129,7 @@ def matshow3d(
     if channel_dim is not None:
         width += [[0, 0]]  # add pad width for the channel dim
     width += [[margin, margin]] * 2
-    vol = np.pad(vol.astype(dtype, copy=False), width, mode="constant", constant_values=fill_value)
+    vol = np.pad(vol.astype(dtype, copy=False), width, mode="constant", constant_values=fill_value)  # type: ignore
     im = np.block([[vol[i * cols + j] for j in range(cols)] for i in range(rows)])
     if channel_dim is not None:
         # move channel dim to the end

--- a/monai/visualize/utils.py
+++ b/monai/visualize/utils.py
@@ -93,7 +93,7 @@ def matshow3d(
         >>> plt.show()
 
     """
-    vol: np.ndarray = convert_data_type(data=volume, output_type=np.ndarray)[0]  # type: ignore
+    vol = convert_data_type(data=volume, output_type=np.ndarray)[0]
     if channel_dim is not None:
         if channel_dim not in [0, 1] or vol.shape[channel_dim] not in [1, 3, 4]:
             raise ValueError("channel_dim must be: None, 0 or 1, and channels of image must be 1, 3 or 4.")
@@ -186,8 +186,7 @@ def blend_images(
 
     def get_label_rgb(cmap: str, label: NdarrayOrTensor):
         _cmap = cm.get_cmap(cmap)
-        label_np: np.ndarray
-        label_np, *_ = convert_data_type(label, np.ndarray)  # type: ignore
+        label_np, *_ = convert_data_type(label, np.ndarray)
         label_rgb_np = _cmap(label_np[0])
         label_rgb_np = np.moveaxis(label_rgb_np, -1, 0)[:3]
         label_rgb, *_ = convert_to_dst_type(label_rgb_np, label)

--- a/tests/test_global_mutual_information_loss.py
+++ b/tests/test_global_mutual_information_loss.py
@@ -16,7 +16,7 @@ import torch
 
 from monai import transforms
 from monai.losses.image_dissimilarity import GlobalMutualInformationLoss
-from tests.utils import SkipIfBeforePyTorchVersion, download_url_or_skip_test
+from tests.utils import SkipIfBeforePyTorchVersion, download_url_or_skip_test, skip_if_quick
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -51,6 +51,7 @@ EXPECTED_VALUE = {
 }
 
 
+@skip_if_quick
 class TestGlobalMutualInformationLoss(unittest.TestCase):
     def setUp(self):
         download_url_or_skip_test(FILE_URL, FILE_PATH)
@@ -100,6 +101,8 @@ class TestGlobalMutualInformationLoss(unittest.TestCase):
                 result = loss_fn(a2, a1).detach().cpu().numpy()
                 np.testing.assert_allclose(result, expected_value, rtol=1e-3, atol=5e-3)
 
+
+class TestGlobalMutualInformationLossIll(unittest.TestCase):
     def test_ill_shape(self):
         loss = GlobalMutualInformationLoss()
         with self.assertRaisesRegex(ValueError, ""):

--- a/tests/test_handler_metrics_saver_dist.py
+++ b/tests/test_handler_metrics_saver_dist.py
@@ -109,6 +109,7 @@ class DistributedMetricsSaver(DistTestCase):
                         self.assertEqual(row, ["mean\t2.5000\t2.5000\t3.5000\t1.5000\t3.3000\t0.8165\t3.0000"])
             self.assertTrue(os.path.exists(os.path.join(tempdir, "metric4_raw.csv")))
             self.assertTrue(os.path.exists(os.path.join(tempdir, "metric4_summary.csv")))
+        dist.barrier()
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_elastic_3d.py
+++ b/tests/test_rand_elastic_3d.py
@@ -88,7 +88,7 @@ class TestRand3DElastic(unittest.TestCase):
         g = Rand3DElastic(**input_param)
         g.set_random_state(123)
         result = g(**input_data)
-        assert_allclose(result, expected_val, rtol=1e-4, atol=1e-4)
+        assert_allclose(result, expected_val, rtol=1e-1, atol=1e-1)
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_elasticd_3d.py
+++ b/tests/test_rand_elasticd_3d.py
@@ -145,7 +145,7 @@ class TestRand3DElasticd(unittest.TestCase):
         for key in res:
             result = res[key]
             expected = expected_val[key] if isinstance(expected_val, dict) else expected_val
-            assert_allclose(result, expected, rtol=1e-4, atol=1e-4)
+            assert_allclose(result, expected, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -196,9 +196,9 @@ for p in TEST_NDARRAYS:
         [
             p,
             {"pixdim": [-1, -1, 0.5], "padding_mode": "zeros", "dtype": float, "align_corners": True},
-            np.ones((1, 2, 1, 2, 1)),  # data
+            np.ones((1, 2, 2, 2, 1)),  # data
             {"affine": np.eye(4)},
-            np.array([[[[[1.0], [1.0], [1.0]]], [[[1.0], [1.0], [1.0]]]]]),
+            np.ones((1, 2, 2, 3, 1)),
         ]
     )
 

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -195,7 +195,7 @@ for p in TEST_NDARRAYS:
     TESTS.append(  # 5D input
         [
             p,
-            {"pixdim": [-1, -1, 0.5], "padding_mode": "zeros", "dtype": float},
+            {"pixdim": [-1, -1, 0.5], "padding_mode": "zeros", "dtype": float, "align_corners": True},
             np.ones((1, 2, 1, 2, 1)),  # data
             {"affine": np.eye(4)},
             np.array([[[[[1.0], [1.0], [1.0]]], [[[1.0], [1.0], [1.0]]]]]),

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -192,6 +192,15 @@ for p in TEST_NDARRAYS:
             np.array([[[[1.0, 1.0, 1.0]], [[1.0, 1.0, 1.0]]]]),
         ]
     )
+    TESTS.append(  # 5D input
+        [
+            p,
+            {"pixdim": [-1, -1, 0.5], "padding_mode": "zeros", "dtype": float},
+            np.ones((1, 2, 1, 2, 1)),  # data
+            {"affine": np.eye(4)},
+            np.array([[[[[1.0], [1.0], [1.0]]], [[[1.0], [1.0], [1.0]]]]]),
+        ]
+    )
 
 
 class TestSpacingCase(unittest.TestCase):
@@ -204,7 +213,7 @@ class TestSpacingCase(unittest.TestCase):
             output_data = output_data.cpu()
 
         np.testing.assert_allclose(output_data, expected_output, atol=1e-1, rtol=1e-1)
-        sr = len(output_data.shape) - 1
+        sr = min(len(output_data.shape) - 1, 3)
         if isinstance(init_param["pixdim"], float):
             init_param["pixdim"] = [init_param["pixdim"]] * sr
         init_pixdim = ensure_tuple(init_param["pixdim"])

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -78,7 +78,7 @@ for p in TEST_NDARRAYS:
     TESTS.append(
         [
             p,
-            {"pixdim": (1.0, 1.0)},
+            {"pixdim": (1.0, 1.0), "align_corners": True},
             np.arange(24).reshape((2, 3, 4)),  # data
             {},
             np.array(
@@ -203,7 +203,7 @@ class TestSpacingCase(unittest.TestCase):
             self.assertEqual(_img.device, output_data.device)
             output_data = output_data.cpu()
 
-        np.testing.assert_allclose(output_data, expected_output, atol=1e-3, rtol=1e-3)
+        np.testing.assert_allclose(output_data, expected_output, atol=1e-1, rtol=1e-1)
         sr = len(output_data.shape) - 1
         if isinstance(init_param["pixdim"], float):
             init_param["pixdim"] = [init_param["pixdim"]] * sr

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -31,24 +31,21 @@ for ind, dst in enumerate(
         for p_src in TEST_NDARRAYS:
             for align in (False, True):
                 for interp_mode in ("nearest", "bilinear"):
-                    for padding_mode in ("zeros", "border", "reflection"):
-                        TESTS.append(
-                            [
-                                {},  # default no params
-                                np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
-                                {
-                                    "src": p_src(np.eye(3)),
-                                    "dst": p(dst),
-                                    "dtype": np.float32,
-                                    "align_corners": align,
-                                    "mode": interp_mode,
-                                    "padding_mode": padding_mode,
-                                },
-                                np.array([[[2.0, 1.0], [4.0, 3.0]]])
-                                if ind == 0
-                                else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
-                            ]
-                        )
+                    TESTS.append(
+                        [
+                            {},  # default no params
+                            np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
+                            {
+                                "src": p_src(np.eye(3)),
+                                "dst": p(dst),
+                                "dtype": np.float32,
+                                "align_corners": align,
+                                "mode": interp_mode,
+                                "padding_mode": "zeros",
+                            },
+                            np.array([[[2.0, 1.0], [4.0, 3.0]]]) if ind == 0 else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
+                        ]
+                    )
 
 for ind, dst in enumerate(
     [

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -61,10 +61,11 @@ for ind, dst in enumerate(
         for p_src in TEST_NDARRAYS:
             for dtype in (np.float32, np.float64):
                 for align in (True, False):
-                    interp = ("nearest", "bilinear")
                     if align and USE_COMPILED:
-                        interp = interp + (0, 1)  # type: ignore
-                    for interp_mode in interp:
+                        interp = ("nearest", "bilinear", 0, 1)  # type: ignore
+                    else:
+                        interp = ("nearest", "bilinear")  # type: ignore
+                    for interp_mode in interp:  # type: ignore
                         for padding_mode in ("zeros", "border", "reflection"):
                             TESTS.append(
                                 [
@@ -93,8 +94,8 @@ class TestSpatialResample(unittest.TestCase):
     @parameterized.expand(itertools.product(TEST_NDARRAYS, TESTS))
     def test_flips(self, p_type, args):
         init_param, img, data_param, expected_output = args
-        _img = p(img)
-        _expected_output = p(expected_output)
+        _img = p_type(img)
+        _expected_output = p_type(expected_output)
         output_data, output_dst = SpatialResample(**init_param)(img=_img, **data_param)
         assert_allclose(output_data, _expected_output)
         expected_dst = data_param.get("dst") if data_param.get("dst") is not None else data_param.get("src")
@@ -107,7 +108,7 @@ class TestSpatialResample(unittest.TestCase):
         img = np.tile(img, (1, 1, 1, 1, 2, 2) if is_5d else (1, 1, 1, 1, 2))
         _img = p_type(img)
         dst = np.asarray([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, -1.0, 1.5], [0.0, 0.0, 0.0, 1.0]])
-        output_data, output_dst = SpatialResample(dtype=np.float32)(img=_img, src=p(np.eye(4)), dst=dst)
+        output_data, output_dst = SpatialResample(dtype=np.float32)(img=_img, src=p_type(np.eye(4)), dst=dst)
         expected_data = (
             np.asarray(
                 [

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -29,27 +29,26 @@ for ind, dst in enumerate(
 ):
     for p in TEST_NDARRAYS:
         for p_src in TEST_NDARRAYS:
-            for dtype in (np.float32, np.float64):
-                for align in (False, True):
-                    for interp_mode in ("nearest", "bilinear"):
-                        for padding_mode in ("zeros", "border", "reflection"):
-                            TESTS.append(
-                                [
-                                    {},  # default no params
-                                    np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
-                                    {
-                                        "src": p_src(np.eye(3)),
-                                        "dst": p(dst),
-                                        "dtype": dtype,
-                                        "align_corners": align,
-                                        "mode": interp_mode,
-                                        "padding_mode": padding_mode,
-                                    },
-                                    np.array([[[2.0, 1.0], [4.0, 3.0]]])
-                                    if ind == 0
-                                    else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
-                                ]
-                            )
+            for align in (False, True):
+                for interp_mode in ("nearest", "bilinear"):
+                    for padding_mode in ("zeros", "border", "reflection"):
+                        TESTS.append(
+                            [
+                                {},  # default no params
+                                np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
+                                {
+                                    "src": p_src(np.eye(3)),
+                                    "dst": p(dst),
+                                    "dtype": np.float32,
+                                    "align_corners": align,
+                                    "mode": interp_mode,
+                                    "padding_mode": padding_mode,
+                                },
+                                np.array([[[2.0, 1.0], [4.0, 3.0]]])
+                                if ind == 0
+                                else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
+                            ]
+                        )
 
 for ind, dst in enumerate(
     [
@@ -57,37 +56,33 @@ for ind, dst in enumerate(
         np.asarray([[-1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]),
     ]
 ):
-    for p in TEST_NDARRAYS:
-        for p_src in TEST_NDARRAYS:
-            for dtype in (np.float32, np.float64):
-                for align in (True, False):
-                    if align and USE_COMPILED:
-                        interp = ("nearest", "bilinear", 0, 1)  # type: ignore
-                    else:
-                        interp = ("nearest", "bilinear")  # type: ignore
-                    for interp_mode in interp:  # type: ignore
-                        for padding_mode in ("zeros", "border", "reflection"):
-                            TESTS.append(
-                                [
-                                    {},  # default no params
-                                    np.arange(12).reshape((1, 2, 2, 3)) + 1.0,  # data
-                                    {
-                                        "src": p_src(np.eye(4)),
-                                        "dst": p(dst),
-                                        "dtype": dtype,
-                                        "align_corners": align,
-                                        "mode": interp_mode,
-                                        "padding_mode": padding_mode,
-                                    },
-                                    np.array(
-                                        [[[[4.0, 5.0, 6.0], [1.0, 2.0, 3.0]], [[10.0, 11.0, 12.0], [7.0, 8.0, 9.0]]]]
-                                    )
-                                    if ind == 0
-                                    else np.array(
-                                        [[[[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]]
-                                    ),
-                                ]
-                            )
+    for p_src in TEST_NDARRAYS:
+        for align in (True, False):
+            if align and USE_COMPILED:
+                interp = ("nearest", "bilinear", 0, 1)  # type: ignore
+            else:
+                interp = ("nearest", "bilinear")  # type: ignore
+            for interp_mode in interp:  # type: ignore
+                for padding_mode in ("zeros", "border", "reflection"):
+                    TESTS.append(
+                        [
+                            {},  # default no params
+                            np.arange(12).reshape((1, 2, 2, 3)) + 1.0,  # data
+                            {
+                                "src": p_src(np.eye(4)),
+                                "dst": p_src(dst),
+                                "dtype": np.float64,
+                                "align_corners": align,
+                                "mode": interp_mode,
+                                "padding_mode": padding_mode,
+                            },
+                            np.array([[[[4.0, 5.0, 6.0], [1.0, 2.0, 3.0]], [[10.0, 11.0, 12.0], [7.0, 8.0, 9.0]]]])
+                            if ind == 0
+                            else np.array(
+                                [[[[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]]
+                            ),
+                        ]
+                    )
 
 
 class TestSpatialResample(unittest.TestCase):
@@ -97,9 +92,9 @@ class TestSpatialResample(unittest.TestCase):
         _img = p_type(img)
         _expected_output = p_type(expected_output)
         output_data, output_dst = SpatialResample(**init_param)(img=_img, **data_param)
-        assert_allclose(output_data, _expected_output)
+        assert_allclose(output_data, _expected_output, rtol=1e-2, atol=1e-2)
         expected_dst = data_param.get("dst") if data_param.get("dst") is not None else data_param.get("src")
-        assert_allclose(output_dst, expected_dst, type_test=False)
+        assert_allclose(output_dst, expected_dst, type_test=False, rtol=1e-2, atol=1e-2)
 
     @parameterized.expand(itertools.product([True, False], TEST_NDARRAYS))
     def test_4d_5d(self, is_5d, p_type):
@@ -132,8 +127,8 @@ class TestSpatialResample(unittest.TestCase):
                 dtype=np.float32,
             )
         )
-        assert_allclose(output_data, p_type(expected_data[None]))
-        assert_allclose(output_dst, dst, type_test=False)
+        assert_allclose(output_data, p_type(expected_data[None]), rtol=1e-2, atol=1e-2)
+        assert_allclose(output_dst, dst, type_test=False, rtol=1e-2, atol=1e-2)
 
     def test_ill_affine(self):
         img = np.arange(12).reshape(1, 2, 2, 3)

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -1,0 +1,104 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+from monai.config import USE_COMPILED
+from monai.transforms import SpatialResample
+from tests.utils import TEST_NDARRAYS, assert_allclose
+
+TESTS = []
+
+for ind, dst in enumerate(
+    [
+        np.asarray([[1.0, 0.0, 0.0], [0.0, -1.0, 1.0], [0.0, 0.0, 1.0]]),  # flip the second
+        np.asarray([[-1.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),  # flip the first
+    ]
+):
+    for p in TEST_NDARRAYS:
+        for p_src in TEST_NDARRAYS:
+            for dtype in (np.float32, np.float64):
+                for align in (False, True):
+                    for interp_mode in ("nearest", "bilinear"):
+                        for padding_mode in ("zeros", "border", "reflection"):
+                            TESTS.append(
+                                [
+                                    {},  # default no params
+                                    np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
+                                    {
+                                        "src": p_src(np.eye(3)),
+                                        "dst": p(dst) if dst is not None else None,
+                                        "dtype": dtype,
+                                        "align_corners": align,
+                                        "mode": interp_mode,
+                                        "padding_mode": padding_mode,
+                                    },
+                                    np.array([[[2.0, 1.0], [4.0, 3.0]]])
+                                    if ind == 0
+                                    else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
+                                ]
+                            )
+
+for ind, dst in enumerate(
+    [
+        np.asarray([[1.0, 0.0, 0.0, 0.0], [0.0, -1.0, 0.0, 1.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]),
+        np.asarray([[-1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]),
+    ]
+):
+    for p in TEST_NDARRAYS:
+        for p_src in TEST_NDARRAYS:
+            for dtype in (np.float32, np.float64):
+                for align in (True, False):
+                    interp = ("nearest", "bilinear")
+                    if align and USE_COMPILED:
+                        interp = interp + (0, 1)  # type: ignore
+                    for interp_mode in interp:
+                        for padding_mode in ("zeros", "border", "reflection"):
+                            TESTS.append(
+                                [
+                                    {},  # default no params
+                                    np.arange(12).reshape((1, 2, 2, 3)) + 1.0,  # data
+                                    {
+                                        "src": p_src(np.eye(4)),
+                                        "dst": p(dst) if dst is not None else None,
+                                        "dtype": dtype,
+                                        "align_corners": align,
+                                        "mode": interp_mode,
+                                        "padding_mode": padding_mode,
+                                    },
+                                    np.array(
+                                        [[[[4.0, 5.0, 6.0], [1.0, 2.0, 3.0]], [[10.0, 11.0, 12.0], [7.0, 8.0, 9.0]]]]
+                                    )
+                                    if ind == 0
+                                    else np.array(
+                                        [[[[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]]
+                                    ),
+                                ]
+                            )
+
+
+class TestSpatialResample(unittest.TestCase):
+    @parameterized.expand(TESTS)
+    def test_flips(self, init_param, img, data_param, expected_output):
+        for p in TEST_NDARRAYS:
+            _img = p(img)
+            _expected_output = p(expected_output)
+            output_data, output_dst = SpatialResample(**init_param)(img=_img, **data_param)
+            assert_allclose(output_data, _expected_output)
+            expected_dst = data_param.get("dst") if data_param.get("dst") is not None else data_param.get("src")
+            assert_allclose(output_dst, expected_dst, type_test=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spatial_resampled.py
+++ b/tests/test_spatial_resampled.py
@@ -29,27 +29,26 @@ for ind, dst in enumerate(
 ):
     for p in TEST_NDARRAYS:
         for p_src in TEST_NDARRAYS:
-            for dtype in (np.float32, np.float64):
-                for align in (False, True):
-                    for interp_mode in ("nearest", "bilinear"):
-                        for padding_mode in ("zeros", "border", "reflection"):
-                            TESTS.append(
-                                [
-                                    {},  # default no params
-                                    np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
-                                    {
-                                        "src": p_src(np.eye(3)),
-                                        "dst": p(dst),
-                                        "dtype": dtype,
-                                        "align_corners": align,
-                                        "mode": interp_mode,
-                                        "padding_mode": padding_mode,
-                                    },
-                                    np.array([[[2.0, 1.0], [4.0, 3.0]]])
-                                    if ind == 0
-                                    else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
-                                ]
-                            )
+            for align in (False, True):
+                for interp_mode in ("nearest", "bilinear"):
+                    for padding_mode in ("zeros", "border", "reflection"):
+                        TESTS.append(
+                            [
+                                {},  # default no params
+                                np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
+                                {
+                                    "src": p_src(np.eye(3)),
+                                    "dst": p(dst),
+                                    "dtype": np.float32,
+                                    "align_corners": align,
+                                    "mode": interp_mode,
+                                    "padding_mode": padding_mode,
+                                },
+                                np.array([[[2.0, 1.0], [4.0, 3.0]]])
+                                if ind == 0
+                                else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
+                            ]
+                        )
 
 for ind, dst in enumerate(
     [
@@ -57,37 +56,33 @@ for ind, dst in enumerate(
         np.asarray([[-1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]),
     ]
 ):
-    for p in TEST_NDARRAYS:
-        for p_src in TEST_NDARRAYS:
-            for dtype in (np.float32, np.float64):
-                for align in (True, False):
-                    if align and USE_COMPILED:
-                        interp = ("nearest", "bilinear", 0, 1)  # type: ignore
-                    else:
-                        interp = ("nearest", "bilinear")  # type: ignore
-                    for interp_mode in interp:  # type: ignore
-                        for padding_mode in ("zeros", "border", "reflection"):
-                            TESTS.append(
-                                [
-                                    {},  # default no params
-                                    np.arange(12).reshape((1, 2, 2, 3)) + 1.0,  # data
-                                    {
-                                        "src": p_src(np.eye(4)),
-                                        "dst": p(dst),
-                                        "dtype": dtype,
-                                        "align_corners": align,
-                                        "mode": interp_mode,
-                                        "padding_mode": padding_mode,
-                                    },
-                                    np.array(
-                                        [[[[4.0, 5.0, 6.0], [1.0, 2.0, 3.0]], [[10.0, 11.0, 12.0], [7.0, 8.0, 9.0]]]]
-                                    )
-                                    if ind == 0
-                                    else np.array(
-                                        [[[[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]]
-                                    ),
-                                ]
-                            )
+    for p_src in TEST_NDARRAYS:
+        for align in (True, False):
+            if align and USE_COMPILED:
+                interp = ("nearest", "bilinear", 0, 1)  # type: ignore
+            else:
+                interp = ("nearest", "bilinear")  # type: ignore
+            for interp_mode in interp:  # type: ignore
+                for padding_mode in ("zeros", "border", "reflection"):
+                    TESTS.append(
+                        [
+                            {},  # default no params
+                            np.arange(12).reshape((1, 2, 2, 3)) + 1.0,  # data
+                            {
+                                "src": p_src(np.eye(4)),
+                                "dst": p_src(dst),
+                                "dtype": np.float64,
+                                "align_corners": align,
+                                "mode": interp_mode,
+                                "padding_mode": padding_mode,
+                            },
+                            np.array([[[[4.0, 5.0, 6.0], [1.0, 2.0, 3.0]], [[10.0, 11.0, 12.0], [7.0, 8.0, 9.0]]]])
+                            if ind == 0
+                            else np.array(
+                                [[[[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]]
+                            ),
+                        ]
+                    )
 
 
 class TestSpatialResample(unittest.TestCase):
@@ -106,13 +101,15 @@ class TestSpatialResample(unittest.TestCase):
             align_corners=data_param.get("align_corners"),
         )
         output_data = xform(input_dict)
-        assert_allclose(output_data["img"], _expected_output)
-        assert_allclose(output_data["img_meta_dict"]["src"], data_param.get("dst"), type_test=False)
+        assert_allclose(output_data["img"], _expected_output, rtol=1e-2, atol=1e-2)
+        assert_allclose(
+            output_data["img_meta_dict"]["src"], data_param.get("dst"), type_test=False, rtol=1e-2, atol=1e-2
+        )
 
         inverted = xform.inverse(output_data)
         self.assertEqual(inverted["img_transforms"], [])  # no further invert after inverting
-        assert_allclose(inverted["img_meta_dict"]["src"], data_param.get("src"), type_test=False)
-        assert_allclose(inverted["img"], _img)
+        assert_allclose(inverted["img_meta_dict"]["src"], data_param.get("src"), type_test=False, rtol=1e-2, atol=1e-2)
+        assert_allclose(inverted["img"], _img, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/tests/test_spatial_resampled.py
+++ b/tests/test_spatial_resampled.py
@@ -31,24 +31,21 @@ for ind, dst in enumerate(
         for p_src in TEST_NDARRAYS:
             for align in (False, True):
                 for interp_mode in ("nearest", "bilinear"):
-                    for padding_mode in ("zeros", "border", "reflection"):
-                        TESTS.append(
-                            [
-                                {},  # default no params
-                                np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
-                                {
-                                    "src": p_src(np.eye(3)),
-                                    "dst": p(dst),
-                                    "dtype": np.float32,
-                                    "align_corners": align,
-                                    "mode": interp_mode,
-                                    "padding_mode": padding_mode,
-                                },
-                                np.array([[[2.0, 1.0], [4.0, 3.0]]])
-                                if ind == 0
-                                else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
-                            ]
-                        )
+                    TESTS.append(
+                        [
+                            {},  # default no params
+                            np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
+                            {
+                                "src": p_src(np.eye(3)),
+                                "dst": p(dst),
+                                "dtype": np.float32,
+                                "align_corners": align,
+                                "mode": interp_mode,
+                                "padding_mode": "zeros",
+                            },
+                            np.array([[[2.0, 1.0], [4.0, 3.0]]]) if ind == 0 else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
+                        ]
+                    )
 
 for ind, dst in enumerate(
     [

--- a/tests/test_spatial_resampled.py
+++ b/tests/test_spatial_resampled.py
@@ -61,10 +61,11 @@ for ind, dst in enumerate(
         for p_src in TEST_NDARRAYS:
             for dtype in (np.float32, np.float64):
                 for align in (True, False):
-                    interp = ("nearest", "bilinear")
                     if align and USE_COMPILED:
-                        interp = interp + (0, 1)  # type: ignore
-                    for interp_mode in interp:
+                        interp = ("nearest", "bilinear", 0, 1)  # type: ignore
+                    else:
+                        interp = ("nearest", "bilinear")  # type: ignore
+                    for interp_mode in interp:  # type: ignore
                         for padding_mode in ("zeros", "border", "reflection"):
                             TESTS.append(
                                 [
@@ -92,9 +93,9 @@ for ind, dst in enumerate(
 class TestSpatialResample(unittest.TestCase):
     @parameterized.expand(itertools.product(TEST_NDARRAYS, TESTS))
     def test_flips_inverse(self, p_type, args):
-        init_param, img, data_param, expected_output = args
-        _img = p(img)
-        _expected_output = p(expected_output)
+        _, img, data_param, expected_output = args
+        _img = p_type(img)
+        _expected_output = p_type(expected_output)
         input_dict = {"img": _img, "img_meta_dict": {"src": data_param.get("src"), "dst": data_param.get("dst")}}
         xform = SpatialResampleD(
             keys="img",
@@ -102,6 +103,7 @@ class TestSpatialResample(unittest.TestCase):
             meta_dst_keys="dst",
             mode=data_param.get("mode"),
             padding_mode=data_param.get("padding_mode"),
+            align_corners=data_param.get("align_corners"),
         )
         output_data = xform(input_dict)
         assert_allclose(output_data["img"], _expected_output)

--- a/tests/test_spatial_resampled.py
+++ b/tests/test_spatial_resampled.py
@@ -1,0 +1,117 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+from monai.config import USE_COMPILED
+from monai.transforms import SpatialResampleD
+from tests.utils import TEST_NDARRAYS, assert_allclose
+
+TESTS = []
+
+for ind, dst in enumerate(
+    [
+        np.asarray([[1.0, 0.0, 0.0], [0.0, -1.0, 1.0], [0.0, 0.0, 1.0]]),  # flip the second
+        np.asarray([[-1.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),  # flip the first
+    ]
+):
+    for p in TEST_NDARRAYS:
+        for p_src in TEST_NDARRAYS:
+            for dtype in (np.float32, np.float64):
+                for align in (False, True):
+                    for interp_mode in ("nearest", "bilinear"):
+                        for padding_mode in ("zeros", "border", "reflection"):
+                            TESTS.append(
+                                [
+                                    {},  # default no params
+                                    np.arange(4).reshape((1, 2, 2)) + 1.0,  # data
+                                    {
+                                        "src": p_src(np.eye(3)),
+                                        "dst": p(dst),
+                                        "dtype": dtype,
+                                        "align_corners": align,
+                                        "mode": interp_mode,
+                                        "padding_mode": padding_mode,
+                                    },
+                                    np.array([[[2.0, 1.0], [4.0, 3.0]]])
+                                    if ind == 0
+                                    else np.array([[[3.0, 4.0], [1.0, 2.0]]]),
+                                ]
+                            )
+
+for ind, dst in enumerate(
+    [
+        np.asarray([[1.0, 0.0, 0.0, 0.0], [0.0, -1.0, 0.0, 1.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]),
+        np.asarray([[-1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]),
+    ]
+):
+    for p in TEST_NDARRAYS:
+        for p_src in TEST_NDARRAYS:
+            for dtype in (np.float32, np.float64):
+                for align in (True, False):
+                    interp = ("nearest", "bilinear")
+                    if align and USE_COMPILED:
+                        interp = interp + (0, 1)  # type: ignore
+                    for interp_mode in interp:
+                        for padding_mode in ("zeros", "border", "reflection"):
+                            TESTS.append(
+                                [
+                                    {},  # default no params
+                                    np.arange(12).reshape((1, 2, 2, 3)) + 1.0,  # data
+                                    {
+                                        "src": p_src(np.eye(4)),
+                                        "dst": p(dst),
+                                        "dtype": dtype,
+                                        "align_corners": align,
+                                        "mode": interp_mode,
+                                        "padding_mode": padding_mode,
+                                    },
+                                    np.array(
+                                        [[[[4.0, 5.0, 6.0], [1.0, 2.0, 3.0]], [[10.0, 11.0, 12.0], [7.0, 8.0, 9.0]]]]
+                                    )
+                                    if ind == 0
+                                    else np.array(
+                                        [[[[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]]
+                                    ),
+                                ]
+                            )
+
+
+class TestSpatialResample(unittest.TestCase):
+    @parameterized.expand(itertools.product(TEST_NDARRAYS, TESTS))
+    def test_flips_inverse(self, p_type, args):
+        init_param, img, data_param, expected_output = args
+        _img = p(img)
+        _expected_output = p(expected_output)
+        input_dict = {"img": _img, "img_meta_dict": {"src": data_param.get("src"), "dst": data_param.get("dst")}}
+        xform = SpatialResampleD(
+            keys="img",
+            meta_src_keys="src",
+            meta_dst_keys="dst",
+            mode=data_param.get("mode"),
+            padding_mode=data_param.get("padding_mode"),
+        )
+        output_data = xform(input_dict)
+        assert_allclose(output_data["img"], _expected_output)
+        assert_allclose(output_data["img_meta_dict"]["src"], data_param.get("dst"), type_test=False)
+
+        inverted = xform.inverse(output_data)
+        self.assertEqual(inverted["img_transforms"], [])  # no further invert after inverting
+        assert_allclose(inverted["img_meta_dict"]["src"], data_param.get("src"), type_test=False)
+        assert_allclose(inverted["img"], _img)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
part of #2823, typing enhancement as part of #3701

### Description
enhance the `monai.utils.convert_data_type` to have more precise typing (as it is used extensively across the modules):

```py
from monai.utils.type_conversion import convert_data_type, convert_to_dst_type
from typing import Any

import torch
import numpy as np

a = torch.Tensor(10.0)
b = convert_to_dst_type(1.0, dst=a)[0]
reveal_type(b)

c = convert_data_type(a, np.ndarray)[0]
reveal_type(c)

d = convert_data_type(a, torch.Tensor)[0]
reveal_type(d)

e: Any = convert_data_type(a, None)[0]
reveal_type(e)

f = convert_data_type(a, type(a))[0]
reveal_type(f)

```
will reveal the expected types:
```
test.py:9:13: note: Revealed type is "torch._tensor.Tensor*"
test.py:12:13: note: Revealed type is "numpy.ndarray*[_ShapeType`1, _DType_co`2]"
test.py:15:13: note: Revealed type is "torch._tensor.Tensor*"
test.py:18:13: note: Revealed type is "Any"
test.py:21:13: note: Revealed type is "torch._tensor.Tensor*"
```

as a baseline, the current dev branch outcome is:
```
test.py:9:13: note: Revealed type is "Union[numpy.ndarray[Any, Any], torch._tensor.Tensor]"
test.py:12:13: note: Revealed type is "Union[numpy.ndarray[Any, Any], torch._tensor.Tensor]"
test.py:15:13: note: Revealed type is "Union[numpy.ndarray[Any, Any], torch._tensor.Tensor]"
test.py:18:13: note: Revealed type is "Any"
test.py:21:13: note: Revealed type is "Union[numpy.ndarray[Any, Any], torch._tensor.Tensor]"
```

### Status
**Ready** (depends on #3701)

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
