### PR TITLE
matshow3d: supports subplot axes input

### DIFF
--- a/monai/visualize/utils.py
+++ b/monai/visualize/utils.py
@@ -52,7 +52,7 @@ def matshow3d(
             Higher dimensional arrays will be reshaped into (-1, H, W, [C]), `C` depends on `channel_dim` arg.
             A list of channel-first (C, H[, W, D]) arrays can also be passed in,
             in which case they will be displayed as a padded and stacked volume.
-        fig: matplotlib figure to use. If None, a new figure will be created.
+        fig: matplotlib figure or Axes to use. If None, a new figure will be created.
         title: title of the figure.
         figsize: size of the figure.
         frames_per_row: number of frames to display in each row. If None, sqrt(firstdim) will be used.
@@ -136,17 +136,20 @@ def matshow3d(
         im = np.moveaxis(im, 0, -1)
 
     # figure related configurations
-    if fig is None:
-        fig = plt.figure(tight_layout=True)
-    if not fig.axes:
-        fig.add_subplot(111)
-    ax = fig.axes[0]
+    if isinstance(fig, plt.Axes):
+        ax = fig
+    else:
+        if fig is None:
+            fig = plt.figure(tight_layout=True)
+        if not fig.axes:
+            fig.add_subplot(111)
+        ax = fig.axes[0]
     ax.matshow(im, vmin=vmin, vmax=vmax, interpolation=interpolation, **kwargs)
     ax.axis("off")
 
     if title is not None:
         ax.set_title(title)
-    if figsize is not None:
+    if figsize is not None and hasattr(fig, "set_size_inches"):
         fig.set_size_inches(figsize)
     if show:
         plt.show()

--- a/tests/test_masked_patch_wsi_dataset.py
+++ b/tests/test_masked_patch_wsi_dataset.py
@@ -49,7 +49,7 @@ TEST_CASE_0 = [
 
 
 @skipUnless(has_cucim or has_osl or has_tiff, "Requires cucim, openslide, or tifffile!")
-def setUpModule():  # noqa: N802
+def setUpModule():
     hash_type = testing_data_config("images", FILE_KEY, "hash_type")
     hash_val = testing_data_config("images", FILE_KEY, "hash_val")
     download_url_or_skip_test(FILE_URL, FILE_PATH, hash_type=hash_type, hash_val=hash_val)

--- a/tests/test_matshow3d.py
+++ b/tests/test_matshow3d.py
@@ -42,6 +42,9 @@ class TestMatshow3d(unittest.TestCase):
             comp = compare_images(f"{testing_dir}/matshow3d_test.png", tempimg, 5e-2)
             self.assertIsNone(comp, f"value of comp={comp}")  # None indicates test passed
 
+        _, axes = pyplot.subplots()
+        matshow3d(ims[keys], fig=axes, figsize=(2, 2), frames_per_row=5, every_n=2, frame_dim=-1, show=False)
+
     def test_samples(self):
         testing_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "testing_data")
         keys = "image"

--- a/tests/test_patch_wsi_dataset_new.py
+++ b/tests/test_patch_wsi_dataset_new.py
@@ -104,7 +104,7 @@ TEST_CASE_5 = [
 
 
 @skipUnless(has_cucim or has_osl or has_tiff, "Requires cucim, openslide, or tifffile!")
-def setUpModule():  # noqa: N802
+def setUpModule():
     hash_type = testing_data_config("images", FILE_KEY, "hash_type")
     hash_val = testing_data_config("images", FILE_KEY, "hash_val")
     download_url_or_skip_test(FILE_URL, FILE_PATH, hash_type=hash_type, hash_val=hash_val)

--- a/tests/test_sliding_patch_wsi_dataset.py
+++ b/tests/test_sliding_patch_wsi_dataset.py
@@ -204,7 +204,7 @@ TEST_CASE_LARGE_1 = [
 
 
 @skipUnless(has_cucim or has_tiff, "Requires cucim, openslide, or tifffile!")
-def setUpModule():  # noqa: N802
+def setUpModule():
     for info in [(ARRAY_SMALL_0, FILE_PATH_SMALL_0), (ARRAY_SMALL_1, FILE_PATH_SMALL_1)]:
         array = info[0].transpose([1, 2, 0])
         imwrite(info[1], array, shape=array.shape, photometric="rgb")

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -109,7 +109,7 @@ def save_rgba_tiff(array: np.ndarray, filename: str, mode: str):
 
 
 @skipUnless(has_cucim or has_osl or has_tiff, "Requires cucim, openslide, or tifffile!")
-def setUpModule():  # noqa: N802
+def setUpModule():
     hash_type = testing_data_config("images", FILE_KEY, "hash_type")
     hash_val = testing_data_config("images", FILE_KEY, "hash_val")
     download_url_or_skip_test(FILE_URL, FILE_PATH, hash_type=hash_type, hash_val=hash_val)

--- a/tests/test_wsireader_new.py
+++ b/tests/test_wsireader_new.py
@@ -127,7 +127,7 @@ def save_gray_tiff(array: np.ndarray, filename: str):
 
 
 @skipUnless(has_cucim or has_osl or has_tiff, "Requires cucim, openslide, or tifffile!")
-def setUpModule():  # noqa: N802
+def setUpModule():
     hash_type = testing_data_config("images", FILE_KEY, "hash_type")
     hash_val = testing_data_config("images", FILE_KEY, "hash_val")
     download_url_or_skip_test(FILE_URL, FILE_PATH, hash_type=hash_type, hash_val=hash_val)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

### Description
issue identified during developing a tutorial https://github.com/Project-MONAI/tutorials/pull/747

the current implementation of `matshow3d` doesn't support displaying multiple subplots within the same `figure()`

this PR enables, a typical usage of:
```py
plt.subplot(1, 2, 1); matshow3d(im_a, fig=plt.gca())
plt.subplot(1, 2, 2); matshow3d(im_b, fig=plt.gca())
```

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
