### PR TITLE
Implement GridSplit using torch.as_strided

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -2989,7 +2989,10 @@ class GridSplit(Transform):
         # Flatten the first two dimensions
         strided_image = strided_image.reshape(-1, *strided_image.shape[2:])
         # Make a list of contiguous patches
-        patches = [np.ascontiguousarray(p) for p in strided_image]
+        if isinstance(image, torch.Tensor):
+            patches = [p.contiguous() for p in strided_image]
+        elif isinstance(image, np.ndarray):
+            patches = [np.ascontiguousarray(p) for p in strided_image]
 
         return patches
 


### PR DESCRIPTION
Fixes #4286 

### Description
This PR implements `GridSplit` using `torch.as_strided` instead of `torch.unfold`, which provides significant speedup.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).