### PR TITLE
Change to EnsureChannelFirst to include behaviour from deprecated transforms

### DIFF
--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -245,12 +245,12 @@ class EnsureChannelFirst(Transform):
                     raise ValueError(msg)
                 warnings.warn(msg)
                 return img
-            meta_dict["original_channel_dim"] = channel_dim = "no_channel"
+            meta_dict["original_channel_dim"] = channel_dim = "no_channel"   # type: ignore
 
         if channel_dim == "no_channel":
             result = img[None]
         else:
-            result = moveaxis(img, channel_dim, 0)
+            result = moveaxis(img, channel_dim, 0)   # type: ignore
 
         return convert_to_tensor(result, track_meta=get_track_meta())  # type: ignore
 

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -245,12 +245,12 @@ class EnsureChannelFirst(Transform):
                     raise ValueError(msg)
                 warnings.warn(msg)
                 return img
-            meta_dict["original_channel_dim"] = channel_dim = "no_channel"   # type: ignore
+            meta_dict["original_channel_dim"] = channel_dim = "no_channel"  # type: ignore
 
         if channel_dim == "no_channel":
             result = img[None]
         else:
-            result = moveaxis(img, channel_dim, 0)   # type: ignore
+            result = moveaxis(img, channel_dim, 0)  # type: ignore
 
         return convert_to_tensor(result, track_meta=get_track_meta())  # type: ignore
 

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -202,43 +202,57 @@ class AddChannel(Transform):
 class EnsureChannelFirst(Transform):
     """
     Automatically adjust or add the channel dimension of input data to ensure `channel_first` shape.
-    It extracts the `original_channel_dim` info from provided meta_data dictionary.
-    Typical values of `original_channel_dim` can be: "no_channel", 0, -1.
-    Convert the data to `channel_first` based on the `original_channel_dim` information.
+
+    This extracts the `original_channel_dim` info from provided meta_data dictionary or MetaTensor input. This value
+    should state which dimension is the channel dimension so that it can be moved forward, or contain "no_channel" to
+    state no dimension is the channel and so a 1-size first dimension is to be added.
+
+    Args:
+        strict_check: whether to raise an error when the meta information is insufficient.
+        add_channel_default: If True and the input image `img` is not a MetaTensor and `meta_dict` is not given,
+            or `img` is a MetaTensor but doesn't specify channel dimension, use the value is `no_channel`
     """
 
     backend = [TransformBackends.TORCH, TransformBackends.NUMPY]
 
-    def __init__(self, strict_check: bool = True):
-        """
-        Args:
-            strict_check: whether to raise an error when the meta information is insufficient.
-        """
+    def __init__(self, strict_check: bool = True, add_channel_default=True):
         self.strict_check = strict_check
+        self.add_channel_default = add_channel_default
 
     def __call__(self, img: torch.Tensor, meta_dict: Optional[Mapping] = None) -> torch.Tensor:
         """
         Apply the transform to `img`.
         """
         if not isinstance(img, MetaTensor) and not isinstance(meta_dict, Mapping):
-            msg = "metadata not available, EnsureChannelFirst is not in use."
-            if self.strict_check:
-                raise ValueError(msg)
-            warnings.warn(msg)
-            return img
+            if not self.add_channel_default:
+                msg = "Metadata not available and default add channel is disabled, EnsureChannelFirst is not in use."
+                if self.strict_check:
+                    raise ValueError(msg)
+                warnings.warn(msg)
+                return img
+            else:
+                img = MetaTensor(img)
+
         if isinstance(img, MetaTensor):
             meta_dict = img.meta
+
         channel_dim = meta_dict.get("original_channel_dim")  # type: ignore
 
         if channel_dim is None:
-            msg = "Unknown original_channel_dim in the meta_dict, EnsureChannelFirst is not in use."
-            if self.strict_check:
-                raise ValueError(msg)
-            warnings.warn(msg)
-            return img
+            if not self.add_channel_default:
+                msg = "Unknown original_channel_dim in the MetaTensor meta dict or `meta_dict`."
+                if self.strict_check:
+                    raise ValueError(msg)
+                warnings.warn(msg)
+                return img
+            meta_dict["original_channel_dim"] = channel_dim = "no_channel"
+
         if channel_dim == "no_channel":
-            return convert_to_tensor(img[None], track_meta=get_track_meta())  # type: ignore
-        return convert_to_tensor(moveaxis(img, channel_dim, 0), track_meta=get_track_meta())  # type: ignore
+            result = img[None]
+        else:
+            result = moveaxis(img, channel_dim, 0)
+
+        return convert_to_tensor(result, track_meta=get_track_meta())  # type: ignore
 
 
 class RepeatChannel(Transform):

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -301,6 +301,7 @@ class EnsureChannelFirstd(MapTransform):
         meta_key_postfix: str = DEFAULT_POST_FIX,
         strict_check: bool = True,
         allow_missing_keys: bool = False,
+        add_channel_default=True,
     ) -> None:
         """
         Args:
@@ -308,9 +309,11 @@ class EnsureChannelFirstd(MapTransform):
                 See also: :py:class:`monai.transforms.compose.MapTransform`
             strict_check: whether to raise an error when the meta information is insufficient.
             allow_missing_keys: don't raise exception if key is missing.
+            add_channel_default: If True and the input image `img` is not a MetaTensor and `meta_dict` is not given,
+                or `img` is a MetaTensor but doesn't specify channel dimension, use the value is `no_channel`
         """
         super().__init__(keys, allow_missing_keys)
-        self.adjuster = EnsureChannelFirst(strict_check=strict_check)
+        self.adjuster = EnsureChannelFirst(strict_check=strict_check, add_channel_default=add_channel_default)
         self.meta_keys = ensure_tuple_rep(meta_keys, len(self.keys))
         self.meta_key_postfix = ensure_tuple_rep(meta_key_postfix, len(self.keys))
 


### PR DESCRIPTION
Signed-off-by: Eric Kerfoot <eric.kerfoot@kcl.ac.uk>

### Description
`EnsureChannelFirst` should be used in place of `AddChannel`, however it requires that metadata be provided as MetaTensor inputs or separate dictionaries. This doesn't substitute for `AddChannel` which required neither of these things and so can't be used in the situation where one has data known to have no channel dimension nor metadata and we just want to hard-code adding a 1-sized channel dimension. This is useful in a lot of examples that use generated data and not loaded files that come with metadata, and avoids forcing the user to use MetaTensor.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
