### PR TITLE
Fix incorrect documentation for ResampleToMatch

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -297,7 +297,44 @@ class ResampleToMatch(SpatialResample):
         padding_mode: Union[GridSamplePadMode, str, None] = None,
         align_corners: Optional[bool] = False,
         dtype: DtypeLike = None,
-    ):
+    ) -> Tuple[NdarrayOrTensor, NdarrayOrTensor]:
+        """
+        Args:
+            img: input image to be resampled to match ``dst_meta``. It currently supports channel-first arrays with
+                at most three spatial dimensions.
+            src_meta: Dictionary containing the source affine matrix in the form ``{'affine':src_affine}``. 
+                If ``affine`` is not specified, an identity matrix is assumed.  Defaults to ``None``. 
+                See also:  https://docs.monai.io/en/stable/transforms.html#spatialresample 
+            dst_meta: Dictionary containing the target affine matrix and target spatial shape in the form 
+                ``{'affine':src_affine, 'spatial_shape':spatial_size}``. If ``affine`` is  not 
+                specified, ``src_affine`` is assumed. If ``spatial_shape`` is not specified, spatial size is 
+                automatically computed, containing the previous field of view.  Defaults to ``None``.
+                See also: https://docs.monai.io/en/stable/transforms.html#spatialresample 
+            mode: {``"bilinear"``, ``"nearest"``}
+                Interpolation mode to calculate output values. Defaults to ``"bilinear"``.
+                See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
+                When `USE_COMPILED` is `True`, this argument uses
+                ``"nearest"``, ``"bilinear"``, ``"bicubic"`` to indicate 0, 1, 3 order interpolations.
+                See also: https://docs.monai.io/en/stable/networks.html#grid-pull
+            padding_mode: {``"zeros"``, ``"border"``, ``"reflection"``}
+                Padding mode for outside grid values. Defaults to ``"border"``.
+                See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
+            align_corners: Geometrically, we consider the pixels of the input as squares rather than points. 
+                Defaults to ``False``.  
+                See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
+            dtype: data type for resampling computation. Defaults to ``self.dtype`` or
+                ``np.float64`` (for best precision). If ``None``, use the data type of input data.
+                To be compatible with other modules, the output data type is always `float32`.
+
+        Raises:
+            RuntimeError: When ``src_meta`` is missing.
+            RuntimeError: When ``dst_meta`` is missing.
+            ValueError: When the affine matrix of the source image is not invertible.
+
+        Returns:
+            Resampled input image, Metadata
+
+        """
         if src_meta is None:
             raise RuntimeError("`in_meta` is missing")
         if dst_meta is None:

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -302,14 +302,14 @@ class ResampleToMatch(SpatialResample):
         Args:
             img: input image to be resampled to match ``dst_meta``. It currently supports channel-first arrays with
                 at most three spatial dimensions.
-            src_meta: Dictionary containing the source affine matrix in the form ``{'affine':src_affine}``. 
-                If ``affine`` is not specified, an identity matrix is assumed.  Defaults to ``None``. 
-                See also:  https://docs.monai.io/en/stable/transforms.html#spatialresample 
-            dst_meta: Dictionary containing the target affine matrix and target spatial shape in the form 
-                ``{'affine':src_affine, 'spatial_shape':spatial_size}``. If ``affine`` is  not 
-                specified, ``src_affine`` is assumed. If ``spatial_shape`` is not specified, spatial size is 
+            src_meta: Dictionary containing the source affine matrix in the form ``{'affine':src_affine}``.
+                If ``affine`` is not specified, an identity matrix is assumed.  Defaults to ``None``.
+                See also:  https://docs.monai.io/en/stable/transforms.html#spatialresample
+            dst_meta: Dictionary containing the target affine matrix and target spatial shape in the form
+                ``{'affine':src_affine, 'spatial_shape':spatial_size}``. If ``affine`` is  not
+                specified, ``src_affine`` is assumed. If ``spatial_shape`` is not specified, spatial size is
                 automatically computed, containing the previous field of view.  Defaults to ``None``.
-                See also: https://docs.monai.io/en/stable/transforms.html#spatialresample 
+                See also: https://docs.monai.io/en/stable/transforms.html#spatialresample
             mode: {``"bilinear"``, ``"nearest"``}
                 Interpolation mode to calculate output values. Defaults to ``"bilinear"``.
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
@@ -319,8 +319,8 @@ class ResampleToMatch(SpatialResample):
             padding_mode: {``"zeros"``, ``"border"``, ``"reflection"``}
                 Padding mode for outside grid values. Defaults to ``"border"``.
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
-            align_corners: Geometrically, we consider the pixels of the input as squares rather than points. 
-                Defaults to ``False``.  
+            align_corners: Geometrically, we consider the pixels of the input as squares rather than points.
+                Defaults to ``False``.
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
             dtype: data type for resampling computation. Defaults to ``self.dtype`` or
                 ``np.float64`` (for best precision). If ``None``, use the data type of input data.

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -297,7 +297,7 @@ class ResampleToMatch(SpatialResample):
         padding_mode: Union[GridSamplePadMode, str, None] = None,
         align_corners: Optional[bool] = False,
         dtype: DtypeLike = None,
-    ) -> Tuple[NdarrayOrTensor, NdarrayOrTensor]:
+    ) -> Tuple[NdarrayOrTensor, Dict]:
         """
         Args:
             img: input image to be resampled to match ``dst_meta``. It currently supports channel-first arrays with

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -412,7 +412,7 @@ class ResampleToMatchd(MapTransform, InvertibleTransform):
                 dtype=dtype,
             )
             d[key] = img
-            d[src_meta_key] = new_meta
+            d[src_meta_key] = new_meta  # type: ignore
 
             # Remove the applied transform
             self.pop_transform(d, key)


### PR DESCRIPTION
Fixes #4570 .

Signed-off-by: Gustav Müller-Franzes <gustav.mueller-franzes@rwth-aachen.de>

closes https://github.com/Project-MONAI/MONAI/issues/4577

### Description
Adds a documentation string for ResampleToMatch so that no longer the only partially matching documentation of SpatialResample is copied automatically.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [x ] Documentation updated, tested `make html` command in the `docs/` folder.
