### PR TITLE
Split patch functionality for `PatchWSIReader`

### DIFF
--- a/monai/data/wsi_datasets.py
+++ b/monai/data/wsi_datasets.py
@@ -122,7 +122,7 @@ class PatchWSIDataset(Dataset):
         location = self._get_location(sample)
         level = self._get_level(sample)
         size = self._get_size(sample)
-        return self.wsi_reader.get_data(wsi=wsi_obj, location=location[::-1], size=size, level=level)
+        return self.wsi_reader.get_data(wsi=wsi_obj, location=location, size=size, level=level)
 
     def _transform(self, index: int):
         # Get a single entry of data

--- a/monai/data/wsi_datasets.py
+++ b/monai/data/wsi_datasets.py
@@ -10,13 +10,13 @@
 # limitations under the License.
 
 import inspect
-from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
 from monai.data import Dataset
 from monai.data.wsi_reader import BaseWSIReader, WSIReader
-from monai.transforms import GridSplit, apply_transform
+from monai.transforms import apply_transform
 from monai.utils import ensure_tuple_rep
 
 __all__ = ["PatchWSIDataset"]

--- a/monai/data/wsi_reader.py
+++ b/monai/data/wsi_reader.py
@@ -174,7 +174,7 @@ class BaseWSIReader(ImageReader):
             # Verify location
             if location is None:
                 location = (0, 0)
-            wsi_size = self.get_size(each_wsi, level)
+            wsi_size = self.get_size(each_wsi, 0)
             if location[0] > wsi_size[0] or location[1] > wsi_size[1]:
                 raise ValueError(f"Location is outside of the image: location={location}, image size={wsi_size}")
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -2541,12 +2541,7 @@ class GridSplit(Transform):
         input_size = self.size if size is None else ensure_tuple_rep(size, len(self.grid))
 
         if self.grid == (1, 1) and input_size is None:
-            if isinstance(image, torch.Tensor):
-                return [image]
-            elif isinstance(image, np.ndarray):
-                return [image]
-            else:
-                raise ValueError(f"Input type [{type(image)}] is not supported.")
+            return [image]
 
         split_size, steps = self._get_params(image.shape[1:], input_size)
         patches: List[NdarrayOrTensor]

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -2174,19 +2174,20 @@ class GridSplitd(MapTransform):
         self,
         keys: KeysCollection,
         grid: Tuple[int, int] = (2, 2),
-        size: Optional[Union[int, Tuple[int, int]]] = None,
+        size: Optional[Union[int, Tuple[int, int], Dict[Hashable, Union[int, Tuple[int, int], None]]]] = None,
         allow_missing_keys: bool = False,
     ):
         super().__init__(keys, allow_missing_keys)
         self.grid = grid
-        self.splitter = GridSplit(grid=grid, size=size)
+        self.size = size if isinstance(size, dict) else {key: size for key in self.keys}
+        self.splitter = GridSplit(grid=grid)
 
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> List[Dict[Hashable, NdarrayOrTensor]]:
         d = dict(data)
         n_outputs = np.prod(self.grid)
         output: List[Dict[Hashable, NdarrayOrTensor]] = [dict(d) for _ in range(n_outputs)]
         for key in self.key_iterator(d):
-            result = self.splitter(d[key])
+            result = self.splitter(d[key], self.size[key])
             for i in range(n_outputs):
                 output[i][key] = result[i]
         return output

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -2160,7 +2160,8 @@ class GridSplitd(MapTransform):
     Args:
         keys: keys of the corresponding items to be transformed.
         grid: a tuple define the shape of the grid upon which the image is split. Defaults to (2, 2)
-        size: a tuple or an integer that defines the output patch sizes.
+        size: a tuple or an integer that defines the output patch sizes,
+            or a dictionary that define it seperately for each key, like {"image": 3, "mask", (2, 2)}.
             If it's an integer, the value will be repeated for each dimension.
             The default is None, where the patch size will be inferred from the grid shape.
         allow_missing_keys: don't raise exception if key is missing.

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -2178,13 +2178,18 @@ class GridSplitd(MapTransform):
         allow_missing_keys: bool = False,
     ):
         super().__init__(keys, allow_missing_keys)
+        self.grid = grid
         self.splitter = GridSplit(grid=grid, size=size)
 
-    def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
+    def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> List[Dict[Hashable, NdarrayOrTensor]]:
         d = dict(data)
+        n_outputs = np.prod(self.grid)
+        output: List[Dict[Hashable, NdarrayOrTensor]] = [dict(d) for _ in range(n_outputs)]
         for key in self.key_iterator(d):
-            d[key] = self.splitter(d[key])
-        return d
+            result = self.splitter(d[key])
+            for i in range(n_outputs):
+                output[i][key] = result[i]
+        return output
 
 
 SpatialResampleD = SpatialResampleDict = SpatialResampled

--- a/tests/test_grid_split.py
+++ b/tests/test_grid_split.py
@@ -26,14 +26,14 @@ A1 = torch.cat([A11, A12], 2)
 A2 = torch.cat([A21, A22], 2)
 A = torch.cat([A1, A2], 1)
 
-TEST_CASE_0 = [{"grid": (2, 2)}, A, torch.stack([A11, A12, A21, A22])]
-TEST_CASE_1 = [{"grid": (2, 1)}, A, torch.stack([A1, A2])]
-TEST_CASE_2 = [{"grid": (1, 2)}, A1, torch.stack([A11, A12])]
-TEST_CASE_3 = [{"grid": (1, 2)}, A2, torch.stack([A21, A22])]
-TEST_CASE_4 = [{"grid": (1, 1), "size": (2, 2)}, A, torch.stack([A11])]
-TEST_CASE_5 = [{"grid": (1, 1), "size": 4}, A, torch.stack([A])]
-TEST_CASE_6 = [{"grid": (2, 2), "size": 2}, A, torch.stack([A11, A12, A21, A22])]
-TEST_CASE_7 = [{"grid": (1, 1)}, A, torch.stack([A])]
+TEST_CASE_0 = [{"grid": (2, 2)}, A, [A11, A12, A21, A22]]
+TEST_CASE_1 = [{"grid": (2, 1)}, A, [A1, A2]]
+TEST_CASE_2 = [{"grid": (1, 2)}, A1, [A11, A12]]
+TEST_CASE_3 = [{"grid": (1, 2)}, A2, [A21, A22]]
+TEST_CASE_4 = [{"grid": (1, 1), "size": (2, 2)}, A, [A11]]
+TEST_CASE_5 = [{"grid": (1, 1), "size": 4}, A, [A]]
+TEST_CASE_6 = [{"grid": (2, 2), "size": 2}, A, [A11, A12, A21, A22]]
+TEST_CASE_7 = [{"grid": (1, 1)}, A, [A]]
 TEST_CASE_8 = [
     {"grid": (2, 2), "size": 2},
     torch.arange(12).reshape(1, 3, 4).to(torch.float32),
@@ -52,9 +52,9 @@ for p in TEST_NDARRAYS:
     TEST_SINGLE.append([p, *TEST_CASE_7])
     TEST_SINGLE.append([p, *TEST_CASE_8])
 
-TEST_CASE_MC_0 = [{"grid": (2, 2)}, [A, A], [torch.stack([A11, A12, A21, A22]), torch.stack([A11, A12, A21, A22])]]
-TEST_CASE_MC_1 = [{"grid": (2, 1)}, [A] * 5, [torch.stack([A1, A2])] * 5]
-TEST_CASE_MC_2 = [{"grid": (1, 2)}, [A1, A2], [torch.stack([A11, A12]), torch.stack([A21, A22])]]
+TEST_CASE_MC_0 = [{"grid": (2, 2)}, [A, A], [[A11, A12, A21, A22], [A11, A12, A21, A22]]]
+TEST_CASE_MC_1 = [{"grid": (2, 1)}, [A] * 5, [[A1, A2]] * 5]
+TEST_CASE_MC_2 = [{"grid": (1, 2)}, [A1, A2], [[A11, A12], [A21, A22]]]
 
 TEST_MULTIPLE = []
 for p in TEST_NDARRAYS:
@@ -69,7 +69,8 @@ class TestGridSplit(unittest.TestCase):
         input_image = in_type(image)
         splitter = GridSplit(**input_parameters)
         output = splitter(input_image)
-        assert_allclose(output, expected, type_test=False)
+        for output_patch, expected_patch in zip(output, expected):
+            assert_allclose(output_patch, expected_patch, type_test=False)
 
     @parameterized.expand(TEST_MULTIPLE)
     def test_split_patch_multiple_call(self, in_type, input_parameters, img_list, expected_list):
@@ -77,7 +78,8 @@ class TestGridSplit(unittest.TestCase):
         for image, expected in zip(img_list, expected_list):
             input_image = in_type(image)
             output = splitter(input_image)
-            assert_allclose(output, expected, type_test=False)
+            for output_patch, expected_patch in zip(output, expected):
+                assert_allclose(output_patch, expected_patch, type_test=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_grid_splitd.py
+++ b/tests/test_grid_splitd.py
@@ -26,14 +26,14 @@ A1 = torch.cat([A11, A12], 2)
 A2 = torch.cat([A21, A22], 2)
 A = torch.cat([A1, A2], 1)
 
-TEST_CASE_0 = [{"keys": "image", "grid": (2, 2)}, {"image": A}, torch.stack([A11, A12, A21, A22])]
-TEST_CASE_1 = [{"keys": "image", "grid": (2, 1)}, {"image": A}, torch.stack([A1, A2])]
-TEST_CASE_2 = [{"keys": "image", "grid": (1, 2)}, {"image": A1}, torch.stack([A11, A12])]
-TEST_CASE_3 = [{"keys": "image", "grid": (1, 2)}, {"image": A2}, torch.stack([A21, A22])]
-TEST_CASE_4 = [{"keys": "image", "grid": (1, 1), "size": (2, 2)}, {"image": A}, torch.stack([A11])]
-TEST_CASE_5 = [{"keys": "image", "grid": (1, 1), "size": 4}, {"image": A}, torch.stack([A])]
-TEST_CASE_6 = [{"keys": "image", "grid": (2, 2), "size": 2}, {"image": A}, torch.stack([A11, A12, A21, A22])]
-TEST_CASE_7 = [{"keys": "image", "grid": (1, 1)}, {"image": A}, torch.stack([A])]
+TEST_CASE_0 = [{"keys": "image", "grid": (2, 2)}, {"image": A}, [A11, A12, A21, A22]]
+TEST_CASE_1 = [{"keys": "image", "grid": (2, 1)}, {"image": A}, [A1, A2]]
+TEST_CASE_2 = [{"keys": "image", "grid": (1, 2)}, {"image": A1}, [A11, A12]]
+TEST_CASE_3 = [{"keys": "image", "grid": (1, 2)}, {"image": A2}, [A21, A22]]
+TEST_CASE_4 = [{"keys": "image", "grid": (1, 1), "size": (2, 2)}, {"image": A}, [A11]]
+TEST_CASE_5 = [{"keys": "image", "grid": (1, 1), "size": 4}, {"image": A}, [A]]
+TEST_CASE_6 = [{"keys": "image", "grid": (2, 2), "size": 2}, {"image": A}, [A11, A12, A21, A22]]
+TEST_CASE_7 = [{"keys": "image", "grid": (1, 1)}, {"image": A}, [A]]
 TEST_CASE_8 = [
     {"keys": "image", "grid": (2, 2), "size": 2},
     {"image": torch.arange(12).reshape(1, 3, 4).to(torch.float32)},
@@ -55,17 +55,17 @@ for p in TEST_NDARRAYS:
 TEST_CASE_MC_0 = [
     {"keys": "image", "grid": (2, 2)},
     [{"image": A}, {"image": A}],
-    [torch.stack([A11, A12, A21, A22]), torch.stack([A11, A12, A21, A22])],
+    [[A11, A12, A21, A22], [A11, A12, A21, A22]],
 ]
 TEST_CASE_MC_1 = [
     {"keys": "image", "grid": (2, 1)},
     [{"image": A}, {"image": A}, {"image": A}],
-    [torch.stack([A1, A2])] * 3,
+    [[A1, A2]] * 3,
 ]
 TEST_CASE_MC_2 = [
     {"keys": "image", "grid": (1, 2)},
     [{"image": A1}, {"image": A2}],
-    [torch.stack([A11, A12]), torch.stack([A21, A22])],
+    [[A11, A12], [A21, A22]],
 ]
 
 TEST_MULTIPLE = []
@@ -82,8 +82,9 @@ class TestGridSplitd(unittest.TestCase):
         for k, v in img_dict.items():
             input_dict[k] = in_type(v)
         splitter = GridSplitd(**input_parameters)
-        output = splitter(input_dict)[input_parameters["keys"]]
-        assert_allclose(output, expected, type_test=False)
+        output = splitter(input_dict)
+        for output_patch, expected_patch in zip(output, expected):
+            assert_allclose(output_patch[input_parameters["keys"]], expected_patch, type_test=False)
 
     @parameterized.expand(TEST_MULTIPLE)
     def test_split_patch_multiple_call(self, in_type, input_parameters, img_list, expected_list):
@@ -92,8 +93,9 @@ class TestGridSplitd(unittest.TestCase):
             input_dict = {}
             for k, v in img_dict.items():
                 input_dict[k] = in_type(v)
-            output = splitter(input_dict)[input_parameters["keys"]]
-            assert_allclose(output, expected, type_test=False)
+            output = splitter(input_dict)
+            for output_patch, expected_patch in zip(output, expected):
+                assert_allclose(output_patch[input_parameters["keys"]], expected_patch, type_test=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_grid_splitd.py
+++ b/tests/test_grid_splitd.py
@@ -57,16 +57,8 @@ TEST_CASE_MC_0 = [
     [{"image": A}, {"image": A}],
     [[A11, A12, A21, A22], [A11, A12, A21, A22]],
 ]
-TEST_CASE_MC_1 = [
-    {"keys": "image", "grid": (2, 1)},
-    [{"image": A}, {"image": A}, {"image": A}],
-    [[A1, A2]] * 3,
-]
-TEST_CASE_MC_2 = [
-    {"keys": "image", "grid": (1, 2)},
-    [{"image": A1}, {"image": A2}],
-    [[A11, A12], [A21, A22]],
-]
+TEST_CASE_MC_1 = [{"keys": "image", "grid": (2, 1)}, [{"image": A}, {"image": A}, {"image": A}], [[A1, A2]] * 3]
+TEST_CASE_MC_2 = [{"keys": "image", "grid": (1, 2)}, [{"image": A1}, {"image": A2}], [[A11, A12], [A21, A22]]]
 
 TEST_MULTIPLE = []
 for p in TEST_NDARRAYS:

--- a/tests/test_grid_splitd.py
+++ b/tests/test_grid_splitd.py
@@ -30,12 +30,12 @@ TEST_CASE_0 = [{"keys": "image", "grid": (2, 2)}, {"image": A}, [A11, A12, A21, 
 TEST_CASE_1 = [{"keys": "image", "grid": (2, 1)}, {"image": A}, [A1, A2]]
 TEST_CASE_2 = [{"keys": "image", "grid": (1, 2)}, {"image": A1}, [A11, A12]]
 TEST_CASE_3 = [{"keys": "image", "grid": (1, 2)}, {"image": A2}, [A21, A22]]
-TEST_CASE_4 = [{"keys": "image", "grid": (1, 1), "size": (2, 2)}, {"image": A}, [A11]]
-TEST_CASE_5 = [{"keys": "image", "grid": (1, 1), "size": 4}, {"image": A}, [A]]
-TEST_CASE_6 = [{"keys": "image", "grid": (2, 2), "size": 2}, {"image": A}, [A11, A12, A21, A22]]
+TEST_CASE_4 = [{"keys": "image", "grid": (1, 1), "size": {"image": (2, 2)}}, {"image": A}, [A11]]
+TEST_CASE_5 = [{"keys": "image", "grid": (1, 1), "size": {"image": 4}}, {"image": A}, [A]]
+TEST_CASE_6 = [{"keys": "image", "grid": (2, 2), "size": {"image": 2}}, {"image": A}, [A11, A12, A21, A22]]
 TEST_CASE_7 = [{"keys": "image", "grid": (1, 1)}, {"image": A}, [A]]
 TEST_CASE_8 = [
-    {"keys": "image", "grid": (2, 2), "size": 2},
+    {"keys": "image", "grid": (2, 2), "size": {"image": 2}},
     {"image": torch.arange(12).reshape(1, 3, 4).to(torch.float32)},
     torch.Tensor([[[[0, 1], [4, 5]]], [[[2, 3], [6, 7]]], [[[4, 5], [8, 9]]], [[[6, 7], [10, 11]]]]).to(torch.float32),
 ]

--- a/tests/test_patch_wsi_dataset_new.py
+++ b/tests/test_patch_wsi_dataset_new.py
@@ -90,35 +90,6 @@ TEST_CASE_5 = [
     ],
 ]
 
-TEST_CASE_SPLIT_0 = [
-    {
-        "data": [{"image": FILE_PATH, "location": [10004, 20004], "label": [0, 2, 0, 1]}],
-        "size": (2, 2),
-        "split_grid": (2, 2),
-    },
-    [
-        {"image": np.array([[[247]], [[245]], [[246]]], dtype=np.uint8), "label": np.array([0])},
-        {"image": np.array([[[246]], [[246]], [[244]]], dtype=np.uint8), "label": np.array([2])},
-        {"image": np.array([[[246]], [[246]], [[244]]], dtype=np.uint8), "label": np.array([0])},
-        {"image": np.array([[[246]], [[246]], [[244]]], dtype=np.uint8), "label": np.array([1])},
-    ],
-]
-
-TEST_CASE_SPLIT_1 = [
-    {
-        "data": [{"image": FILE_PATH, "location": [10004, 20004], "label": [0, 0, 0, 1]}],
-        "size": (8, 8),
-        "split_grid": (2, 2),
-        "split_size": 1,
-    },
-    [
-        {"image": np.array([[[246]], [[245]], [[250]]], dtype=np.uint8), "label": np.array([0])},
-        {"image": np.array([[[247]], [[245]], [[246]]], dtype=np.uint8), "label": np.array([0])},
-        {"image": np.array([[[246]], [[246]], [[244]]], dtype=np.uint8), "label": np.array([0])},
-        {"image": np.array([[[246]], [[246]], [[246]]], dtype=np.uint8), "label": np.array([1])},
-    ],
-]
-
 
 @skipUnless(has_cucim or has_osl or has_tiff, "Requires cucim, openslide, or tifffile!")
 def setUpModule():  # noqa: N802
@@ -178,15 +149,6 @@ class PatchWSIDatasetTests:
                 self.assertTupleEqual(dataset[i]["image"].shape, expected[i]["image"].shape)
                 self.assertIsNone(assert_array_equal(dataset[i]["label"], expected[i]["label"]))
                 self.assertIsNone(assert_array_equal(dataset[i]["image"], expected[i]["image"]))
-
-        @parameterized.expand([TEST_CASE_SPLIT_0, TEST_CASE_SPLIT_1])
-        def test_read_split_patches(self, input_parameters, expected):
-            dataset = PatchWSIDataset(reader=self.backend, **input_parameters)
-            for i, sample in enumerate(dataset[0]):
-                self.assertTupleEqual(sample["label"].shape, expected[i]["label"].shape)
-                self.assertTupleEqual(sample["image"].shape, expected[i]["image"].shape)
-                self.assertIsNone(assert_array_equal(sample["label"], expected[i]["label"]))
-                self.assertIsNone(assert_array_equal(sample["image"], expected[i]["image"]))
 
 
 @skipUnless(has_cucim, "Requires cucim")

--- a/tests/test_patch_wsi_dataset_new.py
+++ b/tests/test_patch_wsi_dataset_new.py
@@ -180,7 +180,7 @@ class PatchWSIDatasetTests:
                 self.assertIsNone(assert_array_equal(dataset[i]["image"], expected[i]["image"]))
 
         @parameterized.expand([TEST_CASE_SPLIT_0, TEST_CASE_SPLIT_1])
-        def test_read_patches_str(self, input_parameters, expected):
+        def test_read_split_patches(self, input_parameters, expected):
             dataset = PatchWSIDataset(reader=self.backend, **input_parameters)
             for i, sample in enumerate(dataset[0]):
                 self.assertTupleEqual(sample["label"].shape, expected[i]["label"].shape)

--- a/tests/test_patch_wsi_dataset_new.py
+++ b/tests/test_patch_wsi_dataset_new.py
@@ -90,6 +90,35 @@ TEST_CASE_5 = [
     ],
 ]
 
+TEST_CASE_SPLIT_0 = [
+    {
+        "data": [{"image": FILE_PATH, "location": [10004, 20004], "label": [0, 2, 0, 1]}],
+        "size": (2, 2),
+        "split_grid": (2, 2),
+    },
+    [
+        {"image": np.array([[[247]], [[245]], [[246]]], dtype=np.uint8), "label": np.array([0])},
+        {"image": np.array([[[246]], [[246]], [[244]]], dtype=np.uint8), "label": np.array([2])},
+        {"image": np.array([[[246]], [[246]], [[244]]], dtype=np.uint8), "label": np.array([0])},
+        {"image": np.array([[[246]], [[246]], [[244]]], dtype=np.uint8), "label": np.array([1])},
+    ],
+]
+
+TEST_CASE_SPLIT_1 = [
+    {
+        "data": [{"image": FILE_PATH, "location": [10004, 20004], "label": [0, 0, 0, 1]}],
+        "size": (8, 8),
+        "split_grid": (2, 2),
+        "split_size": 1,
+    },
+    [
+        {"image": np.array([[[246]], [[245]], [[250]]], dtype=np.uint8), "label": np.array([0])},
+        {"image": np.array([[[247]], [[245]], [[246]]], dtype=np.uint8), "label": np.array([0])},
+        {"image": np.array([[[246]], [[246]], [[244]]], dtype=np.uint8), "label": np.array([0])},
+        {"image": np.array([[[246]], [[246]], [[246]]], dtype=np.uint8), "label": np.array([1])},
+    ],
+]
+
 
 @skipUnless(has_cucim or has_osl or has_tiff, "Requires cucim, openslide, or tifffile!")
 def setUpModule():  # noqa: N802
@@ -150,6 +179,15 @@ class PatchWSIDatasetTests:
                 self.assertIsNone(assert_array_equal(dataset[i]["label"], expected[i]["label"]))
                 self.assertIsNone(assert_array_equal(dataset[i]["image"], expected[i]["image"]))
 
+        @parameterized.expand([TEST_CASE_SPLIT_0, TEST_CASE_SPLIT_1])
+        def test_read_patches_str(self, input_parameters, expected):
+            dataset = PatchWSIDataset(reader=self.backend, **input_parameters)
+            for i, sample in enumerate(dataset[0]):
+                self.assertTupleEqual(sample["label"].shape, expected[i]["label"].shape)
+                self.assertTupleEqual(sample["image"].shape, expected[i]["image"].shape)
+                self.assertIsNone(assert_array_equal(sample["label"], expected[i]["label"]))
+                self.assertIsNone(assert_array_equal(sample["image"], expected[i]["image"]))
+
 
 @skipUnless(has_cucim, "Requires cucim")
 class TestPatchWSIDatasetCuCIM(PatchWSIDatasetTests.Tests):
@@ -158,7 +196,7 @@ class TestPatchWSIDatasetCuCIM(PatchWSIDatasetTests.Tests):
         cls.backend = "cucim"
 
 
-@skipUnless(has_osl, "Requires cucim")
+@skipUnless(has_osl, "Requires openslide")
 class TestPatchWSIDatasetOpenSlide(PatchWSIDatasetTests.Tests):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Fixes #4247 

### Description
This PR add split patch functionality to `PatchWSIReader`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
