### PR TITLE
Update patch merging with a for loop

### DIFF
--- a/monai/networks/nets/swin_unetr.py
+++ b/monai/networks/nets/swin_unetr.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 from typing import Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
@@ -708,26 +709,16 @@ class PatchMergingV2(nn.Module):
             pad_input = (h % 2 == 1) or (w % 2 == 1) or (d % 2 == 1)
             if pad_input:
                 x = F.pad(x, (0, 0, 0, w % 2, 0, h % 2, 0, d % 2))
-            x0 = x[:, 0::2, 0::2, 0::2, :]
-            x1 = x[:, 1::2, 0::2, 0::2, :]
-            x2 = x[:, 0::2, 1::2, 0::2, :]
-            x3 = x[:, 0::2, 0::2, 1::2, :]
-            x4 = x[:, 1::2, 0::2, 1::2, :]
-            x5 = x[:, 1::2, 1::2, 0::2, :]
-            x6 = x[:, 0::2, 1::2, 1::2, :]
-            x7 = x[:, 1::2, 1::2, 1::2, :]
-            x = torch.cat([x0, x1, x2, x3, x4, x5, x6, x7], -1)
+            x = torch.cat(
+                [x[:, i::2, j::2, k::2, :] for i, j, k in itertools.product(range(2), range(2), range(2))], -1
+            )
 
         elif len(x_shape) == 4:
             b, h, w, c = x_shape
             pad_input = (h % 2 == 1) or (w % 2 == 1)
             if pad_input:
                 x = F.pad(x, (0, 0, 0, w % 2, 0, h % 2))
-            x0 = x[:, 0::2, 0::2, :]
-            x1 = x[:, 1::2, 0::2, :]
-            x2 = x[:, 0::2, 1::2, :]
-            x3 = x[:, 1::2, 1::2, :]
-            x = torch.cat([x0, x1, x2, x3], -1)
+            x = torch.cat([x[:, i::2, j::2, :] for i, j in itertools.product(range(2), range(2))], -1)
 
         x = self.norm(x)
         x = self.reduction(x)

--- a/monai/networks/nets/swin_unetr.py
+++ b/monai/networks/nets/swin_unetr.py
@@ -718,7 +718,7 @@ class PatchMergingV2(nn.Module):
             pad_input = (h % 2 == 1) or (w % 2 == 1)
             if pad_input:
                 x = F.pad(x, (0, 0, 0, w % 2, 0, h % 2))
-            x = torch.cat([x[:, i::2, j::2, :] for i, j in itertools.product(range(2), range(2))], -1)
+            x = torch.cat([x[:, j::2, i::2, :] for i, j in itertools.product(range(2), range(2))], -1)
 
         x = self.norm(x)
         x = self.reduction(x)


### PR DESCRIPTION
Fixes #4735

### Description
Update the patch merging process with a for loop to make it less error-prone and more readable.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
