### PR TITLE
resize skip interpolation if spatial shapes match

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -687,26 +687,28 @@ class Resize(Transform):
         anti_aliasing = self.anti_aliasing if anti_aliasing is None else anti_aliasing
         anti_aliasing_sigma = self.anti_aliasing_sigma if anti_aliasing_sigma is None else anti_aliasing_sigma
 
-        img_, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float)
         if self.size_mode == "all":
-            input_ndim = img_.ndim - 1  # spatial ndim
+            input_ndim = img.ndim - 1  # spatial ndim
             output_ndim = len(ensure_tuple(self.spatial_size))
             if output_ndim > input_ndim:
-                input_shape = ensure_tuple_size(img_.shape, output_ndim + 1, 1)
-                img_ = img_.reshape(input_shape)
+                input_shape = ensure_tuple_size(img.shape, output_ndim + 1, 1)
+                img = img.reshape(input_shape)
             elif output_ndim < input_ndim:
                 raise ValueError(
                     "len(spatial_size) must be greater or equal to img spatial dimensions, "
                     f"got spatial_size={output_ndim} img={input_ndim}."
                 )
-            spatial_size_ = fall_back_tuple(self.spatial_size, img_.shape[1:])
+            spatial_size_ = fall_back_tuple(self.spatial_size, img.shape[1:])
         else:  # for the "longest" mode
-            img_size = img_.shape[1:]
+            img_size = img.shape[1:]
             if not isinstance(self.spatial_size, int):
                 raise ValueError("spatial_size must be an int number if size_mode is 'longest'.")
             scale = self.spatial_size / max(img_size)
             spatial_size_ = tuple(int(round(s * scale)) for s in img_size)
 
+        if tuple(img.shape[1:]) == spatial_size_:  # spatial shape is already the desired
+            return img
+        img_, *_ = convert_data_type(img, torch.Tensor, dtype=torch.float)
         if anti_aliasing and any(x < y for x, y in zip(spatial_size_, img_.shape[1:])):
             factors = torch.div(torch.Tensor(list(img_.shape[1:])), torch.Tensor(spatial_size_))
             if anti_aliasing_sigma is None:

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -47,6 +47,7 @@ class TestResize(NumpyImageTestCase2D):
             ((32, 32, 32), "trilinear", True),
             ((256, 256), "bilinear", False),
             ((256, 256), "nearest-exact" if pytorch_after(1, 11) else "nearest", False),
+            ((128, 64), "area", True),  # already in a good shape
         ]
     )
     def test_correct_results(self, spatial_size, mode, anti_aliasing):

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -17,7 +17,7 @@ import torch
 from parameterized import parameterized
 
 from monai.transforms import Resize
-from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, assert_allclose, pytorch_after
+from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, assert_allclose, is_tf32_env, pytorch_after
 
 TEST_CASE_0 = [{"spatial_size": 15}, (6, 10, 15)]
 
@@ -28,6 +28,8 @@ TEST_CASE_2 = [{"spatial_size": 6, "mode": "trilinear", "align_corners": True}, 
 TEST_CASE_3 = [{"spatial_size": 15, "anti_aliasing": True}, (6, 10, 15)]
 
 TEST_CASE_4 = [{"spatial_size": 6, "anti_aliasing": True, "anti_aliasing_sigma": 2.0}, (2, 4, 6)]
+
+diff_t = 0.3 if is_tf32_env() else 0.2
 
 
 class TestResize(NumpyImageTestCase2D):
@@ -78,7 +80,7 @@ class TestResize(NumpyImageTestCase2D):
                     out = out.cpu().detach().numpy()
                 good = np.sum(np.isclose(expected, out, atol=0.9))
                 self.assertLessEqual(
-                    np.abs(good - expected.size) / float(expected.size), 0.21, "at most 21 percent mismatch "
+                    np.abs(good - expected.size) / float(expected.size), diff_t, f"at most {diff_t} percent mismatch "
                 )
 
     @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>


### Description

this enhances the resize transform, to skip interpolation if the shapes match


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
