### PR TITLE
4636 4637 backward compatible types

### DIFF
--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -315,7 +315,7 @@ class MetaTensor(MetaObj, torch.Tensor):
 
         Args:
             dtype: dtypes such as np.float32, torch.float, "np.float32", float.
-            device:  the device if `dtype` is a torch data type.
+            device: the device if `dtype` is a torch data type.
             unused_args: additional args (currently unused).
             unused_kwargs: additional kwargs (currently unused).
 

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -15,13 +15,15 @@ import warnings
 from copy import deepcopy
 from typing import Any, Sequence
 
+import numpy as np
 import torch
 
 from monai.config.type_definitions import NdarrayTensor
 from monai.data.meta_obj import MetaObj, get_track_meta
 from monai.data.utils import affine_to_spacing, decollate_batch, list_data_collate, remove_extra_metadata
+from monai.utils import look_up_option
 from monai.utils.enums import PostFix
-from monai.utils.type_conversion import convert_to_tensor
+from monai.utils.type_conversion import convert_data_type, convert_to_tensor
 
 __all__ = ["MetaTensor"]
 
@@ -306,6 +308,33 @@ class MetaTensor(MetaObj, torch.Tensor):
             PostFix.meta(key): deepcopy(self.meta),
             PostFix.transforms(key): deepcopy(self.applied_operations),
         }
+
+    def astype(self, dtype, device=None, *unused_args, **unused_kwargs):
+        """
+        Cast to ``dtype``, sharing data whenever possible.
+
+        Args:
+            dtype: dtypes such as np.float32, torch.float, "np.float32", float.
+            device:  the device if `dtype` is a torch data type.
+            unused_args: additional args (currently unused).
+            unused_kwargs: additional kwargs (currently unused).
+
+        Returns:
+            data array instance
+        """
+        if isinstance(dtype, str):
+            mod_str, *dtype = dtype.split(".", 1)
+            dtype = mod_str if not dtype else dtype[0]
+        else:
+            mod_str = getattr(dtype, "__module__", "torch")
+        mod_str = look_up_option(mod_str, {"torch", "numpy", "np"}, default="numpy")
+        if mod_str == "torch":
+            out_type = torch.Tensor
+        elif mod_str in ("numpy", "np"):
+            out_type = np.ndarray
+        else:
+            out_type = None
+        return convert_data_type(self, output_type=out_type, device=device, dtype=dtype, wrap_sequence=True)[0]
 
     @property
     def affine(self) -> torch.Tensor:

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -363,7 +363,7 @@ class MetaTensor(MetaObj, torch.Tensor):
         )
 
     @staticmethod
-    def ensure_torch_and_prune_meta(im: NdarrayTensor, meta: dict):
+    def ensure_torch_and_prune_meta(im: NdarrayTensor, meta: dict, simple_keys: bool = False):
         """
         Convert the image to `torch.Tensor`. If `affine` is in the `meta` dictionary,
         convert that to `torch.Tensor`, too. Remove any superfluous metadata.
@@ -382,12 +382,12 @@ class MetaTensor(MetaObj, torch.Tensor):
         if not get_track_meta() or meta is None:
             return img
 
-        # ensure affine is of type `torch.Tensor`
-        if "affine" in meta:
-            meta["affine"] = convert_to_tensor(meta["affine"])
-
         # remove any superfluous metadata.
-        remove_extra_metadata(meta)
+        if simple_keys:
+            # ensure affine is of type `torch.Tensor`
+            if "affine" in meta:
+                meta["affine"] = convert_to_tensor(meta["affine"])  # bc-breaking
+            remove_extra_metadata(meta)  # bc-breaking
 
         # return the `MetaTensor`
         return MetaTensor(img, meta=meta)

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -108,9 +108,10 @@ class LoadImage(Transform):
     def __init__(
         self,
         reader=None,
-        image_only: bool = True,
+        image_only: bool = False,
         dtype: DtypeLike = np.float32,
         ensure_channel_first: bool = False,
+        simple_keys: bool = False,
         *args,
         **kwargs,
     ) -> None:
@@ -127,6 +128,7 @@ class LoadImage(Transform):
             dtype: if not None convert the loaded image to this data type.
             ensure_channel_first: if `True` and loaded both image array and metadata, automatically convert
                 the image array shape to `channel first`. default to `False`.
+            simple_keys: whether to remove redundant metadata keys, default to False for backward compatibility.
             args: additional parameters for reader if providing a reader name.
             kwargs: additional parameters for reader if providing a reader name.
 
@@ -145,6 +147,7 @@ class LoadImage(Transform):
         self.image_only = image_only
         self.dtype = dtype
         self.ensure_channel_first = ensure_channel_first
+        self.simple_keys = simple_keys
 
         self.readers: List[ImageReader] = []
         for r in SUPPORTED_READERS:  # set predefined readers as default
@@ -255,7 +258,7 @@ class LoadImage(Transform):
         meta_data = switch_endianness(meta_data, "<")
 
         meta_data[Key.FILENAME_OR_OBJ] = f"{ensure_tuple(filename)[0]}"  # Path obj should be strings for data loader
-        img = MetaTensor.ensure_torch_and_prune_meta(img_array, meta_data)
+        img = MetaTensor.ensure_torch_and_prune_meta(img_array, meta_data, self.simple_keys)
         if self.ensure_channel_first:
             img = EnsureChannelFirst()(img)
         if self.image_only:

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -72,8 +72,9 @@ class LoadImaged(MapTransform):
         meta_keys: Optional[KeysCollection] = None,
         meta_key_postfix: str = DEFAULT_POST_FIX,
         overwriting: bool = False,
-        image_only: bool = True,
+        image_only: bool = False,
         ensure_channel_first: bool = False,
+        simple_keys: bool = False,
         allow_missing_keys: bool = False,
         *args,
         **kwargs,
@@ -103,12 +104,13 @@ class LoadImaged(MapTransform):
                 dictionary containing image data array and header dict per input key.
             ensure_channel_first: if `True` and loaded both image array and metadata, automatically convert
                 the image array shape to `channel first`. default to `False`.
+            simple_keys: whether to remove redundant metadata keys, default to False for backward compatibility.
             allow_missing_keys: don't raise exception if key is missing.
             args: additional parameters for reader if providing a reader name.
             kwargs: additional parameters for reader if providing a reader name.
         """
         super().__init__(keys, allow_missing_keys)
-        self._loader = LoadImage(reader, image_only, dtype, ensure_channel_first, *args, **kwargs)
+        self._loader = LoadImage(reader, image_only, dtype, ensure_channel_first, simple_keys, *args, **kwargs)
         if not isinstance(meta_key_postfix, str):
             raise TypeError(f"meta_key_postfix must be a str but is {type(meta_key_postfix).__name__}.")
         self.meta_keys = ensure_tuple_rep(None, len(self.keys)) if meta_keys is None else ensure_tuple(meta_keys)

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -435,6 +435,8 @@ class EnsureType(Transform):
         device: for Tensor data type, specify the target device.
         wrap_sequence: if `False`, then lists will recursively call this function, default to `True`.
             E.g., if `False`, `[1, 2]` -> `[tensor(1), tensor(2)]`, if `True`, then `[1, 2]` -> `tensor([1, 2])`.
+        track_meta: whether to convert to `MetaTensor` when `data_type` is "tensor".
+            If False, the output data type will be `torch.Tensor`. Default to the return value of ``get_track_meta``.
 
     """
 
@@ -446,11 +448,16 @@ class EnsureType(Transform):
         dtype: Optional[Union[DtypeLike, torch.dtype]] = None,
         device: Optional[torch.device] = None,
         wrap_sequence: bool = True,
+        track_meta: Optional[bool] = None,
     ) -> None:
         self.data_type = look_up_option(data_type.lower(), {"tensor", "numpy"})
         self.dtype = dtype
         self.device = device
         self.wrap_sequence = wrap_sequence
+        if track_meta is None:
+            self.track_meta = get_track_meta()
+        else:
+            self.track_meta = bool(track_meta)
 
     def __call__(self, data: NdarrayOrTensor):
         """
@@ -461,10 +468,17 @@ class EnsureType(Transform):
                 if applicable and `wrap_sequence=False`.
 
         """
-        output_type = torch.Tensor if self.data_type == "tensor" else np.ndarray
+        if self.data_type == "tensor":
+            output_type = MetaTensor if self.track_meta else torch.Tensor
+        else:
+            output_type = np.ndarray  # type: ignore
         out: NdarrayOrTensor
         out, *_ = convert_data_type(
-            data=data, output_type=output_type, dtype=self.dtype, device=self.device, wrap_sequence=self.wrap_sequence
+            data=data,
+            output_type=output_type,  # type: ignore
+            dtype=self.dtype,
+            device=self.device,
+            wrap_sequence=self.wrap_sequence,
         )
         return out
 

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -454,7 +454,10 @@ class EnsureType(Transform):
         self.dtype = dtype
         self.device = device
         self.wrap_sequence = wrap_sequence
-        self.track_meta = get_track_meta() if track_meta is None else bool(track_meta)
+        if track_meta is None:
+            self.track_meta = get_track_meta()
+        else:
+            self.track_meta = bool(track_meta)
 
     def __call__(self, data: NdarrayOrTensor):
         """

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -454,10 +454,7 @@ class EnsureType(Transform):
         self.dtype = dtype
         self.device = device
         self.wrap_sequence = wrap_sequence
-        if track_meta is None:
-            self.track_meta = get_track_meta()
-        else:
-            self.track_meta = bool(track_meta)
+        self.track_meta = get_track_meta() if track_meta is None else bool(track_meta)
 
     def __call__(self, data: NdarrayOrTensor):
         """

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -15,8 +15,6 @@ defined in :py:class:`monai.transforms.utility.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
-
-import contextlib
 import re
 from copy import deepcopy
 from typing import Any, Callable, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union
@@ -521,7 +519,7 @@ class ToTensord(MapTransform, InvertibleTransform):
         return d
 
 
-class EnsureTyped(MapTransform, InvertibleTransform):
+class EnsureTyped(MapTransform):
     """
     Dictionary-based wrapper of :py:class:`monai.transforms.EnsureType`.
 
@@ -560,7 +558,6 @@ class EnsureTyped(MapTransform, InvertibleTransform):
             allow_missing_keys: don't raise exception if key is missing.
         """
         super().__init__(keys, allow_missing_keys)
-        self.wrap_sequence = wrap_sequence
         self.converter = EnsureType(
             data_type=data_type, dtype=dtype, device=device, wrap_sequence=wrap_sequence, track_meta=track_meta
         )
@@ -569,16 +566,6 @@ class EnsureTyped(MapTransform, InvertibleTransform):
         d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.converter(d[key])
-            self.push_transform(d, key)
-        return d
-
-    def inverse(self, data):
-        d = deepcopy(dict(data))
-        if not self.wrap_sequence:
-            return d
-        for key in self.key_iterator(d):
-            with contextlib.suppress(Exception):
-                self.pop_transform(d, key)
         return d
 
 

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -235,7 +235,8 @@ def convert_data_type(
     wrap_sequence: bool = False,
 ) -> Tuple[NdarrayTensor, type, Optional[torch.device]]:
     """
-    Convert to `torch.Tensor`/`np.ndarray` from `torch.Tensor`/`np.ndarray`/`float`/`int` etc.
+    Convert to `MetaTensor`, `torch.Tensor` or `np.ndarray` from `MetaTensor`, `torch.Tensor`,
+    `np.ndarray`, `float`, `int`, etc.
 
     Args:
         data: data to be converted

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -239,8 +239,8 @@ def convert_data_type(
 
     Args:
         data: data to be converted
-        output_type: `torch.Tensor` or `np.ndarray` (if `None`, unchanged)
-        device: if output is `torch.Tensor`, select device (if `None`, unchanged)
+        output_type: `monai.data.MetaTensor`, `torch.Tensor`, or `np.ndarray` (if `None`, unchanged)
+        device: if output is `MetaTensor` or `torch.Tensor`, select device (if `None`, unchanged)
         dtype: dtype of output data. Converted to correct library type (e.g.,
             `np.float32` is converted to `torch.float32` if output type is `torch.Tensor`).
             If left blank, it remains unchanged.

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -235,8 +235,7 @@ def convert_data_type(
     wrap_sequence: bool = False,
 ) -> Tuple[NdarrayTensor, type, Optional[torch.device]]:
     """
-    Convert to `MetaTensor`, `torch.Tensor` or `np.ndarray` from `MetaTensor`, `torch.Tensor`,
-    `np.ndarray`, `float`, `int`, etc.
+    Convert to `torch.Tensor`/`np.ndarray` from `torch.Tensor`/`np.ndarray`/`float`/`int` etc.
 
     Args:
         data: data to be converted

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -172,7 +172,7 @@ def convert_to_numpy(data, dtype: DtypeLike = None, wrap_sequence: bool = False)
             E.g., `[1, 2]` -> `[array(1), array(2)]`. If `True`, then `[1, 2]` -> `array([1, 2])`.
     """
     if isinstance(data, torch.Tensor):
-        data = data.detach().to(dtype=get_equivalent_dtype(dtype, torch.Tensor), device="cpu").numpy()
+        data = np.asarray(data.detach().to(device="cpu").numpy(), dtype=get_equivalent_dtype(dtype, np.ndarray))
     elif has_cp and isinstance(data, cp_ndarray):
         data = cp.asnumpy(data).astype(dtype, copy=False)
     elif isinstance(data, (np.ndarray, float, int, bool)):

--- a/tests/test_arraydataset.py
+++ b/tests/test_arraydataset.py
@@ -23,15 +23,15 @@ from monai.data import ArrayDataset
 from monai.transforms import AddChannel, Compose, LoadImage, RandAdjustContrast, RandGaussianNoise, Spacing
 
 TEST_CASE_1 = [
-    Compose([LoadImage(), AddChannel(), RandGaussianNoise(prob=1.0)]),
-    Compose([LoadImage(), AddChannel(), RandGaussianNoise(prob=1.0)]),
+    Compose([LoadImage(image_only=True), AddChannel(), RandGaussianNoise(prob=1.0)]),
+    Compose([LoadImage(image_only=True), AddChannel(), RandGaussianNoise(prob=1.0)]),
     (0, 1),
     (1, 128, 128, 128),
 ]
 
 TEST_CASE_2 = [
-    Compose([LoadImage(), AddChannel(), RandAdjustContrast(prob=1.0)]),
-    Compose([LoadImage(), AddChannel(), RandAdjustContrast(prob=1.0)]),
+    Compose([LoadImage(image_only=True), AddChannel(), RandAdjustContrast(prob=1.0)]),
+    Compose([LoadImage(image_only=True), AddChannel(), RandAdjustContrast(prob=1.0)]),
     (0, 1),
     (1, 128, 128, 128),
 ]
@@ -48,13 +48,13 @@ class TestCompose(Compose):
 
 
 TEST_CASE_3 = [
-    TestCompose([LoadImage(), AddChannel(), Spacing(pixdim=(2, 2, 4)), RandAdjustContrast(prob=1.0)]),
-    TestCompose([LoadImage(), AddChannel(), Spacing(pixdim=(2, 2, 4)), RandAdjustContrast(prob=1.0)]),
+    TestCompose([LoadImage(image_only=True), AddChannel(), Spacing(pixdim=(2, 2, 4)), RandAdjustContrast(prob=1.0)]),
+    TestCompose([LoadImage(image_only=True), AddChannel(), Spacing(pixdim=(2, 2, 4)), RandAdjustContrast(prob=1.0)]),
     (0, 2),
     (1, 64, 64, 33),
 ]
 
-TEST_CASE_4 = [Compose([LoadImage(), AddChannel(), RandGaussianNoise(prob=1.0)]), (1, 128, 128, 128)]
+TEST_CASE_4 = [Compose([LoadImage(image_only=True), AddChannel(), RandGaussianNoise(prob=1.0)]), (1, 128, 128, 128)]
 
 
 class TestArrayDataset(unittest.TestCase):

--- a/tests/test_decollate.py
+++ b/tests/test_decollate.py
@@ -131,7 +131,7 @@ class TestDeCollate(unittest.TestCase):
         t_compose = Compose([AddChanneld(KEYS), Compose(transforms), ToTensord(KEYS)])
         # If nibabel present, read from disk
         if has_nib:
-            t_compose = Compose([LoadImaged("image"), t_compose])
+            t_compose = Compose([LoadImaged("image", image_only=True), t_compose])
 
         dataset = CacheDataset(self.data_dict, t_compose, progress=False)
         self.check_decollate(dataset=dataset)
@@ -141,7 +141,7 @@ class TestDeCollate(unittest.TestCase):
         t_compose = Compose([AddChannel(), Compose(transforms), ToTensor()])
         # If nibabel present, read from disk
         if has_nib:
-            t_compose = Compose([LoadImage(), t_compose])
+            t_compose = Compose([LoadImage(image_only=True), t_compose])
 
         dataset = Dataset(self.data_list, t_compose)
         self.check_decollate(dataset=dataset)
@@ -151,7 +151,7 @@ class TestDeCollate(unittest.TestCase):
         t_compose = Compose([AddChannel(), Compose(transforms), ToTensor()])
         # If nibabel present, read from disk
         if has_nib:
-            t_compose = Compose([LoadImage(), t_compose])
+            t_compose = Compose([LoadImage(image_only=True), t_compose])
 
         dataset = Dataset(self.data_list, t_compose)
         self.check_decollate(dataset=dataset)

--- a/tests/test_ensure_channel_first.py
+++ b/tests/test_ensure_channel_first.py
@@ -52,13 +52,13 @@ class TestEnsureChannelFirst(unittest.TestCase):
                 filenames[i] = os.path.join(tempdir, name)
                 nib.save(nib.Nifti1Image(test_image, np.eye(4)), filenames[i])
 
-            result = LoadImage(**input_param)(filenames)
+            result = LoadImage(image_only=True, **input_param)(filenames)
             result = EnsureChannelFirst()(result)
             self.assertEqual(result.shape[0], len(filenames))
 
     @parameterized.expand([TEST_CASE_7])
     def test_itk_dicom_series_reader(self, input_param, filenames, _):
-        result = LoadImage(**input_param)(filenames)
+        result = LoadImage(image_only=True, **input_param)(filenames)
         result = EnsureChannelFirst()(result)
         self.assertEqual(result.shape[0], 1)
 
@@ -68,7 +68,7 @@ class TestEnsureChannelFirst(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             filename = os.path.join(tempdir, "test_image.png")
             Image.fromarray(test_image.astype("uint8")).save(filename)
-            result = LoadImage()(filename)
+            result = LoadImage(image_only=True)(filename)
             result = EnsureChannelFirst()(result)
             self.assertEqual(result.shape[0], 3)
 

--- a/tests/test_ensure_type.py
+++ b/tests/test_ensure_type.py
@@ -14,6 +14,7 @@ import unittest
 import numpy as np
 import torch
 
+from monai.data import MetaTensor
 from monai.transforms import EnsureType
 from tests.utils import assert_allclose
 
@@ -59,9 +60,9 @@ class TestEnsureType(unittest.TestCase):
 
     def test_list_tuple(self):
         for dtype in ("tensor", "numpy"):
-            result = EnsureType(data_type=dtype, wrap_sequence=False)([[1, 2], [3, 4]])
+            result = EnsureType(data_type=dtype, wrap_sequence=False, track_meta=True)([[1, 2], [3, 4]])
             self.assertTrue(isinstance(result, list))
-            self.assertTrue(isinstance(result[0][1], torch.Tensor if dtype == "tensor" else np.ndarray))
+            self.assertTrue(isinstance(result[0][1], MetaTensor if dtype == "tensor" else np.ndarray))
             torch.testing.assert_allclose(result[1][0], torch.as_tensor(3))
             # tuple of numpy arrays
             result = EnsureType(data_type=dtype, wrap_sequence=False)((np.array([1, 2]), np.array([3, 4])))
@@ -77,7 +78,7 @@ class TestEnsureType(unittest.TestCase):
             "extra": None,
         }
         for dtype in ("tensor", "numpy"):
-            result = EnsureType(data_type=dtype)(test_data)
+            result = EnsureType(data_type=dtype, track_meta=False)(test_data)
             self.assertTrue(isinstance(result, dict))
             self.assertTrue(isinstance(result["img"], torch.Tensor if dtype == "tensor" else np.ndarray))
             torch.testing.assert_allclose(result["img"], torch.as_tensor([1.0, 2.0]))

--- a/tests/test_ensure_typed.py
+++ b/tests/test_ensure_typed.py
@@ -41,13 +41,7 @@ class TestEnsureTyped(unittest.TestCase):
             test_datas.append(test_datas[-1].cuda())
         for test_data in test_datas:
             for dtype in ("tensor", "numpy"):
-                xform = EnsureTyped(keys="data", data_type=dtype)
-                result = xform({"data": test_data})
-                if isinstance(result, MetaTensor):
-                    self.assertTrue(result.applied_operations)
-                    out = xform.inverse(result)
-                    self.assertFalse(out.applied_operations)
-                result = result["data"]
+                result = EnsureTyped(keys="data", data_type=dtype)({"data": test_data})["data"]
                 self.assertTrue(isinstance(result, torch.Tensor if dtype == "tensor" else np.ndarray))
                 if isinstance(test_data, bool):
                     self.assertFalse(result)

--- a/tests/test_ensure_typed.py
+++ b/tests/test_ensure_typed.py
@@ -14,6 +14,7 @@ import unittest
 import numpy as np
 import torch
 
+from monai.data import MetaTensor
 from monai.transforms import EnsureTyped
 from tests.utils import assert_allclose
 
@@ -61,9 +62,11 @@ class TestEnsureTyped(unittest.TestCase):
 
     def test_list_tuple(self):
         for dtype in ("tensor", "numpy"):
-            result = EnsureTyped(keys="data", data_type=dtype, wrap_sequence=False)({"data": [[1, 2], [3, 4]]})["data"]
+            result = EnsureTyped(keys="data", data_type=dtype, wrap_sequence=False, track_meta=True)(
+                {"data": [[1, 2], [3, 4]]}
+            )["data"]
             self.assertTrue(isinstance(result, list))
-            self.assertTrue(isinstance(result[0][1], torch.Tensor if dtype == "tensor" else np.ndarray))
+            self.assertTrue(isinstance(result[0][1], MetaTensor if dtype == "tensor" else np.ndarray))
             torch.testing.assert_allclose(result[1][0], torch.as_tensor(3))
             # tuple of numpy arrays
             result = EnsureTyped(keys="data", data_type=dtype, wrap_sequence=False)(

--- a/tests/test_ensure_typed.py
+++ b/tests/test_ensure_typed.py
@@ -41,7 +41,13 @@ class TestEnsureTyped(unittest.TestCase):
             test_datas.append(test_datas[-1].cuda())
         for test_data in test_datas:
             for dtype in ("tensor", "numpy"):
-                result = EnsureTyped(keys="data", data_type=dtype)({"data": test_data})["data"]
+                xform = EnsureTyped(keys="data", data_type=dtype)
+                result = xform({"data": test_data})
+                if isinstance(result, MetaTensor):
+                    self.assertTrue(result.applied_operations)
+                    out = xform.inverse(result)
+                    self.assertFalse(out.applied_operations)
+                result = result["data"]
                 self.assertTrue(isinstance(result, torch.Tensor if dtype == "tensor" else np.ndarray))
                 if isinstance(test_data, bool):
                     self.assertFalse(result)

--- a/tests/test_image_rw.py
+++ b/tests/test_image_rw.py
@@ -52,7 +52,7 @@ class TestLoadSaveNifti(unittest.TestCase):
             saver(test_data)
             saved_path = os.path.join(self.test_dir, filepath + "_trans" + output_ext)
             self.assertTrue(os.path.exists(saved_path))
-            loader = LoadImage(reader=reader, squeeze_non_spatial_dims=True)
+            loader = LoadImage(image_only=True, reader=reader, squeeze_non_spatial_dims=True)
             data = loader(saved_path)
             meta = data.meta
             if meta["original_channel_dim"] == -1:
@@ -101,7 +101,7 @@ class TestLoadSavePNG(unittest.TestCase):
             saver(test_data)
             saved_path = os.path.join(self.test_dir, filepath + "_trans" + output_ext)
             self.assertTrue(os.path.exists(saved_path))
-            loader = LoadImage(reader=reader)
+            loader = LoadImage(image_only=True, reader=reader)
             data = loader(saved_path)
             meta = data.meta
             if meta["original_channel_dim"] == -1:
@@ -157,7 +157,7 @@ class TestLoadSaveNrrd(unittest.TestCase):
             )
             saver(test_data)
             saved_path = os.path.join(self.test_dir, filepath + "_trans" + output_ext)
-            loader = LoadImage(reader=reader)
+            loader = LoadImage(image_only=True, reader=reader)
             data = loader(saved_path)
             assert_allclose(data, torch.as_tensor(test_data))
 

--- a/tests/test_integration_bundle_run.py
+++ b/tests/test_integration_bundle_run.py
@@ -97,7 +97,7 @@ class TestBundleRun(unittest.TestCase):
         test_env = os.environ.copy()
         print(f"CUDA_VISIBLE_DEVICES in {__file__}", test_env.get("CUDA_VISIBLE_DEVICES"))
         subprocess.check_call(la + ["--args_file", def_args_file], env=test_env)
-        loader = LoadImage()
+        loader = LoadImage(image_only=True)
         self.assertTupleEqual(loader(os.path.join(tempdir, "image", "image_seg.nii.gz")).shape, expected_shape)
 
         # here test the script with `google fire` tool as CLI

--- a/tests/test_integration_classification_2d.py
+++ b/tests/test_integration_classification_2d.py
@@ -61,7 +61,7 @@ def run_training_test(root_dir, train_x, train_y, val_x, val_y, device="cuda:0",
     # define transforms for image and classification
     train_transforms = Compose(
         [
-            LoadImage(image_only=True),
+            LoadImage(image_only=True, simple_keys=True),
             AddChannel(),
             Transpose(indices=[0, 2, 1]),
             ScaleIntensity(),
@@ -71,7 +71,9 @@ def run_training_test(root_dir, train_x, train_y, val_x, val_y, device="cuda:0",
         ]
     )
     train_transforms.set_random_state(1234)
-    val_transforms = Compose([LoadImage(image_only=True), AddChannel(), Transpose(indices=[0, 2, 1]), ScaleIntensity()])
+    val_transforms = Compose(
+        [LoadImage(image_only=True, simple_keys=True), AddChannel(), Transpose(indices=[0, 2, 1]), ScaleIntensity()]
+    )
     y_pred_trans = Compose([Activations(softmax=True)])
     y_trans = AsDiscrete(to_onehot=len(np.unique(train_y)))
     auc_metric = ROCAUCMetric()

--- a/tests/test_invertd.py
+++ b/tests/test_invertd.py
@@ -46,7 +46,7 @@ class TestInvertd(unittest.TestCase):
         im_fname, seg_fname = (make_nifti_image(i) for i in create_test_image_3d(101, 100, 107, noise_max=100))
         transform = Compose(
             [
-                LoadImaged(KEYS),
+                LoadImaged(KEYS, image_only=True),
                 EnsureChannelFirstd(KEYS),
                 Orientationd(KEYS, "RPS"),
                 Spacingd(KEYS, pixdim=(1.2, 1.01, 0.9), mode=["bilinear", "nearest"], dtype=np.float32),
@@ -121,7 +121,7 @@ class TestInvertd(unittest.TestCase):
 
         # check labels match
         reverted = item["label_inverted"].detach().cpu().numpy().astype(np.int32)
-        original = LoadImaged(KEYS)(data[-1])["label"]
+        original = LoadImaged(KEYS, image_only=True)(data[-1])["label"]
         n_good = np.sum(np.isclose(reverted, original, atol=1e-3))
         reverted_name = item["label_inverted"].meta["filename_or_obj"]
         original_name = data[-1]["label"]

--- a/tests/test_meta_affine.py
+++ b/tests/test_meta_affine.py
@@ -146,7 +146,7 @@ class TestAffineConsistencyITK(unittest.TestCase):
     @parameterized.expand(TEST_CASES_ARRAY)
     def test_linear_consistent(self, xform_cls, input_dict, atol):
         """xform cls testing itk consistency"""
-        img = LoadImage()(FILE_PATH)
+        img = LoadImage(image_only=True, simple_keys=True)(FILE_PATH)
         img = EnsureChannelFirst()(img)
         ref_1 = _create_itk_obj(img[0], img.affine)
         output = self.run_transform(img, xform_cls, input_dict)
@@ -162,7 +162,7 @@ class TestAffineConsistencyITK(unittest.TestCase):
     @parameterized.expand(TEST_CASES_DICT)
     def test_linear_consistent_dict(self, xform_cls, input_dict, atol):
         """xform cls testing itk consistency"""
-        img = LoadImaged(keys)({keys[0]: FILE_PATH, keys[1]: FILE_PATH_1})
+        img = LoadImaged(keys, image_only=True, simple_keys=True)({keys[0]: FILE_PATH, keys[1]: FILE_PATH_1})
         img = EnsureChannelFirstd(keys)(img)
         ref_1 = {k: _create_itk_obj(img[k][0], img[k].affine) for k in keys}
         output = self.run_transform(img, xform_cls, input_dict)

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -20,6 +20,7 @@ from copy import deepcopy
 from multiprocessing.reduction import ForkingPickler
 from typing import Optional, Union
 
+import numpy as np
 import torch
 import torch.multiprocessing
 from parameterized import parameterized
@@ -433,6 +434,14 @@ class TestMetaTensor(unittest.TestCase):
         for s in (s1, s2):
             self.assertEqual(s, expected_out)
 
+    def test_astype(self):
+        t = MetaTensor([1.0], affine=torch.tensor(1), meta={"fname": "filename"})
+        for np_types in ("float32", "np.float32", "numpy.float32", np.float32, float, "int", np.compat.long):
+            self.assertIsInstance(t.astype(np_types), np.ndarray)
+        for pt_types in ("torch.float", torch.float, "torch.float"):
+            self.assertIsInstance(t.astype("torch.float"), torch.Tensor)
+        self.assertIsInstance(t.astype("torch.float", device="cpu"), torch.Tensor)
+
     def test_transforms(self):
         key = "im"
         _, im = self.get_im()
@@ -441,7 +450,6 @@ class TestMetaTensor(unittest.TestCase):
         data = {key: im, PostFix.meta(key): {"affine": torch.eye(4)}}
 
         # apply one at a time
-        is_meta = isinstance(im, MetaTensor)
         for i, _tr in enumerate(tr.transforms):
             data = _tr(data)
             is_meta = isinstance(_tr, (ToMetaTensord, BorderPadd, DivisiblePadd))
@@ -458,7 +466,6 @@ class TestMetaTensor(unittest.TestCase):
             self.assertEqual(n_applied, i + 1)
 
         # inverse one at a time
-        is_meta = isinstance(im, MetaTensor)
         for i, _tr in enumerate(tr.transforms[::-1]):
             data = _tr.inverse(data)
             is_meta = isinstance(_tr, (FromMetaTensord, BorderPadd, DivisiblePadd))

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -438,8 +438,8 @@ class TestMetaTensor(unittest.TestCase):
         t = MetaTensor([1.0], affine=torch.tensor(1), meta={"fname": "filename"})
         for np_types in ("float32", "np.float32", "numpy.float32", np.float32, float, "int", np.compat.long):
             self.assertIsInstance(t.astype(np_types), np.ndarray)
-        for pt_types in ("torch.float", torch.float, "torch.float"):
-            self.assertIsInstance(t.astype("torch.float"), torch.Tensor)
+        for pt_types in ("torch.float", torch.float, "torch.float64"):
+            self.assertIsInstance(t.astype(pt_types), torch.Tensor)
         self.assertIsInstance(t.astype("torch.float", device="cpu"), torch.Tensor)
 
     def test_transforms(self):

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -436,7 +436,7 @@ class TestMetaTensor(unittest.TestCase):
 
     def test_astype(self):
         t = MetaTensor([1.0], affine=torch.tensor(1), meta={"fname": "filename"})
-        for np_types in ("float32", "np.float32", "numpy.float32", np.float32, float, "int", np.compat.long):
+        for np_types in ("float32", "np.float32", "numpy.float32", np.float32, float, "int", np.compat.long, np.uint16):
             self.assertIsInstance(t.astype(np_types), np.ndarray)
         for pt_types in ("torch.float", torch.float, "torch.float64"):
             self.assertIsInstance(t.astype(pt_types), torch.Tensor)

--- a/tests/test_nifti_rw.py
+++ b/tests/test_nifti_rw.py
@@ -115,7 +115,7 @@ class TestNiftiLoadRead(unittest.TestCase):
     def test_consistency(self):
         np.set_printoptions(suppress=True, precision=3)
         test_image = make_nifti_image(np.arange(64).reshape(1, 8, 8), np.diag([1.5, 1.5, 1.5, 1]))
-        data = LoadImage(reader="NibabelReader", as_closest_canonical=False)(test_image)
+        data = LoadImage(image_only=True, reader="NibabelReader", as_closest_canonical=False)(test_image)
         header = data.meta
         data = Spacing([0.8, 0.8, 0.8])(data[None], header["affine"], mode="nearest")
         original_affine = data.meta["original_affine"]

--- a/tests/test_nifti_saver.py
+++ b/tests/test_nifti_saver.py
@@ -80,7 +80,7 @@ class TestNiftiSaver(unittest.TestCase):
             saver.save_batch(torch.randint(0, 255, (8, 8, 1, 2, 2)), meta_data)
             for i in range(8):
                 filepath = os.path.join(tempdir, "testfile" + str(i), "testfile" + str(i) + "_seg.nii.gz")
-                img = LoadImage("nibabelreader")(filepath)
+                img = LoadImage("nibabelreader", image_only=True)(filepath)
                 self.assertEqual(img.shape, (1, 2, 2, 8))
 
     def test_squeeze_end_dims(self):
@@ -102,7 +102,7 @@ class TestNiftiSaver(unittest.TestCase):
                 # 2d image w channel
                 saver.save(torch.randint(0, 255, (1, 2, 2)), meta_data)
 
-                im = LoadImage()(os.path.join(tempdir, fname, fname + ".nii.gz"))
+                im = LoadImage(image_only=True)(os.path.join(tempdir, fname, fname + ".nii.gz"))
                 self.assertTrue(im.ndim == 2 if squeeze_end_dims else 4)
 
 

--- a/tests/test_scale_intensity_range_percentilesd.py
+++ b/tests/test_scale_intensity_range_percentilesd.py
@@ -54,7 +54,7 @@ class TestScaleIntensityRangePercentilesd(NumpyImageTestCase2D):
         expected_img = (img - expected_a_min) / (expected_a_max - expected_a_min)
         expected_img = (expected_img * (expected_b_max - expected_b_min)) + expected_b_min
 
-        np.testing.assert_allclose(expected_img, scaler(data)["img"])
+        np.testing.assert_allclose(expected_img, scaler(data)["img"], rtol=1e-3, atol=0.1)
 
     def test_invalid_instantiation(self):
         self.assertRaises(

--- a/tests/testing_data/transform_metatensor_cases.yaml
+++ b/tests/testing_data/transform_metatensor_cases.yaml
@@ -9,6 +9,7 @@ TEST_CASE_1:
   - _target_: LoadImageD
     keys: "@input_keys"
     ensure_channel_first: True
+    image_only: True
   - _target_: ToDeviced
     keys: "@input_keys"
     device: "@test_device"
@@ -40,6 +41,7 @@ TEST_CASE_2:
   - _target_: LoadImaged
     keys: "@input_keys"
     ensure_channel_first: False
+    image_only: True
   - _target_: ToDeviced
     keys: "@input_keys"
     device: "@test_device"
@@ -99,6 +101,7 @@ TEST_CASE_3:
   - _target_: LoadImageD
     keys: "@input_keys"
     ensure_channel_first: True
+    image_only: True
   - _target_: CenterScaleCropD
     keys: "@input_keys"
     roi_scale: 0.98


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4636
Fixes #4637
Fixes #4639

### Description
- adds `track_meta` to `EnsureType(d)`
- adds `astype(...)` to `MetaTensor`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
