### PR TITLE
4043 Fix windows PIL issue

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -47,7 +47,9 @@ jobs:
       run: |
         conda activate monai
         # this `cpuonly` and -c conda-forge is needed to reduce the paging file size on a github instance
-        conda install pytorch torchvision torchaudio cpuonly -c pytorch -c conda-forge
+        # force to install `cpuonly==2.0.0` is to fix the same issue as:
+        # https://github.com/pytorch/vision/issues/4240
+        conda install pytorch torchvision torchaudio cpuonly==2.0.0 -c pytorch -c conda-forge
         conda deactivate
     - name: Test env(CPU ${{ runner.os }})
       shell: bash -l {0}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 3 * * *"  # at 03:00 UTC
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  push:
+    branches:
+      - 4043-fix-windows-pil-issue
 
 concurrency:
   # automatically cancel the previously triggered workflows when there's a newer version

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -5,9 +5,6 @@ on:
     - cron: "0 3 * * *"  # at 03:00 UTC
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  push:
-    branches:
-      - 4043-fix-windows-pil-issue
 
 concurrency:
   # automatically cancel the previously triggered workflows when there's a newer version
@@ -16,6 +13,7 @@ concurrency:
 
 jobs:
   cron-conda:
+    if: github.repository == 'Project-MONAI/MONAI'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   cron-conda:
-    if: github.repository == 'Project-MONAI/MONAI'
     strategy:
       fail-fast: false
       matrix:

--- a/monai/handlers/utils.py
+++ b/monai/handlers/utils.py
@@ -121,7 +121,10 @@ def write_metrics_reports(
             with open(os.path.join(save_dir, f"{k}_raw.csv"), "w") as f:
                 f.write(f"filename{deli}{deli.join(class_labels)}\n")
                 for i, b in enumerate(v):
-                    f.write(f"{images[i] if images is not None else str(i)}{deli}{deli.join([str(c) for c in b])}\n")
+                    f.write(
+                        f"{images[i] if images is not None else str(i)}{deli}"
+                        f"{deli.join([f'{c:.4f}' if isinstance(c, (int, float)) else str(c) for c in b])}\n"
+                    )
 
             if summary_ops is not None:
                 supported_ops = OrderedDict(

--- a/tests/test_handler_metrics_saver.py
+++ b/tests/test_handler_metrics_saver.py
@@ -66,7 +66,7 @@ class TestHandlerMetricsSaver(unittest.TestCase):
                 f_csv = csv.reader(f)
                 for i, row in enumerate(f_csv):
                     if i > 0:
-                        self.assertEqual(row, [f"filepath{i}\t{float(i)}\t{float(i + 1)}\t{i + 0.5}"])
+                        self.assertEqual(row, [f"filepath{i}\t{float(i):.4f}\t{float(i + 1):.4f}\t{i + 0.5:.4f}"])
             self.assertTrue(os.path.exists(os.path.join(tempdir, "metric3_summary.csv")))
             # check the metric_summary.csv and content
             with open(os.path.join(tempdir, "metric4_summary.csv")) as f:

--- a/tests/test_handler_metrics_saver_dist.py
+++ b/tests/test_handler_metrics_saver_dist.py
@@ -95,7 +95,7 @@ class DistributedMetricsSaver(DistTestCase):
                 f_csv = csv.reader(f)
                 for i, row in enumerate(f_csv):
                     if i > 0:
-                        expected = [f"{fnames[i-1]}\t{float(i)}\t{float(i + 1)}\t{i + 0.5}"]
+                        expected = [f"{fnames[i-1]}\t{float(i):.4f}\t{float(i + 1):.4f}\t{i + 0.5:.4f}"]
                         self.assertEqual(row, expected)
             self.assertTrue(os.path.exists(os.path.join(tempdir, "metric3_summary.csv")))
             # check the metric_summary.csv and content

--- a/tests/test_write_metrics_reports.py
+++ b/tests/test_write_metrics_reports.py
@@ -45,7 +45,7 @@ class TestWriteMetricsReports(unittest.TestCase):
                 f_csv = csv.reader(f)
                 for i, row in enumerate(f_csv):
                     if i > 0:
-                        self.assertEqual(row, [f"filepath{i}\t{float(i)}\t{float(i + 1)}\t{i + 0.5}"])
+                        self.assertEqual(row, [f"filepath{i}\t{float(i):.4f}\t{float(i + 1):.4f}\t{i + 0.5:.4f}"])
             self.assertTrue(os.path.exists(os.path.join(tempdir, "metric3_summary.csv")))
             # check the metric_summary.csv and content
             with open(os.path.join(tempdir, "metric3_summary.csv")) as f:


### PR DESCRIPTION
Fixes #4043 .

### Description
Via using `cpuonly==2.0.0`, this PR helps to fix the PIL issue (in conda workflow, see here: https://github.com/yiheng-wang-nv/MONAI/actions/runs/2075835896) which is produced by outdated `torchvision`.
In addition, in the latest test, the issue of #4011 is not existing.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
