### PR TITLE
4641 PadListDataCollate for metatensor

### DIFF
--- a/tests/test_pad_collation.py
+++ b/tests/test_pad_collation.py
@@ -98,9 +98,12 @@ class TestPadCollation(unittest.TestCase):
         # check collation in forward direction
         for data in loader:
             if t_type == dict:
+                shapes = []
                 decollated_data = decollate_batch(data)
                 for d in decollated_data:
-                    PadListDataCollate.inverse(d)
+                    output = PadListDataCollate.inverse(d)
+                    shapes.append(output["image"].shape)
+                self.assertTrue(len(set(shapes)) > 1)  # inverted shapes must be different because of random xforms
 
 
 if __name__ == "__main__":

--- a/tests/test_testtimeaugmentation.py
+++ b/tests/test_testtimeaugmentation.py
@@ -58,9 +58,7 @@ class TestTestTimeAugmentation(unittest.TestCase):
         data = []
         for i in range(num_examples):
             im, label = custom_create_test_image_2d()
-            d = {}
-            d["image"] = data_type(im[:, i:])
-            d[PostFix.meta("image")] = {"affine": np.eye(4)}
+            d = {"image": data_type(im[:, i:])}
             if include_label:
                 d["label"] = data_type(label[:, i:])
                 d[PostFix.meta("label")] = {"affine": np.eye(4)}


### PR DESCRIPTION
Fixes #4641 

### Description
inverse PadListDataCollate for metatensors

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
