### PR TITLE
3883 Add addition shape info when raise related errors

### DIFF
--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -54,10 +54,10 @@ class FindAllValidSlicesd(Transform):
         d: Dict = dict(data)
         label = d[self.label]
         if label.shape[0] != 1:
-            raise ValueError("Only supports single channel labels!")
+            raise ValueError("Only supports single channel labels, got label shape {label.shape}!")
 
         if len(label.shape) != 4:  # only for 3D
-            raise ValueError("Only supports label with shape CDHW!")
+            raise ValueError("Only supports label with shape CDHW, got label shape {label.shape}!")
 
         sids = self._apply(label)
         if sids is not None and len(sids):

--- a/monai/metrics/confusion_matrix.py
+++ b/monai/metrics/confusion_matrix.py
@@ -152,7 +152,7 @@ def get_confusion_matrix(y_pred: torch.Tensor, y: torch.Tensor, include_backgrou
     y_pred = y_pred.float()
 
     if y.shape != y_pred.shape:
-        raise ValueError("y_pred and y should have same shapes.")
+        raise ValueError("y_pred and y should have same shapes, got {y_pred.shape} and {y.shape}.")
 
     # get confusion matrix related metric
     batch_size, n_class = y_pred.shape[:2]

--- a/monai/metrics/froc.py
+++ b/monai/metrics/froc.py
@@ -46,7 +46,9 @@ def compute_fp_tp_probs(
 
     """
     if not (probs.shape == y_coord.shape == x_coord.shape):
-        raise AssertionError("the shapes for coordinates and probabilities should be the same.")
+        raise ValueError(
+            "the shapes between probs {probs.shape}, y_coord {y_coord.shape} and x_coord {x_coord.shape} should be the same."
+        )
 
     if isinstance(probs, torch.Tensor):
         probs = probs.detach().cpu().numpy()

--- a/monai/metrics/hausdorff_distance.py
+++ b/monai/metrics/hausdorff_distance.py
@@ -148,7 +148,7 @@ def compute_hausdorff_distance(
         y_pred = y_pred.float()
 
     if y.shape != y_pred.shape:
-        raise ValueError("y_pred and y should have same shapes.")
+        raise ValueError("y_pred and y should have same shapes, got {y_pred.shape} and {y.shape}.")
 
     batch_size, n_class = y_pred.shape[:2]
     hd = np.empty((batch_size, n_class))

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -120,7 +120,7 @@ def compute_meandice(y_pred: torch.Tensor, y: torch.Tensor, include_background: 
     y_pred = y_pred.float()
 
     if y.shape != y_pred.shape:
-        raise ValueError("y_pred and y should have same shapes.")
+        raise ValueError("y_pred and y should have same shapes, got {y_pred.shape} and {y.shape}.")
 
     # reducing only spatial dimensions (not batch nor channels)
     n_len = len(y_pred.shape)

--- a/monai/metrics/rocauc.py
+++ b/monai/metrics/rocauc.py
@@ -136,9 +136,11 @@ def compute_roc_auc(y_pred: torch.Tensor, y: torch.Tensor, average: Union[Averag
     y_pred_ndim = y_pred.ndimension()
     y_ndim = y.ndimension()
     if y_pred_ndim not in (1, 2):
-        raise ValueError("Predictions should be of shape (batch_size, num_classes) or (batch_size, ).")
+        raise ValueError(
+            "Predictions should be of shape (batch_size, num_classes) or (batch_size, ), got {y_pred.shape}."
+        )
     if y_ndim not in (1, 2):
-        raise ValueError("Targets should be of shape (batch_size, num_classes) or (batch_size, ).")
+        raise ValueError("Targets should be of shape (batch_size, num_classes) or (batch_size, ), got {y.shape}.")
     if y_pred_ndim == 2 and y_pred.shape[1] == 1:
         y_pred = y_pred.squeeze(dim=-1)
         y_pred_ndim = 1
@@ -149,7 +151,7 @@ def compute_roc_auc(y_pred: torch.Tensor, y: torch.Tensor, average: Union[Averag
         return _calculate(y_pred, y)
 
     if y.shape != y_pred.shape:
-        raise AssertionError("data shapes of y_pred and y do not match.")
+        raise ValueError("data shapes of y_pred and y do not match, got {y_pred.shape} and {y.shape}.")
 
     average = look_up_option(average, Average)
     if average == Average.MICRO:

--- a/monai/metrics/surface_distance.py
+++ b/monai/metrics/surface_distance.py
@@ -142,7 +142,7 @@ def compute_average_surface_distance(
         y_pred = y_pred.float()
 
     if y.shape != y_pred.shape:
-        raise ValueError("y_pred and y should have same shapes.")
+        raise ValueError("y_pred and y should have same shapes, got {y_pred.shape} and {y.shape}.")
 
     batch_size, n_class = y_pred.shape[:2]
     asd = np.empty((batch_size, n_class))

--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -144,7 +144,7 @@ def get_mask_edges(
         seg_gt = seg_gt.detach().cpu().numpy()
 
     if seg_pred.shape != seg_gt.shape:
-        raise ValueError("seg_pred and seg_gt should have same shapes.")
+        raise ValueError("seg_pred and seg_gt should have same shapes, got {seg_pred.shape} and {seg_gt.shape}.")
 
     # If not binary images, convert them
     if seg_pred.dtype != bool:

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -344,7 +344,7 @@ class SavitzkyGolayFilter(nn.Module):
         x = x.to(dtype=torch.float)
 
         if (self.axis < 0) or (self.axis > len(x.shape) - 1):
-            raise ValueError("Invalid axis for shape of x.")
+            raise ValueError("Invalid axis for shape of x, got axis {self.axis} and shape {x.shape}.")
 
         # Create list of filter kernels (1 per spatial dimension). The kernel for self.axis will be the savgol coeffs,
         # while the other kernels will be set to [1].
@@ -409,7 +409,7 @@ class HilbertTransform(nn.Module):
         x = x.to(dtype=torch.float)
 
         if (self.axis < 0) or (self.axis > len(x.shape) - 1):
-            raise ValueError("Invalid axis for shape of x.")
+            raise ValueError("Invalid axis for shape of x, got axis {self.axis} and shape {x.shape}.")
 
         n = x.shape[self.axis] if self.n is None else self.n
         if n <= 0:

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -1121,8 +1121,10 @@ class IntensityStats(Transform):
             meta_data = {}
 
         if mask is not None:
-            if mask.shape != img_np.shape or mask.dtype != bool:
-                raise TypeError("mask must be bool array with the same shape as input `img`.")
+            if mask.shape != img_np.shape:
+                raise ValueError("mask must have the same shape as input `img`, got {mask.shape} and {img_np.shape}.")
+            if mask.dtype != bool:
+                raise TypeError("mask must be bool array, got type {mask.dtype}.")
             img_np = img_np[mask]
 
         supported_ops = {


### PR DESCRIPTION
Fixes #3883 .

### Description

The way to find the places that should be modified is by using the following regular expression without case sensivity:
```
.*error.*shape
```
Therefore, there may still have some places that are not covered.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
