### PR TITLE
3872 enhance contrastive loss

### DIFF
--- a/monai/losses/contrastive.py
+++ b/monai/losses/contrastive.py
@@ -65,14 +65,13 @@ class ContrastiveLoss(_Loss):
         if target.shape != input.shape:
             raise ValueError(f"ground truth has differing shape ({target.shape}) from input ({input.shape})")
 
-        temperature_tensor = torch.tensor(self.temperature).to(input.device)
+        temperature_tensor = torch.as_tensor(self.temperature).to(input.device)
 
         norm_i = F.normalize(input, dim=1)
         norm_j = F.normalize(target, dim=1)
 
         negatives_mask = ~torch.eye(self.batch_size * 2, self.batch_size * 2, dtype=torch.bool)
-        negatives_mask = torch.tensor(negatives_mask, dtype=torch.float)
-        negatives_mask = torch.clone(torch.as_tensor(negatives_mask)).to(input.device)
+        negatives_mask = torch.clone(negatives_mask.type(torch.float)).to(input.device)
 
         repr = torch.cat([norm_i, norm_j], dim=0)
         sim_matrix = F.cosine_similarity(repr.unsqueeze(1), repr.unsqueeze(0), dim=2)


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #3872 .

### Description
This PR enhances the contrastive loss via:

1. Use `torch.as_tensor` to replace `torch.tensor` for `temperature_tensor`.
2. Remove some duplicate convert type manipulations for `negatives_mask`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
