### PR TITLE
Add Time Profiler Class

### DIFF
--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -93,6 +93,7 @@ from .nvtx import Range
 from .profiling import (
     PerfContext,
     WorkflowProfiler,
+    ProfileHandler,
     select_transform_call,
     torch_profiler_full,
     torch_profiler_time_cpu_gpu,

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -90,7 +90,14 @@ from .module import (
     version_leq,
 )
 from .nvtx import Range
-from .profiling import PerfContext, torch_profiler_full, torch_profiler_time_cpu_gpu, torch_profiler_time_end_to_end
+from .profiling import (
+    PerfContext,
+    WorkflowProfiler,
+    select_transform_call,
+    torch_profiler_full,
+    torch_profiler_time_cpu_gpu,
+    torch_profiler_time_end_to_end,
+)
 from .state_cacher import StateCacher
 from .type_conversion import (
     convert_data_type,

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -92,8 +92,8 @@ from .module import (
 from .nvtx import Range
 from .profiling import (
     PerfContext,
-    WorkflowProfiler,
     ProfileHandler,
+    WorkflowProfiler,
     select_transform_call,
     torch_profiler_full,
     torch_profiler_time_cpu_gpu,

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -154,7 +154,7 @@ class WorkflowProfiler:
     This profiler must be used only within its context because it uses an internal thread to read results from a
     multiprocessing queue. This allows the profiler to function across multiple threads and processes, though the
     multiprocess tracing is at times unreliable and not available in Windows at all.
-    
+
     The profiler uses `sys.settrace` and `threading.settrace` to find all calls to profile, this will be set when
     the context enters and cleared when it exits so proper use of the context is essential to prevent excessive
     tracing. Note that tracing has a high overhead so times will not accurately reflect real world performance

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -323,7 +323,7 @@ class WorkflowProfiler:
         """Wrapper around anything iterable to profile how long it takes to generate items."""
 
         class _Iterable:
-            def __iter__(_self):  # noqa: B902, N805
+            def __iter__(_self):  # noqa: B902 N805 E0213
                 do_iter = True
                 orig_iter = iter(iterable)
                 caller = getframeinfo(stack()[1][0])

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -299,7 +299,7 @@ class WorkflowProfiler:
         """Creates a context to profile, placing a timing result onto the queue when it exits."""
         if caller is None:
             caller = getframeinfo(stack()[2][0])  # caller of context, not something in contextlib
-            
+
         start = perf_counter_ns()
         try:
             yield
@@ -321,9 +321,9 @@ class WorkflowProfiler:
 
     def profile_iter(self, name, iterable):
         """Wrapper around anything iterable to profile how long it takes to generate items."""
-        
+
         class _Iterable:
-            def __iter__(_self):
+            def __iter__(_self):  # noqa: B902 N805
                 do_iter = True
                 orig_iter = iter(iterable)
                 caller = getframeinfo(stack()[1][0])
@@ -338,7 +338,7 @@ class WorkflowProfiler:
                         yield item
                     except StopIteration:
                         do_iter = False
-        
+
         return _Iterable()
 
     def get_times_summary(self, times_in_s=True):
@@ -383,35 +383,36 @@ class WorkflowProfiler:
             for r in rlist:
                 writer.writerow(r._asdict())
 
-                
+
 class ProfileHandler:
     """
     Handler for Ignite Engine classes which measures the time from a start event ton an end event. This can be used to
     profile epoch, iteration, and other events as defined in `ignite.engine.Events`. This class should be used only
     within the context of a profiler object.
-    
+
     Args:
         name: name of event to profile
         profiler: instance of WorkflowProfiler used by the handler, should be within the context of this object
         start_event: item in `ignite.engine.Events` stating event at which to start timing
         end_event: item in `ignite.engine.Events` stating event at which to stop timing
     """
-    def __init__(self,name:str, profiler:WorkflowProfiler, start_event, end_event):
-        self.name=name
-        self.profiler=profiler
-        self.start_event=start_event
-        self.end_event=end_event
-        self.ctx=None
-        
+
+    def __init__(self, name: str, profiler: WorkflowProfiler, start_event, end_event):
+        self.name = name
+        self.profiler = profiler
+        self.start_event = start_event
+        self.end_event = end_event
+        self.ctx = None
+
     def attach(self, engine):
         engine.add_event_handler(self.start_event, self.start)
         engine.add_event_handler(self.end_event, self.end)
         return self
-        
+
     def start(self, engine):
-        self.ctx=self.profiler.profile_ctx(self.name)
+        self.ctx = self.profiler.profile_ctx(self.name)
         self.ctx.__enter__()
-        
+
     def end(self, engine):
         self.ctx.__exit__(None, None, None)
-        self.ctx=None
+        self.ctx = None

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -168,6 +168,9 @@ class WorkflowProfiler:
     .. code-block:: python
 
         import monai.transform as mt
+        from monai.utils import WorkflowProfiler
+        import torch
+
         comp=mt.Compose([mt.ScaleIntensity(),mt.RandAxisFlip(0.5)])
 
         with WorkflowProfiler() as wp:

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -323,7 +323,7 @@ class WorkflowProfiler:
         """Wrapper around anything iterable to profile how long it takes to generate items."""
 
         class _Iterable:
-            def __iter__(_self):  # noqa: B902 N805
+            def __iter__(_self):  # noqa: B902, N805
                 do_iter = True
                 orig_iter = iter(iterable)
                 caller = getframeinfo(stack()[1][0])

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -323,7 +323,7 @@ class WorkflowProfiler:
         """Wrapper around anything iterable to profile how long it takes to generate items."""
 
         class _Iterable:
-            def __iter__(_self):  # noqa: B902 N805 E0213
+            def __iter__(_self):  # noqa: B902, N805
                 do_iter = True
                 orig_iter = iter(iterable)
                 caller = getframeinfo(stack()[1][0])

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -323,7 +323,7 @@ class WorkflowProfiler:
         """Wrapper around anything iterable to profile how long it takes to generate items."""
 
         class _Iterable:
-            def __iter__(_self):  # noqa: B902, N805
+            def __iter__(_self):  # noqa: B902, N805 pylint: disable=E0213
                 do_iter = True
                 orig_iter = iter(iterable)
                 caller = getframeinfo(stack()[1][0])

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -9,12 +9,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+import csv
+import datetime
+import multiprocessing
+import os
+import sys
+import threading
+from collections import defaultdict, namedtuple
+from contextlib import contextmanager
 from functools import wraps
+from inspect import getframeinfo, stack
+from queue import Empty
+from time import perf_counter, perf_counter_ns
 
+import numpy as np
 import torch
 
-__all__ = ["torch_profiler_full", "torch_profiler_time_cpu_gpu", "torch_profiler_time_end_to_end", "PerfContext"]
+from monai.utils import optional_import
+
+pd, has_pandas = optional_import("pandas")
+
+__all__ = [
+    "torch_profiler_full",
+    "torch_profiler_time_cpu_gpu",
+    "torch_profiler_time_end_to_end",
+    "PerfContext",
+    "WorkflowProfiler",
+    "select_transform_call",
+]
 
 
 def torch_profiler_full(func):
@@ -74,16 +96,16 @@ def torch_profiler_time_end_to_end(func):
     def wrapper(*args, **kwargs):
 
         torch.cuda.synchronize()
-        start = time.perf_counter()
+        start = perf_counter()
 
         result = func(*args, **kwargs)
 
         torch.cuda.synchronize()
-        end = time.perf_counter()
+        end = perf_counter()
 
         total_time = (end - start) * 1e6
         total_time_str = torch.autograd.profiler.format_time(total_time)
-        print(f"end to end time: {total_time_str}", flush=True)
+        print(f"End-to-end time: {total_time_str}", flush=True)
 
         return result
 
@@ -102,9 +124,269 @@ class PerfContext:
         self.start_time = None
 
     def __enter__(self):
-        self.start_time = time.perf_counter()
+        self.start_time = perf_counter()
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.total_time += time.perf_counter() - self.start_time
+        self.total_time += perf_counter() - self.start_time
         self.start_time = None
+
+
+# stores the results from profiling with trace or with other helper methods
+ProfileResult = namedtuple("ProfileResult", ["name", "time", "filename", "lineno", "pid", "timestamp"])
+
+
+def select_transform_call(frame):
+    """Returns True if `frame` is a call to a `Transform` object's `_call__` method."""
+    from monai.transforms import Transform  # prevents circular import
+
+    self_obj = frame.f_locals.get("self", None)
+    return frame.f_code.co_name == "__call__" and isinstance(self_obj, Transform)
+
+
+class WorkflowProfiler:
+    """
+    Profiler for timing all aspects of a workflow. This includes using stack tracing to capture call times for
+    all selected calls (by default calls to `Transform.__call__` methods), times within context blocks, times
+    to generate items from iterables, and times to execute decorated functions.
+
+    This profiler must be used only within its context because it uses an internal thread to read results from a
+    multiprocessing queue, this allows the profiler to function across multiple threads and processes. The
+    profiler uses `sys.settrace` and `threading.settrace` to find all calls to profile, this will be set when
+    the context enters and cleared when it exits so proper use of the context is essential to prevent excessive
+    tracing. Note that tracing has a high overhead so times will not accurately reflect real world performance
+    but give an idea of relative share of time spent.
+
+    The tracing functionality uses a selector to choose which calls to trace, since tracing all calls induces
+    infinite loops and would be terribly slow even if not. This selector is a callable accepting a `call` trace
+    frame and returns True if the call should be traced. The dedault is `select_transform_call` which will return
+    True for `Transform.__call__` calls only.
+
+    Example showing use of all profiling functions:
+
+    .. code-block:: python
+
+        import monai.transform as mt
+        comp=mt.Compose([mt.ScaleIntensity(),mt.RandAxisFlip(0.5)])
+
+        with WorkflowProfiler() as wp:
+            for _ in wp.profile_iter("range",range(5)):
+                with wp.profile_ctx("Loop"):
+                    for i in range(10):
+                        comp(torch.rand(1,16,16))
+
+            @wp.profile_callable()
+            def foo(): pass
+
+            foo()
+            foo()
+
+        print(wp.get_times_summary_pd())  # print results
+
+    Args:
+        call_selector: selector to determine which calls to trace, use None to disable tracing
+    """
+
+    def __init__(self, call_selector=select_transform_call):
+        self.results = defaultdict(list)
+        self.parent_pid = os.getpid()
+        self.read_thread = None
+        self.lock = threading.RLock()
+        self.queue = multiprocessing.SimpleQueue()
+        self.queue_timeout = 0.1
+        self.call_selector = call_selector
+
+    def _is_parent(self):
+        """Return True if this is the parent process."""
+        return os.getpid() == self.parent_pid
+
+    def _is_thread_active(self):
+        """Return True if the read thread should be still active."""
+        return self.read_thread is not None or not self.queue.empty()
+
+    def _read_thread_func(self):
+        """Read results from the queue and add to self.results in a thread stared by `__enter__`."""
+        while self._is_parent() and self._is_thread_active():
+            try:
+                result = self.queue.get()
+
+                if result is None:
+                    break
+
+                self.add_result(result)
+            except Empty:
+                pass
+
+        assert not self._is_parent() or self.queue.empty()
+
+    def _put_result(self, name, timedelta, filename, lineno):
+        """Add a ProfileResult object to the queue."""
+        ts = str(datetime.datetime.now())
+        self.queue.put(ProfileResult(name, timedelta, filename, lineno, os.getpid(), ts))
+
+    def _trace_call(self, frame, why, arg):
+        """
+        Trace calls, when a call is encountered that is accepted by self.call_selector, create a new function to
+        trace that call and measure the time from the call to a "return" frame.
+        """
+        if why == "call":
+            if self.call_selector(frame):
+                calling_frame = frame
+                start = perf_counter_ns()
+
+                def _call_profiler(frame, why, arg):
+                    """Defines a new inner trace function just for this call."""
+                    if why == "return":
+                        diff = perf_counter_ns() - start
+                        f_code = calling_frame.f_code
+                        self_obj = calling_frame.f_locals.get("self", None)
+                        name = f_code.co_name
+                        if self_obj is not None:
+                            name = f"{type(self_obj).__name__}.{name}"
+
+                        self._put_result(name, diff, f_code.co_filename, f_code.co_firstlineno)
+
+                # This function will be used to trace this specific call now, however any new functions calls
+                # within will cause a "call" frame to be sent to `_trace_call` rather than to it, ie. it's not
+                # actually recursively tracing everything below as the documentation suggests and so cannot
+                # control whether subsequence calls are traced (see https://bugs.python.org/issue11992).
+                return _call_profiler
+        else:
+            return self._trace_call
+
+    def __enter__(self):
+        """Enter the context, creating the read thread and setting up tracing if needed."""
+        self.read_thread = threading.Thread(target=self._read_thread_func)
+        self.read_thread.start()
+
+        if self.call_selector is not None:
+            threading.settrace(self._trace_call)
+            sys.settrace(self._trace_call)
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Terminate the read thread cleanly and reset tracing if needed."""
+        assert self._is_parent()
+
+        self.queue.put(None)
+
+        read_thread = self.read_thread
+        self.read_thread = None
+
+        read_thread.join()
+
+        if self.call_selector is not None:
+            threading.settrace(None)
+            sys.settrace(None)
+
+    def add_result(self, result: ProfileResult):
+        """Add a result in a thread-safe manner to the internal results dictionary."""
+        with self.lock:
+            self.results[result.name].append(result)
+
+    def get_results(self):
+        """Get a fresh results dictionary containing fresh tuples of ProfileResult objects."""
+        if not self._is_parent():
+            raise RuntimeError("Only parent process can collect results")
+
+        with self.lock:
+            return {k: tuple(v) for k, v in self.results.items()}
+
+    @contextmanager
+    def profile_ctx(self, name, caller=None):
+        """Creates a context to profile, placing a timing result onto the queue when it exits."""
+        if caller is None:
+            caller = getframeinfo(stack()[2][0])  # caller of context, not something in contextlib
+            
+        start = perf_counter_ns()
+        try:
+            yield
+        finally:
+            diff = perf_counter_ns() - start
+            self._put_result(name, diff, caller.filename, caller.lineno)
+
+    def profile_callable(self, name=None):
+        """
+        Decorator which can be applied to a function which profiles any calls to it. All calls to decorated
+        callables must be done within the context of the profiler.
+        """
+
+        def _outer(func):
+            _name = func.__name__ if name is None else name
+
+            return self.profile_ctx(_name)(func)
+            # @wraps(func)
+            # def _wrapper(*args, **kwargs):
+            #     caller = getframeinfo(stack()[1][0])
+            #     with self.profile_ctx(_name, caller):
+            #         return func(*args, **kwargs)
+
+            return _wrapper
+
+        return _outer
+
+    def profile_iter(self, name, iterable):
+        """Wrapper around anything iterable to profile how long it takes to generate items."""
+        
+        class _Iterable:
+            def __iter__(_self):
+                do_iter = True
+                orig_iter = iter(iterable)
+                caller = getframeinfo(stack()[1][0])
+
+                while do_iter:
+                    try:
+                        start = perf_counter_ns()
+                        item = next(orig_iter)
+                        diff = perf_counter_ns() - start
+                        # don't put result when StopIteration is hit
+                        self._put_result(name, diff, caller.filename, caller.lineno)
+                        yield item
+
+                    except StopIteration:
+                        do_iter = False
+        
+        return _Iterable()
+
+    def get_times_summary(self, times_in_s=True):
+        """
+        Returns a dictionary mapping results entries to tuples containing the number of items, time sum, time average,
+        time std dev, time min, and time max.
+        """
+        result = {}
+        for k, v in self.get_results().items():
+            timemult = 1e-9 if times_in_s else 1.0
+            all_times = [res.time * timemult for res in v]
+
+            timesum = sum(all_times)
+            timeavg = timesum / len(all_times)
+            timestd = np.std(all_times)
+            timemin = min(all_times)
+            timemax = max(all_times)
+
+            result[k] = (len(v), timesum, timeavg, timestd, timemin, timemax)
+
+        return result
+
+    def get_times_summary_pd(self, times_in_s=True):
+        """Returns the same informatoin as `get_times_summary` but in a Pandas DataFrame."""
+        import pandas as pd
+
+        summ = self.get_times_summary(times_in_s)
+        suffix = "s" if times_in_s else "ns"
+        columns = ["Count", f"Total Time ({suffix})", "Avg", "Std", "Min", "Max"]
+
+        df = pd.DataFrame.from_dict(summ, orient="index", columns=columns)
+        df = df.sort_values(columns[1], ascending=False)
+        return df
+
+    def dump_csv(self, stream=sys.stdout):
+        """Save all results to a csv file."""
+        all_results = list(self.get_results().values())
+        writer = csv.DictWriter(stream, fieldnames=all_results[0][0]._asdict().keys())
+        writer.writeheader()
+
+        for rlist in all_results:
+            for r in rlist:
+                writer.writerow(r._asdict())

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -152,8 +152,10 @@ class WorkflowProfiler:
     to generate items from iterables, and times to execute decorated functions.
 
     This profiler must be used only within its context because it uses an internal thread to read results from a
-    multiprocessing queue, this allows the profiler to function across multiple threads and processes. The
-    profiler uses `sys.settrace` and `threading.settrace` to find all calls to profile, this will be set when
+    multiprocessing queue. This allows the profiler to function across multiple threads and processes, though the
+    multiprocess tracing is at times unreliable and not available in Windows at all.
+    
+    The profiler uses `sys.settrace` and `threading.settrace` to find all calls to profile, this will be set when
     the context enters and cleared when it exits so proper use of the context is essential to prevent excessive
     tracing. Note that tracing has a high overhead so times will not accurately reflect real world performance
     but give an idea of relative share of time spent.

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -18,7 +18,6 @@ import torch
 
 import monai.transforms as mt
 from monai.data import DataLoader, Dataset, ThreadDataLoader
-from monai.engines import SupervisedTrainer
 from monai.utils import first, optional_import
 from monai.utils.enums import CommonKeys
 from monai.utils.profiling import ProfileHandler, ProfileResult, WorkflowProfiler
@@ -195,6 +194,7 @@ class TestWorkflowProfiler(unittest.TestCase):
     @SkipIfNoModule("ignite")
     def test_handler(self):
         """Test profiling Engine objects works if Ignite is present."""
+        from monai.engines import SupervisedTrainer
         from ignite.engine import Events
 
         net = torch.nn.Conv2d(1, 1, 3, padding=1)

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -68,25 +68,6 @@ class TestWorkflowProfiler(unittest.TestCase):
 
         self.assertIsInstance(dt, datetime.datetime)
 
-    @skip_if_windows
-    @skip_if_darwin
-    def test_profile_multiprocess(self):
-        """Test results are gathered from multiple processes, profiling across processes fails in Windows."""
-        ds = Dataset([self.test_image] * 4, self.scale)
-        dl = DataLoader(ds, batch_size=4, num_workers=4)
-
-        with WorkflowProfiler() as wp:
-            batch = first(dl)
-
-        self.assertSequenceEqual(batch.shape, (4, 1, 16, 16, 16))
-
-        results = wp.get_results()
-        self.assertSequenceEqual(list(results), [self.scale_call_name])
-
-        prs = results[self.scale_call_name]
-
-        self.assertEqual(len(prs), 4)
-
     def test_profile_multithread(self):
         """Test resulst are gathered from multiple threads using ThreadDataLoader."""
         ds = Dataset([self.test_image] * 4, self.scale)

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -21,7 +21,7 @@ from monai.data import DataLoader, Dataset, ThreadDataLoader
 from monai.utils import first, optional_import
 from monai.utils.enums import CommonKeys
 from monai.utils.profiling import ProfileHandler, ProfileResult, WorkflowProfiler
-from tests.utils import SkipIfNoModule, skip_if_windows
+from tests.utils import SkipIfNoModule, skip_if_darwin, skip_if_windows
 
 pd, _ = optional_import("pandas")
 
@@ -69,6 +69,7 @@ class TestWorkflowProfiler(unittest.TestCase):
         self.assertIsInstance(dt, datetime.datetime)
 
     @skip_if_windows
+    @skip_if_darwin
     def test_profile_multiprocess(self):
         """Test results are gathered from multiple processes, profiling across processes fails in Windows."""
         ds = Dataset([self.test_image] * 4, self.scale)

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -194,8 +194,9 @@ class TestWorkflowProfiler(unittest.TestCase):
     @SkipIfNoModule("ignite")
     def test_handler(self):
         """Test profiling Engine objects works if Ignite is present."""
-        from monai.engines import SupervisedTrainer
         from ignite.engine import Events
+
+        from monai.engines import SupervisedTrainer
 
         net = torch.nn.Conv2d(1, 1, 3, padding=1)
         im = torch.rand(1, 1, 16, 16)

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,0 +1,150 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import os
+import unittest
+
+import torch
+
+from tests.utils import SkipIfNoModule
+
+import monai.transforms as mt
+from monai.utils import optional_import
+from monai.utils.profiling import ProfileResult, WorkflowProfiler
+from io import StringIO
+
+pd, _ = optional_import("pandas")
+
+
+class TestWorkflowProfiler(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.scale = mt.ScaleIntensity()
+        self.test_comp = mt.Compose([mt.ScaleIntensity(), mt.RandAxisFlip(0.5)])
+        self.test_image = torch.rand(1, 16, 16, 16)
+        self.pid = os.getpid()
+
+    def test_empty(self):
+        wp = WorkflowProfiler()
+
+        with wp:
+            pass
+
+        self.assertEqual(wp.get_results(), {})
+
+    def test_profile_transforms(self):
+        call_name = "ScaleIntensity.__call__"
+        with WorkflowProfiler() as wp:
+            self.scale(self.test_image)
+
+        results = wp.get_results()
+        self.assertSequenceEqual(list(results), [call_name])
+
+        prs = results[call_name]
+
+        self.assertEqual(len(prs), 1)
+
+        pr = prs[0]
+
+        self.assertIsInstance(pr, ProfileResult)
+        self.assertEqual(pr.name, call_name)
+        self.assertEqual(pr.pid, self.pid)
+        self.assertGreater(pr.time, 0)
+
+        dt = datetime.datetime.fromisoformat(pr.timestamp)
+
+        self.assertIsInstance(dt, datetime.datetime)
+
+    def test_profile_context(self):
+        with WorkflowProfiler() as wp:
+            with wp.profile_ctx("context"):
+                self.scale(self.test_image)
+
+            with wp.profile_ctx("context"):
+                self.scale(self.test_image)
+
+        results = wp.get_results()
+        self.assertSequenceEqual(set(results), {"ScaleIntensity.__call__", "context"})
+
+        prs = results["context"]
+
+        self.assertEqual(len(prs), 2)
+
+    def test_profile_callable(self):
+        def funca():
+            pass
+
+        with WorkflowProfiler() as wp:
+            funca = wp.profile_callable()(funca)
+
+            funca()
+
+            @wp.profile_callable("funcb")
+            def _func():
+                pass
+
+            _func()
+            _func()
+
+        results = wp.get_results()
+        self.assertSequenceEqual(set(results), {"funca", "funcb"})
+
+        self.assertEqual(len(results["funca"]), 1)
+        self.assertEqual(len(results["funcb"]), 2)
+
+    def test_profile_iteration(self):
+        with WorkflowProfiler() as wp:
+            range_vals = []
+
+            for i in wp.profile_iter("range5", range(5)):
+                range_vals.append(i)
+
+            self.assertSequenceEqual(range_vals, list(range(5)))
+
+        results = wp.get_results()
+        self.assertSequenceEqual(set(results), {"range5"})
+
+        self.assertEqual(len(results["range5"]), 5)
+
+    def test_times_summary(self):
+        call_name = "ScaleIntensity.__call__"
+
+        with WorkflowProfiler() as wp:
+            self.scale(self.test_image)
+
+        tsum = wp.get_times_summary()
+
+        self.assertSequenceEqual(list(tsum), [call_name])
+
+        times = tsum[call_name]
+
+        self.assertEqual(len(times), 6)
+        self.assertEqual(times[0], 1)
+
+    @SkipIfNoModule("pandas")
+    def test_times_summary_pd(self):
+        with WorkflowProfiler() as wp:
+            self.scale(self.test_image)
+
+        df = wp.get_times_summary_pd()
+
+        self.assertIsInstance(df, pd.DataFrame)
+
+    def test_csv_dump(self):
+        with WorkflowProfiler() as wp:
+            self.scale(self.test_image)
+            
+        sio=StringIO()
+        wp.dump_csv(sio)
+        self.assertGreater(sio.tell(),0)
+    

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -17,11 +17,11 @@ from io import StringIO
 import torch
 
 import monai.transforms as mt
-from monai.data import DataLoader, Dataset, ThreadDataLoader
+from monai.data import Dataset, ThreadDataLoader
 from monai.utils import first, optional_import
 from monai.utils.enums import CommonKeys
 from monai.utils.profiling import ProfileHandler, ProfileResult, WorkflowProfiler
-from tests.utils import SkipIfNoModule, skip_if_darwin, skip_if_windows
+from tests.utils import SkipIfNoModule
 
 pd, _ = optional_import("pandas")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -212,23 +212,30 @@ class SkipIfModule:
 
 def skip_if_no_cpp_extension(obj):
     """
-    Skip the unit tests if the cpp extension is not available
+    Skip the unit tests if the cpp extension is not available.
     """
     return unittest.skipUnless(USE_COMPILED, "Skipping cpp extension tests")(obj)
 
 
 def skip_if_no_cuda(obj):
     """
-    Skip the unit tests if torch.cuda.is_available is False
+    Skip the unit tests if torch.cuda.is_available is False.
     """
     return unittest.skipUnless(torch.cuda.is_available(), "Skipping CUDA-based tests")(obj)
 
 
 def skip_if_windows(obj):
     """
-    Skip the unit tests if platform is win32
+    Skip the unit tests if platform is win32.
     """
     return unittest.skipIf(sys.platform == "win32", "Skipping tests on Windows")(obj)
+
+
+def skip_if_darwin(obj):
+    """
+    Skip the unit tests if platform is macOS (Darwin).
+    """
+    return unittest.skipIf(sys.platform == "darwin", "Skipping tests on macOS/Darwin")(obj)
 
 
 class SkipIfBeforePyTorchVersion:


### PR DESCRIPTION
### Description
This adds a time profile class to measure how much recorded time various components of workflows consume.  There is a [tutorial notebook here](https://github.com/ericspod/tutorials/blob/profiling_tutorial/modules/workflow_profiling.ipynb) that will be PR'd to the tutorials repo once this is accepted. 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
