### PR TITLE
changed ngc download url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,11 @@ RUN BUILD_MONAI=1 FORCE_CUDA=1 python setup.py develop \
 
 # NGC Client
 WORKDIR /opt/tools
-ARG NGC_CLI_URI="https://ngc.nvidia.com/downloads/ngccli_cat_linux.zip"
-RUN wget -q ${NGC_CLI_URI} && \
-    unzip ngccli_cat_linux.zip && chmod u+x ngc && \
-    md5sum -c ngc.md5 && \
-    rm -rf ngccli_cat_linux.zip ngc.md5
+ARG NGC_CLI_URI="https://ngc.nvidia.com/downloads/ngccli_linux.zip"
+RUN wget -q ${NGC_CLI_URI} && unzip ngccli_linux.zip && chmod u+x ngc-cli/ngc && \
+    find ngc-cli/ -type f -exec md5sum {} + | LC_ALL=C sort | md5sum -c ngc-cli.md5 && \
+    cp ngc-cli/ngc ngc && \
+    rm -rf ngccli_linux.zip ngc-cli.md5
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y libopenslide0  \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #4507 


### Description
##### Root cause
`ngc` moved from `./ngc` to `./ngc-cli/ngc`
`ngc.md5` renamed to `ngc-cli.md5`
so the files cannot be found.
##### Solution
1. copy `/opt/tools/ngc-cli/ngc` to `/opt/tools/ngc` to make sure `/opt/tools/ngc` exist
2. fixed the md5 file name, and replaced md5 check commands to official recommonded.
3. changed ngc download url to https://ngc.nvidia.com/downloads/ngccli_linux.zip, in case ngccli_cat_linux.zip is abandoned.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
