### PR TITLE
some util transforms to support MetaTensor

### DIFF
--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -29,13 +29,10 @@ class TraceableTransform(Transform):
     `trace_key: list of transforms` to each data dictionary.
 
     The ``__call__`` method of this transform class must be implemented so
-    that the transformation information for each key is stored when
-    ``__call__`` is called. If the transforms were applied to keys "image" and
-    "label", there will be two extra keys in the dictionary: "image_transforms"
-    and "label_transforms" (based on `TraceKeys.KEY_SUFFIX`). Each list
-    contains a list of the transforms applied to that key.
+    that the transformation information for each key is stored in ``data.applied_operations``
+    when ``__call__`` is called.
 
-    The information in ``data[key_transform]`` will be compatible with the
+    The information in ``data.applied_operations`` will be compatible with the
     default collate since it only stores strings, numbers and arrays.
 
     `tracing` could be enabled by `self.set_tracing` or setting
@@ -96,20 +93,18 @@ class TraceableTransform(Transform):
         """
         Push to a stack of applied transforms.
 
-        Data can be one of two things:
+        Data can be one of two types:
             1. A `MetaTensor`
-            2. A dictionary of data containing arrays/tensors and auxilliary data. In
-                this case, a key must be supplied.
+            2. A dictionary of data containing arrays/tensors and auxiliary data. In
+                this case, a key must be supplied (the dictionary-based approach is deprecated).
 
-        If `data` is of type `MetaTensor`, then the applied transform will be added to
-            its internal list.
+        If `data` is of type `MetaTensor`, then the applied transform will be added to its internal list.
 
         If `data` is a dictionary, then one of two things can happen:
-            1. If data[key] is a `MetaTensor`, the applied transform will be added to
-                its internal list.
+            1. If data[key] is a `MetaTensor`, the applied transform will be added to its internal list.
             2. Else, the applied transform will be appended to an adjacent list using
                 `trace_key`. If, for example, the key is `image`, then the transform
-                will be appended to `image_transforms`.
+                will be appended to `image_transforms`. (This is deprecated.)
 
         Hopefully it is clear that there are three total possibilities:
             1. data is `MetaTensor`
@@ -170,18 +165,16 @@ class TraceableTransform(Transform):
 
         Data can be one of two things:
             1. A `MetaTensor`
-            2. A dictionary of data containing arrays/tensors and auxilliary data. In
-                this case, a key must be supplied.
+            2. A dictionary of data containing arrays/tensors and auxiliary data. In
+                this case, a key must be supplied (the dictionary-based approach is deprecated).
 
-        If `data` is of type `MetaTensor`, then the applied transform will be added to
-            its internal list.
+        If `data` is of type `MetaTensor`, then the applied transform will be added to its internal list.
 
         If `data` is a dictionary, then one of two things can happen:
-            1. If data[key] is a `MetaTensor`, the applied transform will be added to
-                its internal list.
+            1. If data[key] is a `MetaTensor`, the applied transform will be added to its internal list.
             2. Else, the applied transform will be appended to an adjacent list using
                 `trace_key`. If, for example, the key is `image`, then the transform
-                will be appended to `image_transforms`.
+                will be appended to `image_transforms`. (This is deprecated.)
 
         Hopefully it is clear that there are three total possibilities:
             1. data is `MetaTensor`
@@ -191,8 +184,7 @@ class TraceableTransform(Transform):
         Args:
             - data: dictionary of data or `MetaTensor`
             - key: if data is a dictionary, data[key] will be modified
-            - check: if true, check that `self` is the same type as the most
-                recently-applied transform.
+            - check: if true, check that `self` is the same type as the most recently-applied transform.
             - pop: if true, remove the transform as it is returned.
 
         Returns:
@@ -243,8 +235,7 @@ class TraceableTransform(Transform):
         Args:
             - data: dictionary of data or `MetaTensor`
             - key: if data is a dictionary, data[key] will be modified
-            - check: if true, check that `self` is the same type as the most
-                recently-applied transform.
+            - check: if true, check that `self` is the same type as the most recently-applied transform.
 
         Returns:
             Dictionary of most recently applied transform
@@ -277,7 +268,7 @@ class InvertibleTransform(TraceableTransform):
           different parameters being passed to each label (e.g., different
           interpolation for image and label).
 
-        - the inverse transforms are applied in a last- in-first-out order. As
+        - the inverse transforms are applied in a last-in-first-out order. As
           the inverse is applied, its entry is removed from the list detailing
           the applied transformations. That is to say that during the forward
           pass, the list of applied transforms grows, and then during the

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -11,6 +11,7 @@
 
 import unittest
 
+from monai.data.meta_tensor import MetaTensor
 from monai.transforms.utility.array import Lambda
 from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, assert_allclose
 
@@ -34,7 +35,12 @@ class TestLambda(NumpyImageTestCase2D):
                 return x[:, :, :6, ::2]
 
             lambd = Lambda(func=slice_func)
-            assert_allclose(slice_func(img), lambd(img))
+            out = lambd(img)
+            assert_allclose(slice_func(img), out)
+            if isinstance(out, MetaTensor):
+                self.assertTrue(out.applied_operations)
+                out = lambd.inverse(out)
+                self.assertFalse(out.applied_operations)
 
 
 if __name__ == "__main__":

--- a/tests/test_lambdad.py
+++ b/tests/test_lambdad.py
@@ -11,6 +11,7 @@
 
 import unittest
 
+from monai.data.meta_tensor import MetaTensor
 from monai.transforms.utility.dictionary import Lambdad
 from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, assert_allclose
 
@@ -40,7 +41,11 @@ class TestLambdad(NumpyImageTestCase2D):
             lambd = Lambdad(keys=data.keys(), func=slice_func)
             expected = {}
             expected["img"] = slice_func(data["img"])
-            assert_allclose(expected["img"], lambd(data)["img"])
+            out = lambd(data)
+            assert_allclose(expected["img"], out["img"])
+            if isinstance(out["img"], MetaTensor):
+                inv = lambd.inverse(out)
+                self.assertFalse(inv["img"].applied_operations)
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_lambda.py
+++ b/tests/test_rand_lambda.py
@@ -53,9 +53,8 @@ class TestRandLambda(unittest.TestCase):
         assert_allclose(img, ret)
         if isinstance(ret, MetaTensor):
             out = trans.inverse(ret)
-            out = trans.inverse(out)
             self.assertTrue(isinstance(out, MetaTensor))
-            self.assertFalse(out.applied_operations)
+            self.assertEqual(len(out.applied_operations), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_lambda.py
+++ b/tests/test_rand_lambda.py
@@ -12,9 +12,12 @@
 import unittest
 
 import numpy as np
+from parameterized import parameterized
 
+from monai.data.meta_tensor import MetaTensor
 from monai.transforms.transform import Randomizable
 from monai.transforms.utility.array import RandLambda
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
 
 class RandTest(Randomizable):
@@ -31,22 +34,28 @@ class RandTest(Randomizable):
 
 
 class TestRandLambda(unittest.TestCase):
-    def test_rand_lambdad_identity(self):
-        img = np.zeros((10, 10))
+    @parameterized.expand([[p] for p in TEST_NDARRAYS])
+    def test_rand_lambdad_identity(self, t):
+        img = t(np.zeros((10, 10)))
 
         test_func = RandTest()
         test_func.set_random_state(seed=134)
         expected = test_func(img)
         test_func.set_random_state(seed=134)
         ret = RandLambda(func=test_func)(img)
-        np.testing.assert_allclose(expected, ret)
+        assert_allclose(expected, ret)
         ret = RandLambda(func=test_func, prob=0.0)(img)
-        np.testing.assert_allclose(img, ret)
+        assert_allclose(img, ret)
 
         trans = RandLambda(func=test_func, prob=0.5)
         trans.set_random_state(seed=123)
         ret = trans(img)
-        np.testing.assert_allclose(img, ret)
+        assert_allclose(img, ret)
+        if isinstance(ret, MetaTensor):
+            out = trans.inverse(ret)
+            out = trans.inverse(out)
+            self.assertTrue(isinstance(out, MetaTensor))
+            self.assertFalse(out.applied_operations)
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_lambdad.py
+++ b/tests/test_rand_lambdad.py
@@ -12,9 +12,11 @@
 import unittest
 
 import numpy as np
+from parameterized import parameterized
 
 from monai.transforms.transform import Randomizable
 from monai.transforms.utility.dictionary import RandLambdad
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
 
 class RandTest(Randomizable):
@@ -31,8 +33,9 @@ class RandTest(Randomizable):
 
 
 class TestRandLambdad(unittest.TestCase):
-    def test_rand_lambdad_identity(self):
-        img = np.zeros((10, 10))
+    @parameterized.expand([[p] for p in TEST_NDARRAYS])
+    def test_rand_lambdad_identity(self, t):
+        img = t(np.zeros((10, 10)))
         data = {"img": img, "prop": 1.0}
 
         test_func = RandTest()
@@ -40,17 +43,17 @@ class TestRandLambdad(unittest.TestCase):
         expected = {"img": test_func(data["img"]), "prop": 1.0}
         test_func.set_random_state(seed=134)
         ret = RandLambdad(keys=["img", "prop"], func=test_func, overwrite=[True, False])(data)
-        np.testing.assert_allclose(expected["img"], ret["img"])
-        np.testing.assert_allclose(expected["prop"], ret["prop"])
+        assert_allclose(expected["img"], ret["img"])
+        assert_allclose(expected["prop"], ret["prop"])
         ret = RandLambdad(keys=["img", "prop"], func=test_func, prob=0.0)(data)
-        np.testing.assert_allclose(data["img"], ret["img"])
-        np.testing.assert_allclose(data["prop"], ret["prop"])
+        assert_allclose(data["img"], ret["img"])
+        assert_allclose(data["prop"], ret["prop"])
 
         trans = RandLambdad(keys=["img", "prop"], func=test_func, prob=0.5)
         trans.set_random_state(seed=123)
         ret = trans(data)
-        np.testing.assert_allclose(data["img"], ret["img"])
-        np.testing.assert_allclose(data["prop"], ret["prop"])
+        assert_allclose(data["img"], ret["img"])
+        assert_allclose(data["prop"], ret["prop"])
 
 
 if __name__ == "__main__":

--- a/tests/test_split_channel.py
+++ b/tests/test_split_channel.py
@@ -30,6 +30,7 @@ class TestSplitChannel(unittest.TestCase):
     def test_shape(self, input_param, test_data, expected_shape):
         result = SplitChannel(**input_param)(test_data)
         for data in result:
+            self.assertEqual(type(data), type(test_data))
             self.assertTupleEqual(data.shape, expected_shape)
 
 

--- a/tests/test_splitdim.py
+++ b/tests/test_splitdim.py
@@ -30,6 +30,7 @@ class TestSplitDim(unittest.TestCase):
         for dim in range(arr.ndim):
             out = SplitDim(dim, keepdim)(arr)
             self.assertIsInstance(out, (list, tuple))
+            self.assertEqual(type(out[0]), type(arr))
             self.assertEqual(len(out), arr.shape[dim])
             expected_ndim = arr.ndim if keepdim else arr.ndim - 1
             self.assertEqual(out[0].ndim, expected_ndim)

--- a/tests/test_splitdimd.py
+++ b/tests/test_splitdimd.py
@@ -47,7 +47,7 @@ class TestSplitDimd(unittest.TestCase):
             out = SplitDimd("i", dim=dim, keepdim=keepdim, update_meta=update_meta)(data)
             self.assertIsInstance(out, dict)
             self.assertEqual(len(out.keys()), len(data.keys()) + arr.shape[dim])
-            # if updating meta data, pick some random points and
+            # if updating metadata, pick some random points and
             # check same world coordinates between input and output
             if update_meta:
                 for _ in range(10):


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>


metatensor support for some util transforms

Name | Array impl. | Dict impl. | Array test | Dict test
:------------ | :-------------| :-------------| :-------------| :------------- 
Lambda | done | done | done | done
RandLambda | done | done | done | done
SplitDim | done | done | done | done


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
