### PR TITLE
3867 fix non intensity error

### DIFF
--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1813,9 +1813,11 @@ class RandKSpaceSpikeNoise(RandomizableTransform, Fourier):
         n_dims = len(img.shape[1:])
 
         k = self.shift_fourier(img, n_dims)
-        k, *_ = convert_data_type(k, output_type=np.ndarray)
-        log_abs = np.log(np.absolute(k) + 1e-10)
-        shifted_means = np.mean(log_abs, tuple(range(-n_dims, 0))) * 2.5
+        mod = torch if isinstance(k, torch.Tensor) else np
+        log_abs = mod.log(mod.absolute(k) + 1e-10)
+        shifted_means = mod.mean(log_abs, tuple(range(-n_dims, 0))) * 2.5
+        if isinstance(k, torch.Tensor):
+            shifted_means = shifted_means.to("cpu")
         return tuple((i * 0.95, i * 1.1) for i in shifted_means)
 
 

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1816,7 +1816,7 @@ class RandKSpaceSpikeNoise(RandomizableTransform, Fourier):
         mod = torch if isinstance(k, torch.Tensor) else np
         log_abs = mod.log(mod.absolute(k) + 1e-10)
         shifted_means = mod.mean(log_abs, tuple(range(-n_dims, 0))) * 2.5
-        if isinstance(k, torch.Tensor):
+        if isinstance(shifted_means, torch.Tensor):
             shifted_means = shifted_means.to("cpu")
         return tuple((i * 0.95, i * 1.1) for i in shifted_means)
 

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1814,9 +1814,8 @@ class RandKSpaceSpikeNoise(RandomizableTransform, Fourier):
 
         k = self.shift_fourier(img, n_dims)
         k, *_ = convert_data_type(k, output_type=np.ndarray)
-        mod = torch if isinstance(k, torch.Tensor) else np
-        log_abs = mod.log(mod.absolute(k) + 1e-10)
-        shifted_means = mod.mean(log_abs, tuple(range(-n_dims, 0))) * 2.5
+        log_abs = np.log(np.absolute(k) + 1e-10)
+        shifted_means = np.mean(log_abs, tuple(range(-n_dims, 0))) * 2.5
         return tuple((i * 0.95, i * 1.1) for i in shifted_means)
 
 

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1813,9 +1813,10 @@ class RandKSpaceSpikeNoise(RandomizableTransform, Fourier):
         n_dims = len(img.shape[1:])
 
         k = self.shift_fourier(img, n_dims)
+        k, *_ = convert_data_type(k, output_type=np.ndarray)
         mod = torch if isinstance(k, torch.Tensor) else np
         log_abs = mod.log(mod.absolute(k) + 1e-10)
-        shifted_means = mod.mean(log_abs, dim=tuple(range(-n_dims, 0))) * 2.5
+        shifted_means = mod.mean(log_abs, tuple(range(-n_dims, 0))) * 2.5
         return tuple((i * 0.95, i * 1.1) for i in shifted_means)
 
 

--- a/tests/test_k_space_spike_noise.py
+++ b/tests/test_k_space_spike_noise.py
@@ -25,7 +25,8 @@ from tests.utils import TEST_NDARRAYS
 TESTS = []
 for shape in ((128, 64), (64, 48, 80)):
     for p in TEST_NDARRAYS:
-        TESTS.append((shape, p))
+        for intensity in [10, None]:
+            TESTS.append((shape, p, intensity))
 
 
 class TestKSpaceSpikeNoise(unittest.TestCase):
@@ -43,11 +44,10 @@ class TestKSpaceSpikeNoise(unittest.TestCase):
         return im_type(im[None])
 
     @parameterized.expand(TESTS)
-    def test_same_result(self, im_shape, im_type):
+    def test_same_result(self, im_shape, im_type, k_intensity):
 
         im = self.get_data(im_shape, im_type)
         loc = [0, int(im.shape[1] / 2), 0] if len(im_shape) == 2 else [0, int(im.shape[1] / 2), 0, 0]
-        k_intensity = 10
         t = KSpaceSpikeNoise(loc, k_intensity)
 
         out1 = t(deepcopy(im))
@@ -62,11 +62,10 @@ class TestKSpaceSpikeNoise(unittest.TestCase):
         np.testing.assert_allclose(out1, out2)
 
     @parameterized.expand(TESTS)
-    def test_highlighted_kspace_pixel(self, im_shape, as_tensor_input):
+    def test_highlighted_kspace_pixel(self, im_shape, as_tensor_input, k_intensity):
 
         im = self.get_data(im_shape, as_tensor_input)
         loc = [0, int(im.shape[1] / 2), 0] if len(im_shape) == 2 else [0, int(im.shape[1] / 2), 0, 0]
-        k_intensity = 10
         t = KSpaceSpikeNoise(loc, k_intensity)
         out = t(im)
 
@@ -75,10 +74,11 @@ class TestKSpaceSpikeNoise(unittest.TestCase):
             self.assertEqual(im.device, out.device)
             out = out.cpu()
 
-        n_dims = len(im_shape)
-        out_k = fftshift(fftn(out, axes=tuple(range(-n_dims, 0))), axes=tuple(range(-n_dims, 0)))
-        log_mag = np.log(np.absolute(out_k))
-        np.testing.assert_allclose(k_intensity, log_mag[tuple(loc)], 1e-4)
+        if k_intensity is not None:
+            n_dims = len(im_shape)
+            out_k = fftshift(fftn(out, axes=tuple(range(-n_dims, 0))), axes=tuple(range(-n_dims, 0)))
+            log_mag = np.log(np.absolute(out_k))
+            np.testing.assert_allclose(k_intensity, log_mag[tuple(loc)], 1e-4)
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_k_space_spike_noise.py
+++ b/tests/test_rand_k_space_spike_noise.py
@@ -92,6 +92,13 @@ class TestRandKSpaceSpikeNoise(unittest.TestCase):
         self.assertGreaterEqual(t.sampled_k_intensity[0], 14)
         self.assertLessEqual(t.sampled_k_intensity[0], 14.1)
 
+    @parameterized.expand(TESTS)
+    def test_default_intensity(self, im_shape, im_type, channel_wise):
+        im = self.get_data(im_shape, im_type)
+        t = RandKSpaceSpikeNoise(1.0, intensity_range=None, channel_wise=channel_wise)
+        out = t(deepcopy(im))
+        self.assertEqual(out.shape, im.shape)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #3867 .

### Description
This PR fixes the `_set_default_range` issue in class `RandKSpaceSpikeNoise`.

There are two errors in this function:

1. For numpy based img, `np.mean` does not have the arg `dim` (this bug is reported in #3867 , thanks to @mibaumgartner !)
2. the generated intensity range has the same type as `img`, if `img` is saved in GPU, error will be raised in the following `self.R.uniform` manipulation step.

In addition, this PR adds the test case (none intensity_range) for `RandKSpaceSpikeNoise`, and the test case (none k_intensity) for `KSpaceSpikeNoise`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
