### PR TITLE
add ngc to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,11 @@ RUN BUILD_MONAI=1 FORCE_CUDA=1 python setup.py develop \
 
 # NGC Client
 WORKDIR /opt/tools
-ARG NGC_CLI_URI="https://ngc.nvidia.com/downloads/ngccli_cat_linux.zip"
-RUN wget -q ${NGC_CLI_URI} && \
-    unzip ngccli_cat_linux.zip && chmod u+x ngc && \
-    md5sum -c ngc.md5 && \
-    rm -rf ngccli_cat_linux.zip ngc.md5
+ARG NGC_CLI_URI="https://ngc.nvidia.com/downloads/ngccli_linux.zip"
+RUN wget -q ${NGC_CLI_URI} && unzip ngccli_linux.zip && chmod u+x ngc-cli/ngc && \
+    find ngc-cli/ -type f -exec md5sum {} + | LC_ALL=C sort | md5sum -c ngc-cli.md5 && \
+    cp ngc-cli/ngc ngc && \
+    rm -rf ngccli_linux.zip ngc-cli.md5
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y libopenslide0  \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ WORKDIR /opt/tools
 ARG NGC_CLI_URI="https://ngc.nvidia.com/downloads/ngccli_linux.zip"
 RUN wget -q ${NGC_CLI_URI} && unzip ngccli_linux.zip && chmod u+x ngc-cli/ngc && \
     find ngc-cli/ -type f -exec md5sum {} + | LC_ALL=C sort | md5sum -c ngc-cli.md5 && \
-    cp ngc-cli/ngc ngc && \
     rm -rf ngccli_linux.zip ngc-cli.md5
+ENV PATH=${PATH}:/opt/tools:/opt/tools/ngc-cli
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -y libopenslide0  \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #4507 


### Description
##### Root cause
the executable binary needs to be put in same folder with devpendences.
##### Solution
1. add `opt/tools` and `opt/tools/ngc-cli` to PATH
2. remove `cp ngc-cli/ngc ngc`


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
