### PR TITLE
Add OpenSlide support for new WSIReader

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -300,14 +300,6 @@ CuCIMWSIReader
   :members:
 
 OpenSlideWSIReader
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 .. autoclass:: monai.data.OpenSlideWSIReader
-  :members:
-
-Whole slide image datasets
---------------------------
-
-PatchWSIDataset
-~~~~~~~~~~~~~~~
-.. autoclass:: monai.data.PatchWSIDataset
   :members:

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -152,23 +152,6 @@ PILReader
 .. autoclass:: PILReader
   :members:
 
-Whole slide image reader
-------------------------
-
-BaseWSIReader
-~~~~~~~~~~~~~
-.. autoclass:: BaseWSIReader
-  :members:
-
-WSIReader
-~~~~~~~~~
-.. autoclass:: WSIReader
-  :members:
-
-CuCIMWSIReader
-~~~~~~~~~~~~~~
-.. autoclass:: CuCIMWSIReader
-  :members:
 
 Image writer
 ------------
@@ -295,3 +278,36 @@ MetaTensor
 ----------
 .. autoclass:: monai.data.MetaTensor
    :members:
+
+
+
+Whole slide image reader
+------------------------
+
+BaseWSIReader
+~~~~~~~~~~~~~
+.. autoclass:: monai.data.BaseWSIReader
+  :members:
+
+WSIReader
+~~~~~~~~~
+.. autoclass:: monai.data.WSIReader
+  :members:
+
+CuCIMWSIReader
+~~~~~~~~~~~~~~
+.. autoclass:: monai.data.CuCIMWSIReader
+  :members:
+
+OpenSlideWSIReader
+~~~~~~~~~~~~~~
+.. autoclass:: monai.data.OpenSlideWSIReader
+  :members:
+
+Whole slide image datasets
+--------------------------
+
+PatchWSIDataset
+~~~~~~~~~~~~~~~
+.. autoclass:: monai.data.PatchWSIDataset
+  :members:

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -87,4 +87,4 @@ from .utils import (
     worker_init_fn,
     zoom_affine,
 )
-from .wsi_reader import BaseWSIReader, CuCIMWSIReader, WSIReader
+from .wsi_reader import BaseWSIReader, CuCIMWSIReader, OpenSlideWSIReader, WSIReader

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -809,7 +809,7 @@ class WSIReader(ImageReader):
 
         Args:
             img: a WSIReader image object loaded from a file, or list of CuImage objects
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame,
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame,
             or list of tuples (default=(0, 0))
             size: (height, width) tuple giving the region size, or list of tuples (default to full image size)
             This is the size of image at the given level (`level`)

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -809,7 +809,7 @@ class WSIReader(ImageReader):
 
         Args:
             img: a WSIReader image object loaded from a file, or list of CuImage objects
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame,
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame,
             or list of tuples (default=(0, 0))
             size: (height, width) tuple giving the region size, or list of tuples (default to full image size)
             This is the size of image at the given level (`level`)

--- a/monai/data/wsi_reader.py
+++ b/monai/data/wsi_reader.py
@@ -92,7 +92,7 @@ class BaseWSIReader(ImageReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a lis of such objects
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -109,7 +109,7 @@ class BaseWSIReader(ImageReader):
 
         Args:
             patch: extracted patch from whole slide image
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -131,7 +131,7 @@ class BaseWSIReader(ImageReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a list of such objects
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -252,7 +252,7 @@ class WSIReader(BaseWSIReader):
 
         Args:
             patch: extracted patch from whole slide image
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -268,7 +268,7 @@ class WSIReader(BaseWSIReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a lis of such objects
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -340,7 +340,7 @@ class CuCIMWSIReader(BaseWSIReader):
 
         Args:
             patch: extracted patch from whole slide image
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -388,7 +388,7 @@ class CuCIMWSIReader(BaseWSIReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a lis of such objects
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -468,7 +468,7 @@ class OpenSlideWSIReader(BaseWSIReader):
 
         Args:
             patch: extracted patch from whole slide image
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -515,7 +515,7 @@ class OpenSlideWSIReader(BaseWSIReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a lis of such objects
-            location: (x_min, y_min) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0

--- a/monai/data/wsi_reader.py
+++ b/monai/data/wsi_reader.py
@@ -217,11 +217,10 @@ class WSIReader(BaseWSIReader):
     def __init__(self, backend="cucim", level: int = 0, **kwargs):
         super().__init__(level, **kwargs)
         self.backend = backend.lower()
-        # Any new backend can be added below
         if self.backend == "cucim":
             self.reader = CuCIMWSIReader(level=level, **kwargs)
         elif self.backend == "openslide":
-            self.reader = OpenSlideWSIReader(level=level, **kwargs)
+            self.reader = OpenSlideWSIReader(level=level, **kwargs)  # type: ignore
         else:
             raise ValueError("The supported backends are: cucim")
         self.supported_suffixes = self.reader.supported_suffixes

--- a/monai/data/wsi_reader.py
+++ b/monai/data/wsi_reader.py
@@ -92,7 +92,7 @@ class BaseWSIReader(ImageReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a lis of such objects
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -109,7 +109,7 @@ class BaseWSIReader(ImageReader):
 
         Args:
             patch: extracted patch from whole slide image
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -131,7 +131,7 @@ class BaseWSIReader(ImageReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a list of such objects
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -253,7 +253,7 @@ class WSIReader(BaseWSIReader):
 
         Args:
             patch: extracted patch from whole slide image
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -269,7 +269,7 @@ class WSIReader(BaseWSIReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a lis of such objects
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -341,7 +341,7 @@ class CuCIMWSIReader(BaseWSIReader):
 
         Args:
             patch: extracted patch from whole slide image
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -389,7 +389,7 @@ class CuCIMWSIReader(BaseWSIReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a lis of such objects
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -469,7 +469,7 @@ class OpenSlideWSIReader(BaseWSIReader):
 
         Args:
             patch: extracted patch from whole slide image
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0
@@ -516,7 +516,7 @@ class OpenSlideWSIReader(BaseWSIReader):
 
         Args:
             wsi: a whole slide image object loaded from a file or a lis of such objects
-            location: (y_top, x_left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
+            location: (top, left) tuple giving the top left pixel in the level 0 reference frame. Defaults to (0, 0).
             size: (height, width) tuple giving the patch size at the given level (`level`).
                 If None, it is set to the full image size at the given level.
             level: the level number. Defaults to 0

--- a/tests/test_wsireader_new.py
+++ b/tests/test_wsireader_new.py
@@ -213,6 +213,11 @@ class TestCuCIM(WSIReaderTests.Tests):
     def setUpClass(cls):
         cls.backend = "cucim"
 
+@skipUnless(has_osl, "Requires openslide")
+class TestOpenSlide(WSIReaderTests.Tests):
+    @classmethod
+    def setUpClass(cls):
+        cls.backend = "openslide"
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wsireader_new.py
+++ b/tests/test_wsireader_new.py
@@ -213,11 +213,13 @@ class TestCuCIM(WSIReaderTests.Tests):
     def setUpClass(cls):
         cls.backend = "cucim"
 
+
 @skipUnless(has_osl, "Requires openslide")
 class TestOpenSlide(WSIReaderTests.Tests):
     @classmethod
     def setUpClass(cls):
         cls.backend = "openslide"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #4154 

### Description
This PR implement `OpenSlideWSIReader`, which read patches from whole slide images using openslide library in the back.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
