### PR TITLE
4200 workaround for ci apt

### DIFF
--- a/.github/workflows/pythonapp-gpu.yml
+++ b/.github/workflows/pythonapp-gpu.yml
@@ -64,10 +64,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: apt install
       run: |
-        sudo apt-key del 7fa2af80
+        apt-key del 7fa2af80 && rm -rf /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list
+        apt-get update
+        apt-get install -y wget
         wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb
-        sudo dpkg -i cuda-keyring_1.0-1_all.deb
-
+        dpkg -i cuda-keyring_1.0-1_all.deb
         if [ ${{ matrix.environment }} = "PT17+CUDA102" ] || \
           [ ${{ matrix.environment }} = "PT18+CUDA102" ] || \
           [ ${{ matrix.environment }} = "PT110+CUDA102" ] || \

--- a/.github/workflows/pythonapp-gpu.yml
+++ b/.github/workflows/pythonapp-gpu.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - releasing/*
+      - temp-tests
   pull_request:
 
 concurrency:
@@ -63,6 +64,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: apt install
       run: |
+        sudo apt-key del 7fa2af80
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb
+        sudo dpkg -i cuda-keyring_1.0-1_all.deb
+
         if [ ${{ matrix.environment }} = "PT17+CUDA102" ] || \
           [ ${{ matrix.environment }} = "PT18+CUDA102" ] || \
           [ ${{ matrix.environment }} = "PT110+CUDA102" ] || \

--- a/.github/workflows/pythonapp-gpu.yml
+++ b/.github/workflows/pythonapp-gpu.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - releasing/*
-      - temp-tests
   pull_request:
 
 concurrency:
@@ -64,11 +63,13 @@ jobs:
     - uses: actions/checkout@v2
     - name: apt install
       run: |
+        # workaround for https://github.com/Project-MONAI/MONAI/issues/4200
         apt-key del 7fa2af80 && rm -rf /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list
         apt-get update
         apt-get install -y wget
         wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb
         dpkg -i cuda-keyring_1.0-1_all.deb
+
         if [ ${{ matrix.environment }} = "PT17+CUDA102" ] || \
           [ ${{ matrix.environment }} = "PT18+CUDA102" ] || \
           [ ${{ matrix.environment }} = "PT110+CUDA102" ] || \

--- a/tests/test_delete_itemsd.py
+++ b/tests/test_delete_itemsd.py
@@ -48,7 +48,7 @@ class TestDeleteItemsd(unittest.TestCase):
         input_data = {"image": [1, 2, 3], PostFix.meta(): {"0008|0005": 1, "0008|1050": 2, "0008test": 3}}
         result = DeleteItemsd(**input_param)(input_data)
         self.assertEqual(result[PostFix.meta()]["0008test"], 3)
-        self.assertTrue(len(result[PostFix.meta()]), 1)
+        self.assertEqual(len(result[PostFix.meta()]), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
workaround for #4200

### Description
according to https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
