### PR TITLE
4581 optional final Tanh

### DIFF
--- a/monai/networks/nets/vit.py
+++ b/monai/networks/nets/vit.py
@@ -43,6 +43,7 @@ class ViT(nn.Module):
         num_classes: int = 2,
         dropout_rate: float = 0.0,
         spatial_dims: int = 3,
+        acti="Tanh",
     ) -> None:
         """
         Args:
@@ -58,6 +59,8 @@ class ViT(nn.Module):
             num_classes: number of classes if classification is used.
             dropout_rate: faction of the input units to drop.
             spatial_dims: number of spatial dimensions.
+            acti: add a final acivation function to the classification head when `classification` is True.
+                Default to "Tanh" for `nn.Tanh()`. Set to other values to remove this function.
 
         Examples::
 
@@ -97,7 +100,9 @@ class ViT(nn.Module):
         self.norm = nn.LayerNorm(hidden_size)
         if self.classification:
             self.cls_token = nn.Parameter(torch.zeros(1, 1, hidden_size))
-            self.classification_head = nn.Sequential(nn.Linear(hidden_size, num_classes), nn.Tanh())
+            self.classification_head = nn.Sequential(nn.Linear(hidden_size, num_classes))
+            if acti == "Tanh":
+                self.classification_head.append(nn.Tanh())
 
     def forward(self, x):
         x = self.patch_embedding(x)

--- a/monai/networks/nets/vit.py
+++ b/monai/networks/nets/vit.py
@@ -100,9 +100,10 @@ class ViT(nn.Module):
         self.norm = nn.LayerNorm(hidden_size)
         if self.classification:
             self.cls_token = nn.Parameter(torch.zeros(1, 1, hidden_size))
-            self.classification_head = nn.Sequential(nn.Linear(hidden_size, num_classes))
             if post_activation == "Tanh":
-                self.classification_head.append(nn.Tanh())
+                self.classification_head = nn.Sequential(nn.Linear(hidden_size, num_classes), nn.Tanh())
+            else:
+                self.classification_head = nn.Linear(hidden_size, num_classes)  # type: ignore
 
     def forward(self, x):
         x = self.patch_embedding(x)

--- a/monai/networks/nets/vit.py
+++ b/monai/networks/nets/vit.py
@@ -43,7 +43,7 @@ class ViT(nn.Module):
         num_classes: int = 2,
         dropout_rate: float = 0.0,
         spatial_dims: int = 3,
-        acti="Tanh",
+        post_activation="Tanh",
     ) -> None:
         """
         Args:
@@ -59,7 +59,7 @@ class ViT(nn.Module):
             num_classes: number of classes if classification is used.
             dropout_rate: faction of the input units to drop.
             spatial_dims: number of spatial dimensions.
-            acti: add a final acivation function to the classification head when `classification` is True.
+            post_activation: add a final acivation function to the classification head when `classification` is True.
                 Default to "Tanh" for `nn.Tanh()`. Set to other values to remove this function.
 
         Examples::
@@ -101,7 +101,7 @@ class ViT(nn.Module):
         if self.classification:
             self.cls_token = nn.Parameter(torch.zeros(1, 1, hidden_size))
             self.classification_head = nn.Sequential(nn.Linear(hidden_size, num_classes))
-            if acti == "Tanh":
+            if post_activation == "Tanh":
                 self.classification_head.append(nn.Tanh())
 
     def forward(self, x):

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -51,7 +51,7 @@ for dropout_rate in [0.6]:
                                                 if nd == 2:
                                                     test_case[0]["spatial_dims"] = 2  # type: ignore
                                                     if classification:
-                                                        test_case[0]["acti"] = False  # type: ignore
+                                                        test_case[0]["post_activation"] = False  # type: ignore
                                                 if test_case[0]["classification"]:  # type: ignore
                                                     test_case[2] = (2, test_case[0]["num_classes"])  # type: ignore
                                                 TEST_CASE_Vit.append(test_case)

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -50,6 +50,8 @@ for dropout_rate in [0.6]:
                                                 ]
                                                 if nd == 2:
                                                     test_case[0]["spatial_dims"] = 2  # type: ignore
+                                                    if classification:
+                                                        test_case[0]["acti"] = False  # type: ignore
                                                 if test_case[0]["classification"]:  # type: ignore
                                                     test_case[2] = (2, test_case[0]["num_classes"])  # type: ignore
                                                 TEST_CASE_Vit.append(test_case)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4581
making the final nonlinear optional


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
