### PR TITLE
3987 - fixes docstrings and adds checks

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -543,8 +543,8 @@ Post-processing
     :members:
     :special-members: __call__
 
-`Prob NMS`
-""""""""""
+`ProbNMS`
+"""""""""
 .. autoclass:: ProbNMS
   :members:
 
@@ -560,6 +560,12 @@ Spatial
 `SpatialResample`
 """""""""""""""""
 .. autoclass:: SpatialResample
+    :members:
+    :special-members: __call__
+
+`ResampleToMatch`
+"""""""""""""""""
+.. autoclass:: ResampleToMatch
     :members:
     :special-members: __call__
 
@@ -827,7 +833,6 @@ Utility
     :members:
     :special-members: __call__
 
-
 `Transpose`
 """""""""""
 .. autoclass:: Transpose
@@ -851,6 +856,7 @@ Utility
 .. autoclass:: SimulateDelay
     :members:
     :special-members: __call__
+
 
 `Lambda`
 """"""""
@@ -1401,12 +1407,24 @@ Post-processing (Dict)
     :members:
     :special-members: __call__
 
+`ProbNMSd`
+""""""""""
+.. autoclass:: ProbNMSd
+  :members:
+  :special-members: __call__
+
 Spatial (Dict)
 ^^^^^^^^^^^^^^
 
 `SpatialResampled`
 """"""""""""""""""
 .. autoclass:: SpatialResampled
+    :members:
+    :special-members: __call__
+
+`ResampleToMatchd`
+""""""""""""""""""
+.. autoclass:: ResampleToMatchd
     :members:
     :special-members: __call__
 
@@ -1656,6 +1674,12 @@ Utility (Dict)
     :members:
     :special-members: __call__
 
+`ToPILd`
+""""""""
+.. autoclass:: ToPILd
+    :members:
+    :special-members: __call__
+
 `DeleteItemsd`
 """"""""""""""
 .. autoclass:: DeleteItemsd
@@ -1665,6 +1689,12 @@ Utility (Dict)
 `SelectItemsd`
 """"""""""""""
 .. autoclass:: SelectItemsd
+    :members:
+    :special-members: __call__
+
+`Transposed`
+""""""""""""
+.. autoclass:: Transposed
     :members:
     :special-members: __call__
 
@@ -1707,6 +1737,12 @@ Utility (Dict)
 `RandLambdad`
 """""""""""""
 .. autoclass:: RandLambdad
+    :members:
+    :special-members: __call__
+
+`RemoveRepeatedChanneld`
+""""""""""""""""""""""""
+.. autoclass:: RemoveRepeatedChanneld
     :members:
     :special-members: __call__
 

--- a/tests/test_integration_workers.py
+++ b/tests/test_integration_workers.py
@@ -49,8 +49,8 @@ class IntegrationLoading(DistTestCase):
         for pw in (False, True):
             result = run_loading_test(pw=pw)
             if expected is None:
-                expected = result
-        np.testing.assert_allclose(result, expected)  # test for deterministic in two settings
+                expected = result[0]
+        np.testing.assert_allclose(result[0], expected)  # test for deterministic first epoch in two settings
 
 
 if __name__ == "__main__":

--- a/tests/test_module_list.py
+++ b/tests/test_module_list.py
@@ -48,21 +48,19 @@ class TestAllImport(unittest.TestCase):
         names = sorted(x for x in xforms if x not in to_exclude)
         remained = set(names)
         doc_file = os.path.join(pathlib.Path(__file__).parent.parent, "docs", "source", "transforms.rst")
-        with open(doc_file) as f:
-            contents = f.readlines()
-        contents = "".join(contents)
-
+        contents = pathlib.Path(doc_file).read_text() if os.path.exists(doc_file) else None
         for n in names:
             if not n.endswith("d"):
                 continue
-            basename = n[:-1]  # Transformd basename is Transform
-            for docname in (f"{basename}", f"{basename}d"):
-                if docname in to_exclude_docs:
-                    continue
-                if f"`{docname}`" not in contents:
-                    self.assertTrue(False, f"please add {docname} to docs/source/transforms.rst")
-            for postfix in ("D", "d", "Dict"):
-                remained.remove(f"{basename}{postfix}")
+            with self.subTest(n=n):
+                basename = n[:-1]  # Transformd basename is Transform
+                for docname in (f"{basename}", f"{basename}d"):
+                    if docname in to_exclude_docs:
+                        continue
+                    if contents is not None and f"`{docname}`" not in contents:
+                        self.assertTrue(False, f"please add `{docname}` to docs/source/transforms.rst")
+                for postfix in ("D", "d", "Dict"):
+                    remained.remove(f"{basename}{postfix}")
         self.assertFalse(remained)
 
 

--- a/tests/test_module_list.py
+++ b/tests/test_module_list.py
@@ -57,7 +57,7 @@ class TestAllImport(unittest.TestCase):
                 for docname in (f"{basename}", f"{basename}d"):
                     if docname in to_exclude_docs:
                         continue
-                    if contents is not None and f"`{docname}`" not in contents:
+                    if (contents is not None) and f"`{docname}`" not in contents:  # type: ignore
                         self.assertTrue(False, f"please add `{docname}` to docs/source/transforms.rst")
                 for postfix in ("D", "d", "Dict"):
                     remained.remove(f"{basename}{postfix}")

--- a/tests/test_module_list.py
+++ b/tests/test_module_list.py
@@ -57,7 +57,7 @@ class TestAllImport(unittest.TestCase):
                 for docname in (f"{basename}", f"{basename}d"):
                     if docname in to_exclude_docs:
                         continue
-                    if (contents is not None) and f"`{docname}`" not in contents:  # type: ignore
+                    if (contents is not None) and f"`{docname}`" not in f"{contents}":
                         self.assertTrue(False, f"please add `{docname}` to docs/source/transforms.rst")
                 for postfix in ("D", "d", "Dict"):
                     remained.remove(f"{basename}{postfix}")


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #3987


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
