### PR TITLE
fixes integration test

### DIFF
--- a/tests/test_integration_workflows.py
+++ b/tests/test_integration_workflows.py
@@ -19,11 +19,12 @@ from glob import glob
 import nibabel as nib
 import numpy as np
 import torch
+from ignite.engine import Events
 from ignite.metrics import Accuracy
 from torch.utils.tensorboard import SummaryWriter
 
 import monai
-from monai.data import create_test_image_3d
+from monai.data import create_test_image_3d, decollate_batch
 from monai.engines import IterationEvents, SupervisedEvaluator, SupervisedTrainer
 from monai.handlers import (
     CheckpointLoader,
@@ -46,6 +47,7 @@ from monai.transforms import (
     LoadImaged,
     RandCropByPosNegLabeld,
     RandRotate90d,
+    SaveImage,
     SaveImaged,
     ScaleIntensityd,
     ToTensord,
@@ -257,6 +259,15 @@ def run_inference_test(root_dir, model_file, device="cuda:0", amp=False, num_wor
         CheckpointLoader(load_path=f"{model_file}", load_dict={"net": net}),
     ]
 
+    saver = SaveImage(output_dir=root_dir, output_postfix="seg_handler")
+
+    def save_func(engine):
+        meta_data = from_engine(PostFix.meta("image"))(engine.state.batch)
+        if isinstance(meta_data, dict):
+            meta_data = decollate_batch(meta_data)
+        for m, o in zip(meta_data, from_engine("pred")(engine.state.output)):
+            saver(o, m)
+
     evaluator = SupervisedEvaluator(
         device=device,
         val_data_loader=val_loader,
@@ -270,6 +281,7 @@ def run_inference_test(root_dir, model_file, device="cuda:0", amp=False, num_wor
         val_handlers=val_handlers,
         amp=bool(amp),
     )
+    evaluator.add_event_handler(Events.ITERATION_COMPLETED, save_func)
     evaluator.run()
 
     return evaluator.state.best_metric


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

followup of https://github.com/Project-MONAI/MONAI/pull/4347 

fixes error:
```
 ======================================================================                                                                                                                                                                                                                                       
 ERROR: test_timing (__main__.IntegrationWorkflows)                                                                          
 ----------------------------------------------------------------------                                                      
 ValueError: operands could not be broadcast together with shapes (0,) (40,)                                                 
                                                                                                                             
 The above exception was the direct cause of the following exception:                                                        
                                                                                                                             
 Traceback (most recent call last):                                                                                          
   File "/opt/monai/tests/utils.py", line 575, in _wrapper                                                                   
     raise RuntimeError(res.traceback) from res                                                                              
 RuntimeError: Traceback (most recent call last):                                                                            
   File "/opt/monai/tests/utils.py", line 526, in run_process                                                                
     output = func(*args, **kwargs)                                                                                          
   File "/opt/monai/tests/utils.py", line 607, in _call_original_func                                                        
     return f(*args, **kwargs)                                                                                               
   File "/opt/monai/tests/test_integration_workflows.py", line 354, in test_timing                                           
     self.train_and_infer(idx=2)                                                                                             
   File "/opt/monai/tests/test_integration_workflows.py", line 330, in train_and_infer                                       
     _test_saved_files(postfix="seg_handler")                                                                                
   File "/opt/monai/tests/test_integration_workflows.py", line 326, in _test_saved_files                                     
     self.assertTrue(test_integration_value(TASK, key="output_sums_2", data=values, rtol=1e-2))                              
   File "/opt/monai/tests/testing_data/integration_answers.py", line 593, in test_integration_value                          
     if np.allclose(data, value, rtol=rtol):                                                                                 
   File "<__array_function__ internals>", line 180, in allclose                                                              
   File "/opt/conda/lib/python3.8/site-packages/numpy/core/numeric.py", line 2251, in allclose                               
     res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))                                                     
   File "<__array_function__ internals>", line 180, in isclose                                                               
   File "/opt/conda/lib/python3.8/site-packages/numpy/core/numeric.py", line 2361, in isclose                                
     return within_tol(x, y, atol, rtol)                                                                                     
   File "/opt/conda/lib/python3.8/site-packages/numpy/core/numeric.py", line 2342, in within_tol                             
     return less_equal(abs(x-y), atol + rtol * abs(y))                                                                       
 ValueError: operands could not be broadcast together with shapes (0,) (40,)  
```


### Status
**Readyd**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
