### PR TITLE
4772 adds test cases

### DIFF
--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -398,8 +398,8 @@ class Crop(InvertibleTransform):
             return list(roi_slices)
         else:
             if roi_center is not None and roi_size is not None:
-                roi_center_t = convert_to_tensor(data=roi_center, dtype=torch.int16, wrap_sequence=True)
-                roi_size_t = convert_to_tensor(data=roi_size, dtype=torch.int16, wrap_sequence=True)
+                roi_center_t = convert_to_tensor(data=roi_center, dtype=torch.int16, wrap_sequence=True, device="cpu")
+                roi_size_t = convert_to_tensor(data=roi_size, dtype=torch.int16, wrap_sequence=True, device="cpu")
                 _zeros = torch.zeros_like(roi_center_t)
                 half = (
                     torch.divide(roi_size_t, 2, rounding_mode="floor")

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -99,7 +99,7 @@ def get_dtype(data: Any):
 def convert_to_tensor(
     data,
     dtype: Optional[torch.dtype] = None,
-    device: Optional[torch.device] = None,
+    device: Union[None, str, torch.device] = None,
     wrap_sequence: bool = False,
     track_meta: bool = False,
 ):

--- a/tests/padders.py
+++ b/tests/padders.py
@@ -98,6 +98,8 @@ class PadTest(unittest.TestCase):
                             result = result.cpu()
                         assert_allclose(result[unchanged_slices], im, type_test=False)
                         # we should have the same as the input plus some 2s (if value) or 1s and 2s (if constant_values)
+                        if isinstance(im, torch.Tensor):
+                            im = im.detach().cpu().numpy()
                         expected_vals = np.unique(im).tolist()
                         expected_vals += [2] if "value" in kwargs else [1, 2]
                         assert_allclose(np.unique(result), expected_vals, type_test=False)

--- a/tests/test_k_space_spike_noised.py
+++ b/tests/test_k_space_spike_noised.py
@@ -20,7 +20,7 @@ from parameterized import parameterized
 from monai.data.synthetic import create_test_image_2d, create_test_image_3d
 from monai.transforms import KSpaceSpikeNoised
 from monai.utils.misc import set_determinism
-from tests.utils import TEST_NDARRAYS
+from tests.utils import TEST_NDARRAYS, assert_allclose
 
 TESTS = []
 for shape in ((128, 64), (64, 48, 80)):
@@ -91,7 +91,7 @@ class TestKSpaceSpikeNoised(unittest.TestCase):
 
         t = KSpaceSpikeNoised(KEYS, loc, k_intensity)
         out = t(deepcopy(data))
-        np.testing.assert_allclose(out[KEYS[0]], out[KEYS[1]])
+        assert_allclose(out[KEYS[0]], out[KEYS[1]], type_test=False)
 
 
 if __name__ == "__main__":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -739,7 +739,7 @@ def test_local_inversion(invertible_xform, to_invert, im, dict_key=None):
 TEST_TORCH_TENSORS: Tuple[Callable] = (torch.as_tensor,)
 if torch.cuda.is_available():
     gpu_tensor: Callable = partial(torch.as_tensor, device="cuda")
-    TEST_NDARRAYS = TEST_TORCH_TENSORS + (gpu_tensor,)
+    TEST_TORCH_TENSORS = TEST_TORCH_TENSORS + (gpu_tensor,)
 
 DEFAULT_TEST_AFFINE = torch.tensor(
     [[2.0, 0.0, 0.0, 0.0], [0.0, 2.0, 0.0, 0.0], [0.0, 0.0, 2.0, 0.0], [0.0, 0.0, 0.0, 1.0]]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -736,7 +736,7 @@ def test_local_inversion(invertible_xform, to_invert, im, dict_key=None):
     assert_allclose(im_inv.affine, im_ref.affine, atol=1e-3, rtol=1e-3)
 
 
-TEST_TORCH_TENSORS: Tuple[Callable] = (torch.as_tensor,)
+TEST_TORCH_TENSORS: Tuple = (torch.as_tensor,)
 if torch.cuda.is_available():
     gpu_tensor: Callable = partial(torch.as_tensor, device="cuda")
     TEST_TORCH_TENSORS = TEST_TORCH_TENSORS + (gpu_tensor,)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4772

the updated version in the PR will have the cuda test cases:
```py
>>> from tests.utils import TEST_NDARRAYS
>>> print(TEST_NDARRAYS)
(<built-in function array>, <built-in method as_tensor of type object at 0x7f9fe45bf9c0>, functools.partial(<built-in method as_tensor of type object at 0x7f9fe45bf9c0>, device='cuda'), functools.partial(<class 'monai.data.meta_tensor.MetaTensor'>, meta={'a': 'b', 'affine': tensor([[2., 0., 0., 0.],
        [0., 2., 0., 0.],
        [0., 0., 2., 0.],
        [0., 0., 0., 1.]])}))
>>> 
```

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
