### PR TITLE
Metric: r2

### DIFF
--- a/monai/metrics/__init__.py
+++ b/monai/metrics/__init__.py
@@ -16,7 +16,7 @@ from .generalized_dice import GeneralizedDiceScore, compute_generalized_dice
 from .hausdorff_distance import HausdorffDistanceMetric, compute_hausdorff_distance, compute_percent_hausdorff_distance
 from .meandice import DiceMetric, compute_meandice
 from .metric import Cumulative, CumulativeIterationMetric, IterationMetric, Metric
-from .regression import MAEMetric, MSEMetric, PSNRMetric, RMSEMetric
+from .regression import MAEMetric, MSEMetric, PSNRMetric, R2Metric, RMSEMetric, compute_mean_error_metrics
 from .rocauc import ROCAUCMetric, compute_roc_auc
 from .surface_dice import SurfaceDiceMetric, compute_surface_dice
 from .surface_distance import SurfaceDistanceMetric, compute_average_surface_distance

--- a/tests/test_compute_regression_metrics.py
+++ b/tests/test_compute_regression_metrics.py
@@ -16,6 +16,7 @@ import numpy as np
 import torch
 
 from monai.metrics import MAEMetric, MSEMetric, PSNRMetric, RMSEMetric
+from monai.metrics.regression import R2Metric
 from monai.utils import set_determinism
 
 
@@ -48,7 +49,7 @@ class TestRegressionMetrics(unittest.TestCase):
         device = "cuda" if torch.cuda.is_available() else "cpu"
 
         # regression metrics to check
-        metrics = [MSEMetric, MAEMetric, RMSEMetric, partial(PSNRMetric, max_val=1.0)]
+        metrics = [MSEMetric, MAEMetric, RMSEMetric, partial(PSNRMetric, max_val=1.0), R2Metric]
 
         # define variations in batch/base_dims/spatial_dims
         batch_dims = [1, 2, 4, 16]
@@ -121,7 +122,7 @@ class TestRegressionMetrics(unittest.TestCase):
         device = "cuda" if torch.cuda.is_available() else "cpu"
 
         # regression metrics to check + truth metric function in numpy
-        metrics = [MSEMetric, MAEMetric, RMSEMetric, partial(PSNRMetric, max_val=1.0)]
+        metrics = [MSEMetric, MAEMetric, RMSEMetric, partial(PSNRMetric, max_val=1.0), R2Metric]
         basedim = 10
 
         # too small shape
@@ -140,8 +141,8 @@ class TestRegressionMetrics(unittest.TestCase):
     def test_same_input(self):
         set_determinism(seed=123)
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        metrics = [MSEMetric, MAEMetric, RMSEMetric, partial(PSNRMetric, max_val=1.0)]
-        results = [0.0, 0.0, 0.0, float("inf")]
+        metrics = [MSEMetric, MAEMetric, RMSEMetric, partial(PSNRMetric, max_val=1.0), R2Metric]
+        results = [0.0, 0.0, 0.0, float("inf"), 1.0]
 
         # define variations in batch/base_dims/spatial_dims
         batch_dims = [1, 2, 4, 16]
@@ -166,8 +167,8 @@ class TestRegressionMetrics(unittest.TestCase):
     def test_diff_input(self):
         set_determinism(seed=123)
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        metrics = [MSEMetric, MAEMetric, RMSEMetric, partial(PSNRMetric, max_val=1.0)]
-        results = [1.0, 1.0, 1.0, 0.0]
+        metrics = [MSEMetric, MAEMetric, RMSEMetric, partial(PSNRMetric, max_val=1.0), R2Metric]
+        results = [1.0, 1.0, 1.0, 0.0, 0.0]
 
         # define variations in batch/base_dims/spatial_dims
         batch_dims = [1, 2, 4, 16]
@@ -179,7 +180,7 @@ class TestRegressionMetrics(unittest.TestCase):
             for spatial in spatial_dims:
                 for base in base_dims:
 
-                    # create random tensors
+                    # create tensors
                     in_tensor_a = torch.zeros((batch,) + (base,) * (spatial - 1)).to(device)
                     in_tensor_b = torch.ones((batch,) + (base,) * (spatial - 1)).to(device)
 


### PR DESCRIPTION
### Description
Implements r2 metric to compare similarities between two tensors. This is a useful metric as it can be expressed as a percentage, as opposed to MSE for example which is arbitrary.

Useful in image regression.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
