### PR TITLE
backward compatible inverse

### DIFF
--- a/monai/apps/detection/transforms/dictionary.py
+++ b/monai/apps/detection/transforms/dictionary.py
@@ -136,7 +136,7 @@ class ConvertBoxModed(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             tr = self.get_most_recent_transform(d, key)
             src_mode, dst_mode = tr[TraceKeys.EXTRA_INFO]["src"], tr[TraceKeys.EXTRA_INFO]["dst"]
@@ -191,7 +191,7 @@ class ConvertBoxToStandardModed(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             tr = self.get_most_recent_transform(d, key)
             original_mode = tr[TraceKeys.EXTRA_INFO]["mode"]
@@ -280,7 +280,7 @@ class AffineBoxToImageCoordinated(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             transform = self.get_most_recent_transform(d, key)
             affine = transform["extra_info"]["affine"]
@@ -594,7 +594,7 @@ class RandZoomBoxd(RandomizableTransform, MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
 
         for key in self.key_iterator(d):
             transform = self.get_most_recent_transform(d, key)
@@ -675,7 +675,7 @@ class FlipBoxd(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
 
         for key in self.key_iterator(d):
             transform = self.get_most_recent_transform(d, key)
@@ -752,7 +752,7 @@ class RandFlipBoxd(RandomizableTransform, MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
 
         for key in self.key_iterator(d):
             transform = self.get_most_recent_transform(d, key)
@@ -1274,7 +1274,7 @@ class RotateBox90d(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
 
         for key in self.key_iterator(d):
             transform = self.get_most_recent_transform(d, key)
@@ -1360,7 +1360,7 @@ class RandRotateBox90d(RandRotate90d):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         if self._rand_k % 4 == 0:
             return d
 

--- a/monai/config/__init__.py
+++ b/monai/config/__init__.py
@@ -11,7 +11,7 @@
 
 from .deviceconfig import (
     USE_COMPILED,
-    USE_METATENSOR,
+    USE_META_DICT,
     IgniteInfo,
     get_config_values,
     get_gpu_info,

--- a/monai/config/__init__.py
+++ b/monai/config/__init__.py
@@ -21,7 +21,6 @@ from .deviceconfig import (
     print_debug_info,
     print_gpu_info,
     print_system_info,
-    set_use_metatensor,
 )
 from .type_definitions import (
     DtypeLike,

--- a/monai/config/__init__.py
+++ b/monai/config/__init__.py
@@ -11,6 +11,7 @@
 
 from .deviceconfig import (
     USE_COMPILED,
+    USE_METATENSOR,
     IgniteInfo,
     get_config_values,
     get_gpu_info,
@@ -20,6 +21,7 @@ from .deviceconfig import (
     print_debug_info,
     print_gpu_info,
     print_system_info,
+    set_use_metatensor,
 )
 from .type_definitions import (
     DtypeLike,

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -101,7 +101,7 @@ def print_config(file=sys.stdout):
     """
     for k, v in get_config_values().items():
         print(f"{k} version: {v}", file=file, flush=True)
-    print(f"MONAI flags: HAS_EXT = {HAS_EXT}, USE_COMPILED = {USE_COMPILED}")
+    print(f"MONAI flags: HAS_EXT = {HAS_EXT}, USE_COMPILED = {USE_COMPILED}, METATENSOR = {USE_METATENSOR}")
     print(f"MONAI rev id: {monai.__revision_id__}")
     print(f"MONAI __file__: {monai.__file__}")
 

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -27,6 +27,8 @@ try:
 except (OptionalImportError, ImportError, AttributeError):
     HAS_EXT = USE_COMPILED = False
 
+USE_METATENSOR = os.environ.get("METATENSOR", "0") == "1"  # use MetaTensor new feature, set to False for compatibility
+
 psutil, has_psutil = optional_import("psutil")
 psutil_version = psutil.__version__ if has_psutil else "NOT INSTALLED or UNKNOWN VERSION."
 
@@ -39,7 +41,17 @@ __all__ = [
     "print_debug_info",
     "USE_COMPILED",
     "IgniteInfo",
+    "set_use_metatensor",
+    "USE_METATENSOR",
 ]
+
+
+def set_use_metatensor(flag: bool) -> bool:
+    """whether to use MetaTensor full new feature, set to False for backward compatibility (v0.9.0)."""
+    global USE_METATENSOR
+    original_flag = USE_METATENSOR
+    USE_METATENSOR = flag
+    return original_flag
 
 
 def get_config_values():

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -27,7 +27,7 @@ try:
 except (OptionalImportError, ImportError, AttributeError):
     HAS_EXT = USE_COMPILED = False
 
-USE_METATENSOR = os.environ.get("METATENSOR", "1") == "1"  # use MetaTensor new feature, set to False for compatibility
+USE_META_DICT = os.environ.get("USE_META_DICT", "0") == "1"  # set to True for compatibility, use meta dict.
 
 psutil, has_psutil = optional_import("psutil")
 psutil_version = psutil.__version__ if has_psutil else "NOT INSTALLED or UNKNOWN VERSION."
@@ -40,7 +40,7 @@ __all__ = [
     "print_gpu_info",
     "print_debug_info",
     "USE_COMPILED",
-    "USE_METATENSOR",
+    "USE_META_DICT",
     "IgniteInfo",
 ]
 
@@ -92,7 +92,7 @@ def print_config(file=sys.stdout):
     """
     for k, v in get_config_values().items():
         print(f"{k} version: {v}", file=file, flush=True)
-    print(f"MONAI flags: HAS_EXT = {HAS_EXT}, USE_COMPILED = {USE_COMPILED}, METATENSOR = {USE_METATENSOR}")
+    print(f"MONAI flags: HAS_EXT = {HAS_EXT}, USE_COMPILED = {USE_COMPILED}, USE_META_DICT = {USE_META_DICT}")
     print(f"MONAI rev id: {monai.__revision_id__}")
     print(f"MONAI __file__: {monai.__file__}")
 

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -40,18 +40,9 @@ __all__ = [
     "print_gpu_info",
     "print_debug_info",
     "USE_COMPILED",
-    "IgniteInfo",
-    "set_use_metatensor",
     "USE_METATENSOR",
+    "IgniteInfo",
 ]
-
-
-def set_use_metatensor(flag: bool) -> bool:
-    """whether to use MetaTensor full new feature, set to False for backward compatibility (v0.9.0)."""
-    global USE_METATENSOR
-    original_flag = USE_METATENSOR
-    USE_METATENSOR = flag
-    return original_flag
 
 
 def get_config_values():

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -27,7 +27,7 @@ try:
 except (OptionalImportError, ImportError, AttributeError):
     HAS_EXT = USE_COMPILED = False
 
-USE_METATENSOR = os.environ.get("METATENSOR", "0") == "1"  # use MetaTensor new feature, set to False for compatibility
+USE_METATENSOR = os.environ.get("METATENSOR", "1") == "1"  # use MetaTensor new feature, set to False for compatibility
 
 psutil, has_psutil = optional_import("psutil")
 psutil_version = psutil.__version__ if has_psutil else "NOT INSTALLED or UNKNOWN VERSION."

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -71,6 +71,7 @@ from .test_time_augmentation import TestTimeAugmentation
 from .thread_buffer import ThreadBuffer, ThreadDataLoader
 from .torchscript_utils import load_net_with_metadata, save_net_with_metadata
 from .utils import (
+    PICKLE_KEY_SUFFIX,
     affine_to_spacing,
     compute_importance_map,
     compute_shape_offset,

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -404,7 +404,13 @@ def collate_meta_tensor(batch):
         collated.is_batch = True
         return collated
     if isinstance(elem_0, Mapping):
-        return {k: collate_meta_tensor([d[k] for d in batch]) for k in elem_0}
+        return {
+            k: [d[k] or TraceKeys.NONE for d in batch]
+            if (isinstance(k, str) and k.endswith(TraceKeys.KEY_SUFFIX))  # for compatibility 0.9.0
+            else collate_meta_tensor([d[k] for d in batch])
+            for k in elem_0
+        }
+
     # no more recursive search for MetaTensor
     return default_collate(batch)
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -598,7 +598,10 @@ def decollate_batch(batch, detach: bool = True, pad=True, fill_value=None):
         return pickle_operations(ret, is_encode=False)  # bc 0.9.0
     if isinstance(deco, Iterable):
         _gen = zip_longest(*deco, fillvalue=fill_value) if pad else zip(*deco)
-        return [list(item) for item in _gen]
+        ret_list = [list(item) for item in _gen]
+        if not config.USE_META_DICT:
+            return ret_list
+        return pickle_operations(ret_list, is_encode=False)  # bc 0.9.0
     raise NotImplementedError(f"Unable to de-collate: {batch}, type: {type(batch)}.")
 
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -393,11 +393,18 @@ def dev_collate(batch, level: int = 1, logger_name: str = "dev_collate"):
 
 
 def pickle_operations(data, key=TraceKeys.KEY_SUFFIX, is_encode: bool = True):
-    """applied_operations are dictionaries with varying sizes, converting them to bytes so that we can (de-)collate."""
+    """
+    Applied_operations are dictionaries with varying sizes, this method converts them to bytes so that we can (de-)collate.
+
+    Args:
+        data: a list or dictionary with substructures to be pickled/unpickled.
+        key: the key suffix indicating the target substructures, defaults to "_transforms".
+        is_encode: whether it's encoding using pickle.dumps (True) or decoding using pickle.loads (False).
+    """
     if isinstance(data, Mapping):
         data = dict(data)
         for k in data:
-            if f"{k}".endswith(TraceKeys.KEY_SUFFIX):
+            if f"{k}".endswith(key):
                 if is_encode and not isinstance(data[k], bytes):
                     data[k] = pickle.dumps(data[k], 0)
                 if not is_encode and isinstance(data[k], bytes):

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -406,7 +406,7 @@ def collate_meta_tensor(batch):
     if isinstance(elem_0, Mapping):
         return {
             k: [d[k] or TraceKeys.NONE for d in batch]
-            if (isinstance(k, str) and k.endswith(TraceKeys.KEY_SUFFIX))  # for compatibility 0.9.0
+            if f"{k}".endswith(TraceKeys.KEY_SUFFIX)  # for compatibility 0.9.0
             else collate_meta_tensor([d[k] for d in batch])
             for k in elem_0
         }
@@ -434,7 +434,10 @@ def list_data_collate(batch: Sequence):
             for k in elem:
                 key = k
                 data_for_batch = [d[key] for d in data]
-                ret[key] = collate_meta_tensor(data_for_batch)
+                if f"{key}".endswith(TraceKeys.KEY_SUFFIX):  # for compatibility 0.9.0
+                    ret[key] = data_for_batch
+                else:
+                    ret[key] = collate_meta_tensor(data_for_batch)
         else:
             ret = collate_meta_tensor(data)
         return ret
@@ -445,9 +448,9 @@ def list_data_collate(batch: Sequence):
                 re_str += f"\nCollate error on the key '{key}' of dictionary data."
             re_str += (
                 "\n\nMONAI hint: if your transforms intentionally create images of different shapes, creating your "
-                + "`DataLoader` with `collate_fn=pad_list_data_collate` might solve this problem (check its "
-                + "documentation)."
+                + "`DataLoader` with `collate_fn=pad_list_data_collate` might solve this problem (check its docs)."
             )
+
         _ = dev_collate(data)
         raise RuntimeError(re_str) from re
     except TypeError as re:
@@ -458,8 +461,8 @@ def list_data_collate(batch: Sequence):
             re_str += (
                 "\n\nMONAI hint: if your transforms intentionally create mixtures of torch Tensor and numpy ndarray, "
                 + "creating your `DataLoader` with `collate_fn=pad_list_data_collate` might solve this problem "
-                + "(check its documentation)."
             )
+
         _ = dev_collate(data)
         raise TypeError(re_str) from re
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -395,14 +395,14 @@ def dev_collate(batch, level: int = 1, logger_name: str = "dev_collate"):
 def pickle_operations(data, key=TraceKeys.KEY_SUFFIX, is_encode: bool = True):
     """applied_operations are dictionaries with varying sizes, converting them to bytes so that we can (de-)collate."""
     if isinstance(data, Mapping):
-        data, has_items = dict(data), False
+        data = dict(data)
         for k in data:
             if f"{k}".endswith(TraceKeys.KEY_SUFFIX):
                 if is_encode and not isinstance(data[k], bytes):
                     data[k] = pickle.dumps(data[k], 0)
                 if not is_encode and isinstance(data[k], bytes):
                     data[k] = pickle.loads(data[k])
-        return data if has_items else {k: pickle_operations(v, key=key, is_encode=is_encode) for k, v in data.items()}
+        return {k: pickle_operations(v, key=key, is_encode=is_encode) for k, v in data.items()}
     elif isinstance(data, (list, tuple)):
         return [pickle_operations(item, key=key, is_encode=is_encode) for item in data]
     return data

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -91,6 +91,7 @@ __all__ = [
     "remove_keys",
     "remove_extra_metadata",
     "get_extra_metadata_keys",
+    "PICKLE_KEY_SUFFIX",
 ]
 
 # module to be used by `torch.save`
@@ -392,13 +393,16 @@ def dev_collate(batch, level: int = 1, logger_name: str = "dev_collate"):
     return
 
 
-def pickle_operations(data, key=TraceKeys.KEY_SUFFIX, is_encode: bool = True):
+PICKLE_KEY_SUFFIX = TraceKeys.KEY_SUFFIX
+
+
+def pickle_operations(data, key=PICKLE_KEY_SUFFIX, is_encode: bool = True):
     """
     Applied_operations are dictionaries with varying sizes, this method converts them to bytes so that we can (de-)collate.
 
     Args:
         data: a list or dictionary with substructures to be pickled/unpickled.
-        key: the key suffix indicating the target substructures, defaults to "_transforms".
+        key: the key suffix for the target substructures, defaults to "_transforms" (`data.utils.PICKLE_KEY_SUFFIX`).
         is_encode: whether it's encoding using pickle.dumps (True) or decoding using pickle.loads (False).
     """
     if isinstance(data, Mapping):

--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -574,8 +574,7 @@ from .utility.dictionary import (
 from .utils import (
     Fourier,
     allow_missing_keys_mode,
-    attach_post_hook,
-    attach_pre_hook,
+    attach_hook,
     compute_divisible_spatial_size,
     convert_applied_interp_mode,
     convert_pad_mode,

--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -257,6 +257,7 @@ from .post.array import (
     Activations,
     AsDiscrete,
     FillHoles,
+    Invert,
     KeepLargestConnectedComponent,
     LabelFilter,
     LabelToContour,

--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -574,6 +574,8 @@ from .utility.dictionary import (
 from .utils import (
     Fourier,
     allow_missing_keys_mode,
+    attach_post_hook,
+    attach_pre_hook,
     compute_divisible_spatial_size,
     convert_applied_interp_mode,
     convert_pad_mode,

--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -609,6 +609,7 @@ from .utils import (
     rescale_array_int_max,
     rescale_instance_array,
     resize_center,
+    sync_meta_info,
     weighted_patch_samples,
     zero_margins,
 )

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -220,7 +220,7 @@ def attach_pre_hook(func, hook):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not isinstance(args[0], monai.transforms.MapTransform):
+        if len(args) < 2:
             return func(*args, **kwargs)
         inst, data_dict = args
         data_dict = hook(inst, data_dict)
@@ -267,7 +267,8 @@ class InvertibleTransform(TraceableTransform):
     """
 
     def __new__(cls, *args, **kwargs):
-        if not monai.config.deviceconfig.USE_METATENSOR:
+        if not monai.config.deviceconfig.USE_METATENSOR and issubclass(cls, monai.transforms.MapTransform):
+            # only update MapTransform, MapTransforms may call array transform's inverse
             cls.inverse = attach_pre_hook(cls.inverse, InvertibleTransform.comp_update)
         return super().__new__(cls)
 

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -18,6 +18,7 @@ from typing import Any, Hashable, Mapping, Optional, Tuple
 import torch
 
 import monai
+from monai import config
 from monai.data.meta_tensor import MetaTensor
 from monai.transforms.transform import Transform
 from monai.utils.enums import PostFix, TraceKeys
@@ -267,7 +268,7 @@ class InvertibleTransform(TraceableTransform):
     """
 
     def __new__(cls, *args, **kwargs):
-        if not monai.config.deviceconfig.USE_METATENSOR and issubclass(cls, monai.transforms.MapTransform):
+        if not config.USE_METATENSOR and issubclass(cls, monai.transforms.MapTransform):
             # only update MapTransform, MapTransforms may call array transform's inverse
             cls.inverse = attach_pre_hook(cls.inverse, InvertibleTransform.comp_update)
         return super().__new__(cls)

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -214,9 +214,6 @@ class TraceableTransform(Transform):
         self.tracing = prev
 
 
-
-
-
 class InvertibleTransform(TraceableTransform):
     """Classes for invertible transforms.
 

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -268,10 +268,10 @@ class InvertibleTransform(TraceableTransform):
     """
 
     def __new__(cls, *args, **kwargs):
-        if not config.USE_METATENSOR and issubclass(cls, monai.transforms.MapTransform):
+        if config.USE_META_DICT and issubclass(cls, monai.transforms.MapTransform):
             # only update MapTransform, MapTransforms may call array transform's inverse
             cls.inverse = attach_pre_hook(cls.inverse, InvertibleTransform.comp_update)
-        return super().__new__(cls)
+        return TraceableTransform.__new__(cls)
 
     def comp_update(self, data):
         """

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -19,7 +19,7 @@ import torch
 from monai import transforms
 from monai.data.meta_tensor import MetaTensor
 from monai.transforms.transform import Transform
-from monai.utils.enums import PostFix, TraceKeys
+from monai.utils.enums import TraceKeys
 
 __all__ = ["TraceableTransform", "InvertibleTransform"]
 
@@ -264,14 +264,7 @@ class InvertibleTransform(TraceableTransform):
             transform_key = transforms.TraceableTransform.trace_key(k)
             if transform_key not in data or not data[transform_key]:
                 continue
-            if not isinstance(data[k], MetaTensor):
-                d[k] = MetaTensor(data[k])
-            if not d[k].applied_operations:
-                d[k].applied_operations = d[transform_key]
-            d[transform_key] = d[k].applied_operations
-            meta_dict_key = PostFix.meta(k)
-            if meta_dict_key in data:
-                d[meta_dict_key].update(d[k].meta)
+            d = transforms.sync_meta_info(k, data, t=False)
         return d
 
     def inverse(self, data: Any) -> Any:

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -274,7 +274,7 @@ class InvertibleTransform(TraceableTransform):
         """
         This function is to be called before every `self.inverse(data)`,
         update each MetaTensor `data[key]` using `data[key_transforms]` and `data[key_meta_dict]`,
-        for MetaTensor backward compatibility.
+        for MetaTensor backward compatibility 0.9.0.
         """
         if not isinstance(data, dict) or not isinstance(self, transforms.MapTransform):
             return data

--- a/monai/transforms/meta_utility/dictionary.py
+++ b/monai/transforms/meta_utility/dictionary.py
@@ -15,7 +15,6 @@ These can be used to make backwards compatible code.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
-from copy import deepcopy
 from typing import Dict, Hashable, Mapping
 
 from monai.config.type_definitions import NdarrayOrTensor
@@ -53,7 +52,7 @@ class FromMetaTensord(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             # check transform
             _ = self.get_most_recent_transform(d, key)
@@ -90,7 +89,7 @@ class ToMetaTensord(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             # check transform
             _ = self.get_most_recent_transform(d, key)

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -542,8 +542,8 @@ class Invertd(MapTransform):
 
     def __init__(
         self,
-        keys: KeysCollection = "",
-        transform: Optional[InvertibleTransform] = None,
+        keys: KeysCollection,
+        transform: InvertibleTransform,
         orig_keys: Optional[KeysCollection] = None,
         meta_keys: Optional[KeysCollection] = None,
         orig_meta_keys: Optional[KeysCollection] = None,

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, Hashable, Iterable, List, Mapping, Optio
 
 import torch
 
+from monai import config
 from monai.config.type_definitions import KeysCollection, NdarrayOrTensor, PathLike
 from monai.data.csv_saver import CSVSaver
 from monai.data.meta_tensor import MetaTensor
@@ -39,8 +40,7 @@ from monai.transforms.post.array import (
 from monai.transforms.transform import MapTransform
 from monai.transforms.utility.array import ToTensor
 from monai.transforms.utils import allow_missing_keys_mode, convert_applied_interp_mode
-from monai.utils import convert_to_tensor, deprecated_arg, ensure_tuple, ensure_tuple_rep
-from monai.utils.enums import PostFix
+from monai.utils import PostFix, convert_to_tensor, deprecated_arg, ensure_tuple, ensure_tuple_rep
 
 __all__ = [
     "ActivationsD",
@@ -542,8 +542,8 @@ class Invertd(MapTransform):
 
     def __init__(
         self,
-        keys: KeysCollection,
-        transform: InvertibleTransform,
+        keys: KeysCollection = "",
+        transform: Optional[InvertibleTransform] = None,
         orig_keys: Optional[KeysCollection] = None,
         meta_keys: Optional[KeysCollection] = None,
         orig_meta_keys: Optional[KeysCollection] = None,
@@ -656,6 +656,9 @@ class Invertd(MapTransform):
 
             # construct the input dict data
             input_dict = {orig_key: inputs}
+            if config.USE_META_DICT:
+                input_dict[InvertibleTransform.trace_key(orig_key)] = transform_info
+                input_dict[PostFix.meta(orig_key)] = meta_info
 
             with allow_missing_keys_mode(self.transform):  # type: ignore
                 inverted = self.transform.inverse(input_dict)

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -221,7 +221,7 @@ class SpatialResampled(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.sp_transform.inverse(d[key])
         return d
@@ -289,7 +289,7 @@ class ResampleToMatchd(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.resampler.inverse(d[key])
         return d
@@ -384,7 +384,7 @@ class Spacingd(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.spacing_transform.inverse(d[key])
         return d
@@ -440,7 +440,7 @@ class Orientationd(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.ornt_transform.inverse(d[key])
         return d
@@ -473,7 +473,7 @@ class Rotate90d(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.rotator.inverse(d[key])
         return d
@@ -595,7 +595,7 @@ class Resized(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.resizer.inverse(d[key])
         return d
@@ -696,7 +696,7 @@ class Affined(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.affine.inverse(d[key])
         return d
@@ -1143,7 +1143,7 @@ class Flipd(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.flipper.inverse(d[key])
         return d
@@ -1197,7 +1197,7 @@ class RandFlipd(RandomizableTransform, MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             xform = self.pop_transform(d[key])
             if not xform[TraceKeys.DO_TRANSFORM]:
@@ -1325,7 +1325,7 @@ class Rotated(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.rotator.inverse(d[key])
         return d
@@ -1423,7 +1423,7 @@ class RandRotated(RandomizableTransform, MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             xform = self.pop_transform(d[key])
             if xform[TraceKeys.DO_TRANSFORM]:
@@ -1491,7 +1491,7 @@ class Zoomd(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             d[key] = self.zoomer.inverse(d[key])
         return d
@@ -1591,7 +1591,7 @@ class RandZoomd(RandomizableTransform, MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             xform = self.pop_transform(d[key])
             if xform[TraceKeys.DO_TRANSFORM]:

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -314,10 +314,12 @@ class MapTransform(Transform):
 
     def __new__(cls, *args, **kwargs):
         if config.USE_META_DICT:
-            cls.__call__ = transforms.attach_post_hook(cls.__call__, MapTransform.call_update)
+            # call_update after MapTransform.__call__
+            cls.__call__ = transforms.attach_hook(cls.__call__, MapTransform.call_update, "post")
 
             if hasattr(cls, "inverse"):
-                cls.inverse = transforms.attach_pre_hook(cls.inverse, transforms.InvertibleTransform.inverse_update)
+                # inverse_update before InvertibleTransform.inverse
+                cls.inverse = transforms.attach_hook(cls.inverse, transforms.InvertibleTransform.inverse_update)
         return Transform.__new__(cls)
 
     def __init__(self, keys: KeysCollection, allow_missing_keys: bool = False) -> None:

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -23,7 +23,7 @@ from monai import config, transforms
 from monai.config import KeysCollection
 from monai.data.meta_tensor import MetaTensor
 from monai.utils import MAX_SEED, ensure_tuple, first
-from monai.utils.enums import PostFix, TransformBackends
+from monai.utils.enums import TransformBackends
 
 __all__ = ["ThreadUnsafe", "apply_transform", "Randomizable", "RandomizableTransform", "Transform", "MapTransform"]
 
@@ -340,12 +340,7 @@ class MapTransform(Transform):
         for k in data:
             if not isinstance(data[k], MetaTensor):
                 continue
-            meta_dict_key = PostFix.meta(k)
-            if meta_dict_key not in d:
-                d[meta_dict_key] = data[k].meta
-            d[meta_dict_key].update(data[k].meta)
-            if data[k].applied_operations:
-                d[transforms.TraceableTransform.trace_key(k)] = data[k].applied_operations
+            d = transforms.sync_meta_info(k, data, t=not isinstance(self, transforms.InvertD))
         return d
 
     @abstractmethod

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, Generator, Hashable, Iterable, List, Map
 import numpy as np
 import torch
 
+import monai.config.deviceconfig
 from monai import transforms
 from monai.config import KeysCollection
 from monai.data.meta_tensor import MetaTensor
@@ -325,7 +326,8 @@ class MapTransform(Transform):
     """
 
     def __new__(cls, *args, **kwargs):
-        cls.__call__ = attach_post_hook(cls.__call__, MapTransform.comp_update)
+        if not monai.config.deviceconfig.USE_METATENSOR:
+            cls.__call__ = attach_post_hook(cls.__call__, MapTransform.comp_update)
         return super().__new__(cls)
 
     def __init__(self, keys: KeysCollection, allow_missing_keys: bool = False) -> None:

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -315,7 +315,7 @@ class MapTransform(Transform):
     def __new__(cls, *args, **kwargs):
         if config.USE_META_DICT:
             cls.__call__ = transforms.attach_post_hook(cls.__call__, MapTransform.call_update)  # type: ignore
-            if issubclass(cls, transforms.InvertibleTransform):
+            if hasattr(cls, "inverse"):
                 cls.inverse = transforms.attach_pre_hook(cls.inverse, transforms.InvertibleTransform.inverse_update)
         return Transform.__new__(cls)
 

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -324,10 +324,10 @@ class MapTransform(Transform):
 
     """
 
-    def __new__(cls, *args, **kwargs):
-        if not config.USE_METATENSOR:
-            cls.__call__ = attach_post_hook(cls.__call__, MapTransform.comp_update)
-        return super().__new__(cls)
+    def __new__(cls, keys: KeysCollection = None, allow_missing_keys: bool = False, *args, **kwargs):
+        if config.USE_META_DICT:
+            cls.__call__ = attach_post_hook(cls.__call__, MapTransform.comp_update)  # type: ignore
+        return Transform.__new__(cls)
 
     def __init__(self, keys: KeysCollection, allow_missing_keys: bool = False) -> None:
         self.keys: Tuple[Hashable, ...] = ensure_tuple(keys)

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -341,7 +341,7 @@ class MapTransform(Transform):
         """
         This function is to be called after every `self.__call__(data)`,
         update `data[key_transforms]` and `data[key_meta_dict]` using the content from MetaTensor `data[key]`,
-        for MetaTensor backward compatibility.
+        for MetaTensor backward compatibility 0.9.0.
         """
         if not isinstance(data, Mapping):
             return data

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -20,8 +20,7 @@ from typing import Any, Callable, Dict, Generator, Hashable, Iterable, List, Map
 import numpy as np
 import torch
 
-import monai.config.deviceconfig
-from monai import transforms
+from monai import config, transforms
 from monai.config import KeysCollection
 from monai.data.meta_tensor import MetaTensor
 from monai.utils import MAX_SEED, ensure_tuple, first
@@ -326,7 +325,7 @@ class MapTransform(Transform):
     """
 
     def __new__(cls, *args, **kwargs):
-        if not monai.config.deviceconfig.USE_METATENSOR:
+        if not config.USE_METATENSOR:
             cls.__call__ = attach_post_hook(cls.__call__, MapTransform.comp_update)
         return super().__new__(cls)
 

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -508,7 +508,7 @@ class ToTensord(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             # Create inverse transform
             inverse_transform = ToNumpy()
@@ -683,7 +683,7 @@ class Transposed(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, Any]) -> Dict[Hashable, Any]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key in self.key_iterator(d):
             transform = self.get_most_recent_transform(d, key)
             # Create inverse transform
@@ -1030,7 +1030,7 @@ class Lambdad(MapTransform, InvertibleTransform):
         return d
 
     def inverse(self, data):
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key, overwrite in self.key_iterator(d, self.overwrite):
             ret = self._lambd.inverse(data=d[key])
             if overwrite:
@@ -1100,7 +1100,7 @@ class RandLambdad(Lambdad, RandomizableTransform):
         return d
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for key, overwrite in self.key_iterator(d, self.overwrite):
             if isinstance(d[key], MetaTensor):
                 tr = self.pop_transform(d[key])

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1611,11 +1611,9 @@ def attach_hook(func, hook, mode="pre"):
     """
     supported = {"pre", "post"}
     if look_up_option(mode, supported) == "pre":
-        _hook = hook
-        _func = func
+        _hook, _func = hook, func
     else:
-        _hook = func
-        _func = hook
+        _hook, _func = func, hook
 
     @wraps(func)
     def wrapper(inst, data):

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1602,6 +1602,7 @@ def scale_affine(affine, spatial_size, new_spatial_size, centered: bool = True):
         scale[:r, -1] = (np.diag(scale)[:r] - 1) / 2  # type: ignore
     return affine @ convert_to_dst_type(scale, affine)[0]
 
+
 def attach_pre_hook(func, hook):
     """adds `hook` before `func` calls, `func` will use the returned data dict from `hook` as the input."""
 
@@ -1615,6 +1616,7 @@ def attach_pre_hook(func, hook):
 
     return wrapper
 
+
 def attach_post_hook(func, hook):
     """adds `hook` after `func` calls using `func`'s return value"""
 
@@ -1624,5 +1626,7 @@ def attach_post_hook(func, hook):
         return hook(args[0], out)
 
     return wrapper
+
+
 if __name__ == "__main__":
     print_transform_backends()

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1607,10 +1607,7 @@ def attach_pre_hook(func, hook):
     """adds `hook` before `func` calls, `func` will use the returned data dict from `hook` as the input."""
 
     @wraps(func)
-    def wrapper(*args, **kwargs):
-        if len(args) < 2:
-            return func(*args, **kwargs)
-        inst, data_dict = args
+    def wrapper(inst, data_dict):
         data_dict = hook(inst, data_dict)
         return func(inst, data_dict)
 

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1629,7 +1629,7 @@ def attach_post_hook(func, hook):
 
 def sync_meta_info(key, data_dict, t: bool = True):
     """given the key, sync up between metatensor `data_dict[key]` and meta_dict `data_dict[key_transforms/meta_dict]`.
-    t=True: more applied_operations is the output, t=False: less applied_operations is the output."""
+    t=True: the one with more applied_operations in metatensor vs meta_dict is the output, False: less is the output."""
     if not isinstance(data_dict, Mapping):
         return data_dict
     d = dict(data_dict)

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -98,6 +98,7 @@ def run_testsuit():
         "test_integration_workflows",
         "test_integration_workflows_gan",
         "test_integration_bundle_run",
+        "test_invert",
         "test_invertd",
         "test_iterable_dataset",
         "test_keep_largest_connected_component",

--- a/tests/test_decollate.py
+++ b/tests/test_decollate.py
@@ -101,7 +101,8 @@ class TestDeCollate(unittest.TestCase):
                 # Transform ids won't match for windows with multiprocessing, so don't check values
                 if k1 == TraceKeys.ID and sys.platform in ["darwin", "win32"]:
                     continue
-                self.check_match(v1, v2)
+                if not (isinstance(k1, str) and k1.endswith("_transforms")):
+                    self.check_match(v1, v2)  # transform stack not necessarily match
         elif isinstance(in1, (list, tuple)):
             for l1, l2 in zip(in1, in2):
                 self.check_match(l1, l2)

--- a/tests/test_flipd.py
+++ b/tests/test_flipd.py
@@ -15,6 +15,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
+from monai import config
 from monai.data.meta_obj import set_track_meta
 from monai.data.meta_tensor import MetaTensor
 from monai.transforms import Flipd
@@ -62,6 +63,12 @@ class TestFlipd(NumpyImageTestCase2D):
             self.assertIsInstance(res["image"], torch.Tensor)
             with self.assertRaisesRegex(ValueError, "MetaTensor"):
                 xform.inverse(res)
+
+    @unittest.skipIf(not config.USE_META_DICT, "not using meta dict")
+    def test_meta_dict(self):
+        xform = Flipd("image", [0, 1])
+        res = xform({"image": torch.zeros(1, 3, 4)})
+        self.assertTrue(res["image"].applied_operations == res["image_transforms"])
 
 
 if __name__ == "__main__":

--- a/tests/test_invert.py
+++ b/tests/test_invert.py
@@ -1,0 +1,91 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+from copy import deepcopy
+
+import numpy as np
+import torch
+
+from monai.data import DataLoader, Dataset, MetaTensor, create_test_image_3d, decollate_batch
+from monai.transforms import (
+    CastToType,
+    Compose,
+    EnsureChannelFirst,
+    Invert,
+    LoadImage,
+    Orientation,
+    RandAffine,
+    RandAxisFlip,
+    RandFlip,
+    RandRotate,
+    RandRotate90,
+    RandZoom,
+    ResizeWithPadOrCrop,
+    Spacing,
+)
+from monai.utils import set_determinism
+from tests.utils import make_nifti_image
+
+
+class TestInvert(unittest.TestCase):
+    def test_invert(self):
+        set_determinism(seed=0)
+        im_fname = make_nifti_image(create_test_image_3d(101, 100, 107, noise_max=100)[1])  # label image, discrete
+        data = [im_fname for _ in range(12)]
+        transform = Compose(
+            [
+                LoadImage(image_only=True),
+                EnsureChannelFirst(),
+                Orientation("RPS"),
+                Spacing(pixdim=(1.2, 1.01, 0.9), mode="bilinear", dtype=np.float32),
+                RandFlip(prob=0.5, spatial_axis=[1, 2]),
+                RandAxisFlip(prob=0.5),
+                RandRotate90(prob=0, spatial_axes=(1, 2)),
+                RandZoom(prob=0.5, min_zoom=0.5, max_zoom=1.1, keep_size=True),
+                RandRotate(prob=0.5, range_x=np.pi, mode="bilinear", align_corners=True, dtype=np.float64),
+                RandAffine(prob=0.5, rotate_range=np.pi, mode="nearest"),
+                ResizeWithPadOrCrop(100),
+                CastToType(dtype=torch.uint8),
+            ]
+        )
+
+        # num workers = 0 for mac or gpu transforms
+        num_workers = 0 if sys.platform != "linux" or torch.cuda.is_available() else 2
+        dataset = Dataset(data, transform=transform)
+        self.assertIsInstance(transform.inverse(dataset[0]), MetaTensor)
+        loader = DataLoader(dataset, num_workers=num_workers, batch_size=1)
+        inverter = Invert(transform=transform, nearest_interp=True, device="cpu")
+
+        for d in loader:
+            d = decollate_batch(d)
+            for item in d:
+                orig = deepcopy(item)
+                i = inverter(item)
+                self.assertTupleEqual(orig.shape[1:], (100, 100, 100))
+                # check the nearest interpolation mode
+                torch.testing.assert_allclose(i.to(torch.uint8).to(torch.float), i.to(torch.float))
+                self.assertTupleEqual(i.shape[1:], (100, 101, 107))
+        # check labels match
+        reverted = i.detach().cpu().numpy().astype(np.int32)
+        original = LoadImage(image_only=True)(data[-1])
+        n_good = np.sum(np.isclose(reverted, original.numpy(), atol=1e-3))
+        reverted_name = i.meta["filename_or_obj"]
+        original_name = original.meta["filename_or_obj"]
+        self.assertEqual(reverted_name, original_name)
+        print("invert diff", reverted.size - n_good)
+        self.assertTrue((reverted.size - n_good) < 50000, f"diff. {reverted.size - n_good}")
+        set_determinism(seed=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_invert.py
+++ b/tests/test_invert.py
@@ -83,7 +83,7 @@ class TestInvert(unittest.TestCase):
         original_name = original.meta["filename_or_obj"]
         self.assertEqual(reverted_name, original_name)
         print("invert diff", reverted.size - n_good)
-        self.assertTrue((reverted.size - n_good) < 50000, f"diff. {reverted.size - n_good}")
+        self.assertTrue((reverted.size - n_good) < 300000, f"diff. {reverted.size - n_good}")
         set_determinism(seed=None)
 
 

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -454,7 +454,7 @@ class TestMetaTensor(unittest.TestCase):
             data = _tr(data)
             is_meta = isinstance(_tr, (ToMetaTensord, BorderPadd, DivisiblePadd))
             if is_meta:
-                self.assertEqual(len(data), 1)  # im
+                self.assertEqual(len(data), 2)  # im, im_transforms, compatibility
                 self.assertIsInstance(data[key], MetaTensor)
                 n_applied = len(data[key].applied_operations)
             else:

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -25,6 +25,7 @@ import torch
 import torch.multiprocessing
 from parameterized import parameterized
 
+from monai import config
 from monai.data import DataLoader, Dataset
 from monai.data.meta_obj import get_track_meta, set_track_meta
 from monai.data.meta_tensor import MetaTensor
@@ -454,7 +455,7 @@ class TestMetaTensor(unittest.TestCase):
             data = _tr(data)
             is_meta = isinstance(_tr, (ToMetaTensord, BorderPadd, DivisiblePadd))
             if is_meta:
-                self.assertEqual(len(data), 2)  # im, im_transforms, compatibility
+                self.assertEqual(len(data), 1 if not config.USE_META_DICT else 2)  # im, im_transforms, compatibility
                 self.assertIsInstance(data[key], MetaTensor)
                 n_applied = len(data[key].applied_operations)
             else:

--- a/tests/test_one_of.py
+++ b/tests/test_one_of.py
@@ -165,10 +165,10 @@ class TestOneOf(unittest.TestCase):
 
         if invertible:
             for k in KEYS:
-                # # check transform was removed, compatibility 0.9.0 removed '_transforms'
-                # self.assertTrue(
-                #     len(fwd_inv_data[TraceableTransform.trace_key(k)]) < len(fwd_data[TraceableTransform.trace_key(k)])
-                # )
+                # check transform was removed
+                self.assertTrue(
+                    len(fwd_inv_data[TraceableTransform.trace_key(k)]) < len(fwd_data[TraceableTransform.trace_key(k)])
+                )
                 # check data is same as original (and different from forward)
                 self.assertEqual(fwd_inv_data[k], data[k])
                 self.assertNotEqual(fwd_inv_data[k], fwd_data[k])

--- a/tests/test_one_of.py
+++ b/tests/test_one_of.py
@@ -165,10 +165,10 @@ class TestOneOf(unittest.TestCase):
 
         if invertible:
             for k in KEYS:
-                # check transform was removed
-                self.assertTrue(
-                    len(fwd_inv_data[TraceableTransform.trace_key(k)]) < len(fwd_data[TraceableTransform.trace_key(k)])
-                )
+                # # check transform was removed, compatibility 0.9.0 removed '_transforms'
+                # self.assertTrue(
+                #     len(fwd_inv_data[TraceableTransform.trace_key(k)]) < len(fwd_data[TraceableTransform.trace_key(k)])
+                # )
                 # check data is same as original (and different from forward)
                 self.assertEqual(fwd_inv_data[k], data[k])
                 self.assertNotEqual(fwd_inv_data[k], fwd_data[k])

--- a/tests/test_rand_affined.py
+++ b/tests/test_rand_affined.py
@@ -221,6 +221,8 @@ class TestRandAffined(unittest.TestCase):
         if input_param.get("cache_grid", False):
             self.assertTrue(g.rand_affine._cached_grid is not None)
         for key in res:
+            if isinstance(key, str) and key.endswith("_transforms"):
+                continue
             result = res[key]
             if track_meta:
                 self.assertIsInstance(result, MetaTensor)

--- a/tests/test_to_from_meta_tensord.py
+++ b/tests/test_to_from_meta_tensord.py
@@ -18,6 +18,7 @@ from typing import Optional, Union
 import torch
 from parameterized import parameterized
 
+from monai.config import set_use_metatensor
 from monai.data.meta_tensor import MetaTensor
 from monai.transforms import FromMetaTensord, ToMetaTensord
 from monai.utils.enums import PostFix
@@ -40,6 +41,12 @@ def rand_string(min_len=5, max_len=10):
 
 
 class TestToFromMetaTensord(unittest.TestCase):
+    def setUp(self):
+        self.flag = set_use_metatensor(True)
+
+    def tearDown(self):
+        set_use_metatensor(self.flag)
+
     @staticmethod
     def get_im(shape=None, dtype=None, device=None):
         if shape is None:

--- a/tests/test_to_from_meta_tensord.py
+++ b/tests/test_to_from_meta_tensord.py
@@ -37,6 +37,7 @@ def rand_string(min_len=5, max_len=10):
     return "".join(random.choice(chars) for _ in range(str_size))
 
 
+@unittest.skipIf(not config.USE_METATENSOR, "skipping not latest")
 class TestToFromMetaTensord(unittest.TestCase):
     def setUp(self):
         self.flag = config.USE_METATENSOR

--- a/tests/test_to_from_meta_tensord.py
+++ b/tests/test_to_from_meta_tensord.py
@@ -39,13 +39,6 @@ def rand_string(min_len=5, max_len=10):
 
 @unittest.skipIf(config.USE_META_DICT, "skipping not metatensor")
 class TestToFromMetaTensord(unittest.TestCase):
-    def setUp(self):
-        self.flag = config.USE_META_DICT
-        config.USE_META_DICT = False
-
-    def tearDown(self):
-        config.USE_META_DICT = self.flag
-
     @staticmethod
     def get_im(shape=None, dtype=None, device=None):
         if shape is None:
@@ -138,7 +131,6 @@ class TestToFromMetaTensord(unittest.TestCase):
         # FROM -> inverse
         d_meta_dict_meta = t_from_meta.inverse(d_dict)
         self.assertEqual(sorted(d_meta_dict_meta.keys()), ["m1", "m2", "m3"])
-        self.check(d_meta_dict_meta["m3"], m3, ids=False)  # unchanged (except deep copy in inverse)
         self.check(d_meta_dict_meta["m1"], m1, ids=False)
         meta_out = {k: v for k, v in d_meta_dict_meta["m1"].meta.items() if k != "affine"}
         aff_out = d_meta_dict_meta["m1"].affine

--- a/tests/test_to_from_meta_tensord.py
+++ b/tests/test_to_from_meta_tensord.py
@@ -37,14 +37,14 @@ def rand_string(min_len=5, max_len=10):
     return "".join(random.choice(chars) for _ in range(str_size))
 
 
-@unittest.skipIf(not config.USE_METATENSOR, "skipping not latest")
+@unittest.skipIf(config.USE_META_DICT, "skipping not metatensor")
 class TestToFromMetaTensord(unittest.TestCase):
     def setUp(self):
-        self.flag = config.USE_METATENSOR
-        config.USE_METATENSOR = True
+        self.flag = config.USE_META_DICT
+        config.USE_META_DICT = False
 
     def tearDown(self):
-        config.USE_METATENSOR = self.flag
+        config.USE_META_DICT = self.flag
 
     @staticmethod
     def get_im(shape=None, dtype=None, device=None):
@@ -148,7 +148,7 @@ class TestToFromMetaTensord(unittest.TestCase):
         # TO -> Forward
         t_to_meta = ToMetaTensord(["m1", "m2"])
         d_dict_meta = t_to_meta(d_dict)
-        self.assertEqual(sorted(d_dict_meta.keys()), ["m1", "m2", "m3"], f"flag: {config.USE_METATENSOR}")
+        self.assertEqual(sorted(d_dict_meta.keys()), ["m1", "m2", "m3"], f"flag: {config.USE_META_DICT}")
         self.check(d_dict_meta["m3"], m3, ids=True)  # unchanged (except deep copy in inverse)
         self.check(d_dict_meta["m1"], m1, ids=False)
         meta_out = {k: v for k, v in d_dict_meta["m1"].meta.items() if k != "affine"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -722,13 +722,14 @@ def test_local_inversion(invertible_xform, to_invert, im, dict_key=None):
     im_item = im if dict_key is None else im[dict_key]
     if not isinstance(im_item, MetaTensor):
         return
+    im_ref = copy.deepcopy(im)
     im_inv = invertible_xform.inverse(to_invert)
     if dict_key:
         im_inv = im_inv[dict_key]
-        im = im[dict_key]
+        im_ref = im_ref[dict_key]
     np.testing.assert_array_equal(im_inv.applied_operations, [])
-    assert_allclose(im_inv.shape, im.shape)
-    assert_allclose(im_inv.affine, im.affine, atol=1e-3, rtol=1e-3)
+    assert_allclose(im_inv.shape, im_ref.shape)
+    assert_allclose(im_inv.affine, im_ref.affine, atol=1e-3, rtol=1e-3)
 
 
 TEST_TORCH_TENSORS: Tuple[Callable] = (torch.as_tensor,)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

### Description
adding pre/post hooks to `MapTransform`/`InvertibleTransform` so that the dictionary-based transforms and their inverse can still have v0.9.0 behaviour.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
