### PR TITLE
4351 - adds StrEnum

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -291,9 +291,9 @@ class GeneralizedDiceLoss(_Loss):
         self.batch = batch
 
     def w_func(self, grnd):
-        if self.w_type == Weight.SIMPLE:
+        if self.w_type == str(Weight.SIMPLE):
             return torch.reciprocal(grnd)
-        if self.w_type == Weight.SQUARE:
+        if self.w_type == str(Weight.SQUARE):
             return torch.reciprocal(grnd * grnd)
         return torch.ones_like(grnd)
 

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -36,6 +36,7 @@ from .enums import (
     ProbMapKeys,
     PytorchPadMode,
     SkipMode,
+    StrEnum,
     TraceKeys,
     TransformBackends,
     UpsampleMode,

--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -16,6 +16,7 @@ from typing import Optional
 from monai.utils.deprecate_utils import deprecated
 
 __all__ = [
+    "StrEnum",
     "NumpyPadMode",
     "GridSampleMode",
     "InterpolateMode",
@@ -42,7 +43,29 @@ __all__ = [
 ]
 
 
-class NumpyPadMode(Enum):
+class StrEnum(str, Enum):
+    """
+    Enum subclass that converts its value to a string.
+
+    .. code-block:: python
+
+        from monai.utils import StrEnum
+
+        class Example(StrEnum):
+            MODE_A = "A"
+            MODE_B = "B"
+
+        assert (list(Example) == ["A", "B"])
+        assert Example.MODE_A == "A"
+        assert str(Example.MODE_A) == "A"
+        assert monai.utils.look_up_option("A", Example) == "A"
+    """
+
+    def __str__(self):
+        return self.value
+
+
+class NumpyPadMode(StrEnum):
     """
     See also: https://numpy.org/doc/1.18/reference/generated/numpy.pad.html
     """
@@ -60,7 +83,7 @@ class NumpyPadMode(Enum):
     EMPTY = "empty"
 
 
-class GridSampleMode(Enum):
+class GridSampleMode(StrEnum):
     """
     See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
 
@@ -78,7 +101,7 @@ class GridSampleMode(Enum):
     BICUBIC = "bicubic"
 
 
-class InterpolateMode(Enum):
+class InterpolateMode(StrEnum):
     """
     See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.interpolate.html
     """
@@ -92,7 +115,7 @@ class InterpolateMode(Enum):
     AREA = "area"
 
 
-class UpsampleMode(Enum):
+class UpsampleMode(StrEnum):
     """
     See also: :py:class:`monai.networks.blocks.UpSample`
     """
@@ -102,7 +125,7 @@ class UpsampleMode(Enum):
     PIXELSHUFFLE = "pixelshuffle"
 
 
-class BlendMode(Enum):
+class BlendMode(StrEnum):
     """
     See also: :py:class:`monai.data.utils.compute_importance_map`
     """
@@ -111,7 +134,7 @@ class BlendMode(Enum):
     GAUSSIAN = "gaussian"
 
 
-class PytorchPadMode(Enum):
+class PytorchPadMode(StrEnum):
     """
     See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html
     """
@@ -122,7 +145,7 @@ class PytorchPadMode(Enum):
     CIRCULAR = "circular"
 
 
-class GridSamplePadMode(Enum):
+class GridSamplePadMode(StrEnum):
     """
     See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
     """
@@ -132,7 +155,7 @@ class GridSamplePadMode(Enum):
     REFLECTION = "reflection"
 
 
-class Average(Enum):
+class Average(StrEnum):
     """
     See also: :py:class:`monai.metrics.rocauc.compute_roc_auc`
     """
@@ -143,7 +166,7 @@ class Average(Enum):
     NONE = "none"
 
 
-class MetricReduction(Enum):
+class MetricReduction(StrEnum):
     """
     See also: :py:func:`monai.metrics.utils.do_metric_reduction`
     """
@@ -157,7 +180,7 @@ class MetricReduction(Enum):
     SUM_CHANNEL = "sum_channel"
 
 
-class LossReduction(Enum):
+class LossReduction(StrEnum):
     """
     See also:
         - :py:class:`monai.losses.dice.DiceLoss`
@@ -171,7 +194,7 @@ class LossReduction(Enum):
     SUM = "sum"
 
 
-class DiceCEReduction(Enum):
+class DiceCEReduction(StrEnum):
     """
     See also:
         - :py:class:`monai.losses.dice.DiceCELoss`
@@ -181,7 +204,7 @@ class DiceCEReduction(Enum):
     SUM = "sum"
 
 
-class Weight(Enum):
+class Weight(StrEnum):
     """
     See also: :py:class:`monai.losses.dice.GeneralizedDiceLoss`
     """
@@ -191,7 +214,7 @@ class Weight(Enum):
     UNIFORM = "uniform"
 
 
-class ChannelMatching(Enum):
+class ChannelMatching(StrEnum):
     """
     See also: :py:class:`monai.networks.nets.HighResBlock`
     """
@@ -200,7 +223,7 @@ class ChannelMatching(Enum):
     PROJECT = "project"
 
 
-class SkipMode(Enum):
+class SkipMode(StrEnum):
     """
     See also: :py:class:`monai.networks.layers.SkipConnection`
     """
@@ -210,7 +233,7 @@ class SkipMode(Enum):
     MUL = "mul"
 
 
-class Method(Enum):
+class Method(StrEnum):
     """
     See also: :py:class:`monai.transforms.croppad.array.SpatialPad`
     """
@@ -219,7 +242,7 @@ class Method(Enum):
     END = "end"
 
 
-class ForwardMode(Enum):
+class ForwardMode(StrEnum):
     """
     See also: :py:class:`monai.transforms.engines.evaluator.Evaluator`
     """
@@ -228,7 +251,7 @@ class ForwardMode(Enum):
     EVAL = "eval"
 
 
-class TraceKeys:
+class TraceKeys(StrEnum):
     """Extra metadata keys used for traceable transforms."""
 
     CLASS_NAME: str = "class"
@@ -259,7 +282,7 @@ class InverseKeys:
     NONE = "none"
 
 
-class CommonKeys:
+class CommonKeys(StrEnum):
     """
     A set of common keys for dictionary based supervised training process.
     `IMAGE` is the input image data.
@@ -277,7 +300,7 @@ class CommonKeys:
     METADATA = "metadata"
 
 
-class PostFix:
+class PostFix(StrEnum):
     """Post-fixes."""
 
     @staticmethod
@@ -297,7 +320,7 @@ class PostFix:
         return PostFix._get_str(key, TraceKeys.KEY_SUFFIX[1:])
 
 
-class TransformBackends(Enum):
+class TransformBackends(StrEnum):
     """
     Transform backends.
     """
@@ -306,7 +329,7 @@ class TransformBackends(Enum):
     NUMPY = "numpy"
 
 
-class JITMetadataKeys(Enum):
+class JITMetadataKeys(StrEnum):
     """
     Keys stored in the metadata file for saved Torchscript models. Some of these are generated by the routines
     and others are optionally provided by users.
@@ -318,7 +341,7 @@ class JITMetadataKeys(Enum):
     DESCRIPTION = "description"
 
 
-class BoxModeName(Enum):
+class BoxModeName(StrEnum):
     """
     Box mode names.
     """
@@ -334,7 +357,7 @@ class BoxModeName(Enum):
     CCCWHD = "cccwhd"  # [xcenter, ycenter, zcenter, xsize, ysize, zsize]
 
 
-class ProbMapKeys(str, Enum):
+class ProbMapKeys(StrEnum):
     """
     The keys to be used for generating the probability maps from patches
     """
@@ -345,7 +368,7 @@ class ProbMapKeys(str, Enum):
     NAME = "name"
 
 
-class GridPatchSort(str, Enum):
+class GridPatchSort(StrEnum):
     """
     The sorting method for the generated patches in `GridPatch`
     """
@@ -377,7 +400,7 @@ class GridPatchSort(str, Enum):
             )
 
 
-class WSIPatchKeys(str, Enum):
+class WSIPatchKeys(StrEnum):
     """
     The keys to be used for metadata of patches extracted from whole slide images
     """

--- a/tests/test_look_up_option.py
+++ b/tests/test_look_up_option.py
@@ -14,7 +14,7 @@ from enum import Enum
 
 from parameterized import parameterized
 
-from monai.utils import look_up_option
+from monai.utils import StrEnum, look_up_option
 
 
 class _CaseEnum(Enum):
@@ -25,6 +25,11 @@ class _CaseEnum(Enum):
 class _CaseEnum1(Enum):
     CONST = "constant"
     EMPTY = "empty"
+
+
+class _CaseStrEnum(StrEnum):
+    MODE_A = "A"
+    MODE_B = "B"
 
 
 TEST_CASES = (
@@ -45,6 +50,14 @@ class TestLookUpOption(unittest.TestCase):
     def test_default(self):
         output = look_up_option("not here", {"a", "b"}, default=None)
         self.assertEqual(output, None)
+
+    def test_str_enum(self):
+        output = look_up_option("C", {"A", "B"}, default=None)
+        self.assertEqual(output, None)
+        self.assertEqual(list(_CaseStrEnum), ["A", "B"])
+        self.assertEqual(_CaseStrEnum.MODE_A, "A")
+        self.assertEqual(str(_CaseStrEnum.MODE_A), "A")
+        self.assertEqual(look_up_option("A", _CaseStrEnum), "A")
 
     def test_no_found(self):
         with self.assertRaisesRegex(ValueError, "Unsupported"):

--- a/tests/test_rand_zoom.py
+++ b/tests/test_rand_zoom.py
@@ -16,7 +16,7 @@ from parameterized import parameterized
 from scipy.ndimage import zoom as zoom_scipy
 
 from monai.transforms import RandZoom
-from monai.utils import GridSampleMode, InterpolateMode
+from monai.utils import InterpolateMode
 from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, assert_allclose
 
 VALID_CASES = [(0.8, 1.2, "nearest", False), (0.8, 1.2, InterpolateMode.NEAREST, False)]

--- a/tests/test_rand_zoom.py
+++ b/tests/test_rand_zoom.py
@@ -49,11 +49,7 @@ class TestRandZoom(NumpyImageTestCase2D):
             self.assertTrue(np.array_equal(zoomed.shape, self.imt.shape[1:]))
 
     @parameterized.expand(
-        [
-            ("no_min_zoom", None, 1.1, "bilinear", TypeError),
-            ("invalid_mode", 0.9, 1.1, "s", ValueError),
-            ("invalid_mode", 0.9, 1.1, GridSampleMode.NEAREST, ValueError),
-        ]
+        [("no_min_zoom", None, 1.1, "bilinear", TypeError), ("invalid_mode", 0.9, 1.1, "s", ValueError)]
     )
     def test_invalid_inputs(self, _, min_zoom, max_zoom, mode, raises):
         for p in TEST_NDARRAYS:


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

part of #4351 

### Description
after this PR we can 
- simplify `look_up_option(mode, InterpolateMode).value` -> `look_up_option(mode, InterpolateMode)`
- simplify type hint `Union[NumpyPadMode, PytorchPadMode, str]` -> `str`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
