### PR TITLE
Define `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION` only when `protobuf>=4.0.0` is used 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,7 +40,7 @@ pandas
 requests
 einops
 transformers
-mlflow!=1.26.1  # https://github.com/Project-MONAI/MONAI/issues/4375
+mlflow
 matplotlib!=3.5.0
 tensorboardX
 types-PyYAML

--- a/runtests.sh
+++ b/runtests.sh
@@ -19,7 +19,7 @@ protobuf_major_version=$(pip list | grep '^protobuf ' | tr -s ' ' | cut -d' ' -f
 if [ "$protobuf_major_version" -ge "4" ]
 then
     export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
-if
+fi
 
 # output formatting
 separator=""

--- a/runtests.sh
+++ b/runtests.sh
@@ -15,7 +15,10 @@
 set -e
 
 # FIXME: https://github.com/Project-MONAI/MONAI/issues/4354
-export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+protobuf_major_version=$(pip list | grep '^protobuf ' | tr -s ' ' | cut -d' ' -f2 | cut -d'.' -f1)
+if [ "$protobuf_major_version" -ge "4" ]
+    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+then
 
 # output formatting
 separator=""

--- a/runtests.sh
+++ b/runtests.sh
@@ -17,8 +17,9 @@ set -e
 # FIXME: https://github.com/Project-MONAI/MONAI/issues/4354
 protobuf_major_version=$(pip list | grep '^protobuf ' | tr -s ' ' | cut -d' ' -f2 | cut -d'.' -f1)
 if [ "$protobuf_major_version" -ge "4" ]
-    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 then
+    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+if
 
 # output formatting
 separator=""


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/4375

### Description
A few sentences describing the changes proposed in this pull request.

As suggested in https://github.com/mlflow/mlflow/issues/5968#issuecomment-1140372245, `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` is only required in `protobuf >= 4.0.0`.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
