### PR TITLE
Fixes pad list data collate

### DIFF
--- a/monai/transforms/croppad/batch.py
+++ b/monai/transforms/croppad/batch.py
@@ -13,8 +13,7 @@ A collection of "vanilla" transforms for crop and pad operations acting on batch
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
-from copy import deepcopy
-from typing import Any, Dict, Hashable
+from typing import Any, Dict, Hashable, Mapping
 
 import numpy as np
 import torch
@@ -101,17 +100,22 @@ class PadListDataCollate(InvertibleTransform):
 
                 # If we have a dictionary of data, append to list
                 if is_list_of_dicts:
-                    self.push_transform(batch[idx], key_or_idx, orig_size=orig_size)
+                    self.push_transform(
+                        batch[idx],
+                        key_or_idx,
+                        orig_size=orig_size,
+                        extra_info=self.pop_transform(batch[idx], key_or_idx, check=False),
+                    )
 
         # After padding, use default list collator
         return list_data_collate(batch)
 
     @staticmethod
     def inverse(data: dict) -> Dict[Hashable, np.ndarray]:
-        if not isinstance(data, dict):
+        if not isinstance(data, Mapping):
             raise RuntimeError("Inverse can only currently be applied on dictionaries.")
 
-        d = deepcopy(data)
+        d = dict(data)
         for key in d:
             transforms = None
             if isinstance(d[key], MetaTensor):

--- a/monai/transforms/croppad/batch.py
+++ b/monai/transforms/croppad/batch.py
@@ -99,6 +99,7 @@ class PadListDataCollate(InvertibleTransform):
                 batch = replace_element(padded, batch, idx, key_or_idx)
 
                 # If we have a dictionary of data, append to list
+                # padder transform info is re-added with self.push_transform to ensure one info dict per transform.
                 if is_list_of_dicts:
                     self.push_transform(
                         batch[idx],

--- a/monai/transforms/inverse_batch_transform.py
+++ b/monai/transforms/inverse_batch_transform.py
@@ -88,7 +88,9 @@ class BatchInverseTransform(Transform):
         self.detach = detach
         self.pad_batch = pad_batch
         self.fill_value = fill_value
-        self.pad_collation_used = loader.collate_fn.__doc__ == pad_list_data_collate.__doc__
+        self.pad_collation_used = loader.collate_fn.__doc__ == pad_list_data_collate.__doc__ or isinstance(
+            loader.collate_fn, PadListDataCollate
+        )
 
     def __call__(self, data: Dict[str, Any]) -> Any:
         decollated_data = decollate_batch(data, detach=self.detach, pad=self.pad_batch, fill_value=self.fill_value)

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -16,7 +16,6 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
 import warnings
-from copy import deepcopy
 from typing import Any, Callable, Dict, Hashable, Iterable, List, Mapping, Optional, Sequence, Union
 
 import torch
@@ -643,7 +642,7 @@ class Invertd(MapTransform):
                 meta_info = d.get(orig_meta_key, {})
             if nearest_interp:
                 transform_info = convert_applied_interp_mode(
-                    trans_info=deepcopy(transform_info), mode="nearest", align_corners=None
+                    trans_info=transform_info, mode="nearest", align_corners=None
                 )
 
             inputs = d[key]

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -274,7 +274,7 @@ class ResampleToMatchd(MapTransform, InvertibleTransform):
         self.resampler = ResampleToMatch()
 
     def __call__(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
-        d = deepcopy(dict(data))
+        d = dict(data)
         for (key, mode, padding_mode, align_corners, dtype) in self.key_iterator(
             d, self.mode, self.padding_mode, self.align_corners, self.dtype
         ):

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -332,7 +332,7 @@ class SplitDim(Transform):
                 outputs[idx] = item.squeeze(self.dim)
             if self.update_meta and isinstance(img, MetaTensor):
                 if not isinstance(item, MetaTensor):
-                    item = MetaTensor(item, meta=deepcopy(img.meta))
+                    item = MetaTensor(item, meta=img.meta)
                 if self.dim == 0:  # don't update affine if channel dim
                     continue
                 ndim = len(item.affine)

--- a/tests/test_pad_collation.py
+++ b/tests/test_pad_collation.py
@@ -11,6 +11,7 @@
 
 import random
 import unittest
+from functools import wraps
 from typing import List, Tuple
 
 import numpy as np
@@ -20,6 +21,7 @@ from parameterized import parameterized
 from monai.data import CacheDataset, DataLoader
 from monai.data.utils import decollate_batch, pad_list_data_collate
 from monai.transforms import (
+    BatchInverseTransform,
     Compose,
     PadListDataCollate,
     RandRotate,
@@ -34,11 +36,17 @@ from monai.transforms import (
 )
 from monai.utils import set_determinism
 
+
+@wraps(pad_list_data_collate)
+def _testing_collate(x):
+    return pad_list_data_collate(batch=x, method="end", mode="constant")
+
+
 TESTS: List[Tuple] = []
 
 for pad_collate in [
-    lambda x: pad_list_data_collate(batch=x, method="end", mode="constant"),
-    PadListDataCollate(method="end", mode="constant"),
+    _testing_collate,
+    PadListDataCollate(method="end", mode="constant")
 ]:
     TESTS.append((dict, pad_collate, RandSpatialCropd("image", roi_size=[8, 7], random_size=True)))
     TESTS.append((dict, pad_collate, RandRotated("image", prob=1, range_x=np.pi, keep_size=False, dtype=np.float64)))
@@ -57,13 +65,13 @@ class _Dataset(torch.utils.data.Dataset):
     def __init__(self, images, labels, transforms):
         self.images = images
         self.labels = labels
-        self.transforms = transforms
+        self.transform = transforms
 
     def __len__(self):
         return len(self.images)
 
     def __getitem__(self, index):
-        return self.transforms(self.images[index]), self.labels[index]
+        return self.transform(self.images[index]), self.labels[index]
 
 
 class TestPadCollation(unittest.TestCase):
@@ -105,6 +113,12 @@ class TestPadCollation(unittest.TestCase):
                     shapes.append(output["image"].shape)
                     self.assertTrue(len(output["image"].applied_operations), len(dataset.transform.transforms))
                 self.assertTrue(len(set(shapes)) > 1)  # inverted shapes must be different because of random xforms
+
+        if t_type == dict:
+            batch_inverse = BatchInverseTransform(dataset.transform, loader)
+            for data in loader:
+                output = batch_inverse(data)
+                self.assertTrue(output[0]["image"].shape, (1, 10, 9))
 
 
 if __name__ == "__main__":

--- a/tests/test_pad_collation.py
+++ b/tests/test_pad_collation.py
@@ -103,6 +103,7 @@ class TestPadCollation(unittest.TestCase):
                 for d in decollated_data:
                     output = PadListDataCollate.inverse(d)
                     shapes.append(output["image"].shape)
+                    self.assertTrue(len(output["image"].applied_operations), len(dataset.transform.transforms))
                 self.assertTrue(len(set(shapes)) > 1)  # inverted shapes must be different because of random xforms
 
 

--- a/tests/test_pad_collation.py
+++ b/tests/test_pad_collation.py
@@ -44,10 +44,7 @@ def _testing_collate(x):
 
 TESTS: List[Tuple] = []
 
-for pad_collate in [
-    _testing_collate,
-    PadListDataCollate(method="end", mode="constant")
-]:
+for pad_collate in [_testing_collate, PadListDataCollate(method="end", mode="constant")]:
     TESTS.append((dict, pad_collate, RandSpatialCropd("image", roi_size=[8, 7], random_size=True)))
     TESTS.append((dict, pad_collate, RandRotated("image", prob=1, range_x=np.pi, keep_size=False, dtype=np.float64)))
     TESTS.append((dict, pad_collate, RandZoomd("image", prob=1, min_zoom=1.1, max_zoom=2.0, keep_size=False)))


### PR DESCRIPTION
### Description
the current `PadListDataCollate` pushes to the applied operations twice, but it pops once in the inverse, this causes inconsistencies. This PR fixes this issue and adds more tests about `PadListDataCollate` and `BatchInverseTransform `

https://github.com/Project-MONAI/MONAI/blob/e8672aa8ed3fdc266216f17faa5562d9f5cac5b5/monai/transforms/croppad/batch.py#L96-L104



### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
