### PR TITLE
Support block type strings in resnet

### DIFF
--- a/monai/networks/nets/resnet.py
+++ b/monai/networks/nets/resnet.py
@@ -172,7 +172,7 @@ class ResNet(nn.Module):
     @deprecated_arg("n_classes", since="0.6")
     def __init__(
         self,
-        block: Type[Union[ResNetBlock, ResNetBottleneck]],
+        block: Union[Type[Union[ResNetBlock, ResNetBottleneck]], str],
         layers: List[int],
         block_inplanes: List[int],
         spatial_dims: int = 3,
@@ -191,6 +191,14 @@ class ResNet(nn.Module):
         # in case the new num_classes is default but you still call deprecated n_classes
         if n_classes is not None and num_classes == 400:
             num_classes = n_classes
+
+        if isinstance(block, str):
+            if block == "basic":
+                block = ResNetBlock
+            elif block == "bottleneck":
+                block = ResNetBottleneck
+            else:
+                raise ValueError("Unknown block '%s', use basic or bottleneck" % block)
 
         conv_type: Type[Union[nn.Conv1d, nn.Conv2d, nn.Conv3d]] = Conv[Conv.CONV, spatial_dims]
         norm_type: Type[Union[nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d]] = Norm[Norm.BATCH, spatial_dims]

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -16,7 +16,8 @@ import torch
 from parameterized import parameterized
 
 from monai.networks import eval_mode
-from monai.networks.nets import resnet10, resnet18, resnet34, resnet50, resnet101, resnet152, resnet200
+from monai.networks.nets import ResNet, resnet10, resnet18, resnet34, resnet50, resnet101, resnet152, resnet200
+from monai.networks.nets.resnet import ResNetBlock
 from monai.utils import optional_import
 from tests.utils import test_script_save
 
@@ -95,10 +96,57 @@ TEST_CASE_4 = [  # 2D, batch 2, 1 input channel
     ((2, 512), (2, 2048)),
 ]
 
+TEST_CASE_5 = [  # 1D, batch 1, 2 input channels
+    {
+        "block": "basic",
+        "layers": [1, 1, 1, 1],
+        "block_inplanes": [64, 128, 256, 512],
+        "spatial_dims": 1,
+        "n_input_channels": 2,
+        "num_classes": 3,
+        "conv1_t_size": [3],
+        "conv1_t_stride": 1,
+    },
+    (1, 2, 32),
+    (1, 3),
+]
+
+TEST_CASE_5_A = [  # 1D, batch 1, 2 input channels
+    {
+        "block": ResNetBlock,
+        "layers": [1, 1, 1, 1],
+        "block_inplanes": [64, 128, 256, 512],
+        "spatial_dims": 1,
+        "n_input_channels": 2,
+        "num_classes": 3,
+        "conv1_t_size": [3],
+        "conv1_t_stride": 1,
+    },
+    (1, 2, 32),
+    (1, 3),
+]
+
+TEST_CASE_6 = [  # 1D, batch 1, 2 input channels
+    {
+        "block": "bottleneck",
+        "layers": [3, 4, 6, 3],
+        "block_inplanes": [64, 128, 256, 512],
+        "spatial_dims": 1,
+        "n_input_channels": 2,
+        "num_classes": 3,
+        "conv1_t_size": [3],
+        "conv1_t_stride": 1,
+    },
+    (1, 2, 32),
+    (1, 3),
+]
+
 TEST_CASES = []
 for case in [TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_2_A, TEST_CASE_3_A]:
     for model in [resnet10, resnet18, resnet34, resnet50, resnet101, resnet152, resnet200]:
         TEST_CASES.append([model, *case])
+for case in [TEST_CASE_5, TEST_CASE_5_A, TEST_CASE_6]:
+    TEST_CASES.append([ResNet, *case])
 
 TEST_SCRIPT_CASES = [
     [model, *TEST_CASE_1] for model in [resnet10, resnet18, resnet34, resnet50, resnet101, resnet152, resnet200]


### PR DESCRIPTION
Signed-off-by: KumoLiu <yunl@nvidia.com>

Fixes # .

### Description
Support block type strings in resnet from #4691

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
