### PR TITLE
enhance vit model

### DIFF
--- a/monai/networks/nets/vit.py
+++ b/monai/networks/nets/vit.py
@@ -97,7 +97,7 @@ class ViT(nn.Module):
         self.norm = nn.LayerNorm(hidden_size)
         if self.classification:
             self.cls_token = nn.Parameter(torch.zeros(1, 1, hidden_size))
-            self.classification_head = nn.Sequential(nn.Linear(hidden_size, num_classes), nn.Tanh())
+            self.classification_head = nn.Linear(hidden_size, num_classes)
 
     def forward(self, x):
         x = self.patch_embedding(x)


### PR DESCRIPTION
Signed-off-by: ahatamizadeh <ahatamizadeh@nvidia.com>

PR Removes the activation function in ViT classification head. 

### Description
For some unknown reason, there is an activation function in the classification head of the ViT model. This PR removes it as the architecture should be agnostic to the choice of final activation function.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
