### PR TITLE
update mmar tests

### DIFF
--- a/tests/ngc_mmar_loading.py
+++ b/tests/ngc_mmar_loading.py
@@ -40,7 +40,7 @@ class TestAllDownloadingMMAR(unittest.TestCase):
             )
             pretrained_weights = {k.split(".", 1)[1]: v for k, v in pretrained_weights["state_dict"].items()}
             sys.path.append(os.path.join(f"{item['name']}", "custom"))  # custom model folder
-            from vit_network import ViTAutoEnc
+            from vit_network import ViTAutoEnc  # pylint: disable=E0401
 
             model = ViTAutoEnc(
                 in_channels=1,

--- a/tests/ngc_mmar_loading.py
+++ b/tests/ngc_mmar_loading.py
@@ -40,7 +40,7 @@ class TestAllDownloadingMMAR(unittest.TestCase):
             )
             pretrained_weights = {k.split(".", 1)[1]: v for k, v in pretrained_weights["state_dict"].items()}
             sys.path.append(os.path.join(f"{item['name']}", "custom"))  # custom model folder
-            from vit_network import ViTAutoEnc  # noqa
+            from vit_network import ViTAutoEnc
 
             model = ViTAutoEnc(
                 in_channels=1,

--- a/tests/ngc_mmar_loading.py
+++ b/tests/ngc_mmar_loading.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import os
+import sys
 import unittest
 
 import torch
@@ -17,6 +18,7 @@ from parameterized import parameterized
 
 from monai.apps.mmars import MODEL_DESC, load_from_mmar
 from monai.config import print_debug_info
+from monai.networks.utils import copy_model_state
 
 
 class TestAllDownloadingMMAR(unittest.TestCase):
@@ -26,10 +28,33 @@ class TestAllDownloadingMMAR(unittest.TestCase):
 
     @parameterized.expand((item,) for item in MODEL_DESC)
     def test_loading_mmar(self, item):
+        if item["name"] == "clara_pt_self_supervised_learning_segmentation":  # test the byow model
+            default_model_file = os.path.join("ssl_models_2gpu", "best_metric_model.pt")
+            pretrained_weights = load_from_mmar(
+                item=item["name"],
+                mmar_dir="./",
+                map_location="cpu",
+                api=True,
+                model_file=default_model_file,
+                weights_only=True,
+            )
+            pretrained_weights = {k.split(".", 1)[1]: v for k, v in pretrained_weights["state_dict"].items()}
+            sys.path.append(os.path.join(f"{item['name']}", "custom"))  # custom model folder
+            from vit_network import ViTAutoEnc  # noqa
+
+            model = ViTAutoEnc(
+                in_channels=1,
+                img_size=(96, 96, 96),
+                patch_size=(16, 16, 16),
+                pos_embed="conv",
+                hidden_size=768,
+                mlp_dim=3072,
+            )
+            _, loaded, not_loaded = copy_model_state(model, pretrained_weights)
+            self.assertTrue(len(loaded) > 0 and len(not_loaded) == 0)
+            return
         if item["name"] == "clara_pt_fed_learning_brain_tumor_mri_segmentation":
             default_model_file = os.path.join("models", "server", "best_FL_global_model.pt")
-        elif item["name"] == "clara_pt_self_supervised_learning_segmentation":
-            default_model_file = os.path.join("models_2gpu", "best_metric_model.pt")
         else:
             default_model_file = None
         pretrained_model = load_from_mmar(


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

we can now resume the mmar model loading tests with this patch.
previously `clara_pt_self_supervised_learning_segmentation` was not ready for download.
it's available now but the byow model is not automatically accessible like the other models.

verified here https://github.com/Project-MONAI/MONAI/runs/5881211496?check_suite_focus=true

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
