### PR TITLE
fix deepedit/nuclick transforms for metatensor

### DIFF
--- a/monai/apps/deepedit/transforms.py
+++ b/monai/apps/deepedit/transforms.py
@@ -72,24 +72,11 @@ class DiscardAddGuidanced(MapTransform):
         d: Dict = dict(data)
         for key in self.key_iterator(d):
             if key == "image":
-                image = d[key]
-                tmp_image = self._apply(image)
-                d[key] = (
-                    MetaTensor(
-                        tmp_image,
-                        affine=image.affine,
-                        applied_operations=image.applied_operations,
-                        meta={
-                            "spatial_shape": image.meta.get("spatial_shape"),
-                            "pixdim": image.meta.get("pixdim"),
-                            "affine": image.meta.get("affine"),
-                            "original_affine": image.meta.get("original_affine"),
-                            "original_channel_dim": image.meta.get("original_channel_dim"),
-                        },
-                    )
-                    if isinstance(image, MetaTensor)
-                    else tmp_image
-                )
+                tmp_image = self._apply(d[key])
+                if isinstance(d[key], MetaTensor):
+                    d[key].array = tmp_image
+                else:
+                    d[key] = tmp_image
             else:
                 print("This transform only applies to the image")
         return d
@@ -257,22 +244,10 @@ class AddGuidanceSignalDeepEditd(MapTransform):
                     # Getting signal based on guidance
                     signal = self._get_signal(image, guidance[key_label])
                     tmp_image = np.concatenate([tmp_image, signal], axis=0)
-                    d[key] = (
-                        MetaTensor(
-                            tmp_image,
-                            affine=image.affine,
-                            applied_operations=image.applied_operations,
-                            meta={
-                                "spatial_shape": image.meta.get("spatial_shape"),
-                                "pixdim": image.meta.get("pixdim"),
-                                "affine": image.meta.get("affine"),
-                                "original_affine": image.meta.get("original_affine"),
-                                "original_channel_dim": image.meta.get("original_channel_dim"),
-                            },
-                        )
-                        if isinstance(image, MetaTensor)
-                        else tmp_image
-                    )
+                    if isinstance(d[key], MetaTensor):
+                        d[key].array = tmp_image
+                    else:
+                        d[key] = tmp_image
                 return d
             else:
                 print("This transform only applies to image key")

--- a/monai/apps/nuclick/transforms.py
+++ b/monai/apps/nuclick/transforms.py
@@ -17,6 +17,7 @@ import numpy as np
 import torch
 
 from monai.config import KeysCollection
+from monai.data import MetaTensor
 from monai.transforms import MapTransform, Randomizable, SpatialPad
 from monai.utils import StrEnum, optional_import
 
@@ -61,7 +62,7 @@ class FlattenLabeld(MapTransform):
     def __call__(self, data):
         d = dict(data)
         for key in self.keys:
-            img = d[key].numpy() if isinstance(d[key], torch.Tensor) else d[key]
+            img = d[key].array if isinstance(d[key], MetaTensor) else d[key]
             d[key] = measure.label(img, connectivity=self.connectivity).astype(np.uint8)
         return d
 
@@ -161,8 +162,8 @@ class SplitLabeld(MapTransform):
         for key in self.keys:
             self.label = key
 
-        label = d[self.label].numpy() if isinstance(d[self.label], torch.Tensor) else d[self.label]
-        mask_value = d[self.mask_value].numpy() if isinstance(d[self.mask_value], torch.Tensor) else d[self.mask_value]
+        label = d[self.label].array if isinstance(d[self.label], MetaTensor) else d[self.label]
+        mask_value = d[self.mask_value].array if isinstance(d[self.mask_value], MetaTensor) else d[self.mask_value]
 
         mask = np.uint8(label == mask_value)
         others = (1 - mask) * label
@@ -203,7 +204,7 @@ class FilterImaged(MapTransform):
     def __call__(self, data):
         d = dict(data)
         for key in self.keys:
-            img = d[key].numpy() if isinstance(d[key], torch.Tensor) else d[key]
+            img = d[key].array if isinstance(d[key], MetaTensor) else d[key]
             d[key] = self.filter(img)
         return d
 
@@ -287,9 +288,9 @@ class AddPointGuidanceSignald(Randomizable, MapTransform):
     def __call__(self, data):
         d = dict(data)
 
-        image = d[self.image].numpy() if isinstance(d[self.image], torch.Tensor) else d[self.image]
-        mask = d[self.label].numpy() if isinstance(d[self.label], torch.Tensor) else d[self.label]
-        others = d[self.others].numpy() if isinstance(d[self.others], torch.Tensor) else d[self.others]
+        image = d[self.image].array if isinstance(d[self.image], MetaTensor) else d[self.image]
+        mask = d[self.label].array if isinstance(d[self.label], MetaTensor) else d[self.label]
+        others = d[self.others].array if isinstance(d[self.others], MetaTensor) else d[self.others]
 
         inc_sig = self.inclusion_map(mask[0])
         exc_sig = self.exclusion_map(others[0], drop_rate=self.drop_rate, jitter_range=self.jitter_range)
@@ -356,7 +357,7 @@ class AddClickSignalsd(MapTransform):
         cx = [xy[0] for xy in pos]
         cy = [xy[1] for xy in pos]
 
-        img = d[self.image].numpy() if isinstance(d[self.image], torch.Tensor) else d[self.image]
+        img = d[self.image].array if isinstance(d[self.image], MetaTensor) else d[self.image]
         img = img.astype(np.uint8)
         img_width = img.shape[-1]
         img_height = img.shape[-2]

--- a/monai/apps/nuclick/transforms.py
+++ b/monai/apps/nuclick/transforms.py
@@ -14,7 +14,6 @@ import random
 from typing import Any, Tuple, Union
 
 import numpy as np
-import torch
 
 from monai.config import KeysCollection
 from monai.data import MetaTensor


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

Fixes # .
 - Using array instead of numpy
 - Create MetaTensor when array channels are added for deepedit to restore previous image state

### Description
Verified for all radiology, pathology and scribble functionalities in MONAILabel (including infer and training tasks)

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
