### PR TITLE
Fix the location type returned in GridPatch when padding

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -2770,7 +2770,7 @@ class GridPatch(Transform):
             patch = convert_to_dst_type(
                 src=np.full((array.shape[0], *self.patch_size), self.pad_kwargs.get("constant_values", 0)), dst=array
             )[0]
-            start_location = convert_to_dst_type(src=np.zeros((len(self.patch_size), 1)), dst=array)[0]
+            start_location = convert_to_dst_type(src=np.zeros(len(self.patch_size)), dst=array)[0]
             output += [(patch, start_location)] * (self.num_patches - len(output))
 
         return output

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -2667,7 +2667,7 @@ class GridPatch(Transform):
     Args:
         patch_size: size of patches to generate slices for, 0 or None selects whole dimension
         offset: offset of starting position in the array, default is 0 for each dimension.
-        num_patches: number of patches to return. Defaults to None, which returns all the available patches. 
+        num_patches: number of patches to return. Defaults to None, which returns all the available patches.
             If the required patches are more than the available patches, padding will be applied.
         overlap: the amount of overlap of neighboring patches in each dimension (a value between 0.0 and 1.0).
             If only one float number is given, it will be applied to all dimensions. Defaults to 0.0.

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -2667,7 +2667,8 @@ class GridPatch(Transform):
     Args:
         patch_size: size of patches to generate slices for, 0 or None selects whole dimension
         offset: offset of starting position in the array, default is 0 for each dimension.
-        num_patches: number of patches to return. Defaults to None, which returns all the available patches.
+        num_patches: number of patches to return. Defaults to None, which returns all the available patches. 
+            If the required patches are more than the available patches, padding will be applied.
         overlap: the amount of overlap of neighboring patches in each dimension (a value between 0.0 and 1.0).
             If only one float number is given, it will be applied to all dimensions. Defaults to 0.0.
         sort_fn: when `num_patches` is provided, it determines if keep patches with highest values (`"max"`),


### PR DESCRIPTION
Fixes #4597  .

### Description
The location type returned in GridPatch when padding should be List to be consistent with the locations returned when not padding

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
