### PR TITLE
Contain WSIReader to colored 2D images

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -923,19 +923,20 @@ class WSIReader(ImageReader):
 
         # convert to numpy (if not already in numpy)
         raw_region = np.asarray(raw_region, dtype=dtype)
-        
+
         # check if the image has three dimensions (2D + color)
         if raw_region.ndim != 3:
             raise ValueError(
                 f"The input image dimension should be 3 but {raw_region.ndim} is given. "
                 "`WSIReader` is designed to work only with 2D colored images."
-                )
+            )
 
         # check if the color channel is 3 (RGB) or 4 (RGBA)
         if raw_region.shape[-1] not in [3, 4]:
             raise ValueError(
                 f"There should be three or four color channels but {raw_region.shape[-1]} is given. "
-                "`WSIReader` is designed to work only with 2D colored images.")
+                "`WSIReader` is designed to work only with 2D colored images."
+            )
 
         # remove alpha channel if exist (RGBA)
         if raw_region.shape[-1] > 3:

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -923,6 +923,19 @@ class WSIReader(ImageReader):
 
         # convert to numpy (if not already in numpy)
         raw_region = np.asarray(raw_region, dtype=dtype)
+        
+        # # check if the image has three dimensions (2D + color)
+        if raw_region.ndim != 3:
+            raise ValueError(
+                f"The input image dimension should be 3 but {raw_region.ndim} is given. "
+                "`WSIReader` is designed to work only with 2D colored images."
+                )
+
+        # check if the color channel is 3 (RGB) or 4 (RGBA)
+        if raw_region.shape[-1] not in [3, 4]:
+            raise ValueError(
+                f"There should be three or four color channels but {raw_region.shape[-1]} is given. "
+                "`WSIReader` is designed to work only with 2D colored images.")
 
         # remove alpha channel if exist (RGBA)
         if raw_region.shape[-1] > 3:

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -924,7 +924,7 @@ class WSIReader(ImageReader):
         # convert to numpy (if not already in numpy)
         raw_region = np.asarray(raw_region, dtype=dtype)
         
-        # # check if the image has three dimensions (2D + color)
+        # check if the image has three dimensions (2D + color)
         if raw_region.ndim != 3:
             raise ValueError(
                 f"The input image dimension should be 3 but {raw_region.ndim} is given. "

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -192,10 +192,9 @@ class WSIReaderTests:
         def test_read_malformats(self, img_expected):
             reader = WSIReader(self.backend)
             file_path = save_gray_tiff(
-                img_expected,
-                os.path.join(os.path.dirname(__file__), "testing_data", "temp_tiff_image_gray.tiff"),
+                img_expected, os.path.join(os.path.dirname(__file__), "testing_data", "temp_tiff_image_gray.tiff")
             )
-            with self.assertRaises((RuntimeError, ValueError, openslide.OpenSlideError)):
+            with self.assertRaises((RuntimeError, ValueError, openslide.OpenSlideError if has_osl else ValueError)):
                 with reader.read(file_path) as img_obj:
                     reader.get_data(img_obj)
 

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -28,7 +28,7 @@ from tests.utils import download_url_or_skip_test, testing_data_config
 cucim, has_cucim = optional_import("cucim")
 has_cucim = has_cucim and hasattr(cucim, "CuImage")
 _, has_osl = optional_import("openslide")
-imsave, has_tiff = optional_import("tifffile", name="imsave")
+imwrite, has_tiff = optional_import("tifffile", name="imwrite")
 _, has_codec = optional_import("imagecodecs")
 has_tiff = has_tiff and has_codec
 
@@ -98,7 +98,7 @@ def save_rgba_tiff(array: np.ndarray, filename: str, mode: str):
         array = np.concatenate([array, 255 * np.ones_like(array[0])[np.newaxis]]).astype(np.uint8)
 
     img_rgb = array.transpose(1, 2, 0)
-    imsave(filename, img_rgb, shape=img_rgb.shape, tile=(16, 16))
+    imwrite(filename, img_rgb, shape=img_rgb.shape, tile=(16, 16))
 
     return filename
 

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -84,8 +84,9 @@ TEST_CASE_RGB_0 = [np.ones((3, 2, 2), dtype=np.uint8)]  # CHW
 
 TEST_CASE_RGB_1 = [np.ones((3, 100, 100), dtype=np.uint8)]  # CHW
 
-TEST_CASE_ERROR_GRAY = [np.ones((16, 16), dtype=np.uint8)] # no color channel
-TEST_CASE_ERROR_3D = [np.ones((16, 16, 16, 3), dtype=np.uint8)] # 3D + color
+TEST_CASE_ERROR_GRAY = [np.ones((16, 16), dtype=np.uint8)]  # no color channel
+TEST_CASE_ERROR_3D = [np.ones((16, 16, 16, 3), dtype=np.uint8)]  # 3D + color
+
 
 def save_rgba_tiff(array: np.ndarray, filename: str, mode: str):
     """
@@ -104,18 +105,20 @@ def save_rgba_tiff(array: np.ndarray, filename: str, mode: str):
 
     return filename
 
+
 def save_gray_tiff(array: np.ndarray, filename: str):
     """
     Save numpy array into a TIFF file
 
     Args:
-        array: numpy ndarray with any shape 
+        array: numpy ndarray with any shape
         filename: the filename to be used for the tiff file.
     """
     img_gray = array
-    imwrite(filename, img_gray, shape=img_gray.shape, photometric='rgb')
+    imwrite(filename, img_gray, shape=img_gray.shape, photometric="rgb")
 
     return filename
+
 
 @skipUnless(has_cucim or has_osl or has_tiff, "Requires cucim, openslide, or tifffile!")
 def setUpModule():  # noqa: N802
@@ -184,19 +187,17 @@ class WSIReaderTests:
             self.assertIsNone(assert_array_equal(image["RGB"], img_expected))
             self.assertIsNone(assert_array_equal(image["RGBA"], img_expected))
 
-
         @parameterized.expand([TEST_CASE_ERROR_GRAY, TEST_CASE_ERROR_3D])
         @skipUnless(has_tiff, "Requires tifffile.")
         def test_read_malformats(self, img_expected):
             reader = WSIReader(self.backend)
             file_path = save_gray_tiff(
                 img_expected,
-                os.path.join(os.path.dirname(__file__), "testing_data", f"temp_tiff_image_gray.tiff"),
+                os.path.join(os.path.dirname(__file__), "testing_data", "temp_tiff_image_gray.tiff"),
             )
             with self.assertRaises((RuntimeError, ValueError, openslide.OpenSlideError)):
                 with reader.read(file_path) as img_obj:
                     reader.get_data(img_obj)
-
 
         @parameterized.expand([TEST_CASE_TRANSFORM_0])
         def test_with_dataloader(self, file_path, level, expected_spatial_shape, expected_shape):


### PR DESCRIPTION
Fixes #3878  

### Description
This PR make the WSIReader with TiffFile backend to raise an error for images without the color dimension. It also raise error when the input image is no three dimensional (two spatial and one color).

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
