### PR TITLE
4432 inv affine resampling

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -228,7 +228,7 @@ class SpatialResample(Transform):
                 src_affine, *_ = convert_to_dst_type(src_affine, dst_affine)
                 xform = np.linalg.solve(src_affine, dst_affine)
             else:
-                # https://github.com/Project-MONAI/MONAI/issues/4432
+                # https://github.com/Project-MONAI/MONAI/issues/4432
                 _d = convert_data_type(dst_affine, torch.Tensor, device=torch.device("cpu"))[0]
                 _s = convert_to_dst_type(src_affine, _d)[0]
                 xform = (

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -136,12 +136,13 @@ class TestSpatialResample(unittest.TestCase):
         ill_affine = np.asarray(
             [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, -1.0, 1.5], [0.0, 0.0, 0.0, 1.0]]
         )
-        with self.assertRaises(ValueError):
-            SpatialResample()(img=img, src_affine=np.eye(4), dst_affine=ill_affine)
-        with self.assertRaises(ValueError):
-            SpatialResample()(img=img, src_affine=ill_affine, dst_affine=np.eye(3))
-        with self.assertRaises(ValueError):
-            SpatialResample(mode=None)(img=img, src_affine=np.eye(4), dst_affine=0.1 * np.eye(4))
+        for p in TEST_NDARRAYS:
+            with self.assertRaises(ValueError):
+                SpatialResample()(img=img, src_affine=p(np.eye(4)), dst_affine=p(ill_affine))
+            with self.assertRaises(ValueError):
+                SpatialResample()(img=img, src_affine=p(ill_affine), dst_affine=p(np.eye(3)))
+            with self.assertRaises(ValueError):
+                SpatialResample(mode=None)(img=img, src_affine=p(np.eye(4)), dst_affine=p(0.1 * np.eye(4)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes https://github.com/Project-MONAI/MONAI/issues/4432

the exception (RuntimeError when src_affine not invertible) on cuda device somehow not handled properly,
so this PR moves the computation to CPU to have more stable outcome.


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
