### PR TITLE
enhance copy in metatensor

### DIFF
--- a/monai/data/meta_obj.py
+++ b/monai/data/meta_obj.py
@@ -80,7 +80,7 @@ class MetaObj:
         self._is_batch: bool = False
 
     @staticmethod
-    def flatten_meta_objs(args: Iterable):
+    def flatten_meta_objs(*args: Iterable):
         """
         Recursively flatten input and yield all instances of `MetaObj`.
         This means that for both `torch.add(a, b)`, `torch.stack([a, b])` (and
@@ -88,11 +88,11 @@ class MetaObj:
         `MetaObj`.
 
         Args:
-            args: Iterable of inputs to be flattened.
+            args: Iterables of inputs to be flattened.
         Returns:
             list of nested `MetaObj` from input.
         """
-        for a in args:
+        for a in itertools.chain(*args):
             if isinstance(a, (list, tuple)):
                 yield from MetaObj.flatten_meta_objs(a)
             elif isinstance(a, MetaObj):
@@ -130,7 +130,7 @@ class MetaObj:
                 setattr(self, a, d() if callable(defaults) else d)
         return
 
-    def _copy_meta(self, input_objs) -> None:
+    def _copy_meta(self, input_objs, deep_copy=False) -> None:
         """
         Copy metadata from an iterable of `MetaObj` instances. For a given attribute, we copy the
         adjunct data from the first element in the list containing that attribute.
@@ -140,10 +140,10 @@ class MetaObj:
 
         """
         self._copy_attr(
-            ["meta", "applied_operations", "is_batch"],
+            ["meta", "applied_operations"],
             input_objs,
-            [MetaObj.get_default_meta(), MetaObj.get_default_applied_operations(), False],
-            False,
+            [MetaObj.get_default_meta(), MetaObj.get_default_applied_operations()],
+            deep_copy,
         )
 
     @staticmethod

--- a/monai/data/meta_obj.py
+++ b/monai/data/meta_obj.py
@@ -11,8 +11,9 @@
 
 from __future__ import annotations
 
+import itertools
 from copy import deepcopy
-from typing import Any, Callable, Sequence
+from typing import Any, Iterable
 
 from monai.utils.enums import TraceKeys
 
@@ -74,78 +75,79 @@ class MetaObj:
     """
 
     def __init__(self):
-        self._meta: dict = self.get_default_meta()
-        self._applied_operations: list = self.get_default_applied_operations()
+        self._meta: dict = MetaObj.get_default_meta()
+        self._applied_operations: list = MetaObj.get_default_applied_operations()
         self._is_batch: bool = False
 
     @staticmethod
-    def flatten_meta_objs(args: Sequence[Any]) -> list[MetaObj]:
+    def flatten_meta_objs(args: Iterable):
         """
-        Recursively flatten input and return all instances of `MetaObj` as a single
-        list. This means that for both `torch.add(a, b)`, `torch.stack([a, b])` (and
+        Recursively flatten input and yield all instances of `MetaObj`.
+        This means that for both `torch.add(a, b)`, `torch.stack([a, b])` (and
         their numpy equivalents), we return `[a, b]` if both `a` and `b` are of type
         `MetaObj`.
 
         Args:
-            args: Sequence of inputs to be flattened.
+            args: Iterable of inputs to be flattened.
         Returns:
             list of nested `MetaObj` from input.
         """
-        out = []
         for a in args:
             if isinstance(a, (list, tuple)):
-                out += MetaObj.flatten_meta_objs(a)
+                yield from MetaObj.flatten_meta_objs(a)
             elif isinstance(a, MetaObj):
-                out.append(a)
-        return out
+                yield a
 
-    def _copy_attr(self, attribute: str, input_objs: list[MetaObj], default_fn: Callable, deep_copy: bool) -> None:
+    def _copy_attr(self, attributes: list[str], input_objs, defaults: list, deep_copy: bool) -> None:
         """
-        Copy an attribute from the first in a list of `MetaObj`. In the case of
+        Copy attributes from the first in a list of `MetaObj`. In the case of
         `torch.add(a, b)`, both `a` and `b` could be `MetaObj` or something else, so
         check them all. Copy the first to `self`.
 
         We also perform a deep copy of the data if desired.
 
         Args:
-            attribute: string corresponding to attribute to be copied (e.g., `meta`).
-            input_objs: List of `MetaObj`. We'll copy the attribute from the first one
+            attributes: a sequence of strings corresponding to attributes to be copied (e.g., `['meta']`).
+            input_objs: an iterable of `MetaObj` instances. We'll copy the attribute from the first one
                 that contains that particular attribute.
-            default_fn: If none of `input_objs` have the attribute that we're
-                interested in, then use this default function (e.g., `lambda: {}`.)
-            deep_copy: Should the attribute be deep copied? See `_copy_meta`.
+            defaults: If none of `input_objs` have the attribute that we're
+                interested in, then use this default value/function (e.g., `lambda: {}`.)
+                the defaults must be the same length as `attributes`.
+            deep_copy: whether to deep copy the corresponding attribute.
 
         Returns:
             Returns `None`, but `self` should be updated to have the copied attribute.
         """
-        attributes = [getattr(i, attribute) for i in input_objs if hasattr(i, attribute)]
-        if len(attributes) > 0:
-            val = attributes[0]
-            if deep_copy:
-                val = deepcopy(val)
-            setattr(self, attribute, val)
-        else:
-            setattr(self, attribute, default_fn())
+        found = [False] * len(attributes)
+        for i, (idx, a) in itertools.product(input_objs, enumerate(attributes)):
+            if not found[idx] and hasattr(i, a):
+                setattr(self, a, deepcopy(getattr(i, a)) if deep_copy else getattr(i, a))
+                found[idx] = True
+            if all(found):
+                return
+        for a, f, d in zip(attributes, found, defaults):
+            if not f:
+                setattr(self, a, d() if callable(defaults) else d)
+        return
 
-    def _copy_meta(self, input_objs: list[MetaObj]) -> None:
+    def _copy_meta(self, input_objs) -> None:
         """
-        Copy metadata from a list of `MetaObj`. For a given attribute, we copy the
+        Copy metadata from an iterable of `MetaObj` instances. For a given attribute, we copy the
         adjunct data from the first element in the list containing that attribute.
-
-        If there has been a change in `id` (e.g., `a=b+c`), then deepcopy. Else (e.g.,
-        `a+=1`), then don't.
 
         Args:
             input_objs: list of `MetaObj` to copy data from.
 
         """
-        id_in = id(input_objs[0]) if len(input_objs) > 0 else None
-        deep_copy = id(self) != id_in
-        self._copy_attr("meta", input_objs, self.get_default_meta, deep_copy)
-        self._copy_attr("applied_operations", input_objs, self.get_default_applied_operations, deep_copy)
-        self.is_batch = input_objs[0].is_batch if len(input_objs) > 0 else False
+        self._copy_attr(
+            ["meta", "applied_operations", "is_batch"],
+            input_objs,
+            [MetaObj.get_default_meta(), MetaObj.get_default_applied_operations(), False],
+            False,
+        )
 
-    def get_default_meta(self) -> dict:
+    @staticmethod
+    def get_default_meta() -> dict:
         """Get the default meta.
 
         Returns:
@@ -153,7 +155,8 @@ class MetaObj:
         """
         return {}
 
-    def get_default_applied_operations(self) -> list:
+    @staticmethod
+    def get_default_applied_operations() -> list:
         """Get the default applied operations.
 
         Returns:
@@ -183,13 +186,13 @@ class MetaObj:
     @property
     def meta(self) -> dict:
         """Get the meta."""
-        return self._meta if hasattr(self, "_meta") else self.get_default_meta()
+        return self._meta if hasattr(self, "_meta") else MetaObj.get_default_meta()
 
     @meta.setter
     def meta(self, d) -> None:
         """Set the meta."""
         if d == TraceKeys.NONE:
-            self._meta = self.get_default_meta()
+            self._meta = MetaObj.get_default_meta()
         self._meta = d
 
     @property
@@ -197,14 +200,14 @@ class MetaObj:
         """Get the applied operations."""
         if hasattr(self, "_applied_operations"):
             return self._applied_operations
-        return self.get_default_applied_operations()
+        return MetaObj.get_default_applied_operations()
 
     @applied_operations.setter
     def applied_operations(self, t) -> None:
         """Set the applied operations."""
         if t == TraceKeys.NONE:
             # received no operations when decollating a batch
-            self._applied_operations = self.get_default_applied_operations()
+            self._applied_operations = MetaObj.get_default_applied_operations()
             return
         self._applied_operations = t
 

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -11,7 +11,6 @@
 
 from __future__ import annotations
 
-import itertools
 import warnings
 from copy import deepcopy
 from typing import Any, Sequence

--- a/tests/test_integration_fast_train.py
+++ b/tests/test_integration_fast_train.py
@@ -34,7 +34,6 @@ from monai.transforms import (
     Compose,
     CropForegroundd,
     EnsureChannelFirstd,
-    EnsureTyped,
     FgBgToIndicesd,
     LoadImaged,
     RandAffined,
@@ -94,7 +93,6 @@ class IntegrationFastTrain(DistTestCase):
                 # and cache them to accelerate training
                 FgBgToIndicesd(keys="label", fg_postfix="_fg", bg_postfix="_bg"),
                 # move the data to GPU and cache to avoid CPU -> GPU sync in every epoch
-                EnsureTyped(keys=["image", "label"], drop_meta=True),
                 ToDeviced(keys=["image", "label"], device=device),
                 # randomly crop out patch samples from big
                 # image based on pos / neg ratio

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -96,9 +96,12 @@ class TestMetaTensor(unittest.TestCase):
         self.assertIsInstance(out, type(orig))
         if shape:
             assert_allclose(torch.as_tensor(out.shape), torch.as_tensor(orig.shape))
+        if vals:
+            assert_allclose(out, orig, **kwargs)
         if check_ids:
             self.check_ids(out, orig, ids)
         self.assertTrue(str(device) in str(out.device))
+
         # check meta and affine are equal and affine is on correct device
         if isinstance(orig, MetaTensor) and isinstance(out, MetaTensor) and meta:
             self.check_meta(orig, out)
@@ -106,8 +109,6 @@ class TestMetaTensor(unittest.TestCase):
             if check_ids:
                 self.check_ids(out.affine, orig.affine, ids)
                 self.check_ids(out.meta, orig.meta, ids)
-        if vals:
-            assert_allclose(out, orig, **kwargs)
 
     @parameterized.expand(TESTS)
     def test_as_tensor(self, device, dtype):
@@ -147,17 +148,17 @@ class TestMetaTensor(unittest.TestCase):
         orig, _ = self.get_im(device=device, dtype=dtype)
         m = orig.clone()
         m = m.to("cuda")
-        self.check(m, orig, check_ids=False, device="cuda")
+        self.check(m, orig, ids=False, device="cuda")
         m = m.cpu()
-        self.check(m, orig, check_ids=False, device="cpu")
+        self.check(m, orig, ids=False, device="cpu")
         m = m.cuda()
-        self.check(m, orig, check_ids=False, device="cuda")
+        self.check(m, orig, ids=False, device="cuda")
         m = m.to("cpu")
-        self.check(m, orig, check_ids=False, device="cpu")
+        self.check(m, orig, ids=False, device="cpu")
         m = m.to(device="cuda")
-        self.check(m, orig, check_ids=False, device="cuda")
+        self.check(m, orig, ids=False, device="cuda")
         m = m.to(device="cpu")
-        self.check(m, orig, check_ids=False, device="cpu")
+        self.check(m, orig, ids=False, device="cpu")
 
     @skip_if_no_cuda
     def test_affine_device(self):
@@ -173,10 +174,10 @@ class TestMetaTensor(unittest.TestCase):
         self.check(a, m, ids=True)
         # deepcopy
         a = deepcopy(m)
-        self.check(a, m, check_ids=False)
+        self.check(a, m, ids=False)
         # clone
         a = m.clone()
-        self.check(a, m, check_ids=False)
+        self.check(a, m, ids=False)
 
     @parameterized.expand(TESTS)
     def test_add(self, device, dtype):
@@ -201,7 +202,7 @@ class TestMetaTensor(unittest.TestCase):
         conv = torch.nn.Conv3d(im.shape[1], 5, 3)
         conv.to(device)
         out = conv(im)
-        self.check(out, im, shape=False, vals=False, check_ids=False)
+        self.check(out, im, shape=False, vals=False, ids=False)
 
     @parameterized.expand(TESTS)
     def test_stack(self, device, dtype):
@@ -209,8 +210,8 @@ class TestMetaTensor(unittest.TestCase):
         ims = [self.get_im(device=device, dtype=dtype)[0] for _ in range(numel)]
         stacked = torch.stack(ims)
         self.assertIsInstance(stacked, MetaTensor)
-        orig_affine = ims[0].meta.get("affine")
-        stacked_affine = stacked.meta.get("affine")
+        orig_affine = ims[0].meta.pop("affine")
+        stacked_affine = stacked.meta.pop("affine")
         assert_allclose(orig_affine, stacked_affine)
         self.assertEqual(stacked.meta, ims[0].meta)
 
@@ -243,7 +244,7 @@ class TestMetaTensor(unittest.TestCase):
                     "your pytorch version if this is important to you."
                 )
                 im_conv = im_conv.as_tensor()
-            self.check(out, im_conv, check_ids=False)
+            self.check(out, im_conv, ids=False)
 
     def test_pickling(self):
         m, _ = self.get_im()
@@ -266,7 +267,7 @@ class TestMetaTensor(unittest.TestCase):
         im_conv = conv(im)
         with torch.cuda.amp.autocast():
             im_conv2 = conv(im)
-        self.check(im_conv2, im_conv, check_ids=False, rtol=1e-2, atol=1e-2)
+        self.check(im_conv2, im_conv, ids=False, rtol=1e-2, atol=1e-2)
 
     def test_out(self):
         """Test when `out` is given as an argument."""


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

addresses https://github.com/Project-MONAI/MONAI/issues/4462#issuecomment-1155128136

### Description
- the `_copy_meta` is currently making `outputs = model(image)` slow because of the meta attributes deepcop, this PR updates it to use a shallow copy, now the fast training pipeline can achieve the expected speed
- the PR makes `get_default_meta` static to have some minor speed up.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
