### PR TITLE
4799 change deprecation warning category to provide more info at runtime

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -21,7 +21,6 @@ dependencies:
   - flake8>=3.8.1
   - flake8-bugbear
   - flake8-comprehensions
-  - flake8-pyi
   - pylint
   - mccabe
   - pep8-naming

--- a/monai/utils/deprecate_utils.py
+++ b/monai/utils/deprecate_utils.py
@@ -31,7 +31,7 @@ def warn_deprecated(obj, msg, warning_category=FutureWarning):
     """
     Issue the warning message `msg`.
     """
-    warnings.warn(msg, category=warning_category, stacklevel=2)
+    warnings.warn(f"{obj}: {msg}", category=warning_category, stacklevel=2)
 
 
 def deprecated(
@@ -89,7 +89,7 @@ def deprecated(
         is_func = isinstance(obj, FunctionType)
         call_obj = obj if is_func else obj.__init__
 
-        msg_prefix = f"{'Function' if is_func else 'Class'} `{obj.__name__}`"
+        msg_prefix = f"{'Function' if is_func else 'Class'} `{obj.__qualname__}`"
 
         if is_removed:
             msg_infix = f"was removed in version {removed}."
@@ -178,7 +178,7 @@ def deprecated_arg(
         is_removed = removed is not None and version_leq(removed, version_val)
 
     def _decorator(func):
-        argname = f"{func.__name__}_{name}"
+        argname = f"{func.__module__} {func.__qualname__}:{name}"
 
         msg_prefix = f"Argument `{name}`"
 

--- a/monai/utils/deprecate_utils.py
+++ b/monai/utils/deprecate_utils.py
@@ -27,15 +27,19 @@ class DeprecatedError(Exception):
     pass
 
 
-def warn_deprecated(obj, msg):
+def warn_deprecated(obj, msg, warning_category=FutureWarning):
     """
     Issue the warning message `msg`.
     """
-    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+    warnings.warn(msg, category=warning_category, stacklevel=2)
 
 
 def deprecated(
-    since: Optional[str] = None, removed: Optional[str] = None, msg_suffix: str = "", version_val: str = __version__
+    since: Optional[str] = None,
+    removed: Optional[str] = None,
+    msg_suffix: str = "",
+    version_val: str = __version__,
+    warning_category=FutureWarning,
 ):
     """
     Marks a function or class as deprecated. If `since` is given this should be a version at or earlier than the
@@ -43,7 +47,7 @@ def deprecated(
     this can be any version and marks when the definition was removed.
 
     When the decorated definition is called, that is when the function is called or the class instantiated,
-    a `DeprecationWarning` is issued if `since` is given and the current version is at or later than that given.
+    a `warning_category` is issued if `since` is given and the current version is at or later than that given.
     a `DeprecatedError` exception is instead raised if `removed` is given and the current version is at or later
     than that, or if neither `since` nor `removed` is provided.
 
@@ -56,6 +60,7 @@ def deprecated(
         removed: version at which the definition was removed and no longer usable.
         msg_suffix: message appended to warning/exception detailing reasons for deprecation and what to use instead.
         version_val: (used for testing) version to compare since and removed against, default is MONAI version.
+        warning_category: a warning category class, defaults to `FutureWarning`.
 
     Returns:
         Decorated definition which warns or raises exception when used
@@ -102,7 +107,7 @@ def deprecated(
             if is_removed:
                 raise DeprecatedError(msg)
             if is_deprecated:
-                warn_deprecated(obj, msg)
+                warn_deprecated(obj, msg, warning_category)
 
             return call_obj(*args, **kwargs)
 
@@ -121,13 +126,14 @@ def deprecated_arg(
     msg_suffix: str = "",
     version_val: str = __version__,
     new_name: Optional[str] = None,
+    warning_category=FutureWarning,
 ):
     """
     Marks a particular named argument of a callable as deprecated. The same conditions for `since` and `removed` as
     described in the `deprecated` decorator.
 
     When the decorated definition is called, that is when the function is called or the class instantiated with args,
-    a `DeprecationWarning` is issued if `since` is given and the current version is at or later than that given.
+    a `warning_category` is issued if `since` is given and the current version is at or later than that given.
     a `DeprecatedError` exception is instead raised if `removed` is given and the current version is at or later
     than that, or if neither `since` nor `removed` is provided.
 
@@ -147,6 +153,7 @@ def deprecated_arg(
         new_name: name of position or keyword argument to replace the deprecated argument.
             if it is specified and the signature of the decorated function has a `kwargs`, the value to the
             deprecated argument `name` will be removed.
+        warning_category: a warning category class, defaults to `FutureWarning`.
 
     Returns:
         Decorated callable which warns or raises exception when deprecated argument used.
@@ -212,7 +219,7 @@ def deprecated_arg(
                 if is_removed:
                     raise DeprecatedError(msg)
                 if is_deprecated:
-                    warn_deprecated(argname, msg)
+                    warn_deprecated(argname, msg, warning_category)
 
             return func(*args, **kwargs)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,6 @@ flake8>=3.8.1
 flake8-bugbear
 flake8-comprehensions
 flake8-executable
-flake8-pyi
 pylint!=2.13  # https://github.com/PyCQA/pylint/issues/5969
 mccabe
 pep8-naming

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -38,7 +38,7 @@ class TestDeprecatedRC(unittest.TestCase):
         def foo2():
             pass
 
-        self.assertWarns(DeprecationWarning, foo2)
+        self.assertWarns(FutureWarning, foo2)
 
     def test_warning_last(self):
         """Test deprecated decorator with `since` and `removed` set, for the last version"""
@@ -72,7 +72,7 @@ class TestDeprecated(unittest.TestCase):
         def foo1():
             pass
 
-        self.assertWarns(DeprecationWarning, foo1)
+        self.assertWarns(FutureWarning, foo1)
 
     def test_warning2(self):
         """Test deprecated decorator with `since` and `removed` set."""
@@ -81,7 +81,7 @@ class TestDeprecated(unittest.TestCase):
         def foo2():
             pass
 
-        self.assertWarns(DeprecationWarning, foo2)
+        self.assertWarns(FutureWarning, foo2)
 
     def test_except1(self):
         """Test deprecated decorator raises exception with no versions set."""
@@ -108,7 +108,7 @@ class TestDeprecated(unittest.TestCase):
         class Foo1:
             pass
 
-        self.assertWarns(DeprecationWarning, Foo1)
+        self.assertWarns(FutureWarning, Foo1)
 
     def test_class_warning2(self):
         """Test deprecated decorator with `since` and `removed` set."""
@@ -117,7 +117,7 @@ class TestDeprecated(unittest.TestCase):
         class Foo2:
             pass
 
-        self.assertWarns(DeprecationWarning, Foo2)
+        self.assertWarns(FutureWarning, Foo2)
 
     def test_class_except1(self):
         """Test deprecated decorator raises exception with no versions set."""
@@ -145,7 +145,7 @@ class TestDeprecated(unittest.TestCase):
             def meth1(self):
                 pass
 
-        self.assertWarns(DeprecationWarning, lambda: Foo5().meth1())
+        self.assertWarns(FutureWarning, lambda: Foo5().meth1())
 
     def test_meth_except1(self):
         """Test deprecated decorator with just `since` set."""
@@ -166,7 +166,7 @@ class TestDeprecated(unittest.TestCase):
 
         afoo1(1)  # ok when no b provided
 
-        self.assertWarns(DeprecationWarning, lambda: afoo1(1, 2))
+        self.assertWarns(FutureWarning, lambda: afoo1(1, 2))
 
     def test_arg_warn2(self):
         """Test deprecated_arg decorator with just `since` set."""
@@ -177,7 +177,7 @@ class TestDeprecated(unittest.TestCase):
 
         afoo2(1)  # ok when no b provided
 
-        self.assertWarns(DeprecationWarning, lambda: afoo2(1, b=2))
+        self.assertWarns(FutureWarning, lambda: afoo2(1, b=2))
 
     def test_arg_except1(self):
         """Test deprecated_arg decorator raises exception with no versions set."""
@@ -207,8 +207,8 @@ class TestDeprecated(unittest.TestCase):
 
         afoo5(1)  # ok when no b or c provided
 
-        self.assertWarns(DeprecationWarning, lambda: afoo5(1, 2))
-        self.assertWarns(DeprecationWarning, lambda: afoo5(1, 2, 3))
+        self.assertWarns(FutureWarning, lambda: afoo5(1, 2))
+        self.assertWarns(FutureWarning, lambda: afoo5(1, 2, 3))
 
     def test_future(self):
         """Test deprecated decorator with `since` set to a future version."""
@@ -217,9 +217,9 @@ class TestDeprecated(unittest.TestCase):
         def future1():
             pass
 
-        with self.assertWarns(DeprecationWarning) as aw:
+        with self.assertWarns(FutureWarning) as aw:
             future1()
-            warnings.warn("fake warning", DeprecationWarning)
+            warnings.warn("fake warning", FutureWarning)
 
         self.assertEqual(aw.warning.args[0], "fake warning")
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4799
Fixes #4803

### Description
update `warn_deprecated` category

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
