### PR TITLE
Make `pixelshuffle` scriptable

### DIFF
--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -281,14 +281,16 @@ def pixelshuffle(
             f"divisible by scale_factor ** dimensions ({factor}**{dim}={scale_divisor})."
         )
 
-    org_channels = channels // scale_divisor
+    org_channels = int(channels // scale_divisor)
     output_size = [batch_size, org_channels] + [d * factor for d in input_size[2:]]
 
-    indices = tuple(range(2, 2 + 2 * dim))
-    indices_factor, indices_dim = indices[:dim], indices[dim:]
-    permute_indices = (0, 1) + sum(zip(indices_dim, indices_factor), ())
+    indices = list(range(2, 2 + 2 * dim))
+    indices = indices[dim:] + indices[:dim]
+    permute_indices = [0, 1]
+    for idx in range(dim):
+        permute_indices.extend(indices[idx::dim])
 
-    x = x.reshape(batch_size, org_channels, *([factor] * dim + input_size[2:]))
+    x = x.reshape([batch_size, org_channels] + [factor] * dim + input_size[2:])
     x = x.permute(permute_indices).reshape(output_size)
     return x
 

--- a/tests/test_subpixel_upsample.py
+++ b/tests/test_subpixel_upsample.py
@@ -18,6 +18,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.blocks import SubpixelUpsample
 from monai.networks.layers.factories import Conv
+from tests.utils import test_script_save
 
 TEST_CASE_SUBPIXEL = []
 for inch in range(1, 5):
@@ -72,6 +73,12 @@ class TestSUBPIXEL(unittest.TestCase):
         with eval_mode(net):
             result = net.forward(torch.randn(input_shape))
             self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        input_param, input_shape, _ = TEST_CASE_SUBPIXEL[0]
+        net = SubpixelUpsample(**input_param)
+        test_data = torch.randn(input_shape)
+        test_script_save(net, test_data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Ramon Emiliani <ramon.emiliani@umontreal.ca>

Fixes #4108.

### Description
Modifies the existing `pixelshuffle` function in such a way that it is scriptable using `torch.jit.script`.

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
