### PR TITLE
unify spelling of metdata in docstrings

### DIFF
--- a/monai/apps/deepedit/transforms.py
+++ b/monai/apps/deepedit/transforms.py
@@ -614,12 +614,12 @@ class AddGuidanceFromPointsDeepEditd(Transform):
     Args:
         ref_image: key to reference image to fetch current and original image details.
         guidance: output key to store guidance.
-        meta_keys: explicitly indicate the key of the meta data dictionary of `ref_image`.
+        meta_keys: explicitly indicate the key of the metadata dictionary of `ref_image`.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             if None, will try to construct meta_keys by `{ref_image}_{meta_key_postfix}`.
-        meta_key_postfix: if meta_key is None, use `{ref_image}_{meta_key_postfix}` to to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_key is None, use `{ref_image}_{meta_key_postfix}` to to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
 

--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -372,13 +372,13 @@ class SpatialCropForegroundd(MapTransform):
         allow_smaller: when computing box size with `margin`, whether allow the image size to be smaller
             than box size, default to `True`. if the margined size is bigger than image size, will pad with
             specified `mode`.
-        meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+        meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `{key}_{meta_key_postfix}` to fetch/store the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_keys is None, use `{key}_{meta_key_postfix}` to fetch/store the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
         start_coord_key: key to record the start coordinate of spatial bounding box for foreground.
@@ -475,12 +475,12 @@ class AddGuidanceFromPointsd(Transform):
         depth_first: if depth (slices) is positioned at first dimension.
         spatial_dims: dimensions based on model used for deepgrow (2D vs 3D).
         slice_key: key that represents applicable slice to add guidance.
-        meta_keys: explicitly indicate the key of the meta data dictionary of `ref_image`.
+        meta_keys: explicitly indicate the key of the metadata dictionary of `ref_image`.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             if None, will try to construct meta_keys by `{ref_image}_{meta_key_postfix}`.
-        meta_key_postfix: if meta_key is None, use `{ref_image}_{meta_key_postfix}` to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_key is None, use `{ref_image}_{meta_key_postfix}` to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
 
@@ -589,13 +589,13 @@ class SpatialCropGuidanced(MapTransform):
         guidance: key to the guidance. It is used to generate the bounding box of foreground
         spatial_size: minimal spatial size of the image patch e.g. [128, 128, 128] to fit in.
         margin: add margin value to spatial dims of the bounding box, if only 1 value provided, use it for all dims.
-        meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+        meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
         start_coord_key: key to record the start coordinate of spatial bounding box for foreground.
@@ -712,12 +712,12 @@ class ResizeGuidanced(Transform):
     Args:
         guidance: key to guidance
         ref_image: key to reference image to fetch current and original image details
-        meta_keys: explicitly indicate the key of the meta data dictionary of `ref_image`.
+        meta_keys: explicitly indicate the key of the metadata dictionary of `ref_image`.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             if None, will try to construct meta_keys by `{ref_image}_{meta_key_postfix}`.
-        meta_key_postfix: if meta_key is None, use `{ref_image}_{meta_key_postfix}` to to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_key is None, use `{ref_image}_{meta_key_postfix}` to to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
         cropped_shape_key: key that records cropped shape for foreground.
@@ -787,13 +787,13 @@ class RestoreLabeld(MapTransform):
         align_corners: Geometrically, we consider the pixels of the input as squares rather than points.
             See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
             It also can be a sequence of bool, each element corresponds to a key in ``keys``.
-        meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+        meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_key is None, use `key_{meta_key_postfix} to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_key is None, use `key_{meta_key_postfix} to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
         start_coord_key: key that records the start coordinate of spatial bounding box for foreground.
@@ -897,13 +897,13 @@ class Fetch2DSliced(MapTransform):
         keys: keys of the corresponding items to be transformed.
         guidance: key that represents guidance.
         axis: axis that represents slice in 3D volume.
-        meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+        meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: use `key_{meta_key_postfix}` to fetch the meta data according to the key data,
-            default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: use `key_{meta_key_postfix}` to fetch the metadata according to the key data,
+            default is `meta_dict`, the metadata is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
         allow_missing_keys: don't raise exception if key is missing.

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -591,7 +591,7 @@ def ckpt_export(
     else:
         copy_model_state(dst=net, src=ckpt_file_ if key_in_ckpt_ == "" else ckpt_file_[key_in_ckpt_])
 
-    # convert to TorchScript model and save with meta data, config content
+    # convert to TorchScript model and save with metadata, config content
     net = convert_to_torchscript(model=net)
 
     extra_files: Dict = {}

--- a/monai/data/csv_saver.py
+++ b/monai/data/csv_saver.py
@@ -27,7 +27,7 @@ class CSVSaver:
     Save the data in a dictionary format cache, and write to a CSV file finally.
     Typically, the data can be classification predictions, call `save` for single data
     or call `save_batch` to save a batch of data together, and call `finalize` to write
-    the cached data into CSV file. If no meta data provided, use index from 0 to save data.
+    the cached data into CSV file. If no metadata provided, use index from 0 to save data.
     Note that this saver can't support multi-processing because it reads / writes single
     CSV file and can't guarantee the data order in multi-processing situation.
 
@@ -88,7 +88,7 @@ class CSVSaver:
 
         Args:
             data: target data content that save into cache.
-            meta_data: the meta data information corresponding to the data.
+            meta_data: the metadata information corresponding to the data.
 
         """
         save_key = meta_data[Key.FILENAME_OR_OBJ] if meta_data else str(self._data_index)

--- a/monai/data/dataset_summary.py
+++ b/monai/data/dataset_summary.py
@@ -54,12 +54,12 @@ class DatasetSummary:
             dataset: dataset from which to load the data.
             image_key: key name of images (default: ``image``).
             label_key: key name of labels (default: ``label``).
-            meta_key: explicitly indicate the key of the corresponding meta data dictionary.
+            meta_key: explicitly indicate the key of the corresponding metadata dictionary.
                 for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-                the meta data is a dictionary object which contains: filename, affine, original_shape, etc.
+                the metadata is a dictionary object which contains: filename, affine, original_shape, etc.
                 if None, will try to construct meta_keys by `{image_key}_{meta_key_postfix}`.
-            meta_key_postfix: use `{image_key}_{meta_key_postfix}` to fetch the meta data from dict,
-                the meta data is a dictionary object (default: ``meta_dict``).
+            meta_key_postfix: use `{image_key}_{meta_key_postfix}` to fetch the metadata from dict,
+                the metadata is a dictionary object (default: ``meta_dict``).
             num_workers: how many subprocesses to use for data loading.
                 ``0`` means that the data will be loaded in the main process (default: ``0``).
             kwargs: other parameters (except `batch_size` and `num_workers`) for DataLoader,
@@ -76,12 +76,12 @@ class DatasetSummary:
 
     def collect_meta_data(self):
         """
-        This function is used to collect the meta data for all images of the dataset.
+        This function is used to collect the metadata for all images of the dataset.
         """
 
         for data in self.data_loader:
             if self.meta_key not in data:
-                raise ValueError(f"To collect meta data for the dataset, key `{self.meta_key}` must exist in `data`.")
+                raise ValueError(f"To collect metadata for the dataset, key `{self.meta_key}` must exist in `data`.")
             self.all_meta_data.append(data[self.meta_key])
 
     def get_target_spacing(self, spacing_key: str = "pixdim", anisotropic_threshold: int = 3, percentile: float = 10.0):
@@ -93,7 +93,7 @@ class DatasetSummary:
         After loading with `monai.DataLoader`, "pixdim" is in the form of `torch.Tensor` with size `(batch_size, 8)`.
 
         Args:
-            spacing_key: key of spacing in meta data (default: ``pixdim``).
+            spacing_key: key of spacing in metadata (default: ``pixdim``).
             anisotropic_threshold: threshold to decide if the target spacing is anisotropic (default: ``3``).
             percentile: for anisotropic target spacing, use the percentile of all spacings of the anisotropic axis to
                 replace that axis.

--- a/monai/data/image_dataset.py
+++ b/monai/data/image_dataset.py
@@ -59,7 +59,7 @@ class ImageDataset(Dataset, Randomizable):
             image_only: if True return only the image volume, otherwise, return image volume and the metadata.
             transform_with_metadata: if True, the metadata will be passed to the transforms whenever possible.
             dtype: if not None convert the loaded image to this data type.
-            reader: register reader to load image file and meta data, if None, will use the default readers.
+            reader: register reader to load image file and metadata, if None, will use the default readers.
                 If a string of reader name provided, will construct a reader object with the `*args` and `**kwargs`
                 parameters, supported reader name: "NibabelReader", "PILReader", "ITKReader", "NumpyReader"
             args: additional parameters for reader if providing a reader name.

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -58,7 +58,7 @@ class ImageReader(ABC):
         img_data, meta_data = image_reader.get_data(img_obj)
 
     - The `read` call converts image filenames into image objects,
-    - The `get_data` call fetches the image data, as well as meta data.
+    - The `get_data` call fetches the image data, as well as metadata.
     - A reader should implement `verify_suffix` with the logic of checking the input filename
       by the filename extensions.
 
@@ -94,9 +94,9 @@ class ImageReader(ABC):
     @abstractmethod
     def get_data(self, img) -> Tuple[np.ndarray, Dict]:
         """
-        Extract data array and meta data from loaded image and return them.
+        Extract data array and metadata from loaded image and return them.
         This function must return two objects, the first is a numpy array of image data,
-        the second is a dictionary of meta data.
+        the second is a dictionary of metadata.
 
         Args:
             img: an image object loaded from an image file or a list of image objects.
@@ -150,7 +150,7 @@ class ITKReader(ImageReader):
 
     Args:
         channel_dim: the channel dimension of the input image, default is None.
-            This is used to set original_channel_dim in the meta data, EnsureChannelFirstD reads this field.
+            This is used to set original_channel_dim in the metadata, EnsureChannelFirstD reads this field.
             If None, `original_channel_dim` will be either `no_channel` or `-1`.
 
                 - Nifti file is usually "channel last", so there is no need to specify this argument.
@@ -251,11 +251,11 @@ class ITKReader(ImageReader):
 
     def get_data(self, img):
         """
-        Extract data array and meta data from loaded image and return them.
-        This function returns two objects, first is numpy array of image data, second is dict of meta data.
+        Extract data array and metadata from loaded image and return them.
+        This function returns two objects, first is numpy array of image data, second is dict of metadata.
         It constructs `affine`, `original_affine`, and `spatial_shape` and stores them in meta dict.
         When loading a list of files, they are stacked together at a new dimension as the first dimension,
-        and the meta data of the first image is used to represent the output meta data.
+        and the metadata of the first image is used to represent the output metadata.
 
         Args:
             img: an ITK image object loaded from an image file or a list of ITK image objects.
@@ -281,7 +281,7 @@ class ITKReader(ImageReader):
 
     def _get_meta_dict(self, img) -> Dict:
         """
-        Get all the meta data of the image and convert to dict type.
+        Get all the metadata of the image and convert to dict type.
 
         Args:
             img: an ITK image object loaded from an image file.
@@ -363,7 +363,7 @@ class NibabelReader(ImageReader):
         as_closest_canonical: if True, load the image as closest to canonical axis format.
         squeeze_non_spatial_dims: if True, non-spatial singletons will be squeezed, e.g. (256,256,1,3) -> (256,256,3)
         channel_dim: the channel dimension of the input image, default is None.
-            this is used to set original_channel_dim in the meta data, EnsureChannelFirstD reads this field.
+            this is used to set original_channel_dim in the metadata, EnsureChannelFirstD reads this field.
             if None, `original_channel_dim` will be either `no_channel` or `-1`.
             most Nifti files are usually "channel last", no need to specify this argument for them.
         dtype: dtype of the output data array when loading with Nibabel library.
@@ -425,11 +425,11 @@ class NibabelReader(ImageReader):
 
     def get_data(self, img):
         """
-        Extract data array and meta data from loaded image and return them.
-        This function returns two objects, first is numpy array of image data, second is dict of meta data.
+        Extract data array and metadata from loaded image and return them.
+        This function returns two objects, first is numpy array of image data, second is dict of metadata.
         It constructs `affine`, `original_affine`, and `spatial_shape` and stores them in meta dict.
         When loading a list of files, they are stacked together at a new dimension as the first dimension,
-        and the meta data of the first image is used to present the output meta data.
+        and the metadata of the first image is used to present the output metadata.
 
         Args:
             img: a Nibabel image object loaded from an image file or a list of Nibabel image objects.
@@ -463,7 +463,7 @@ class NibabelReader(ImageReader):
 
     def _get_meta_dict(self, img) -> Dict:
         """
-        Get the all the meta data of the image and convert to dict type.
+        Get the all the metadata of the image and convert to dict type.
 
         Args:
             img: a Nibabel image object loaded from an image file.
@@ -590,11 +590,11 @@ class NumpyReader(ImageReader):
 
     def get_data(self, img):
         """
-        Extract data array and meta data from loaded image and return them.
-        This function returns two objects, first is numpy array of image data, second is dict of meta data.
+        Extract data array and metadata from loaded image and return them.
+        This function returns two objects, first is numpy array of image data, second is dict of metadata.
         It constructs `affine`, `original_affine`, and `spatial_shape` and stores them in meta dict.
         When loading a list of files, they are stacked together at a new dimension as the first dimension,
-        and the meta data of the first image is used to represent the output meta data.
+        and the metadata of the first image is used to represent the output metadata.
 
         Args:
             img: a Numpy array loaded from a file or a list of Numpy arrays.
@@ -676,11 +676,11 @@ class PILReader(ImageReader):
 
     def get_data(self, img):
         """
-        Extract data array and meta data from loaded image and return them.
-        This function returns two objects, first is numpy array of image data, second is dict of meta data.
+        Extract data array and metadata from loaded image and return them.
+        This function returns two objects, first is numpy array of image data, second is dict of metadata.
         It computes `spatial_shape` and stores it in meta dict.
         When loading a list of files, they are stacked together at a new dimension as the first dimension,
-        and the meta data of the first image is used to represent the output meta data.
+        and the metadata of the first image is used to represent the output metadata.
         Note that it will swap axis 0 and 1 after loading the array because the `HW` definition in PIL
         is different from other common medical packages.
 
@@ -703,7 +703,7 @@ class PILReader(ImageReader):
 
     def _get_meta_dict(self, img) -> Dict:
         """
-        Get the all the meta data of the image and convert to dict type.
+        Get the all the metadata of the image and convert to dict type.
         Args:
             img: a PIL Image object loaded from an image file.
 
@@ -996,7 +996,7 @@ class NrrdReader(ImageReader):
 
     Args:
         channel_dim: the channel dimension of the input image, default is None.
-            This is used to set original_channel_dim in the meta data, EnsureChannelFirstD reads this field.
+            This is used to set original_channel_dim in the metadata, EnsureChannelFirstD reads this field.
             If None, `original_channel_dim` will be either `no_channel` or `0`.
             NRRD files are usually "channel first".
         dtype: dtype of the data array when loading image.
@@ -1052,9 +1052,9 @@ class NrrdReader(ImageReader):
 
     def get_data(self, img: Union[NrrdImage, List[NrrdImage]]) -> Tuple[np.ndarray, Dict]:
         """
-        Extract data array and meta data from loaded image and return them.
+        Extract data array and metadata from loaded image and return them.
         This function must return two objects, the first is a numpy array of image data,
-        the second is a dictionary of meta data.
+        the second is a dictionary of metadata.
 
         Args:
             img: a `NrrdImage` loaded from an image file or a list of image objects.
@@ -1110,7 +1110,7 @@ class NrrdReader(ImageReader):
         but is not LPS, the unchanged header is returned.
 
         Args:
-            header: The image meta data as dict
+            header: The image metadata as dict
 
         """
         if "space" not in header or header["space"] == "left-posterior-superior":
@@ -1126,7 +1126,7 @@ class NrrdReader(ImageReader):
         For more details refer to: https://pynrrd.readthedocs.io/en/latest/user-guide.html#index-ordering
 
         Args:
-            header: The image meta data as dict
+            header: The image metadata as dict
 
         """
 

--- a/monai/data/nifti_saver.py
+++ b/monai/data/nifti_saver.py
@@ -29,8 +29,8 @@ class NiftiSaver:
     Typically, the data can be segmentation predictions, call `save` for single data
     or call `save_batch` to save a batch of data together.
     The name of saved file will be `{input_image_name}_{output_postfix}{output_ext}`,
-    where the input image name is extracted from the provided meta data dictionary.
-    If no meta data provided, use index from 0 as the filename prefix.
+    where the input image name is extracted from the provided metadata dictionary.
+    If no metadata provided, use index from 0 as the filename prefix.
 
     Note: image should include channel dimension: [B],C,H,W,[D].
 
@@ -129,7 +129,7 @@ class NiftiSaver:
         Args:
             data: target data content that to be saved as a NIfTI format file.
                 Assuming the data shape starts with a channel dimension and followed by spatial dimensions.
-            meta_data: the meta data information corresponding to the data.
+            meta_data: the metadata information corresponding to the data.
 
         See Also
             :py:meth:`monai.data.nifti_writer.write_nifti`

--- a/monai/data/png_saver.py
+++ b/monai/data/png_saver.py
@@ -28,8 +28,8 @@ class PNGSaver:
     Typically, the data can be segmentation predictions, call `save` for single data
     or call `save_batch` to save a batch of data together.
     The name of saved file will be `{input_image_name}_{output_postfix}{output_ext}`,
-    where the input image name is extracted from the provided meta data dictionary.
-    If no meta data provided, use index from 0 as the filename prefix.
+    where the input image name is extracted from the provided metadata dictionary.
+    If no metadata provided, use index from 0 as the filename prefix.
 
     .. deprecated:: 0.8
         Use :py:class:`monai.transforms.SaveImage` instead.
@@ -103,7 +103,7 @@ class PNGSaver:
                 Assuming the data shape are spatial dimensions.
                 Shape of the spatial dimensions (C,H,W).
                 C should be 1, 3 or 4
-            meta_data: the meta data information corresponding to the data.
+            meta_data: the metadata information corresponding to the data.
 
         Raises:
             ValueError: When ``data`` channels is not one of [1, 3, 4].

--- a/monai/data/test_time_augmentation.py
+++ b/monai/data/test_time_augmentation.py
@@ -72,11 +72,11 @@ class TestTimeAugmentation:
         image_key: key used to extract image from input dictionary.
         orig_key: the key of the original input data in the dict. will get the applied transform information
             for this input data, then invert them for the expected data with `image_key`.
-        orig_meta_keys: the key of the meta data of original input data, will get the `affine`, `data_shape`, etc.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+        orig_meta_keys: the key of the metadata of original input data, will get the `affine`, `data_shape`, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             if None, will try to construct meta_keys by `{orig_key}_{meta_key_postfix}`.
-        meta_key_postfix: use `key_{postfix}` to fetch the meta data according to the key data,
-            default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: use `key_{postfix}` to fetch the metadata according to the key data,
+            default is `meta_dict`, the metadata is a dictionary object.
             For example, to handle key `image`,  read/write affine matrices from the
             metadata `image_meta_dict` dictionary's `affine` field.
             this arg only works when `meta_keys=None`.

--- a/monai/data/wsi_reader.py
+++ b/monai/data/wsi_reader.py
@@ -40,7 +40,7 @@ class BaseWSIReader(ImageReader):
         img_data, meta_data = image_reader.get_data(wsi)
 
     - The `read` call converts an image filename into whole slide image object,
-    - The `get_data` call fetches the image data, as well as meta data.
+    - The `get_data` call fetches the image data, as well as metadata.
 
     The following methods needs to be implemented for any concrete implementation of this class:
 

--- a/monai/handlers/segmentation_saver.py
+++ b/monai/handlers/segmentation_saver.py
@@ -30,10 +30,10 @@ else:
 class SegmentationSaver:
     """
     Event handler triggered on completing every iteration to save the segmentation predictions into files.
-    It can extract the input image meta data(filename, affine, original_shape, etc.) and resample the predictions
-    based on the meta data.
+    It can extract the input image metadata(filename, affine, original_shape, etc.) and resample the predictions
+    based on the metadata.
     The name of saved file will be `{input_image_name}_{output_postfix}{output_ext}`,
-    where the input image name is extracted from the meta data dictionary. If no meta data provided,
+    where the input image name is extracted from the metadata dictionary. If no metadata provided,
     use index from 0 as the filename prefix.
     The predictions can be PyTorch Tensor with [B, C, H, W, [D]] shape or a list of Tensor without batch dim.
 
@@ -111,7 +111,7 @@ class SegmentationSaver:
                 `image.nii`, postfix is `seg` and folder_path is `output`, if `True`, save as:
                 `output/image/image_seg.nii`, if `False`, save as `output/image_seg.nii`. default to `True`.
             batch_transform: a callable that is used to extract the `meta_data` dictionary of the input images
-                from `ignite.engine.state.batch`. the purpose is to extract necessary information from the meta data:
+                from `ignite.engine.state.batch`. the purpose is to extract necessary information from the metadata:
                 filename, affine, original_shape, etc.
                 `engine.state` and `batch_transform` inherit from the ignite concept:
                 https://pytorch.org/ignite/concepts.html#state, explanation and usage example are in the tutorial:

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -109,7 +109,7 @@ class Compose(Randomizable, InvertibleTransform):
             defaults to `False`.
         log_stats: whether to log the detailed information of data and applied transform when error happened,
             for NumPy array and PyTorch Tensor, log the data shape and value range,
-            for other meta data, log the values directly. default to `False`.
+            for other metadata, log the values directly. default to `False`.
 
     """
 
@@ -199,7 +199,7 @@ class OneOf(Compose):
             defaults to `False`.
         log_stats: whether to log the detailed information of data and applied transform when error happened,
             for NumPy array and PyTorch Tensor, log the data shape and value range,
-            for other meta data, log the values directly. default to `False`.
+            for other metadata, log the values directly. default to `False`.
 
     """
 

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -706,7 +706,7 @@ class RandSpatialCropSamplesd(Randomizable, MapTransform, InvertibleTransform):
     Crop image with random size or specific size ROI to generate a list of N samples.
     It can crop at a random position as center or at the image center. And allows to set
     the minimum size to limit the randomly generated ROI. Suppose all the expected fields
-    specified by `keys` have same shape, and add `patch_index` to the corresponding meta data.
+    specified by `keys` have same shape, and add `patch_index` to the corresponding metadata.
     It will return a list of dictionaries for all the cropped images.
 
     Note: even `random_size=False`, if a dimension of the expected ROI size is bigger than the input image size,
@@ -729,14 +729,14 @@ class RandSpatialCropSamplesd(Randomizable, MapTransform, InvertibleTransform):
         random_center: crop at random position as center or the image center.
         random_size: crop with random size or specific size ROI.
             The actual size is sampled from `randint(roi_size, img_size)`.
-        meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+        meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
             used to add `patch_index` to the meta dict.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             used to add `patch_index` to the meta dict.
         allow_missing_keys: don't raise exception if key is missing.
 
@@ -791,7 +791,7 @@ class RandSpatialCropSamplesd(Randomizable, MapTransform, InvertibleTransform):
             for key in self.key_iterator(cropped):
                 cropped[self.trace_key(key)][-1][TraceKeys.CLASS_NAME] = self.__class__.__name__  # type: ignore
                 cropped[self.trace_key(key)][-1][TraceKeys.ID] = id(self)  # type: ignore
-            # add `patch_index` to the meta data
+            # add `patch_index` to the metadata
             for key, meta_key, meta_key_postfix in self.key_iterator(d, self.meta_keys, self.meta_key_postfix):
                 meta_key = meta_key or f"{key}_{meta_key_postfix}"
                 if meta_key not in cropped:
@@ -936,14 +936,14 @@ class RandWeightedCropd(Randomizable, MapTransform, InvertibleTransform):
             If its components have non-positive values, the corresponding size of `img` will be used.
         num_samples: number of samples (image patches) to take in the returned list.
         center_coord_key: if specified, the actual sampling location will be stored with the corresponding key.
-        meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+        meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
             used to add `patch_index` to the meta dict.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             used to add `patch_index` to the meta dict.
         allow_missing_keys: don't raise exception if key is missing.
 
@@ -1007,7 +1007,7 @@ class RandWeightedCropd(Randomizable, MapTransform, InvertibleTransform):
                     results[i][self.center_coord_key] = center
         # fill in the extra keys with unmodified data
         for i in range(self.num_samples):
-            # add `patch_index` to the meta data
+            # add `patch_index` to the metadata
             for key, meta_key, meta_key_postfix in self.key_iterator(d, self.meta_keys, self.meta_key_postfix):
                 meta_key = meta_key or f"{key}_{meta_key_postfix}"
                 if meta_key not in results[i]:
@@ -1045,7 +1045,7 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform, InvertibleTransform):
     Crop random fixed sized regions with the center being a foreground or background voxel
     based on the Pos Neg Ratio.
     Suppose all the expected fields specified by `keys` have same shape,
-    and add `patch_index` to the corresponding meta data.
+    and add `patch_index` to the corresponding metadata.
     And will return a list of dictionaries for all the cropped images.
 
     If a dimension of the expected spatial size is bigger than the input image size,
@@ -1078,14 +1078,14 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform, InvertibleTransform):
             `image_threshold`, and randomly select crop centers based on them, need to provide `fg_indices_key`
             and `bg_indices_key` together, expect to be 1 dim array of spatial indices after flattening.
             a typical usage is to call `FgBgToIndicesd` transform first and cache the results.
-        meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+        meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
             used to add `patch_index` to the meta dict.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             used to add `patch_index` to the meta dict.
         allow_smaller: if `False`, an exception will be raised if the image is smaller than
             the requested ROI in any dimension. If `True`, any smaller dimensions will be set to
@@ -1185,7 +1185,7 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform, InvertibleTransform):
                 cropper = SpatialCrop(roi_center=tuple(center), roi_size=roi_size)
                 results[i][key] = cropper(img)
                 self.push_transform(results[i], key, extra_info={"center": center}, orig_size=orig_size)
-            # add `patch_index` to the meta data
+            # add `patch_index` to the metadata
             for key, meta_key, meta_key_postfix in self.key_iterator(d, self.meta_keys, self.meta_key_postfix):
                 meta_key = meta_key or f"{key}_{meta_key_postfix}"
                 if meta_key not in results[i]:
@@ -1281,14 +1281,14 @@ class RandCropByLabelClassesd(Randomizable, MapTransform, InvertibleTransform):
             `image_threshold`, and randomly select crop centers based on them, expect to be 1 dim array
             of spatial indices after flattening. a typical usage is to call `ClassesToIndices` transform first
             and cache the results for better performance.
-        meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+        meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
             used to add `patch_index` to the meta dict.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             used to add `patch_index` to the meta dict.
         allow_smaller: if `False`, an exception will be raised if the image is smaller than
             the requested ROI in any dimension. If `True`, any smaller dimensions will remain
@@ -1369,7 +1369,7 @@ class RandCropByLabelClassesd(Randomizable, MapTransform, InvertibleTransform):
                 cropper = SpatialCrop(roi_center=tuple(center), roi_size=roi_size)
                 results[i][key] = cropper(img)
                 self.push_transform(results[i], key, extra_info={"center": center}, orig_size=orig_size)
-            # add `patch_index` to the meta data
+            # add `patch_index` to the metadata
             for key, meta_key, meta_key_postfix in self.key_iterator(d, self.meta_keys, self.meta_key_postfix):
                 meta_key = meta_key or f"{key}_{meta_key_postfix}"
                 if meta_key not in results[i]:

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -297,18 +297,18 @@ class ShiftIntensityd(MapTransform):
                 See also: :py:class:`monai.transforms.compose.MapTransform`
             offset: offset value to shift the intensity of image.
             factor_key: if not None, use it as the key to extract a value from the corresponding
-                meta data dictionary of `key` at runtime, and multiply the `offset` to shift intensity.
+                metadata dictionary of `key` at runtime, and multiply the `offset` to shift intensity.
                 Usually, `IntensityStatsd` transform can pre-compute statistics of intensity values
-                and store in the meta data.
+                and store in the metadata.
                 it also can be a sequence of strings, map to `keys`.
-            meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+            meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
                 used to extract the factor value is `factor_key` is not None.
                 for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-                the meta data is a dictionary object which contains: filename, original_shape, etc.
+                the metadata is a dictionary object which contains: filename, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
-                to the key data, default is `meta_dict`, the meta data is a dictionary object.
+            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the metadata according
+                to the key data, default is `meta_dict`, the metadata is a dictionary object.
                 used to extract the factor value is `factor_key` is not None.
             allow_missing_keys: don't raise exception if key is missing.
         """
@@ -356,18 +356,18 @@ class RandShiftIntensityd(RandomizableTransform, MapTransform):
             offsets: offset range to randomly shift.
                 if single number, offset value is picked from (-offsets, offsets).
             factor_key: if not None, use it as the key to extract a value from the corresponding
-                meta data dictionary of `key` at runtime, and multiply the random `offset` to shift intensity.
+                metadata dictionary of `key` at runtime, and multiply the random `offset` to shift intensity.
                 Usually, `IntensityStatsd` transform can pre-compute statistics of intensity values
-                and store in the meta data.
+                and store in the metadata.
                 it also can be a sequence of strings, map to `keys`.
-            meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+            meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
                 used to extract the factor value is `factor_key` is not None.
                 for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-                the meta data is a dictionary object which contains: filename, original_shape, etc.
+                the metadata is a dictionary object which contains: filename, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
-                to the key data, default is `meta_dict`, the meta data is a dictionary object.
+            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the metadata according
+                to the key data, default is `meta_dict`, the metadata is a dictionary object.
                 used to extract the factor value is `factor_key` is not None.
             prob: probability of rotating.
                 (Default 0.1, with 10% probability it returns a rotated array.)

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -106,7 +106,7 @@ class LoadImage(Transform):
     ) -> None:
         """
         Args:
-            reader: reader to load image file and meta data
+            reader: reader to load image file and metadata
                 - if `reader` is None, a default set of `SUPPORTED_READERS` will be used.
                 - if `reader` is a string, it's treated as a class name or dotted path
                 (such as ``"monai.data.ITKReader"``), the supported built-in reader classes are
@@ -115,7 +115,7 @@ class LoadImage(Transform):
                 - if `reader` is a reader class/instance, it will be registered to this loader accordingly.
             image_only: if True return only the image volume, otherwise return image data array and header dict.
             dtype: if not None convert the loaded image to this data type.
-            ensure_channel_first: if `True` and loaded both image array and meta data, automatically convert
+            ensure_channel_first: if `True` and loaded both image array and metadata, automatically convert
                 the image array shape to `channel first`. default to `False`.
             args: additional parameters for reader if providing a reader name.
             kwargs: additional parameters for reader if providing a reader name.
@@ -123,7 +123,7 @@ class LoadImage(Transform):
         Note:
 
             - The transform returns an image data array if `image_only` is True,
-              or a tuple of two elements containing the data array, and the meta data in a dictionary format otherwise.
+              or a tuple of two elements containing the data array, and the metadata in a dictionary format otherwise.
             - If `reader` is specified, the loader will attempt to use the specified readers and the default supported
               readers. This might introduce overheads when handling the exceptions of trying the incompatible loaders.
               In this case, it is therefore recommended setting the most appropriate reader as
@@ -176,7 +176,7 @@ class LoadImage(Transform):
 
     def register(self, reader: ImageReader):
         """
-        Register image reader to load image file and meta data.
+        Register image reader to load image file and metadata.
 
         Args:
             reader: reader instance to be registered with this loader.
@@ -188,7 +188,7 @@ class LoadImage(Transform):
 
     def __call__(self, filename: Union[Sequence[PathLike], PathLike], reader: Optional[ImageReader] = None):
         """
-        Load image file and meta data from the given filename(s).
+        Load image file and metadata from the given filename(s).
         If `reader` is not specified, this class automatically chooses readers based on the
         reversed order of registered readers `self.readers`.
 
@@ -199,7 +199,7 @@ class LoadImage(Transform):
                 and will stack them together as multi-channels data.
                 if provided directory path instead of file path, will treat it as
                 DICOM images series and read.
-            reader: runtime reader to load image file and meta data.
+            reader: runtime reader to load image file and metadata.
 
         """
         filename = tuple(f"{Path(s).expanduser()}" for s in ensure_tuple(filename))  # allow Path objects

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -38,7 +38,7 @@ class LoadImaged(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.LoadImage`,
     It can load both image data and metadata. When loading a list of files in one key,
     the arrays will be stacked and a new dimension will be added as the first dimension
-    In this case, the meta data of the first image will be used to represent the stacked result.
+    In this case, the metadata of the first image will be used to represent the stacked result.
     The affine transform of all the stacked images should be same.
     The output metadata field will be created as ``meta_keys`` or ``key_{meta_key_postfix}``.
 
@@ -82,7 +82,7 @@ class LoadImaged(MapTransform):
         Args:
             keys: keys of the corresponding items to be transformed.
                 See also: :py:class:`monai.transforms.compose.MapTransform`
-            reader: reader to load image file and meta data
+            reader: reader to load image file and metadata
                 - if `reader` is None, a default set of `SUPPORTED_READERS` will be used.
                 - if `reader` is a string, it's treated as a class name or dotted path
                 (such as ``"monai.data.ITKReader"``), the supported built-in reader classes are
@@ -90,18 +90,18 @@ class LoadImaged(MapTransform):
                 a reader instance will be constructed with the `*args` and `**kwargs` parameters.
                 - if `reader` is a reader class/instance, it will be registered to this loader accordingly.
             dtype: if not None, convert the loaded image data to this data type.
-            meta_keys: explicitly indicate the key to store the corresponding meta data dictionary.
-                the meta data is a dictionary object which contains: filename, original_shape, etc.
+            meta_keys: explicitly indicate the key to store the corresponding metadata dictionary.
+                the metadata is a dictionary object which contains: filename, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
             meta_key_postfix: if meta_keys is None, use `key_{postfix}` to store the metadata of the nifti image,
-                default is `meta_dict`. The meta data is a dictionary object.
+                default is `meta_dict`. The metadata is a dictionary object.
                 For example, load nifti file for `image`, store the metadata into `image_meta_dict`.
-            overwriting: whether allow overwriting existing meta data of same key.
+            overwriting: whether allow overwriting existing metadata of same key.
                 default is False, which will raise exception if encountering existing key.
             image_only: if True return dictionary containing just only the image volumes, otherwise return
                 dictionary containing image data array and header dict per input key.
-            ensure_channel_first: if `True` and loaded both image array and meta data, automatically convert
+            ensure_channel_first: if `True` and loaded both image array and metadata, automatically convert
                 the image array shape to `channel first`. default to `False`.
             allow_missing_keys: don't raise exception if key is missing.
             args: additional parameters for reader if providing a reader name.
@@ -141,7 +141,7 @@ class LoadImaged(MapTransform):
                     raise ValueError("metadata must be a dict.")
                 meta_key = meta_key or f"{key}_{meta_key_postfix}"
                 if meta_key in d and not self.overwriting:
-                    raise KeyError(f"Meta data with key {meta_key} already exists and overwriting=False.")
+                    raise KeyError(f"Metadata with key {meta_key} already exists and overwriting=False.")
                 d[meta_key] = data[1]
         return d
 

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -561,17 +561,17 @@ class Invertd(MapTransform):
             orig_keys: the key of the original input data in the dict.
                 the transform trace information of ``transforms`` should be stored at ``{orig_keys}_transforms``.
                 It can also be a list of keys, each matches the ``keys``.
-            meta_keys: The key to output the inverted meta data dictionary.
-                The meta data is a dictionary optionally containing: filename, original_shape.
+            meta_keys: The key to output the inverted metadata dictionary.
+                The metadata is a dictionary optionally containing: filename, original_shape.
                 It can be a sequence of strings, maps to ``keys``.
-                If None, will try to create a meta data dict with the default key: `{key}_{meta_key_postfix}`.
-            orig_meta_keys: the key of the meta data of original input data.
-                The meta data is a dictionary optionally containing: filename, original_shape.
+                If None, will try to create a metadata dict with the default key: `{key}_{meta_key_postfix}`.
+            orig_meta_keys: the key of the metadata of original input data.
+                The metadata is a dictionary optionally containing: filename, original_shape.
                 It can be a sequence of strings, maps to the `keys`.
-                If None, will try to create a meta data dict with the default key: `{orig_key}_{meta_key_postfix}`.
-                This meta data dict will also be included in the inverted dict, stored in `meta_keys`.
+                If None, will try to create a metadata dict with the default key: `{orig_key}_{meta_key_postfix}`.
+                This metadata dict will also be included in the inverted dict, stored in `meta_keys`.
             meta_key_postfix: if `orig_meta_keys` is None, use `{orig_key}_{meta_key_postfix}` to fetch the
-                meta data from dict, if `meta_keys` is None, use `{key}_{meta_key_postfix}`. Default: ``"meta_dict"``.
+                metadata from dict, if `meta_keys` is None, use `{key}_{meta_key_postfix}`. Default: ``"meta_dict"``.
             nearest_interp: whether to use `nearest` interpolation mode when inverting the spatial transforms,
                 default to `True`. If `False`, use the same interpolation mode as the original transform.
                 It also can be a list of bool, each matches to the `keys` data.
@@ -660,7 +660,7 @@ class Invertd(MapTransform):
 
 class SaveClassificationd(MapTransform):
     """
-    Save the classification results and meta data into CSV file or other storage.
+    Save the classification results and metadata into CSV file or other storage.
 
     """
 
@@ -681,16 +681,16 @@ class SaveClassificationd(MapTransform):
         Args:
             keys: keys of the corresponding items to model output, this transform only supports 1 key.
                 See also: :py:class:`monai.transforms.compose.MapTransform`
-            meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+            meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
                 for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-                the meta data is a dictionary object which contains: filename, original_shape, etc.
+                the metadata is a dictionary object which contains: filename, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
                 will extract the filename of input image to save classification results.
             meta_key_postfix: `key_{postfix}` was used to store the metadata in `LoadImaged`.
                 so need the key to extract the metadata of input image, like filename, etc. default is `meta_dict`.
                 for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-                the meta data is a dictionary object which contains: filename, original_shape, etc.
+                the metadata is a dictionary object which contains: filename, original_shape, etc.
                 this arg only works when `meta_keys=None`. if no corresponding metadata, set to `None`.
             saver: the saver instance to save classification results, if None, create a CSVSaver internally.
                 the saver must provide `save(data, meta_data)` and `finalize()` APIs.

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -274,7 +274,7 @@ class SpatialResample(Transform):
 
 
 class ResampleToMatch(SpatialResample):
-    """Resample an image to match given meta data. The affine matrix will be aligned,
+    """Resample an image to match given metadata. The affine matrix will be aligned,
     and the size of the output image will match."""
 
     def __call__(  # type: ignore

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -190,13 +190,13 @@ class SpatialResampled(MapTransform, InvertibleTransform):
                 If None, use the data type of input data. To be compatible with other modules,
                 the output data type is always ``np.float32``.
                 It also can be a sequence of dtypes, each element corresponds to a key in ``keys``.
-            meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+            meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
                 for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-                the meta data is a dictionary object which contains: filename, affine, original_shape, etc.
+                the metadata is a dictionary object which contains: filename, affine, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys=None, use `key_{postfix}` to fetch the meta data according
-                to the key data, default is `meta_dict`, the meta data is a dictionary object.
+            meta_key_postfix: if meta_keys=None, use `key_{postfix}` to fetch the metadata according
+                to the key data, default is `meta_dict`, the metadata is a dictionary object.
                 For example, to handle key `image`,  read/write affine matrices from the
                 metadata `image_meta_dict` dictionary's `affine` field.
             meta_src_keys: the key of the corresponding ``src_affine`` in the metadata dictionary.
@@ -314,7 +314,7 @@ class ResampleToMatchd(MapTransform, InvertibleTransform):
         """
         Args:
             keys: keys of the corresponding items to be transformed.
-            template_key: key to meta data that output should be resampled to match.
+            template_key: key to metadata that output should be resampled to match.
             mode: {``"bilinear"``, ``"nearest"``}
                 Interpolation mode to calculate output values. Defaults to ``"bilinear"``.
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
@@ -474,13 +474,13 @@ class Spacingd(MapTransform, InvertibleTransform):
                 If None, use the data type of input data. To be compatible with other modules,
                 the output data type is always ``np.float32``.
                 It also can be a sequence of dtypes, each element corresponds to a key in ``keys``.
-            meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+            meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
                 for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-                the meta data is a dictionary object which contains: filename, affine, original_shape, etc.
+                the metadata is a dictionary object which contains: filename, affine, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys=None, use `key_{postfix}` to fetch the meta data according
-                to the key data, default is `meta_dict`, the meta data is a dictionary object.
+            meta_key_postfix: if meta_keys=None, use `key_{postfix}` to fetch the metadata according
+                to the key data, default is `meta_dict`, the metadata is a dictionary object.
                 For example, to handle key `image`,  read/write affine matrices from the
                 metadata `image_meta_dict` dictionary's `affine` field.
             allow_missing_keys: don't raise exception if key is missing.
@@ -612,13 +612,13 @@ class Orientationd(MapTransform, InvertibleTransform):
             labels: optional, None or sequence of (2,) sequences
                 (2,) sequences are labels for (beginning, end) of output axis.
                 Defaults to ``(('L', 'R'), ('P', 'A'), ('I', 'S'))``.
-            meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+            meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
                 for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-                the meta data is a dictionary object which contains: filename, affine, original_shape, etc.
+                the metadata is a dictionary object which contains: filename, affine, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
-                to the key data, default is `meta_dict`, the meta data is a dictionary object.
+            meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the metadata according
+                to the key data, default is `meta_dict`, the metadata is a dictionary object.
                 For example, to handle key `image`,  read/write affine matrices from the
                 metadata `image_meta_dict` dictionary's `affine` field.
             allow_missing_keys: don't raise exception if key is missing.

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -75,7 +75,7 @@ def apply_transform(
         unpack_items: whether to unpack parameters using `*`. Defaults to False.
         log_stats: whether to log the detailed information of data and applied transform when error happened,
             for NumPy array and PyTorch Tensor, log the data shape and value range,
-            for other meta data, log the values directly. default to `False`.
+            for other metadata, log the values directly. default to `False`.
 
     Raises:
         Exception: When ``transform`` raises an exception.
@@ -102,7 +102,7 @@ def apply_transform(
                     # log data type, shape, range for array
                     datastats(img=data, data_shape=True, value_range=True, prefix=prefix)
                 else:
-                    # log data type and value for other meta data
+                    # log data type and value for other metadata
                     datastats(img=data, data_value=True, prefix=prefix)
 
             if isinstance(data, dict):

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -1105,7 +1105,7 @@ class MapLabelValue:
 
 class IntensityStats(Transform):
     """
-    Compute statistics for the intensity values of input image and store into the meta data dictionary.
+    Compute statistics for the intensity values of input image and store into the metadata dictionary.
     For example: if `ops=[lambda x: np.mean(x), "max"]` and `key_prefix="orig"`, may generate below stats:
     `{"orig_custom_0": 1.5, "orig_max": 3.0}`.
 
@@ -1115,7 +1115,7 @@ class IntensityStats(Transform):
             mapping to `np.nanmean`, `np.nanmedian`, `np.nanmax`, `np.nanmin`, `np.nanstd`.
             if a callable function, will execute the function on input image.
         key_prefix: the prefix to combine with `ops` name to generate the key to store the results in the
-            meta data dictionary. if some `ops` are callable functions, will use "{key_prefix}_custom_{index}"
+            metadata dictionary. if some `ops` are callable functions, will use "{key_prefix}_custom_{index}"
             as the key, where index counts from 0.
         channel_wise: whether to compute statistics for every channel of input image separately.
             if True, return a list of values for every operation, default to False.
@@ -1137,7 +1137,7 @@ class IntensityStats(Transform):
 
         Args:
             img: input image to compute intensity stats.
-            meta_data: meta data dictionary to store the statistics data, if None, will create an empty dictionary.
+            meta_data: metadata dictionary to store the statistics data, if None, will create an empty dictionary.
             mask: if not None, mask the image to extract only the interested area to compute statistics.
                 mask must have the same shape as input `img`.
 

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -302,9 +302,9 @@ class EnsureChannelFirstd(MapTransform):
         Args:
             keys: keys of the corresponding items to be transformed.
                 See also: :py:class:`monai.transforms.compose.MapTransform`
-            meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+            meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
                 for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-                the meta data is a dictionary object which contains: filename, original_shape, etc.
+                the metadata is a dictionary object which contains: filename, original_shape, etc.
                 it can be a sequence of string, map to the `keys`.
                 if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
             meta_key_postfix: if meta_keys is None and `key_{postfix}` was used to store the metadata in `LoadImaged`.
@@ -1457,7 +1457,7 @@ class MapLabelValued(MapTransform):
 class IntensityStatsd(MapTransform):
     """
     Dictionary-based wrapper of :py:class:`monai.transforms.IntensityStats`.
-    Compute statistics for the intensity values of input image and store into the meta data dictionary.
+    Compute statistics for the intensity values of input image and store into the metadata dictionary.
     For example: if `ops=[lambda x: np.mean(x), "max"]` and `key_prefix="orig"`, may generate below stats:
     `{"orig_custom_0": 1.5, "orig_max": 3.0}`.
 
@@ -1469,21 +1469,21 @@ class IntensityStatsd(MapTransform):
             mapping to `np.nanmean`, `np.nanmedian`, `np.nanmax`, `np.nanmin`, `np.nanstd`.
             if a callable function, will execute the function on input image.
         key_prefix: the prefix to combine with `ops` name to generate the key to store the results in the
-            meta data dictionary. if some `ops` are callable functions, will use "{key_prefix}_custom_{index}"
+            metadata dictionary. if some `ops` are callable functions, will use "{key_prefix}_custom_{index}"
             as the key, where index counts from 0.
         mask_keys: if not None, specify the mask array for the image to extract only the interested area to compute
             statistics, mask must have the same shape as the image.
             it should be a sequence of strings or None, map to the `keys`.
         channel_wise: whether to compute statistics for every channel of input image separately.
             if True, return a list of values for every operation, default to False.
-        meta_keys: explicitly indicate the key of the corresponding meta data dictionary.
+        meta_keys: explicitly indicate the key of the corresponding metadata dictionary.
             used to store the computed statistics to the meta dict.
             for example, for data with key `image`, the metadata by default is in `image_meta_dict`.
-            the meta data is a dictionary object which contains: filename, original_shape, etc.
+            the metadata is a dictionary object which contains: filename, original_shape, etc.
             it can be a sequence of string, map to the `keys`.
             if None, will try to construct meta_keys by `key_{meta_key_postfix}`.
-        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the meta data according
-            to the key data, default is `meta_dict`, the meta data is a dictionary object.
+        meta_key_postfix: if meta_keys is None, use `key_{postfix}` to fetch the metadata according
+            to the key data, default is `meta_dict`, the metadata is a dictionary object.
             used to store the computed statistics to the meta dict.
         allow_missing_keys: don't raise exception if key is missing.
 

--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -225,7 +225,7 @@ class ForwardMode(Enum):
 
 
 class TraceKeys:
-    """Extra meta data keys used for traceable transforms."""
+    """Extra metadata keys used for traceable transforms."""
 
     CLASS_NAME: str = "class"
     ID: str = "id"
@@ -239,7 +239,7 @@ class TraceKeys:
 @deprecated(since="0.8.0", msg_suffix="use monai.utils.enums.TraceKeys instead.")
 class InverseKeys:
     """
-    Extra meta data keys used for inverse transforms.
+    Extra metadata keys used for inverse transforms.
 
     .. deprecated:: 0.8.0
         Use :class:`monai.utils.enums.TraceKeys` instead.

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -354,7 +354,7 @@ def copy_to_device(
 
 class ImageMetaKey:
     """
-    Common key names in the meta data header of images
+    Common key names in the metadata header of images
     """
 
     FILENAME_OR_OBJ = "filename_or_obj"


### PR DESCRIPTION

Signed-off-by: kbressem <kenobressem@gmail.com>

Fixes #4110  .

### Description
Unifies the spelling of metadata in the docstrings

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] In-line docstrings updated.
