### PR TITLE
enhance to use spatial_shape ResampleToMatch

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -293,13 +293,11 @@ class ResampleToMatch(SpatialResample):
         dtype = dtype or self.dtype
         src_affine = src_meta.get("affine")
         dst_affine = dst_meta.get("affine")
-        ndim = len(img.shape[1:])
-        spatial_size = dst_meta.get("dim", [])[1 : ndim + 2]
         img, updated_affine = super().__call__(
             img=img,
             src_affine=src_affine,
             dst_affine=dst_affine,
-            spatial_size=spatial_size,
+            spatial_size=dst_meta.get("spatial_shape"),
             mode=mode,
             padding_mode=padding_mode,
             align_corners=align_corners,
@@ -307,6 +305,8 @@ class ResampleToMatch(SpatialResample):
         )
         dst_meta = deepcopy(dst_meta)
         dst_meta["affine"] = updated_affine
+        if "spatial_shape" in dst_meta:
+            dst_meta["spatial_shape"] = src_meta.get("spatial_shape")
         if "dim" in dst_meta:
             dst_meta["dim"] = src_meta.get("dim", [])
         if "pixdim" in dst_meta:

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -305,12 +305,6 @@ class ResampleToMatch(SpatialResample):
         )
         dst_meta = deepcopy(dst_meta)
         dst_meta["affine"] = updated_affine
-        if "spatial_shape" in dst_meta:
-            dst_meta["spatial_shape"] = src_meta.get("spatial_shape")
-        if "dim" in dst_meta:
-            dst_meta["dim"] = src_meta.get("dim", [])
-        if "pixdim" in dst_meta:
-            dst_meta["pixdim"] = src_meta.get("pixdim", [])
         return img, dst_meta
 
 

--- a/tests/test_resample_to_match.py
+++ b/tests/test_resample_to_match.py
@@ -9,12 +9,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import os
 import tempfile
 import unittest
 
+from parameterized import parameterized
+
+from monai.data.image_reader import ITKReader, NibabelReader
+from monai.data.image_writer import ITKWriter, NibabelWriter
 from monai.transforms import Compose, EnsureChannelFirstd, LoadImaged, ResampleToMatch, SaveImaged
 from tests.utils import assert_allclose, download_url_or_skip_test, testing_data_config
+
+TEST_CASES = ["itkreader", "nibabelreader"]
 
 
 class TestResampleToMatch(unittest.TestCase):
@@ -28,14 +35,15 @@ class TestResampleToMatch(unittest.TestCase):
             download_url_or_skip_test(url=url, filepath=fname, hash_type=hash_type, hash_val=hash_val)
             self.fnames.append(fname)
 
-    def test_correct(self):
+    @parameterized.expand(itertools.product([NibabelReader, ITKReader], [NibabelWriter, ITKWriter]))
+    def test_correct(self, reader, writer):
         with tempfile.TemporaryDirectory() as temp_dir:
-            loader = Compose([LoadImaged(("im1", "im2")), EnsureChannelFirstd(("im1", "im2"))])
+            loader = Compose([LoadImaged(("im1", "im2"), reader=reader), EnsureChannelFirstd(("im1", "im2"))])
             data = loader({"im1": self.fnames[0], "im2": self.fnames[1]})
 
             im_mod, meta = ResampleToMatch()(data["im2"], data["im2_meta_dict"], data["im1_meta_dict"])
             # for visual inspection
-            saver = SaveImaged("im3", output_dir=temp_dir, output_postfix="", separate_folder=False)
+            saver = SaveImaged("im3", output_dir=temp_dir, output_postfix="", separate_folder=False, writer=writer)
             meta["filename_or_obj"] = "file3.nii.gz"
             saver({"im3": im_mod, "im3_meta_dict": meta})
 

--- a/tests/test_resample_to_match.py
+++ b/tests/test_resample_to_match.py
@@ -14,6 +14,8 @@ import os
 import tempfile
 import unittest
 
+import nibabel as nib
+import numpy as np
 from parameterized import parameterized
 
 from monai.data.image_reader import ITKReader, NibabelReader
@@ -47,7 +49,9 @@ class TestResampleToMatch(unittest.TestCase):
             meta["filename_or_obj"] = "file3.nii.gz"
             saver({"im3": im_mod, "im3_meta_dict": meta})
 
-            assert_allclose(im_mod.shape, data["im1"].shape)
+            saved = nib.load(os.path.join(temp_dir, meta["filename_or_obj"]))
+            assert_allclose(im_mod.shape[1:], saved.shape)
+            assert_allclose(saved.header["dim"][:4], np.array([3, 384, 384, 19]))
 
 
 if __name__ == "__main__":

--- a/tests/test_resample_to_match.py
+++ b/tests/test_resample_to_match.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import itertools
 import os
 import tempfile
@@ -44,6 +45,7 @@ class TestResampleToMatch(unittest.TestCase):
             data = loader({"im1": self.fnames[0], "im2": self.fnames[1]})
 
             im_mod, meta = ResampleToMatch()(data["im2"], data["im2_meta_dict"], data["im1_meta_dict"])
+            current_dims = copy.deepcopy(meta.get("dim"))
             saver = SaveImaged("im3", output_dir=temp_dir, output_postfix="", separate_folder=False, writer=writer)
             meta["filename_or_obj"] = "file3.nii.gz"
             saver({"im3": im_mod, "im3_meta_dict": meta})
@@ -51,6 +53,8 @@ class TestResampleToMatch(unittest.TestCase):
             saved = nib.load(os.path.join(temp_dir, meta["filename_or_obj"]))
             assert_allclose(data["im1"].shape[1:], saved.shape)
             assert_allclose(saved.header["dim"][:4], np.array([3, 384, 384, 19]))
+            if current_dims is not None:
+                assert_allclose(saved.header["dim"], current_dims)
 
 
 if __name__ == "__main__":

--- a/tests/test_resample_to_match.py
+++ b/tests/test_resample_to_match.py
@@ -44,13 +44,12 @@ class TestResampleToMatch(unittest.TestCase):
             data = loader({"im1": self.fnames[0], "im2": self.fnames[1]})
 
             im_mod, meta = ResampleToMatch()(data["im2"], data["im2_meta_dict"], data["im1_meta_dict"])
-            # for visual inspection
             saver = SaveImaged("im3", output_dir=temp_dir, output_postfix="", separate_folder=False, writer=writer)
             meta["filename_or_obj"] = "file3.nii.gz"
             saver({"im3": im_mod, "im3_meta_dict": meta})
 
             saved = nib.load(os.path.join(temp_dir, meta["filename_or_obj"]))
-            assert_allclose(im_mod.shape[1:], saved.shape)
+            assert_allclose(data["im1"].shape[1:], saved.shape)
             assert_allclose(saved.header["dim"][:4], np.array([3, 384, 384, 19]))
 
 

--- a/tests/test_resample_to_matchd.py
+++ b/tests/test_resample_to_matchd.py
@@ -47,6 +47,7 @@ class TestResampleToMatchd(unittest.TestCase):
             )
             data = transforms({"im1": self.fnames[0], "im2": self.fnames[1]})
             assert_allclose(data["im1"].shape, data["im3"].shape)
+            assert_allclose(data["im3"].shape[1:], data["im3_meta_dict"]["spatial_shape"], type_test=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_resample_to_matchd.py
+++ b/tests/test_resample_to_matchd.py
@@ -46,8 +46,21 @@ class TestResampleToMatchd(unittest.TestCase):
                 ]
             )
             data = transforms({"im1": self.fnames[0], "im2": self.fnames[1]})
+            # check that output sizes match
             assert_allclose(data["im1"].shape, data["im3"].shape)
+            # and that the meta data has been updated accordingly
             assert_allclose(data["im3"].shape[1:], data["im3_meta_dict"]["spatial_shape"], type_test=False)
+            assert_allclose(data["im3_meta_dict"]["affine"], data["im1_meta_dict"]["affine"])
+            # check we're different from the original
+            self.assertTrue(any(i != j for i, j in zip(data["im3"].shape, data["im2"].shape)))
+            self.assertTrue(
+                any(
+                    i != j
+                    for i, j in zip(
+                        data["im3_meta_dict"]["affine"].flatten(), data["im2_meta_dict"]["affine"].flatten()
+                    )
+                )
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

follow up of https://github.com/Project-MONAI/MONAI/pull/3833

### Description
spatial_shape is a more reliable attribute from the readers for resampletomatch

https://github.com/Project-MONAI/MONAI/blob/127e823dc52224e3b201679b16c5d76e9c57e2ab/monai/data/image_reader.py#L266
### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
