### PR TITLE
4774 dtype-percentile

### DIFF
--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -107,8 +107,8 @@ def percentile(
     if isinstance(x, np.ndarray):
         result = np.percentile(x, q, axis=dim, keepdims=keepdim, **kwargs)
     else:
-        q = torch.tensor(q, device=x.device)
-        result = torch.quantile(x, q / 100.0, dim=dim, keepdim=keepdim)
+        q = convert_to_dst_type(q / 100.0, x)[0]
+        result = torch.quantile(x, q, dim=dim, keepdim=keepdim)
     return result
 
 

--- a/tests/test_utils_pytorch_numpy_unification.py
+++ b/tests/test_utils_pytorch_numpy_unification.py
@@ -33,8 +33,9 @@ class TestPytorchNumpyUnification(unittest.TestCase):
         for size in (1, 100):
             q = np.random.randint(0, 100, size=size)
             results = []
-            for p in TEST_NDARRAYS:
-                arr = p(np.arange(100 * 101).reshape(1, 100, 101).astype(np.float32))
+            for idx, p in enumerate(TEST_NDARRAYS):
+                dtype = [np.float32, float][idx % 2]
+                arr = p(np.arange(100 * 101).reshape(1, 100, 101).astype(dtype))
                 results.append(percentile(arr, q))
                 assert_allclose(results[0], results[-1], type_test=False, atol=1e-4, rtol=1e-4)
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4774


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
