### PR TITLE
4741 Support MetaTensor data type in `Concatitemd`

### DIFF
--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -112,6 +112,7 @@ class Identity(Transform):
         return img
 
 
+@deprecated(since="0.8", msg_suffix="please use MetaTensor data type and monai.transforms.EnsureChannelFirst instead.")
 class AsChannelFirst(Transform):
     """
     Change the channel dimension of the image to the first dimension.
@@ -173,6 +174,7 @@ class AsChannelLast(Transform):
         return out
 
 
+@deprecated(since="0.8", msg_suffix="please use MetaTensor data type and monai.transforms.EnsureChannelFirst instead.")
 class AddChannel(Transform):
     """
     Adds a 1-length channel dimension to the input image.

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -928,7 +928,8 @@ class CopyItemsd(MapTransform):
 class ConcatItemsd(MapTransform):
     """
     Concatenate specified items from data dictionary together on the first dim to construct a big array.
-    Expect all the items are numpy array or PyTorch Tensor.
+    Expect all the items are numpy array or PyTorch Tensor or MetaTensor.
+    Return the first input's meta information when items are MetaTensor.
     """
 
     backend = [TransformBackends.TORCH, TransformBackends.NUMPY]
@@ -950,7 +951,7 @@ class ConcatItemsd(MapTransform):
         """
         Raises:
             TypeError: When items in ``data`` differ in type.
-            TypeError: When the item type is not in ``Union[numpy.ndarray, torch.Tensor]``.
+            TypeError: When the item type is not in ``Union[numpy.ndarray, torch.Tensor, MetaTensor]``.
 
         """
         d = dict(data)
@@ -970,8 +971,12 @@ class ConcatItemsd(MapTransform):
             d[self.name] = np.concatenate(output, axis=self.dim)
         elif data_type is torch.Tensor:
             d[self.name] = torch.cat(output, dim=self.dim)  # type: ignore
+        elif isinstance(d[key], MetaTensor):
+            d[self.name] = torch.cat(output, dim=self.dim)
         else:
-            raise TypeError(f"Unsupported data type: {data_type}, available options are (numpy.ndarray, torch.Tensor).")
+            raise TypeError(
+                f"Unsupported data type: {data_type}, available options are (numpy.ndarray, torch.Tensor, MetaTensor)."
+            )
         return d
 
 

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -969,7 +969,7 @@ class ConcatItemsd(MapTransform):
 
         if data_type is np.ndarray:
             d[self.name] = np.concatenate(output, axis=self.dim)
-        elif issubclass(data_type, torch.Tensor):
+        elif issubclass(data_type, torch.Tensor):  # type: ignore
             d[self.name] = torch.cat(output, dim=self.dim)  # type: ignore
         else:
             raise TypeError(

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -969,10 +969,8 @@ class ConcatItemsd(MapTransform):
 
         if data_type is np.ndarray:
             d[self.name] = np.concatenate(output, axis=self.dim)
-        elif data_type is torch.Tensor:
+        elif issubclass(data_type, torch.Tensor):
             d[self.name] = torch.cat(output, dim=self.dim)  # type: ignore
-        elif isinstance(d[key], MetaTensor):
-            d[self.name] = torch.cat(output, dim=self.dim)
         else:
             raise TypeError(
                 f"Unsupported data type: {data_type}, available options are (numpy.ndarray, torch.Tensor, MetaTensor)."


### PR DESCRIPTION
Fixes #4741 .

### Description
Support `MetaTensor` data type in `Concatitemd`.
Only support basic cat for `MetaTensor` using torch.cat. The output meta is the first input's meta by default.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
