### PR TITLE
Fixed generalized dice score

### DIFF
--- a/monai/metrics/generalized_dice.py
+++ b/monai/metrics/generalized_dice.py
@@ -169,9 +169,15 @@ def compute_generalized_dice(
     numer = 2.0 * (intersection * w).sum(dim=1)
     denom = (denominator * w).sum(dim=1)
 
-    # Compute the score. Where the denominator (and numerator) is 0, score is 1
+    # Compute the score
     generalized_dice_score = numer / denom
-    generalized_dice_score[denom == 0] = 1
 
-    # Compute the final score, replacing nans (where denominator is 0)
+    # Handle zero deivision. Where denom == 0 and the prediction volume is 0, score is 1.
+    # Where denom == 0 but the prediction volume is not 0, score is 0
+    y_pred_o = y_pred_o.sum(dim=-1)
+    denom_zeros = denom == 0
+    generalized_dice_score[denom_zeros] = torch.where(
+        (y_pred_o == 0)[denom_zeros], torch.tensor(1.0), torch.tensor(0.0)
+    )
+
     return generalized_dice_score

--- a/tests/test_compute_generalized_dice.py
+++ b/tests/test_compute_generalized_dice.py
@@ -107,12 +107,16 @@ TEST_CASE_5 = [
 
 TEST_CASE_6 = [{"y": torch.ones((2, 2, 3, 3)), "y_pred": torch.ones((2, 2, 3, 3))}, [1.0000, 1.0000]]
 
-TEST_CASE_7 = [{"y": torch.zeros((2, 2, 3, 3)), "y_pred": torch.ones((2, 2, 3, 3))}, [1.0000, 1.0000]]
+TEST_CASE_7 = [{"y": torch.zeros((2, 2, 3, 3)), "y_pred": torch.ones((2, 2, 3, 3))}, [0.0000, 0.0000]]
+
+TEST_CASE_8 = [{"y": torch.ones((2, 2, 3, 3)), "y_pred": torch.zeros((2, 2, 3, 3))}, [0.0000, 0.0000]]
+
+TEST_CASE_9 = [{"y": torch.zeros((2, 2, 3, 3)), "y_pred": torch.zeros((2, 2, 3, 3))}, [1.0000, 1.0000]]
 
 
 class TestComputeMeanDice(unittest.TestCase):
     # Functional part tests
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_6, TEST_CASE_7])
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_6, TEST_CASE_7, TEST_CASE_8, TEST_CASE_9])
     def test_value(self, input_data, expected_value):
         result = compute_generalized_dice(**input_data)
         np.testing.assert_allclose(result.cpu().numpy(), expected_value, atol=1e-4)


### PR DESCRIPTION
Signed-off-by: João Lourenço Silva <joao.lourenco.silva@tecnico.ulisboa.pt>

Fixes #4510 .

### Description
Fixed generalized dice score metric to be 1 when denominator is 1 and prediction is empty, and 1 if denominator is 0 but prediction is not empty.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
