### PR TITLE
Add support for `level` in `PatchWSIDataset`

### DIFF
--- a/monai/apps/pathology/data/datasets.py
+++ b/monai/apps/pathology/data/datasets.py
@@ -32,10 +32,10 @@ class PatchWSIDataset(Dataset):
         region_size: the size of regions to be extracted from the whole slide image.
         grid_shape: the grid shape on which the patches should be extracted.
         patch_size: the size of patches extracted from the region on the grid.
-        level: the level at which the patches to be extracted (default to 0).
         transform: transforms to be executed on input data.
         image_reader_name: the name of library to be used for loading whole slide imaging, either CuCIM or OpenSlide.
             Defaults to CuCIM.
+        kwargs: additional parameters for ``WSIReader``
 
     Note:
         The input data has the following form as an example:
@@ -132,6 +132,7 @@ class SmartCachePatchWSIDataset(SmartCacheDataset):
             may set `copy=False` for better performance.
         as_contiguous: whether to convert the cached NumPy array or PyTorch tensor to be contiguous.
             it may help improve the performance of following logic.
+        kwargs: additional parameters for ``WSIReader``
 
     """
 
@@ -187,7 +188,8 @@ class MaskedInferenceWSIDataset(Dataset):
         patch_size: the size of patches to be extracted from the whole slide image for inference.
         transform: transforms to be executed on extracted patches.
         image_reader_name: the name of library to be used for loading whole slide imaging, either CuCIM or OpenSlide.
-        Defaults to CuCIM.
+            Defaults to CuCIM.
+        kwargs: additional parameters for ``WSIReader``
 
     Note:
         The resulting output (probability maps) after performing inference using this dataset is

--- a/monai/apps/pathology/data/datasets.py
+++ b/monai/apps/pathology/data/datasets.py
@@ -54,6 +54,7 @@ class PatchWSIDataset(Dataset):
         region_size: Union[int, Tuple[int, int]],
         grid_shape: Union[int, Tuple[int, int]],
         patch_size: Union[int, Tuple[int, int]],
+        level: int = 0,
         transform: Optional[Callable] = None,
         image_reader_name: str = "cuCIM",
     ):
@@ -65,7 +66,7 @@ class PatchWSIDataset(Dataset):
 
         self.image_path_list = list({x["image"] for x in self.data})
         self.image_reader_name = image_reader_name.lower()
-        self.image_reader = WSIReader(image_reader_name)
+        self.image_reader = WSIReader(backend=image_reader_name, level=level)
         self.wsi_object_dict = None
         if self.image_reader_name != "openslide":
             # OpenSlide causes memory issue if we prefetch image objects

--- a/monai/apps/pathology/data/datasets.py
+++ b/monai/apps/pathology/data/datasets.py
@@ -32,6 +32,7 @@ class PatchWSIDataset(Dataset):
         region_size: the size of regions to be extracted from the whole slide image.
         grid_shape: the grid shape on which the patches should be extracted.
         patch_size: the size of patches extracted from the region on the grid.
+        level: the level at which the patches to be extracted (default to 0).
         transform: transforms to be executed on input data.
         image_reader_name: the name of library to be used for loading whole slide imaging, either CuCIM or OpenSlide.
             Defaults to CuCIM.

--- a/monai/apps/pathology/data/datasets.py
+++ b/monai/apps/pathology/data/datasets.py
@@ -55,9 +55,9 @@ class PatchWSIDataset(Dataset):
         region_size: Union[int, Tuple[int, int]],
         grid_shape: Union[int, Tuple[int, int]],
         patch_size: Union[int, Tuple[int, int]],
-        level: int = 0,
         transform: Optional[Callable] = None,
         image_reader_name: str = "cuCIM",
+        **kwargs,
     ):
         super().__init__(data, transform)
 
@@ -67,7 +67,7 @@ class PatchWSIDataset(Dataset):
 
         self.image_path_list = list({x["image"] for x in self.data})
         self.image_reader_name = image_reader_name.lower()
-        self.image_reader = WSIReader(backend=image_reader_name, level=level)
+        self.image_reader = WSIReader(backend=image_reader_name, **kwargs)
         self.wsi_object_dict = None
         if self.image_reader_name != "openslide":
             # OpenSlide causes memory issue if we prefetch image objects
@@ -121,10 +121,10 @@ class SmartCachePatchWSIDataset(SmartCacheDataset):
             will take the minimum of (cache_num, data_length x cache_rate, data_length).
         num_init_workers: the number of worker threads to initialize the cache for first epoch.
             If num_init_workers is None then the number returned by os.cpu_count() is used.
-            If a value less than 1 is speficied, 1 will be used instead.
+            If a value less than 1 is specified, 1 will be used instead.
         num_replace_workers: the number of worker threads to prepare the replacement cache for every epoch.
             If num_replace_workers is None then the number returned by os.cpu_count() is used.
-            If a value less than 1 is speficied, 1 will be used instead.
+            If a value less than 1 is specified, 1 will be used instead.
         progress: whether to display a progress bar when caching for the first epoch.
         copy_cache: whether to `deepcopy` the cache content before applying the random transforms,
             default to `True`. if the random transforms don't modify the cache content
@@ -151,6 +151,7 @@ class SmartCachePatchWSIDataset(SmartCacheDataset):
         progress: bool = True,
         copy_cache: bool = True,
         as_contiguous: bool = True,
+        **kwargs,
     ):
         patch_wsi_dataset = PatchWSIDataset(
             data=data,
@@ -158,6 +159,7 @@ class SmartCachePatchWSIDataset(SmartCacheDataset):
             grid_shape=grid_shape,
             patch_size=patch_size,
             image_reader_name=image_reader_name,
+            **kwargs,
         )
         super().__init__(
             data=patch_wsi_dataset,  # type: ignore
@@ -198,6 +200,7 @@ class MaskedInferenceWSIDataset(Dataset):
         patch_size: Union[int, Tuple[int, int]],
         transform: Optional[Callable] = None,
         image_reader_name: str = "cuCIM",
+        **kwargs,
     ) -> None:
         super().__init__(data, transform)
 
@@ -205,7 +208,7 @@ class MaskedInferenceWSIDataset(Dataset):
 
         # set up whole slide image reader
         self.image_reader_name = image_reader_name.lower()
-        self.image_reader = WSIReader(image_reader_name)
+        self.image_reader = WSIReader(backend=image_reader_name, **kwargs)
 
         # process data and create a list of dictionaries containing all required data and metadata
         self.data = self._prepare_data(data)

--- a/tests/test_patch_wsi_dataset.py
+++ b/tests/test_patch_wsi_dataset.py
@@ -41,6 +41,31 @@ TEST_CASE_0 = [
     [{"image": np.array([[[239]], [[239]], [[239]]], dtype=np.uint8), "label": np.array([[[1]]])}],
 ]
 
+TEST_CASE_0_L1 = [
+    {
+        "data": [{"image": FILE_PATH, "location": [0, 0], "label": [1]}],
+        "region_size": (1, 1),
+        "grid_shape": (1, 1),
+        "patch_size": 1,
+        "level": 1,
+        "image_reader_name": "cuCIM",
+    },
+    [{"image": np.array([[[239]], [[239]], [[239]]], dtype=np.uint8), "label": np.array([[[1]]])}],
+]
+
+TEST_CASE_0_L2 = [
+    {
+        "data": [{"image": FILE_PATH, "location": [0, 0], "label": [1]}],
+        "region_size": (1, 1),
+        "grid_shape": (1, 1),
+        "patch_size": 1,
+        "level": 1,
+        "image_reader_name": "cuCIM",
+    },
+    [{"image": np.array([[[239]], [[239]], [[239]]], dtype=np.uint8), "label": np.array([[[1]]])}],
+]
+
+
 TEST_CASE_1 = [
     {
         "data": [{"image": FILE_PATH, "location": [10004, 20004], "label": [0, 0, 0, 1]}],
@@ -57,6 +82,41 @@ TEST_CASE_1 = [
     ],
 ]
 
+
+TEST_CASE_1_L0 = [
+    {
+        "data": [{"image": FILE_PATH, "location": [10004, 20004], "label": [0, 0, 0, 1]}],
+        "region_size": (8, 8),
+        "grid_shape": (2, 2),
+        "patch_size": 1,
+        "level": 0,
+        "image_reader_name": "cuCIM",
+    },
+    [
+        {"image": np.array([[[247]], [[245]], [[248]]], dtype=np.uint8), "label": np.array([[[0]]])},
+        {"image": np.array([[[245]], [[247]], [[244]]], dtype=np.uint8), "label": np.array([[[0]]])},
+        {"image": np.array([[[246]], [[246]], [[246]]], dtype=np.uint8), "label": np.array([[[0]]])},
+        {"image": np.array([[[246]], [[246]], [[246]]], dtype=np.uint8), "label": np.array([[[1]]])},
+    ],
+]
+
+
+TEST_CASE_1_L1 = [
+    {
+        "data": [{"image": FILE_PATH, "location": [10004, 20004], "label": [0, 0, 0, 1]}],
+        "region_size": (8, 8),
+        "grid_shape": (2, 2),
+        "patch_size": 1,
+        "level": 1,
+        "image_reader_name": "cuCIM",
+    },
+    [
+        {"image": np.array([[[248]], [[246]], [[249]]], dtype=np.uint8), "label": np.array([[[0]]])},
+        {"image": np.array([[[196]], [[187]], [[192]]], dtype=np.uint8), "label": np.array([[[0]]])},
+        {"image": np.array([[[245]], [[243]], [[244]]], dtype=np.uint8), "label": np.array([[[0]]])},
+        {"image": np.array([[[246]], [[242]], [[243]]], dtype=np.uint8), "label": np.array([[[1]]])},
+    ],
+]
 TEST_CASE_2 = [
     {
         "data": [{"image": FILE_PATH, "location": [0, 0], "label": [1]}],
@@ -90,6 +150,43 @@ TEST_CASE_OPENSLIDE_0 = [
     [{"image": np.array([[[239]], [[239]], [[239]]], dtype=np.uint8), "label": np.array([[[1]]])}],
 ]
 
+TEST_CASE_OPENSLIDE_0_L0 = [
+    {
+        "data": [{"image": FILE_PATH, "location": [0, 0], "label": [1]}],
+        "region_size": (1, 1),
+        "grid_shape": (1, 1),
+        "patch_size": 1,
+        "level": 0,
+        "image_reader_name": "OpenSlide",
+    },
+    [{"image": np.array([[[239]], [[239]], [[239]]], dtype=np.uint8), "label": np.array([[[1]]])}],
+]
+
+TEST_CASE_OPENSLIDE_0_L1 = [
+    {
+        "data": [{"image": FILE_PATH, "location": [0, 0], "label": [1]}],
+        "region_size": (1, 1),
+        "grid_shape": (1, 1),
+        "patch_size": 1,
+        "level": 1,
+        "image_reader_name": "OpenSlide",
+    },
+    [{"image": np.array([[[239]], [[239]], [[239]]], dtype=np.uint8), "label": np.array([[[1]]])}],
+]
+
+
+TEST_CASE_OPENSLIDE_0_L2 = [
+    {
+        "data": [{"image": FILE_PATH, "location": [0, 0], "label": [1]}],
+        "region_size": (1, 1),
+        "grid_shape": (1, 1),
+        "patch_size": 1,
+        "level": 2,
+        "image_reader_name": "OpenSlide",
+    },
+    [{"image": np.array([[[239]], [[239]], [[239]]], dtype=np.uint8), "label": np.array([[[1]]])}],
+]
+
 TEST_CASE_OPENSLIDE_1 = [
     {
         "data": [{"image": FILE_PATH, "location": [10004, 20004], "label": [0, 0, 0, 1]}],
@@ -113,7 +210,18 @@ class TestPatchWSIDataset(unittest.TestCase):
         hash_val = testing_data_config("images", FILE_KEY, "hash_val")
         download_url_or_skip_test(FILE_URL, FILE_PATH, hash_type=hash_type, hash_val=hash_val)
 
-    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
+    @parameterized.expand(
+        [
+            TEST_CASE_0,
+            TEST_CASE_0_L1,
+            TEST_CASE_0_L2,
+            TEST_CASE_1,
+            TEST_CASE_1_L0,
+            TEST_CASE_1_L1,
+            TEST_CASE_2,
+            TEST_CASE_3,
+        ]
+    )
     @skipUnless(has_cim, "Requires CuCIM")
     def test_read_patches_cucim(self, input_parameters, expected):
         dataset = PatchWSIDataset(**input_parameters)
@@ -124,7 +232,15 @@ class TestPatchWSIDataset(unittest.TestCase):
             self.assertIsNone(assert_array_equal(samples[i]["label"], expected[i]["label"]))
             self.assertIsNone(assert_array_equal(samples[i]["image"], expected[i]["image"]))
 
-    @parameterized.expand([TEST_CASE_OPENSLIDE_0, TEST_CASE_OPENSLIDE_1])
+    @parameterized.expand(
+        [
+            TEST_CASE_OPENSLIDE_0,
+            TEST_CASE_OPENSLIDE_0_L0,
+            TEST_CASE_OPENSLIDE_0_L1,
+            TEST_CASE_OPENSLIDE_0_L2,
+            TEST_CASE_OPENSLIDE_1,
+        ]
+    )
     @skipUnless(has_osl, "Requires OpenSlide")
     def test_read_patches_openslide(self, input_parameters, expected):
         dataset = PatchWSIDataset(**input_parameters)


### PR DESCRIPTION
Fixes #4034 

### Description
Add supports in `PatchWSIDataset` to accept `level` as an argument and extract patches from the whole slide images at that `level`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.