### PR TITLE
Handle immutable data inputs for patch wsi datasets

### DIFF
--- a/monai/data/wsi_datasets.py
+++ b/monai/data/wsi_datasets.py
@@ -255,7 +255,7 @@ class SlidingPatchWSIDataset(Randomizable, PatchWSIDataset):
 
         self.mask_level = mask_level
         # Create single sample for each patch (in a sliding window manner)
-        self.data = []
+        self.data: list
         self.image_data = list(data)
         for sample in self.image_data:
             patch_samples = self._evaluate_patch_locations(sample)
@@ -365,7 +365,7 @@ class MaskedPatchWSIDataset(PatchWSIDataset):
 
         self.mask_level = mask_level
         # Create single sample for each patch (in a sliding window manner)
-        self.data = []
+        self.data: list
         self.image_data = list(data)
         for sample in self.image_data:
             patch_samples = self._evaluate_patch_locations(sample)

--- a/monai/data/wsi_datasets.py
+++ b/monai/data/wsi_datasets.py
@@ -214,7 +214,7 @@ class SlidingPatchWSIDataset(Randomizable, PatchWSIDataset):
         **kwargs,
     ):
         super().__init__(
-            data=data,
+            data=[],
             patch_size=patch_size,
             patch_level=patch_level,
             transform=transform,
@@ -256,7 +256,7 @@ class SlidingPatchWSIDataset(Randomizable, PatchWSIDataset):
         self.mask_level = mask_level
         # Create single sample for each patch (in a sliding window manner)
         self.data = []
-        self.image_data = data
+        self.image_data = list(data)
         for sample in self.image_data:
             patch_samples = self._evaluate_patch_locations(sample)
             self.data.extend(patch_samples)
@@ -352,7 +352,7 @@ class MaskedPatchWSIDataset(PatchWSIDataset):
         **kwargs,
     ):
         super().__init__(
-            data=data,
+            data=[],
             patch_size=patch_size,
             patch_level=patch_level,
             transform=transform,
@@ -366,7 +366,7 @@ class MaskedPatchWSIDataset(PatchWSIDataset):
         self.mask_level = mask_level
         # Create single sample for each patch (in a sliding window manner)
         self.data = []
-        self.image_data = data
+        self.image_data = list(data)
         for sample in self.image_data:
             patch_samples = self._evaluate_patch_locations(sample)
             self.data.extend(patch_samples)

--- a/tests/test_masked_patch_wsi_dataset.py
+++ b/tests/test_masked_patch_wsi_dataset.py
@@ -16,7 +16,8 @@ from unittest import skipUnless
 from numpy.testing import assert_array_equal
 from parameterized import parameterized
 
-from monai.data import MaskedPatchWSIDataset
+from monai.data import Dataset, MaskedPatchWSIDataset
+from monai.transforms import Lambdad
 from monai.utils import ProbMapKeys, WSIPatchKeys, optional_import, set_determinism
 from tests.utils import download_url_or_skip_test, testing_data_config
 
@@ -48,7 +49,12 @@ TEST_CASE_0 = [
 ]
 
 TEST_CASE_1 = [
-    {"data": ({"image": FILE_PATH, WSIPatchKeys.LEVEL: 8, WSIPatchKeys.SIZE: (2, 2)},), "mask_level": 8},
+    {
+        "data": Dataset([{"image": FILE_PATH}], transform=Lambdad(keys="image", func=lambda x: x[:])),
+        "mask_level": 8,
+        "patch_level": 8,
+        "patch_size": (2, 2),
+    },
     {
         "num_patches": 4256,
         "wsi_size": [32914, 46000],

--- a/tests/test_masked_patch_wsi_dataset.py
+++ b/tests/test_masked_patch_wsi_dataset.py
@@ -17,7 +17,7 @@ from numpy.testing import assert_array_equal
 from parameterized import parameterized
 
 from monai.data import MaskedPatchWSIDataset
-from monai.utils import WSIPatchKeys, optional_import, set_determinism
+from monai.utils import ProbMapKeys, WSIPatchKeys, optional_import, set_determinism
 from tests.utils import download_url_or_skip_test, testing_data_config
 
 set_determinism(0)
@@ -47,6 +47,18 @@ TEST_CASE_0 = [
     },
 ]
 
+TEST_CASE_1 = [
+    {"data": ({"image": FILE_PATH, WSIPatchKeys.LEVEL: 8, WSIPatchKeys.SIZE: (2, 2)},), "mask_level": 8},
+    {
+        "num_patches": 4256,
+        "wsi_size": [32914, 46000],
+        "mask_level": 8,
+        "patch_level": 8,
+        "mask_size": (128, 179),
+        "patch_size": (2, 2),
+    },
+]
+
 
 @skipUnless(has_cucim or has_osl or has_tiff, "Requires cucim, openslide, or tifffile!")
 def setUpModule():
@@ -59,10 +71,15 @@ class MaskedPatchWSIDatasetTests:
     class Tests(unittest.TestCase):
         backend = None
 
-        @parameterized.expand([TEST_CASE_0])
+        @parameterized.expand([TEST_CASE_0, TEST_CASE_1])
         def test_gen_patches(self, input_parameters, expected):
             dataset = MaskedPatchWSIDataset(reader=self.backend, **input_parameters)
             self.assertEqual(len(dataset), expected["num_patches"])
+            self.assertTrue(isinstance(dataset.image_data, list))
+            for d1, d2 in zip(dataset.image_data, input_parameters["data"]):
+                self.assertTrue(d1["image"] == d2["image"])
+                self.assertTrue(d1[ProbMapKeys.NAME] == os.path.basename(d2["image"]))
+
             for i, sample in enumerate(dataset):
                 self.assertEqual(sample["metadata"][WSIPatchKeys.LEVEL], expected["patch_level"])
                 assert_array_equal(sample["metadata"][WSIPatchKeys.SIZE], expected["patch_size"])


### PR DESCRIPTION
Fixes #4724 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
