### PR TITLE
4708 update multiprocessing  metatensor properties

### DIFF
--- a/monai/data/meta_obj.py
+++ b/monai/data/meta_obj.py
@@ -141,7 +141,7 @@ class MetaObj:
 
         """
         if self.is_batch:
-            self.__dict__ = next(iter(input_objs)).__dict__  # shallow copy for performance
+            self.__dict__ = dict(next(iter(input_objs)).__dict__)  # shallow copy for performance
             return
         self._copy_attr(
             ["meta", "applied_operations"],

--- a/monai/data/meta_obj.py
+++ b/monai/data/meta_obj.py
@@ -140,6 +140,9 @@ class MetaObj:
             input_objs: list of `MetaObj` to copy data from.
 
         """
+        if self._is_batch:
+            self.__dict__ = next(iter(input_objs)).__dict__  # shallow copy for performance
+            return
         self._copy_attr(
             ["meta", "applied_operations"],
             input_objs,

--- a/monai/data/meta_obj.py
+++ b/monai/data/meta_obj.py
@@ -140,7 +140,7 @@ class MetaObj:
             input_objs: list of `MetaObj` to copy data from.
 
         """
-        if self._is_batch:
+        if self.is_batch:
             self.__dict__ = next(iter(input_objs)).__dict__  # shallow copy for performance
             return
         self._copy_attr(

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -15,7 +15,6 @@ defined in :py:class:`monai.transforms.croppad.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
-from copy import deepcopy
 from typing import Any, Callable, Dict, Hashable, List, Mapping, Optional, Sequence, Union
 
 import numpy as np
@@ -23,7 +22,7 @@ import torch
 
 from monai.config import IndexSelection, KeysCollection, SequenceStr
 from monai.config.type_definitions import NdarrayOrTensor
-from monai.data.meta_tensor import MetaTensor
+from monai.data.meta_tensor import MetaObj, MetaTensor
 from monai.transforms.croppad.array import (
     BorderPad,
     BoundingRect,
@@ -591,7 +590,7 @@ class RandSpatialCropSamplesd(Randomizable, MapTransform):
         # deep copy all the unmodified data
         for i in range(self.cropper.num_samples):
             for key in set(data.keys()).difference(set(self.keys)):
-                ret[i][key] = deepcopy(data[key])
+                ret[i][key] = MetaObj.copy_items(data[key])
 
         # for each key we reset the random state to ensure crops are the same
         self.randomize()
@@ -739,7 +738,7 @@ class RandWeightedCropd(Randomizable, MapTransform):
         # deep copy all the unmodified data
         for i in range(self.cropper.num_samples):
             for key in set(data.keys()).difference(set(self.keys)):
-                ret[i][key] = deepcopy(data[key])
+                ret[i][key] = MetaObj.copy_items(data[key])
 
         self.randomize(weight_map=data[self.w_key])
         for key in self.key_iterator(data):
@@ -865,7 +864,7 @@ class RandCropByPosNegLabeld(Randomizable, MapTransform):
         # deep copy all the unmodified data
         for i in range(self.cropper.num_samples):
             for key in set(d.keys()).difference(set(self.keys)):
-                ret[i][key] = deepcopy(d[key])
+                ret[i][key] = MetaObj.copy_items(d[key])
 
         for key in self.key_iterator(d):
             for i, im in enumerate(self.cropper(d[key], label=label, randomize=False)):
@@ -1003,7 +1002,7 @@ class RandCropByLabelClassesd(Randomizable, MapTransform):
         # deep copy all the unmodified data
         for i in range(self.cropper.num_samples):
             for key in set(d.keys()).difference(set(self.keys)):
-                ret[i][key] = deepcopy(d[key])
+                ret[i][key] = MetaObj.copy_items(d[key])
 
         for key in self.key_iterator(d):
             for i, im in enumerate(self.cropper(d[key], label=label, randomize=False)):

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -16,7 +16,6 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
 import re
-from copy import deepcopy
 from typing import Any, Callable, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -24,7 +23,7 @@ import torch
 
 from monai.config import DtypeLike, KeysCollection
 from monai.config.type_definitions import NdarrayOrTensor
-from monai.data.meta_tensor import MetaTensor
+from monai.data.meta_tensor import MetaObj, MetaTensor
 from monai.data.utils import no_collation
 from monai.transforms.inverse import InvertibleTransform
 from monai.transforms.transform import MapTransform, Randomizable, RandomizableTransform
@@ -916,11 +915,7 @@ class CopyItemsd(MapTransform):
             for key, new_key in self.key_iterator(d, self.names[i * key_len : (i + 1) * key_len]):
                 if new_key in d:
                     raise KeyError(f"Key {new_key} already exists in data.")
-                val = d[key]
-                if isinstance(val, torch.Tensor):
-                    d[new_key] = val.detach().clone()
-                else:
-                    d[new_key] = deepcopy(val)
+                d[new_key] = MetaObj.copy_items(d[key])
         return d
 
 

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -107,7 +107,6 @@ class TestMetaTensor(unittest.TestCase):
         # check meta and affine are equal and affine is on correct device
         if isinstance(orig, MetaTensor) and isinstance(out, MetaTensor) and meta:
             self.check_meta(orig, out)
-            self.assertTrue(str(device) in str(out.affine.device))
             if check_ids:
                 self.check_ids(out.affine, orig.affine, ids)
                 self.check_ids(out.meta, orig.meta, ids)
@@ -166,7 +165,7 @@ class TestMetaTensor(unittest.TestCase):
     def test_affine_device(self):
         m, _ = self.get_im()  # device="cuda")
         m.affine = torch.eye(4)
-        self.assertEqual(m.device, m.affine.device)
+        self.assertTrue("cpu" in str(m.affine.device))
 
     @parameterized.expand(TESTS)
     def test_copy(self, device, dtype):

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -513,6 +513,7 @@ class TestMetaTensor(unittest.TestCase):
         """multiprocessing sharing with 'device' and 'dtype'"""
         buf = io.BytesIO()
         t = MetaTensor([0.0, 0.0], device=device, dtype=dtype)
+        t.is_batch = True
         if t.is_cuda:
             with self.assertRaises(NotImplementedError):
                 ForkingPickler(buf).dump(t)
@@ -521,6 +522,7 @@ class TestMetaTensor(unittest.TestCase):
         obj = ForkingPickler.loads(buf.getvalue())
         self.assertIsInstance(obj, MetaTensor)
         assert_allclose(obj.as_tensor(), t)
+        assert_allclose(obj.is_batch, True)
 
     @parameterized.expand(TESTS)
     def test_array_function(self, device="cpu", dtype=float):

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -221,7 +221,7 @@ class TestOrientationCase(unittest.TestCase):
     def test_inverse(self, device):
         img_t = torch.rand((1, 10, 9, 8), dtype=torch.float32, device=device)
         affine = torch.tensor(
-            [[0, 0, -1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=torch.float32, device=device
+            [[0, 0, -1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=torch.float32, device="cpu"
         )
         meta = {"fname": "somewhere"}
         img = MetaTensor(img_t, affine=affine, meta=meta)

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -263,7 +263,7 @@ class TestSpacingCase(unittest.TestCase):
     def test_inverse(self, device):
         img_t = torch.rand((1, 10, 9, 8), dtype=torch.float32, device=device)
         affine = torch.tensor(
-            [[0, 0, -1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=torch.float32, device=device
+            [[0, 0, -1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=torch.float32, device="cpu"
         )
         meta = {"fname": "somewhere"}
         img = MetaTensor(img_t, affine=affine, meta=meta)

--- a/tests/test_to_from_meta_tensord.py
+++ b/tests/test_to_from_meta_tensord.py
@@ -93,7 +93,6 @@ class TestToFromMetaTensord(unittest.TestCase):
             del out_meta_no_affine["affine"]
             self.assertEqual(orig_meta_no_affine, out_meta_no_affine)
             assert_allclose(out.affine, orig.affine)
-            self.assertTrue(str(device) in str(out.affine.device))
             if check_ids:
                 self.check_ids(out.affine, orig.affine, ids)
                 self.check_ids(out.meta, orig.meta, ids)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4708

### Description
change to assign `metatensor.__dict__` instead of each property individually.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
