### PR TITLE
sw inferer progress

### DIFF
--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -119,6 +119,7 @@ class SlidingWindowInferer(Inferer):
             By default the device (and accordingly the memory) of the `inputs` is used. If for example
             set to device=torch.device('cpu') the gpu memory consumption is less and independent of the
             `inputs` and `roi_size`. Output is on the `device`.
+        progress: whether to print a tqdm progress bar.
 
     Note:
         ``sw_batch_size`` denotes the max number of windows per network inference iteration,
@@ -137,6 +138,7 @@ class SlidingWindowInferer(Inferer):
         cval: float = 0.0,
         sw_device: Union[torch.device, str, None] = None,
         device: Union[torch.device, str, None] = None,
+        progress: bool = False,
     ) -> None:
         Inferer.__init__(self)
         self.roi_size = roi_size
@@ -148,6 +150,7 @@ class SlidingWindowInferer(Inferer):
         self.cval = cval
         self.sw_device = sw_device
         self.device = device
+        self.progress = progress
 
     def __call__(
         self, inputs: torch.Tensor, network: Callable[..., torch.Tensor], *args: Any, **kwargs: Any
@@ -174,6 +177,7 @@ class SlidingWindowInferer(Inferer):
             self.cval,
             self.sw_device,
             self.device,
+            self.progress,
             *args,
             **kwargs,
         )

--- a/tests/test_sliding_window_inference.py
+++ b/tests/test_sliding_window_inference.py
@@ -16,7 +16,10 @@ import torch
 from parameterized import parameterized
 
 from monai.inferers import SlidingWindowInferer, sliding_window_inference
+from monai.utils import optional_import
 from tests.utils import skip_if_no_cuda
+
+_, has_tqdm = optional_import("tqdm")
 
 TEST_CASES = [
     [(2, 3, 16), (4,), 3, 0.25, "constant", torch.device("cpu:0")],  # 1D small roi
@@ -145,6 +148,7 @@ class TestSlidingWindowInference(unittest.TestCase):
             cval=-1,
             mode="gaussian",
             sigma_scale=1.0,
+            progress=has_tqdm,
         )
         expected = np.array(
             [
@@ -222,15 +226,16 @@ class TestSlidingWindowInference(unittest.TestCase):
             0.0,
             device,
             device,
+            has_tqdm,
             t1,
             test2=t2,
         )
         expected = np.ones((1, 1, 3, 3)) + 2.0
         np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-4)
 
-        result = SlidingWindowInferer(roi_shape, sw_batch_size, overlap=0.5, mode="constant", cval=-1)(
-            inputs, compute, t1, test2=t2
-        )
+        result = SlidingWindowInferer(
+            roi_shape, sw_batch_size, overlap=0.5, mode="constant", cval=-1, progress=has_tqdm
+        )(inputs, compute, t1, test2=t2)
         np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-4)
 
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

adds an optional sliding window progress bar according to the feedback


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
