### PR TITLE
4907 invertd for resizing same spatial shapes

### DIFF
--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -285,7 +285,7 @@ def cumsum(a: NdarrayOrTensor, axis=None, **kwargs) -> NdarrayOrTensor:
 def isfinite(x: NdarrayOrTensor) -> NdarrayOrTensor:
     """`np.isfinite` with equivalent implementation for torch."""
     if not isinstance(x, torch.Tensor):
-        return np.isfinite(x)
+        return np.isfinite(x)  # type: ignore
     return torch.isfinite(x)
 
 
@@ -333,7 +333,7 @@ def isnan(x: NdarrayOrTensor) -> NdarrayOrTensor:
 
     """
     if isinstance(x, np.ndarray):
-        return np.isnan(x)
+        return np.isnan(x)  # type: ignore
     return torch.isnan(x)
 
 

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -74,8 +74,6 @@ class TestResize(NumpyImageTestCase2D):
             im = p(self.imt[0])
             out = resize(im)
             if isinstance(im, MetaTensor):
-                if not out.applied_operations:
-                    return  # skipped because good shape
                 im_inv = resize.inverse(out)
                 self.assertTrue(not im_inv.applied_operations)
                 assert_allclose(im_inv.shape, im.shape)

--- a/tests/test_resized.py
+++ b/tests/test_resized.py
@@ -82,7 +82,7 @@ class TestResized(NumpyImageTestCase2D):
 
     def test_identical_spatial(self):
         test_input = {"X": np.ones((1, 10, 16, 17))}
-        xform = Resized("X", (-1, 18, 19))
+        xform = Resized("X", (-1, 16, 17))
         out = xform(test_input)
         out["Y"] = 2 * out["X"]
         transform_inverse = Invertd(keys="Y", transform=xform, orig_keys="X")

--- a/tests/test_resized.py
+++ b/tests/test_resized.py
@@ -16,7 +16,7 @@ import skimage.transform
 from parameterized import parameterized
 
 from monai.data import MetaTensor, set_track_meta
-from monai.transforms import Resized
+from monai.transforms import Invertd, Resized
 from tests.utils import TEST_NDARRAYS_ALL, NumpyImageTestCase2D, assert_allclose, test_local_inversion
 
 TEST_CASE_0 = [{"keys": "img", "spatial_size": 15}, (6, 10, 15)]
@@ -79,6 +79,14 @@ class TestResized(NumpyImageTestCase2D):
         self.assertNotIsInstance(result["img"], MetaTensor)
         np.testing.assert_allclose(result["img"].shape[1:], expected_shape)
         set_track_meta(True)
+
+    def test_identical_spatial(self):
+        test_input = {"X": np.ones((1, 10, 16, 17))}
+        xform = Resized("X", (-1, 18, 19))
+        out = xform(test_input)
+        out["Y"] = 2 * out["X"]
+        transform_inverse = Invertd(keys="Y", transform=xform, orig_keys="X")
+        assert_allclose(transform_inverse(out)["Y"].array, np.ones((1, 10, 16, 17)) * 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4907

### Description
push to applied operations even if `tuple(img.shape[1:]) == spatial_size_`

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
