### PR TITLE
multiprocessing test metatensor

### DIFF
--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -109,8 +109,6 @@ from .wsi_reader import BaseWSIReader, CuCIMWSIReader, OpenSlideWSIReader, WSIRe
 with contextlib.suppress(BaseException):
     from multiprocessing.reduction import ForkingPickler
 
-    from torch.multiprocessing.reductions import reduce_tensor
-
     def _rebuild_meta(cls, storage, metadata):
         storage_offset, size, stride, meta_obj = metadata
         t = cls([], meta=meta_obj, dtype=storage.dtype, device=storage.device)

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+
 from .box_utils import (
     box_area,
     box_centers,
@@ -103,3 +105,23 @@ from .utils import (
 )
 from .wsi_datasets import PatchWSIDataset
 from .wsi_reader import BaseWSIReader, CuCIMWSIReader, OpenSlideWSIReader, WSIReader
+
+with contextlib.suppress(BaseException):
+    from multiprocessing.reduction import ForkingPickler
+
+    from torch.multiprocessing.reductions import reduce_tensor
+
+    def _rebuild_meta(cls, storage, metadata):
+        storage_offset, size, stride, meta_obj = metadata
+        t = cls([], meta=meta_obj, dtype=storage.dtype, device=storage.device)
+        t.set_(storage._untyped() if hasattr(storage, "_untyped") else storage, storage_offset, size, stride)
+        return t
+
+    def reduce_meta_tensor(meta_tensor):
+        storage = meta_tensor.storage()
+        if storage.is_cuda:
+            raise NotImplementedError("sharing CUDA metatensor across processes not implemented")
+        metadata = (meta_tensor.storage_offset(), meta_tensor.size(), meta_tensor.stride(), meta_tensor.meta)
+        return _rebuild_meta, (type(meta_tensor), storage, metadata)
+
+    ForkingPickler.register(MetaTensor, reduce_meta_tensor)

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
 import random
 import string
@@ -16,9 +17,11 @@ import tempfile
 import unittest
 import warnings
 from copy import deepcopy
+from multiprocessing.reduction import ForkingPickler
 from typing import Optional, Union
 
 import torch
+import torch.multiprocessing
 from parameterized import parameterized
 
 from monai.data import DataLoader, Dataset
@@ -30,11 +33,11 @@ from monai.utils.enums import PostFix
 from monai.utils.module import pytorch_after
 from tests.utils import TEST_DEVICES, SkipIfBeforePyTorchVersion, assert_allclose, skip_if_no_cuda
 
-DTYPES = [[torch.float32], [torch.float64], [torch.float16], [torch.int64], [torch.int32]]
+DTYPES = [[torch.float32], [torch.float64], [torch.float16], [torch.int64], [torch.int32], [None]]
 TESTS = []
 for _device in TEST_DEVICES:
     for _dtype in DTYPES:
-        TESTS.append((*_device, *_dtype))
+        TESTS.append((*_device, *_dtype))  # type: ignore
 
 
 def rand_string(min_len=5, max_len=10):
@@ -487,6 +490,16 @@ class TestMetaTensor(unittest.TestCase):
         data = tr({key: im})
         m = MetaTensor(im, applied_operations=data[PostFix.transforms(key)])
         self.assertEqual(len(m.applied_operations), len(tr.transforms))
+
+    @parameterized.expand(DTYPES)
+    def test_multiprocessing(self, dtype=None):
+        """multiprocessing sharing with 'dtype'"""
+        buf = io.BytesIO()
+        t = MetaTensor([0.0, 0.0], dtype=dtype)
+        ForkingPickler(buf).dump(t)
+        obj = ForkingPickler.loads(buf.getvalue())
+        self.assertIsInstance(obj, MetaTensor)
+        assert_allclose(obj.as_tensor(), t)
 
 
 if __name__ == "__main__":

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -491,11 +491,15 @@ class TestMetaTensor(unittest.TestCase):
         m = MetaTensor(im, applied_operations=data[PostFix.transforms(key)])
         self.assertEqual(len(m.applied_operations), len(tr.transforms))
 
-    @parameterized.expand(DTYPES)
-    def test_multiprocessing(self, dtype=None):
-        """multiprocessing sharing with 'dtype'"""
+    @parameterized.expand(TESTS)
+    def test_multiprocessing(self, device=None, dtype=None):
+        """multiprocessing sharing with 'device' and 'dtype'"""
         buf = io.BytesIO()
-        t = MetaTensor([0.0, 0.0], dtype=dtype)
+        t = MetaTensor([0.0, 0.0], device=device, dtype=dtype)
+        if t.is_cuda:
+            with self.assertRaises(NotImplementedError):
+                ForkingPickler(buf).dump(t)
+            return
         ForkingPickler(buf).dump(t)
         obj = ForkingPickler.loads(buf.getvalue())
         self.assertIsInstance(obj, MetaTensor)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

- Fixes https://github.com/Project-MONAI/MONAI/runs/6521801558?check_suite_focus=true


### Description
may need to register new logic to the pickler
according to https://github.com/pytorch/pytorch/blob/53e0d7a3bae621ef0d07cfd44957736e9149dd8e/torch/_tensor.py#L77-L79

cc @rijobro 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
