### PR TITLE
Add GaussianSmooth as antialiasing filter in Resize

### DIFF
--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -13,6 +13,7 @@ import unittest
 
 import numpy as np
 import skimage.transform
+import torch
 from parameterized import parameterized
 
 from monai.transforms import Resize
@@ -23,6 +24,10 @@ TEST_CASE_0 = [{"spatial_size": 15}, (6, 10, 15)]
 TEST_CASE_1 = [{"spatial_size": 15, "mode": "area"}, (6, 10, 15)]
 
 TEST_CASE_2 = [{"spatial_size": 6, "mode": "trilinear", "align_corners": True}, (2, 4, 6)]
+
+TEST_CASE_3 = [{"spatial_size": 15, "anti_aliasing": True}, (6, 10, 15)]
+
+TEST_CASE_4 = [{"spatial_size": 6, "anti_aliasing": True, "anti_aliasing_sigma": 2.0}, (2, 4, 6)]
 
 
 class TestResize(NumpyImageTestCase2D):
@@ -36,10 +41,15 @@ class TestResize(NumpyImageTestCase2D):
             resize(self.imt[0])
 
     @parameterized.expand(
-        [((32, -1), "area"), ((32, 32), "area"), ((32, 32, 32), "trilinear"), ((256, 256), "bilinear")]
+        [
+            ((32, -1), "area", True),
+            ((32, 32), "area", False),
+            ((32, 32, 32), "trilinear", True),
+            ((256, 256), "bilinear", False),
+        ]
     )
-    def test_correct_results(self, spatial_size, mode):
-        resize = Resize(spatial_size, mode=mode)
+    def test_correct_results(self, spatial_size, mode, anti_aliasing):
+        resize = Resize(spatial_size, mode=mode, anti_aliasing=anti_aliasing)
         _order = 0
         if mode.endswith("linear"):
             _order = 1
@@ -47,7 +57,7 @@ class TestResize(NumpyImageTestCase2D):
             spatial_size = (32, 64)
         expected = [
             skimage.transform.resize(
-                channel, spatial_size, order=_order, clip=False, preserve_range=False, anti_aliasing=False
+                channel, spatial_size, order=_order, clip=False, preserve_range=False, anti_aliasing=anti_aliasing
             )
             for channel in self.imt[0]
         ]
@@ -55,9 +65,20 @@ class TestResize(NumpyImageTestCase2D):
         expected = np.stack(expected).astype(np.float32)
         for p in TEST_NDARRAYS:
             out = resize(p(self.imt[0]))
-            assert_allclose(out, expected, type_test=False, atol=0.9)
+            if not anti_aliasing:
+                assert_allclose(out, expected, type_test=False, atol=0.9)
+            else:
+                # skimage uses reflect padding for anti-aliasing filter.
+                # Our implementation reuses GaussianSmooth() as anti-aliasing filter, which uses zero padding instead.
+                # Thus their results near the image boundary will be different.
+                if isinstance(out, torch.Tensor):
+                    out = out.cpu().detach().numpy()
+                good = np.sum(np.isclose(expected, out, atol=0.9))
+                self.assertLessEqual(
+                    np.abs(good - expected.size) / float(expected.size), 0.2, "at most 20 percent mismatch "
+                )
 
-    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2])
+    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
     def test_longest_shape(self, input_param, expected_shape):
         input_data = np.random.randint(0, 2, size=[3, 4, 7, 10])
         input_param["size_mode"] = "longest"


### PR DESCRIPTION
Fixes #4020.

### Description
Add GaussianSmooth as anti-aliasing filter in Resize Transform

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [X] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [X] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
