### PR TITLE
debug device conflict

### DIFF
--- a/monai/data/box_utils.py
+++ b/monai/data/box_utils.py
@@ -965,8 +965,8 @@ def spatial_crop_boxes(
     # convert to float32 since torch.clamp_ does not support float16
     boxes_t = boxes_t.to(dtype=COMPUTE_DTYPE)
 
-    roi_start_t, *_ = convert_to_dst_type(src=roi_start, dst=boxes_t, wrap_sequence=True).to(torch.int16)
-    roi_end_t, *_ = convert_to_dst_type(src=roi_end, dst=boxes_t, wrap_sequence=True).to(torch.int16)
+    roi_start_t = convert_to_dst_type(src=roi_start, dst=boxes_t, wrap_sequence=True)[0].to(torch.int16)
+    roi_end_t = convert_to_dst_type(src=roi_end, dst=boxes_t, wrap_sequence=True)[0].to(torch.int16)
     roi_end_t = torch.maximum(roi_end_t, roi_start_t)
 
     # makes sure the bounding boxes are within the patch


### PR DESCRIPTION
Signed-off-by: Can Zhao <canz@nvidia.com>

Fixes #4608 .

### Description
Solve the bug of inconsistent device in spatial_crop_boxes

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
