### PR TITLE
3791 orientation xform warning spatial dims

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -489,6 +489,11 @@ class Orientation(Transform):
         else:
             if self.axcodes is None:
                 raise ValueError("Incompatible values: axcodes=None and as_closest_canonical=True.")
+            if sr < len(self.axcodes):
+                warnings.warn(
+                    f"axcodes ('{self.axcodes}') length is smaller than the number of input spatial dimensions D={sr}.\n"
+                    f"{self.__class__.__name__}: input spatial shape is {spatial_shape}, num. channels is {data_array.shape[0]}."
+                )
             dst = nib.orientations.axcodes2ornt(self.axcodes[:sr], labels=self.labels)
             if len(dst) < sr:
                 raise ValueError(


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #3791

### Description
adds a warning message when reorienting if needed

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
