### PR TITLE
4073 Enhance DynUNet doc-strings

### DIFF
--- a/monai/networks/nets/dynunet.py
+++ b/monai/networks/nets/dynunet.py
@@ -77,8 +77,7 @@ class DynUNet(nn.Module):
     by the product of all strides in the corresponding dimension. In addition, the minimal spatial size should have
     at least one dimension that has twice the size of the product of all strides.
     For example, if `strides=((1, 2, 4), 2, 2, 1)`, the spatial size should be divisible by `(4, 8, 16)`,
-    and the minimal spatial size is `(8, 8, 16)` (its corresponding output is `(8, 8, 8)`)
-    or `(4, 16, 16)` or `(4, 8, 32)`.
+    and the minimal spatial size is `(8, 8, 16)` or `(4, 16, 16)` or `(4, 8, 32)`.
 
     The output size for each spatial dimension equals to the input size of the corresponding dimension divided by the
     stride in strides[0].

--- a/monai/networks/nets/dynunet.py
+++ b/monai/networks/nets/dynunet.py
@@ -74,10 +74,15 @@ class DynUNet(nn.Module):
     is no less than 3 in order to have at least one downsample and upsample blocks.
 
     To meet the requirements of the structure, the input size for each spatial dimension should be divisible
-    by `2 * the product of all strides in the corresponding dimension`. The output size for each spatial dimension
-    equals to the input size of the corresponding dimension divided by the stride in strides[0].
-    For example, if `strides=((1, 2, 4), 2, 1, 1)`, the minimal spatial size of the input is `(8, 16, 32)`, and
-    the spatial size of the output is `(8, 8, 8)`.
+    by the product of all strides in the corresponding dimension. In addition, the minimal spatial size should have
+    at least one dimension that has twice the size of the product of all strides.
+    For example, if `strides=((1, 2, 4), 2, 2, 1)`, the spatial size should be divisible by `(4, 8, 16)`,
+    and the minimal spatial size is `(8, 8, 16)` (its corresponding output is `(8, 8, 8)`)
+    or `(4, 16, 16)` or `(4, 8, 32)`.
+
+    The output size for each spatial dimension equals to the input size of the corresponding dimension divided by the
+    stride in strides[0].
+    For example, if `strides=((1, 2, 4), 2, 2, 1)` and the input size is `(64, 32, 32)`, the output size is `(64, 16, 8)`.
 
     For backwards compatibility with old weights, please set `strict=False` when calling `load_state_dict`.
 


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Related to #4073 .

### Description
This PR is used to add more explanations of the relationship between `strides` and the input/output size.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
