### PR TITLE
Update dice.py

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -834,15 +834,15 @@ class DiceFocalLoss(_Loss):
         """
         if len(input.shape) != len(target.shape):
             raise ValueError("the number of dimensions for input and target should be the same.")
-           
+
         n_pred_ch = input.shape[1]
-        
+
         if self.to_onehot_y:
             if n_pred_ch == 1:
                 warnings.warn("single channel prediction, `to_onehot_y=True` ignored.")
             else:
                 target = one_hot(target, num_classes=n_pred_ch)
-        
+
         if not self.include_background:
             if n_pred_ch == 1:
                 warnings.warn("single channel prediction, `include_background=False` ignored.")

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -806,11 +806,7 @@ class DiceFocalLoss(_Loss):
             smooth_dr=smooth_dr,
             batch=batch,
         )
-        self.focal = FocalLoss(
-            gamma=gamma,
-            weight=focal_weight,
-            reduction=reduction,
-        )
+        self.focal = FocalLoss(gamma=gamma, weight=focal_weight, reduction=reduction)
         if lambda_dice < 0.0:
             raise ValueError("lambda_dice should be no less than 0.0.")
         if lambda_focal < 0.0:

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -796,8 +796,6 @@ class DiceFocalLoss(_Loss):
         """
         super().__init__()
         self.dice = DiceLoss(
-            include_background=include_background,
-            to_onehot_y=to_onehot_y,
             sigmoid=sigmoid,
             softmax=softmax,
             other_act=other_act,
@@ -809,8 +807,6 @@ class DiceFocalLoss(_Loss):
             batch=batch,
         )
         self.focal = FocalLoss(
-            include_background=include_background,
-            to_onehot_y=to_onehot_y,
             gamma=gamma,
             weight=focal_weight,
             reduction=reduction,
@@ -821,6 +817,8 @@ class DiceFocalLoss(_Loss):
             raise ValueError("lambda_focal should be no less than 0.0.")
         self.lambda_dice = lambda_dice
         self.lambda_focal = lambda_focal
+        self.to_onehot_y = to_onehot_y
+        self.include_background = include_background
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """
@@ -836,6 +834,22 @@ class DiceFocalLoss(_Loss):
         """
         if len(input.shape) != len(target.shape):
             raise ValueError("the number of dimensions for input and target should be the same.")
+           
+        n_pred_ch = input.shape[1]
+        
+        if self.to_onehot_y:
+            if n_pred_ch == 1:
+                warnings.warn("single channel prediction, `to_onehot_y=True` ignored.")
+            else:
+                target = one_hot(target, num_classes=n_pred_ch)
+        
+        if not self.include_background:
+            if n_pred_ch == 1:
+                warnings.warn("single channel prediction, `include_background=False` ignored.")
+            else:
+                # if skipping background, removing first channel
+                target = target[:, 1:]
+                input = input[:, 1:]
 
         dice_loss = self.dice(input, target)
         focal_loss = self.focal(input, target)


### PR DESCRIPTION
reduce redundant operations in DiceFocalLoss, initially caused oom

Fixes # None

### Description
A few sentences describing the changes proposed in this pull request.

I was reaching out of memory error on DiceFocalLoss, I notice redundant operations within such as including background and to_onehot_y and replaced with one operation. In my situation there is 95 labels and appears to not be completely deleted before trying to onehot in focal loss as well.

### Status
**Ready/Work in progress/Hold**
The function is working for me, Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).

