### PR TITLE
Preserve ordering of input dict's keys in crop transforms

### DIFF
--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -861,11 +861,11 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
         self.randomize(label, fg_indices, bg_indices, image)
 
         # initialize returned list with shallow copy to preserve key ordering
-        ret: List = [dict(data) for _ in range(self.cropper.num_samples)]
+        ret: List = [dict(d) for _ in range(self.cropper.num_samples)]
         # deep copy all the unmodified data
         for i in range(self.cropper.num_samples):
             for key in set(d.keys()).difference(set(self.keys)):
-                ret[i][key] = deepcopy(data[key])
+                ret[i][key] = deepcopy(d[key])
 
         for key in self.key_iterator(d):
             for i, im in enumerate(self.cropper(d[key], label=label, randomize=False)):
@@ -999,11 +999,11 @@ class RandCropByLabelClassesd(Randomizable, MapTransform):
         self.randomize(label, indices, image)
 
         # initialize returned list with shallow copy to preserve key ordering
-        ret: List = [dict(data) for _ in range(self.cropper.num_samples)]
+        ret: List = [dict(d) for _ in range(self.cropper.num_samples)]
         # deep copy all the unmodified data
         for i in range(self.cropper.num_samples):
-            for key in set(data.keys()).difference(set(self.keys)):
-                ret[i][key] = deepcopy(data[key])
+            for key in set(d.keys()).difference(set(self.keys)):
+                ret[i][key] = deepcopy(d[key])
 
         for key in self.key_iterator(d):
             for i, im in enumerate(self.cropper(d[key], label=label, randomize=False)):

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -587,12 +587,11 @@ class RandSpatialCropSamplesd(Randomizable, MapTransform):
         self.sub_seed = self.R.randint(MAX_SEED, dtype="uint32")
 
     def __call__(self, data: Mapping[Hashable, torch.Tensor]) -> List[Dict[Hashable, torch.Tensor]]:
-        # output starts as empty list of dictionaries
-        ret: List[Dict[Hashable, torch.Tensor]] = [{} for _ in range(self.cropper.num_samples)]
+        ret: List[Dict[Hashable, torch.Tensor]] = [dict(data) for _ in range(self.cropper.num_samples)]
         # deep copy all the unmodified data
-        for key in set(data.keys()).difference(set(self.keys)):
-            for r in ret:
-                r[key] = deepcopy(data[key])
+        for i in range(self.cropper.num_samples):
+            for key in set(data.keys()).difference(set(self.keys)):
+                ret[i][key] = deepcopy(data[key])
 
         # for each key we reset the random state to ensure crops are the same
         self.randomize()
@@ -736,11 +735,11 @@ class RandWeightedCropd(Randomizable, MapTransform):
 
     def __call__(self, data: Mapping[Hashable, torch.Tensor]) -> List[Dict[Hashable, torch.Tensor]]:
         # output starts as empty list of dictionaries
-        ret: List = [{} for _ in range(self.cropper.num_samples)]
+        ret: List = [dict(data) for _ in range(self.cropper.num_samples)]
         # deep copy all the unmodified data
-        for key in set(data.keys()).difference(set(self.keys)):
-            for r in ret:
-                r[key] = deepcopy(data[key])
+        for i in range(self.cropper.num_samples):
+            for key in set(data.keys()).difference(set(self.keys)):
+                ret[i][key] = deepcopy(data[key])
 
         self.randomize(weight_map=data[self.w_key])
         for key in self.key_iterator(data):
@@ -862,11 +861,11 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
         self.randomize(label, fg_indices, bg_indices, image)
 
         # initialize returned list with shallow copy to preserve key ordering
-        ret: List = [{} for _ in range(self.cropper.num_samples)]
+        ret: List = [dict(data) for _ in range(self.cropper.num_samples)]
         # deep copy all the unmodified data
-        for key in set(d.keys()).difference(set(self.keys)):
-            for r in ret:
-                r[key] = deepcopy(d[key])
+        for i in range(self.cropper.num_samples):
+            for key in set(d.keys()).difference(set(self.keys)):
+                ret[i][key] = deepcopy(data[key])
 
         for key in self.key_iterator(d):
             for i, im in enumerate(self.cropper(d[key], label=label, randomize=False)):
@@ -1000,11 +999,11 @@ class RandCropByLabelClassesd(Randomizable, MapTransform):
         self.randomize(label, indices, image)
 
         # initialize returned list with shallow copy to preserve key ordering
-        ret: List = [{} for _ in range(self.cropper.num_samples)]
+        ret: List = [dict(data) for _ in range(self.cropper.num_samples)]
         # deep copy all the unmodified data
-        for key in set(d.keys()).difference(set(self.keys)):
-            for r in ret:
-                r[key] = deepcopy(d[key])
+        for i in range(self.cropper.num_samples):
+            for key in set(data.keys()).difference(set(self.keys)):
+                ret[i][key] = deepcopy(data[key])
 
         for key in self.key_iterator(d):
             for i, im in enumerate(self.cropper(d[key], label=label, randomize=False)):

--- a/tests/test_rand_crop_by_label_classesd.py
+++ b/tests/test_rand_crop_by_label_classesd.py
@@ -126,6 +126,8 @@ class TestRandCropByLabelClassesd(unittest.TestCase):
         result = RandCropByLabelClassesd(**input_param)(input_data)
         self.assertIsInstance(result, expected_type)
         self.assertTupleEqual(result[0]["img"].shape, expected_shape)
+        _len = len(tuple(input_data.keys()))
+        self.assertTupleEqual(tuple(result[0].keys())[:_len], tuple(input_data.keys()))
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_crop_by_label_classesd.py
+++ b/tests/test_rand_crop_by_label_classesd.py
@@ -126,8 +126,8 @@ class TestRandCropByLabelClassesd(unittest.TestCase):
         result = RandCropByLabelClassesd(**input_param)(input_data)
         self.assertIsInstance(result, expected_type)
         self.assertTupleEqual(result[0]["img"].shape, expected_shape)
-        _len = len(tuple(input_data.keys()))
-        self.assertTupleEqual(tuple(result[0].keys())[:_len], tuple(input_data.keys()))
+        _len = len(tuple(input_data.keys())) - 1  # except for the indices_key
+        self.assertTupleEqual(tuple(result[0].keys())[:_len], tuple(input_data.keys())[:-1])
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_spatial_crop_samplesd.py
+++ b/tests/test_rand_spatial_crop_samplesd.py
@@ -85,6 +85,8 @@ class TestRandSpatialCropSamplesd(unittest.TestCase):
         xform = RandSpatialCropSamplesd(**input_param)
         xform.set_random_state(1234)
         result = xform(input_data)
+        _len = len(tuple(input_data.keys()))
+        self.assertTupleEqual(tuple(result[0].keys())[:_len], tuple(input_data.keys()))
         for item, expected in zip(result, expected_shape):
             self.assertTupleEqual(item["img"].shape, expected)
             self.assertTupleEqual(item["seg"].shape, expected)

--- a/tests/test_rand_weighted_cropd.py
+++ b/tests/test_rand_weighted_cropd.py
@@ -150,6 +150,8 @@ class TestRandWeightedCrop(unittest.TestCase):
         crop.set_random_state(10)
         result = crop(input_data)
         self.assertTrue(len(result) == init_params["num_samples"])
+        _len = len(tuple(input_data.keys()))
+        self.assertTupleEqual(tuple(result[0].keys())[:_len], tuple(input_data.keys()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: KumoLiu <yunl@nvidia.com>

Fixes # .

### Description
Preserve ordering of input dict's keys in crop transforms from test error (https://github.com/Project-MONAI/tutorials/issues/791)

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
