### PR TITLE
4589 enable dropout in dynunet

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -398,11 +398,6 @@ class PydicomReader(ImageReader):
             (for example, when using this reader with `monai.transforms.LoadImage`), please ensure that the argument
             `stop_before_pixels` is `True`, and `specific_tags` covers all necessary tags, such as `PixelSpacing`,
             `ImagePositionPatient`, `ImageOrientationPatient` and all `pixel_array` related tags.
-
-    Note::
-
-        the current
-
     """
 
     def __init__(

--- a/monai/networks/blocks/convolutions.py
+++ b/monai/networks/blocks/convolutions.py
@@ -159,19 +159,22 @@ class Convolution(nn.Sequential):
 
         self.add_module("conv", conv)
 
-        if not conv_only:
-            self.add_module(
-                "adn",
-                ADN(
-                    ordering=adn_ordering,
-                    in_channels=out_channels,
-                    act=act,
-                    norm=norm,
-                    norm_dim=self.dimensions,
-                    dropout=dropout,
-                    dropout_dim=dropout_dim,
-                ),
-            )
+        if conv_only:
+            return
+        if act is None and norm is None and dropout is None:
+            return
+        self.add_module(
+            "adn",
+            ADN(
+                ordering=adn_ordering,
+                in_channels=out_channels,
+                act=act,
+                norm=norm,
+                norm_dim=self.dimensions,
+                dropout=dropout,
+                dropout_dim=dropout_dim,
+            ),
+        )
 
 
 class ResidualUnit(nn.Module):

--- a/monai/networks/blocks/dynunet_block.py
+++ b/monai/networks/blocks/dynunet_block.py
@@ -57,10 +57,20 @@ class UnetResBlock(nn.Module):
             kernel_size=kernel_size,
             stride=stride,
             dropout=dropout,
-            conv_only=True,
+            act=None,
+            norm=None,
+            conv_only=False,
         )
         self.conv2 = get_conv_layer(
-            spatial_dims, out_channels, out_channels, kernel_size=kernel_size, stride=1, dropout=dropout, conv_only=True
+            spatial_dims,
+            out_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=1,
+            dropout=dropout,
+            act=None,
+            norm=None,
+            conv_only=False,
         )
         self.lrelu = get_act_layer(name=act_name)
         self.norm1 = get_norm_layer(name=norm_name, spatial_dims=spatial_dims, channels=out_channels)
@@ -71,7 +81,15 @@ class UnetResBlock(nn.Module):
             self.downsample = True
         if self.downsample:
             self.conv3 = get_conv_layer(
-                spatial_dims, in_channels, out_channels, kernel_size=1, stride=stride, dropout=dropout, conv_only=True
+                spatial_dims,
+                in_channels,
+                out_channels,
+                kernel_size=1,
+                stride=stride,
+                dropout=dropout,
+                act=None,
+                norm=None,
+                conv_only=False,
             )
             self.norm3 = get_norm_layer(name=norm_name, spatial_dims=spatial_dims, channels=out_channels)
 
@@ -93,7 +111,7 @@ class UnetResBlock(nn.Module):
 
 class UnetBasicBlock(nn.Module):
     """
-    A CNN module module that can be used for DynUNet, based on:
+    A CNN module that can be used for DynUNet, based on:
     `Automated Design of Deep Learning Methods for Biomedical Image Segmentation <https://arxiv.org/abs/1904.08128>`_.
     `nnU-Net: Self-adapting Framework for U-Net-Based Medical Image Segmentation <https://arxiv.org/abs/1809.10486>`_.
 
@@ -128,10 +146,20 @@ class UnetBasicBlock(nn.Module):
             kernel_size=kernel_size,
             stride=stride,
             dropout=dropout,
-            conv_only=True,
+            act=None,
+            norm=None,
+            conv_only=False,
         )
         self.conv2 = get_conv_layer(
-            spatial_dims, out_channels, out_channels, kernel_size=kernel_size, stride=1, dropout=dropout, conv_only=True
+            spatial_dims,
+            out_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=1,
+            dropout=dropout,
+            act=None,
+            norm=None,
+            conv_only=False,
         )
         self.lrelu = get_act_layer(name=act_name)
         self.norm1 = get_norm_layer(name=norm_name, spatial_dims=spatial_dims, channels=out_channels)
@@ -190,7 +218,9 @@ class UnetUpBlock(nn.Module):
             stride=upsample_stride,
             dropout=dropout,
             bias=trans_bias,
-            conv_only=True,
+            act=None,
+            norm=None,
+            conv_only=False,
             is_transposed=True,
         )
         self.conv_block = UnetBasicBlock(
@@ -218,7 +248,16 @@ class UnetOutBlock(nn.Module):
     ):
         super().__init__()
         self.conv = get_conv_layer(
-            spatial_dims, in_channels, out_channels, kernel_size=1, stride=1, dropout=dropout, bias=True, conv_only=True
+            spatial_dims,
+            in_channels,
+            out_channels,
+            kernel_size=1,
+            stride=1,
+            dropout=dropout,
+            bias=True,
+            act=None,
+            norm=None,
+            conv_only=False,
         )
 
     def forward(self, inp):
@@ -232,7 +271,7 @@ def get_conv_layer(
     kernel_size: Union[Sequence[int], int] = 3,
     stride: Union[Sequence[int], int] = 1,
     act: Optional[Union[Tuple, str]] = Act.PRELU,
-    norm: Union[Tuple, str] = Norm.INSTANCE,
+    norm: Optional[Union[Tuple, str]] = Norm.INSTANCE,
     dropout: Optional[Union[Tuple, str, float]] = None,
     bias: bool = False,
     conv_only: bool = True,

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -105,9 +105,11 @@ for spatial_dims in [2, 3]:
 
 
 class TestDynUNet(unittest.TestCase):
-    @parameterized.expand(TEST_CASE_DYNUNET_2D + TEST_CASE_DYNUNET_3D)
+    @parameterized.expand(TEST_CASE_DYNUNET_3D)
     def test_shape(self, input_param, input_shape, expected_shape):
         net = DynUNet(**input_param).to(device)
+        if "alphadropout" in input_param.get("dropout"):
+            self.assertTrue(any(isinstance(x, torch.nn.AlphaDropout) for x in net.modules()))
         with eval_mode(net):
             result = net(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4589

### Description
when `conv_only=True`, the dropout parameter is ignored in `get_conv_layer`, this causes some misconfiguration of the networks.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
