### PR TITLE
correct blossom trigger list format

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -29,9 +29,12 @@ jobs:
       args: ${{ env.args }}
 
     # This job only runs for pull request comments
-    if: |
-         contains( 'Nic-Ma,wyli,pxLi,YanxuanLiu', format('{0},', github.actor)) &&
-         github.event.comment.body == '/build'
+    if: contains('\
+      Nic-Ma,\
+      wyli,\
+      pxLi,\
+      YanxuanLiu,\
+      ', format('{0},', github.actor)) && github.event.comment.body == '/build'
     steps:
       - name: Check if comment is issued by authorized person
         run: blossom-ci


### PR DESCRIPTION
### Description
Fix the issue `Cannot trigger pre-merge correctly`

Modifications:
1. add a missing ',' after usre ID.
2. switch the trigger list to new line pattern to avoid the issue.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
