### PR TITLE
update meta tensor api

### DIFF
--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -46,7 +46,7 @@ from .image_writer import (
     resolve_writer,
 )
 from .iterable_dataset import CSVIterableDataset, IterableDataset, ShuffleBuffer
-from .meta_obj import get_track_meta, get_track_transforms, set_track_meta, set_track_transforms
+from .meta_obj import MetaObj, get_track_meta, get_track_transforms, set_track_meta, set_track_transforms
 from .meta_tensor import MetaTensor
 from .nifti_saver import NiftiSaver
 from .nifti_writer import write_nifti

--- a/monai/data/meta_obj.py
+++ b/monai/data/meta_obj.py
@@ -109,7 +109,8 @@ class MetaObj:
 
     """
 
-    _meta: dict
+    def __init__(self):
+        self._meta: dict = self.get_default_meta()
 
     @staticmethod
     def flatten_meta_objs(args: Sequence[Any]) -> list[MetaObj]:

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -77,8 +77,6 @@ class MetaTensor(MetaObj, torch.Tensor):
             self.meta = meta
         elif isinstance(x, MetaObj):
             self.meta = x.meta
-        else:
-            self.meta = self.get_default_meta()
         # set the affine
         if affine is not None:
             if "affine" in self.meta:
@@ -141,8 +139,6 @@ class MetaTensor(MetaObj, torch.Tensor):
     @property
     def affine(self) -> torch.Tensor:
         """Get the affine."""
-        if "affine" not in self.meta:
-            self.meta["affine"] = self.get_default_affine()
         return self.meta["affine"]  # type: ignore
 
     @affine.setter

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -44,7 +44,7 @@ class TestMetaTensor(unittest.TestCase):
     @staticmethod
     def get_im(shape=None, dtype=None, device=None):
         if shape is None:
-            shape = shape = (1, 10, 8)
+            shape = (1, 10, 8)
         affine = torch.randint(0, 10, (4, 4))
         meta = {"fname": rand_string()}
         t = torch.rand(shape)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>



### Description
follow up on https://github.com/Project-MONAI/MONAI/pull/4077#discussion_r849044886,
it seems having both `__new__` and `__init__` would make subclassing metatensor easier.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
