### PR TITLE
no skip if before pytorch 1.7

### DIFF
--- a/tests/test_cachedataset_persistent_workers.py
+++ b/tests/test_cachedataset_persistent_workers.py
@@ -13,10 +13,8 @@ import unittest
 
 from monai.data import CacheDataset, DataLoader, create_test_image_2d
 from monai.transforms import Compose, RandAffined, Spacingd
-from tests.utils import SkipIfBeforePyTorchVersion
 
 
-@SkipIfBeforePyTorchVersion((1, 7))
 class TestTransformsWCacheDatasetAndPersistentWorkers(unittest.TestCase):
     def test_duplicate_transforms(self):
         data = [{"img": create_test_image_2d(128, 128, num_seg_classes=1, channel_dim=0)[0]} for _ in range(2)]

--- a/tests/test_detect_envelope.py
+++ b/tests/test_detect_envelope.py
@@ -16,8 +16,8 @@ import torch
 from parameterized import parameterized
 
 from monai.transforms import DetectEnvelope
-from monai.utils import InvalidPyTorchVersionError, OptionalImportError
-from tests.utils import SkipIfAtLeastPyTorchVersion, SkipIfBeforePyTorchVersion, SkipIfModule, SkipIfNoModule
+from monai.utils import OptionalImportError
+from tests.utils import SkipIfModule, SkipIfNoModule
 
 n_samples = 500
 hann_windowed_sine = np.sin(2 * np.pi * 10 * np.linspace(0, 1, n_samples)) * np.hanning(n_samples)
@@ -112,7 +112,6 @@ TEST_CASE_INVALID_IMG_LEN = [
 TEST_CASE_INVALID_OBJ = [{}, "a string", "__call__"]  # method expected to raise exception
 
 
-@SkipIfBeforePyTorchVersion((1, 7))
 @SkipIfNoModule("torch.fft")
 class TestDetectEnvelope(unittest.TestCase):
     @parameterized.expand(
@@ -147,18 +146,10 @@ class TestDetectEnvelope(unittest.TestCase):
             raise ValueError("Expected raising method invalid. Should be __init__ or __call__.")
 
 
-@SkipIfBeforePyTorchVersion((1, 7))
 @SkipIfModule("torch.fft")
 class TestHilbertTransformNoFFTMod(unittest.TestCase):
     def test_no_fft_module_error(self):
         self.assertRaises(OptionalImportError, DetectEnvelope(), np.random.rand(1, 10))
-
-
-@SkipIfAtLeastPyTorchVersion((1, 7))
-class TestDetectEnvelopeInvalidPyTorch(unittest.TestCase):
-    def test_invalid_pytorch_error(self):
-        with self.assertRaisesRegex(InvalidPyTorchVersionError, "version"):
-            DetectEnvelope()
 
 
 if __name__ == "__main__":

--- a/tests/test_dice_ce_loss.py
+++ b/tests/test_dice_ce_loss.py
@@ -16,7 +16,7 @@ import torch
 from parameterized import parameterized
 
 from monai.losses import DiceCELoss
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import test_script_save
 
 TEST_CASES = [
     [  # shape: (2, 2, 3), (2, 1, 3)
@@ -85,7 +85,6 @@ class TestDiceCELoss(unittest.TestCase):
             loss = DiceCELoss(reduction="none")
             loss(torch.ones((1, 2, 3)), torch.ones((1, 1, 2, 3)))
 
-    @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         loss = DiceCELoss()
         test_input = torch.ones(2, 1, 8, 8)

--- a/tests/test_dice_focal_loss.py
+++ b/tests/test_dice_focal_loss.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch
 
 from monai.losses import DiceFocalLoss, DiceLoss, FocalLoss
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import test_script_save
 
 
 class TestDiceFocalLoss(unittest.TestCase):
@@ -61,7 +61,6 @@ class TestDiceFocalLoss(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, ""):
             DiceFocalLoss(lambda_dice=-1.0)
 
-    @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         loss = DiceFocalLoss()
         test_input = torch.ones(2, 1, 8, 8)

--- a/tests/test_dice_loss.py
+++ b/tests/test_dice_loss.py
@@ -16,7 +16,7 @@ import torch
 from parameterized import parameterized
 
 from monai.losses import DiceLoss
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import test_script_save
 
 TEST_CASES = [
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
@@ -184,7 +184,6 @@ class TestDiceLoss(unittest.TestCase):
             loss = DiceLoss(to_onehot_y=True)
             loss.forward(chn_input, chn_target)
 
-    @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         loss = DiceLoss()
         test_input = torch.ones(2, 1, 8, 8)

--- a/tests/test_focal_loss.py
+++ b/tests/test_focal_loss.py
@@ -17,7 +17,7 @@ import torch.nn.functional as F
 
 from monai.losses import FocalLoss
 from monai.networks import one_hot
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import test_script_save
 
 
 class TestFocalLoss(unittest.TestCase):
@@ -261,7 +261,6 @@ class TestFocalLoss(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, ""):
             FocalLoss(include_background=False, weight=(1.0, 1.0, -1.0))(chn_input, chn_target)
 
-    @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         loss = FocalLoss()
         test_input = torch.ones(2, 2, 8, 8)

--- a/tests/test_gaussian_filter.py
+++ b/tests/test_gaussian_filter.py
@@ -16,7 +16,7 @@ import torch
 from parameterized import parameterized
 
 from monai.networks.layers import GaussianFilter
-from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick
+from tests.utils import skip_if_quick
 
 TEST_CASES = [[{"type": "erf", "gt": 2.0}], [{"type": "scalespace", "gt": 3.0}], [{"type": "sampled", "gt": 5.0}]]
 TEST_CASES_GPU = [[{"type": "erf", "gt": 0.8, "device": "cuda"}], [{"type": "sampled", "gt": 5.0, "device": "cuda"}]]
@@ -82,7 +82,6 @@ class TestGaussianFilterBackprop(unittest.TestCase):
             )
 
     @parameterized.expand(TEST_CASES + TEST_CASES_GPU + TEST_CASES_3d)
-    @SkipIfBeforePyTorchVersion((1, 7))
     def test_train_quick(self, input_args):
         self.code_to_run(input_args)
 

--- a/tests/test_generalized_dice_loss.py
+++ b/tests/test_generalized_dice_loss.py
@@ -16,7 +16,7 @@ import torch
 from parameterized import parameterized
 
 from monai.losses import GeneralizedDiceLoss
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import test_script_save
 
 TEST_CASES = [
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
@@ -193,7 +193,6 @@ class TestGeneralizedDiceLoss(unittest.TestCase):
         loss = generalized_dice_loss(prediction, target)
         self.assertNotEqual(loss.grad_fn, None)
 
-    @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         loss = GeneralizedDiceLoss()
         test_input = torch.ones(2, 1, 8, 8)

--- a/tests/test_generalized_wasserstein_dice_loss.py
+++ b/tests/test_generalized_wasserstein_dice_loss.py
@@ -18,7 +18,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 from monai.losses import GeneralizedWassersteinDiceLoss
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import test_script_save
 
 
 class TestGeneralizedWassersteinDiceLoss(unittest.TestCase):
@@ -216,7 +216,6 @@ class TestGeneralizedWassersteinDiceLoss(unittest.TestCase):
             # check that the predicted segmentation has improved
             self.assertGreater(diff_start, diff_end)
 
-    @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         target = torch.tensor([[0, 0, 0, 0], [0, 1, 1, 0], [0, 1, 1, 0], [0, 0, 0, 0]])
 

--- a/tests/test_handler_smartcache.py
+++ b/tests/test_handler_smartcache.py
@@ -17,10 +17,8 @@ from ignite.engine import Engine
 
 from monai.data import SmartCacheDataset
 from monai.handlers import SmartCacheHandler
-from tests.utils import SkipIfBeforePyTorchVersion
 
 
-@SkipIfBeforePyTorchVersion((1, 7))
 class TestHandlerSmartCache(unittest.TestCase):
     def test_content(self):
         data = [0, 1, 2, 3, 4, 5, 6, 7, 8]

--- a/tests/test_hilbert_transform.py
+++ b/tests/test_hilbert_transform.py
@@ -17,13 +17,7 @@ from parameterized import parameterized
 
 from monai.networks.layers import HilbertTransform
 from monai.utils import InvalidPyTorchVersionError, OptionalImportError
-from tests.utils import (
-    SkipIfAtLeastPyTorchVersion,
-    SkipIfBeforePyTorchVersion,
-    SkipIfModule,
-    SkipIfNoModule,
-    skip_if_no_cuda,
-)
+from tests.utils import SkipIfModule, SkipIfNoModule, skip_if_no_cuda
 
 
 def create_expected_numpy_output(input_datum, **kwargs):
@@ -164,7 +158,6 @@ if torch.cuda.is_available():
 # TESTS CHECKING PADDING, AXIS SELECTION ETC ARE COVERED BY test_detect_envelope.py
 
 
-@SkipIfBeforePyTorchVersion((1, 7))
 @SkipIfNoModule("torch.fft")
 class TestHilbertTransformCPU(unittest.TestCase):
     @parameterized.expand(
@@ -183,7 +176,6 @@ class TestHilbertTransformCPU(unittest.TestCase):
 
 
 @skip_if_no_cuda
-@SkipIfBeforePyTorchVersion((1, 7))
 @SkipIfNoModule("torch.fft")
 class TestHilbertTransformGPU(unittest.TestCase):
     @parameterized.expand(
@@ -204,14 +196,12 @@ class TestHilbertTransformGPU(unittest.TestCase):
         np.testing.assert_allclose(result, expected_data.squeeze(), atol=atol)
 
 
-@SkipIfBeforePyTorchVersion((1, 7))
 @SkipIfModule("torch.fft")
 class TestHilbertTransformNoFFTMod(unittest.TestCase):
     def test_no_fft_module_error(self):
         self.assertRaises(OptionalImportError, HilbertTransform(), torch.randn(1, 1, 10))
 
 
-@SkipIfAtLeastPyTorchVersion((1, 7))
 class TestHilbertTransformInvalidPyTorch(unittest.TestCase):
     def test_invalid_pytorch_error(self):
         with self.assertRaisesRegex(InvalidPyTorchVersionError, "version"):

--- a/tests/test_hilbert_transform.py
+++ b/tests/test_hilbert_transform.py
@@ -202,11 +202,5 @@ class TestHilbertTransformNoFFTMod(unittest.TestCase):
         self.assertRaises(OptionalImportError, HilbertTransform(), torch.randn(1, 1, 10))
 
 
-class TestHilbertTransformInvalidPyTorch(unittest.TestCase):
-    def test_invalid_pytorch_error(self):
-        with self.assertRaisesRegex(InvalidPyTorchVersionError, "version"):
-            HilbertTransform()
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hilbert_transform.py
+++ b/tests/test_hilbert_transform.py
@@ -16,7 +16,7 @@ import torch
 from parameterized import parameterized
 
 from monai.networks.layers import HilbertTransform
-from monai.utils import InvalidPyTorchVersionError, OptionalImportError
+from monai.utils import OptionalImportError
 from tests.utils import SkipIfModule, SkipIfNoModule, skip_if_no_cuda
 
 

--- a/tests/test_integration_fast_train.py
+++ b/tests/test_integration_fast_train.py
@@ -52,12 +52,11 @@ from monai.transforms import (
     ToDeviced,
 )
 from monai.utils import set_determinism
-from tests.utils import DistTestCase, SkipIfBeforePyTorchVersion, TimedCall, skip_if_no_cuda, skip_if_quick
+from tests.utils import DistTestCase, TimedCall, skip_if_no_cuda, skip_if_quick
 
 
 @skip_if_no_cuda
 @skip_if_quick
-@SkipIfBeforePyTorchVersion((1, 7))
 class IntegrationFastTrain(DistTestCase):
     def setUp(self):
         set_determinism(seed=0)

--- a/tests/test_keep_largest_connected_component.py
+++ b/tests/test_keep_largest_connected_component.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.transforms import KeepLargestConnectedComponent
 from monai.transforms.utils_pytorch_numpy_unification import moveaxis
 from monai.utils.type_conversion import convert_to_dst_type
-from tests.utils import TEST_NDARRAYS, SkipIfBeforePyTorchVersion, assert_allclose
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
 
 def to_onehot(x):
@@ -353,7 +353,6 @@ class TestKeepLargestConnectedComponent(unittest.TestCase):
         assert_allclose(result, expected, type_test=False)
 
     @parameterized.expand(TESTS)
-    @SkipIfBeforePyTorchVersion((1, 7))
     def test_correct_results_before_after_onehot(self, _, args, input_image, expected):
         """
         From torch==1.7, torch.argmax changes its mechanism that if there are multiple maximal values then the

--- a/tests/test_masked_loss.py
+++ b/tests/test_masked_loss.py
@@ -17,7 +17,7 @@ from parameterized import parameterized
 from monai.losses.dice import DiceFocalLoss, DiceLoss
 from monai.losses.spatial_mask import MaskedLoss
 from monai.utils import set_determinism
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -73,7 +73,6 @@ class TestMaskedLoss(unittest.TestCase):
             masked = MaskedLoss(loss=dice_loss)
             masked(input=torch.zeros((3, 3, 2, 2)), target=torch.zeros((3, 2, 2, 2)), mask=torch.zeros((3, 3, 2, 2)))
 
-    @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         input_param, expected_val = TEST_CASES[0]
         size = [3, 3, 5, 5]

--- a/tests/test_multi_scale.py
+++ b/tests/test_multi_scale.py
@@ -16,7 +16,7 @@ from parameterized import parameterized
 
 from monai.losses import DiceLoss
 from monai.losses.multi_scale import MultiScaleLoss
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import test_script_save
 
 dice_loss = DiceLoss(include_background=True, sigmoid=True, smooth_nr=1e-5, smooth_dr=1e-5)
 device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -67,7 +67,6 @@ class TestMultiScale(unittest.TestCase):
                 torch.ones((1, 1, 3), device=device), torch.ones((1, 1, 3), device=device)
             )
 
-    @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         input_param, input_data, expected_val = TEST_CASES[0]
         loss = MultiScaleLoss(**input_param)

--- a/tests/test_randtorchvisiond.py
+++ b/tests/test_randtorchvisiond.py
@@ -16,7 +16,6 @@ from parameterized import parameterized
 
 from monai.transforms import Randomizable, RandTorchVisiond
 from monai.utils import set_determinism
-from tests.utils import SkipIfBeforePyTorchVersion
 
 TEST_CASE_1 = [
     {"keys": "img", "name": "ColorJitter"},
@@ -49,7 +48,6 @@ TEST_CASE_3 = [
 ]
 
 
-@SkipIfBeforePyTorchVersion((1, 7))
 class TestRandTorchVisiond(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_value(self, input_param, input_data, expected_value):

--- a/tests/test_torchvision.py
+++ b/tests/test_torchvision.py
@@ -15,7 +15,7 @@ from parameterized import parameterized
 
 from monai.transforms import TorchVision
 from monai.utils import set_determinism
-from tests.utils import TEST_NDARRAYS, SkipIfBeforePyTorchVersion, assert_allclose
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
 TESTS = []
 for p in TEST_NDARRAYS:
@@ -52,7 +52,6 @@ for p in TEST_NDARRAYS:
     )
 
 
-@SkipIfBeforePyTorchVersion((1, 7))
 class TestTorchVision(unittest.TestCase):
     @parameterized.expand(TESTS)
     def test_value(self, input_param, input_data, expected_value):

--- a/tests/test_torchvisiond.py
+++ b/tests/test_torchvisiond.py
@@ -16,7 +16,6 @@ from parameterized import parameterized
 
 from monai.transforms import TorchVisiond
 from monai.utils import set_determinism
-from tests.utils import SkipIfBeforePyTorchVersion
 
 TEST_CASE_1 = [
     {"keys": "img", "name": "ColorJitter"},
@@ -49,7 +48,6 @@ TEST_CASE_3 = [
 ]
 
 
-@SkipIfBeforePyTorchVersion((1, 7))
 class TestTorchVisiond(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_value(self, input_param, input_data, expected_value):

--- a/tests/test_tversky_loss.py
+++ b/tests/test_tversky_loss.py
@@ -16,7 +16,7 @@ import torch
 from parameterized import parameterized
 
 from monai.losses import TverskyLoss
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import test_script_save
 
 TEST_CASES = [
     [  # shape: (1, 1, 2, 2), (1, 1, 2, 2)
@@ -175,7 +175,6 @@ class TestTverskyLoss(unittest.TestCase):
             loss = TverskyLoss(to_onehot_y=True)
             loss.forward(chn_input, chn_target)
 
-    @SkipIfBeforePyTorchVersion((1, 7, 0))
     def test_script(self):
         loss = TverskyLoss()
         test_input = torch.ones(2, 1, 8, 8)

--- a/tests/test_utils_pytorch_numpy_unification.py
+++ b/tests/test_utils_pytorch_numpy_unification.py
@@ -16,7 +16,7 @@ from parameterized import parameterized
 
 from monai.transforms.utils_pytorch_numpy_unification import mode, percentile
 from monai.utils import set_determinism
-from tests.utils import TEST_NDARRAYS, SkipIfBeforePyTorchVersion, assert_allclose
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
 TEST_MODE = []
 for p in TEST_NDARRAYS:
@@ -45,7 +45,6 @@ class TestPytorchNumpyUnification(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     percentile(arr, q)
 
-    @SkipIfBeforePyTorchVersion((1, 7))
     def test_dim(self):
         q = np.random.randint(0, 100, size=50)
         results = []


### PR DESCRIPTION
No need for "skip if before pytorch 1.7", since we have bumped the minimum version number to 1.8.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).