### PR TITLE
4269 - fixes resample mode typos

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -137,8 +137,8 @@ class SpatialResample(Transform):
         src_affine: Optional[NdarrayOrTensor] = None,
         dst_affine: Optional[NdarrayOrTensor] = None,
         spatial_size: Optional[Union[Sequence[int], np.ndarray, int]] = None,
-        mode: Union[GridSampleMode, str, None] = GridSampleMode.BILINEAR,
-        padding_mode: Union[GridSamplePadMode, str, None] = GridSamplePadMode.BORDER,
+        mode: Union[GridSampleMode, str, None] = None,
+        padding_mode: Union[GridSamplePadMode, str, None] = None,
         align_corners: Optional[bool] = False,
         dtype: DtypeLike = None,
     ) -> Tuple[NdarrayOrTensor, NdarrayOrTensor]:
@@ -282,8 +282,8 @@ class ResampleToMatch(SpatialResample):
         img: NdarrayOrTensor,
         src_meta: Optional[Dict] = None,
         dst_meta: Optional[Dict] = None,
-        mode: Union[GridSampleMode, str, None] = GridSampleMode.BILINEAR,
-        padding_mode: Union[GridSamplePadMode, str, None] = GridSamplePadMode.BORDER,
+        mode: Union[GridSampleMode, str, None] = None,
+        padding_mode: Union[GridSamplePadMode, str, None] = None,
         align_corners: Optional[bool] = False,
         dtype: DtypeLike = None,
     ):

--- a/tests/test_resample_to_match.py
+++ b/tests/test_resample_to_match.py
@@ -44,6 +44,8 @@ class TestResampleToMatch(unittest.TestCase):
             loader = Compose([LoadImaged(("im1", "im2"), reader=reader), EnsureChannelFirstd(("im1", "im2"))])
             data = loader({"im1": self.fnames[0], "im2": self.fnames[1]})
 
+            with self.assertRaises(ValueError):
+                ResampleToMatch(mode=None)(data["im2"], data["im2_meta_dict"], data["im1_meta_dict"])
             im_mod, meta = ResampleToMatch()(data["im2"], data["im2_meta_dict"], data["im1_meta_dict"])
             current_dims = copy.deepcopy(meta.get("dim"))
             saver = SaveImaged("im3", output_dir=temp_dir, output_postfix="", separate_folder=False, writer=writer)

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -140,6 +140,8 @@ class TestSpatialResample(unittest.TestCase):
             SpatialResample()(img=img, src_affine=np.eye(4), dst_affine=ill_affine)
         with self.assertRaises(ValueError):
             SpatialResample()(img=img, src_affine=ill_affine, dst_affine=np.eye(3))
+        with self.assertRaises(ValueError):
+            SpatialResample(mode=None)(img=img, src_affine=np.eye(4), dst_affine=0.1 * np.eye(4))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4269 

### Description
prefer `self.mode` when `mode` is not provided by the user.

I searched through `transforms/**/array.py`, cannot found additional bugs

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
