### PR TITLE
inverse ResampleToMatchd

### DIFF
--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -390,7 +390,7 @@ class ResampleToMatchd(MapTransform, InvertibleTransform):
 
             img, new_meta = self.resampler(
                 img=d[key],
-                src_meta=src_meta,
+                src_meta=src_meta,  # type: ignore
                 dst_meta=orig_meta,
                 mode=mode,
                 padding_mode=padding_mode,

--- a/tests/test_resample_to_matchd.py
+++ b/tests/test_resample_to_matchd.py
@@ -13,7 +13,16 @@ import os
 import tempfile
 import unittest
 
-from monai.transforms import Compose, CopyItemsd, EnsureChannelFirstd, Lambda, LoadImaged, ResampleToMatchd, SaveImaged
+from monai.transforms import (
+    Compose,
+    CopyItemsd,
+    EnsureChannelFirstd,
+    Invertd,
+    Lambda,
+    LoadImaged,
+    ResampleToMatchd,
+    SaveImaged,
+)
 from tests.utils import assert_allclose, download_url_or_skip_test, testing_data_config
 
 
@@ -47,6 +56,9 @@ class TestResampleToMatchd(unittest.TestCase):
             )
             data = transforms({"im1": self.fnames[0], "im2": self.fnames[1]})
             assert_allclose(data["im1"].shape, data["im3"].shape)
+            # test the inverse
+            data = Invertd("im3", transforms, "im3")(data)
+            assert_allclose(data["im2"].shape, data["im3"].shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
Adds an `inverse` method for `ResampleToMatchd`.

This will create small conflicts with https://github.com/Project-MONAI/MONAI/pull/3847 that will need to be cleaned first.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.