### PR TITLE
Improve FL ExchangeObject printing and summary

### DIFF
--- a/monai/fl/utils/exchange_object.py
+++ b/monai/fl/utils/exchange_object.py
@@ -40,7 +40,7 @@ class ExchangeObject(dict):
         self.metrics = metrics
         self.weight_type = weight_type
         self.statistics = statistics
-        self._summary = {}
+        self._summary: Dict = {}
 
     @property
     def metrics(self):

--- a/monai/fl/utils/exchange_object.py
+++ b/monai/fl/utils/exchange_object.py
@@ -40,6 +40,7 @@ class ExchangeObject(dict):
         self.metrics = metrics
         self.weight_type = weight_type
         self.statistics = statistics
+        self._summary = {}
 
     @property
     def metrics(self):
@@ -81,5 +82,26 @@ class ExchangeObject(dict):
             return False
         return True
 
+    def _add_to_summary(self, key, value):
+        if value:
+            if isinstance(value, dict):
+                self._summary[key] = len(value)
+            elif isinstance(value, WeightType):
+                self._summary[key] = value
+            else:
+                self._summary[key] = type(value)
+
     def summary(self):
-        return dir(self)
+        self._summary.update(self)
+        for k, v in zip(
+            ["weights", "optim", "metrics", "weight_type", "statistics"],
+            [self.weights, self.optim, self.metrics, self.weight_type, self.statistics],
+        ):
+            self._add_to_summary(k, v)
+        return self._summary
+
+    def __repr__(self):
+        return str(self.summary())
+
+    def __str__(self):
+        return str(self.summary())

--- a/tests/test_fl_exchange_object.py
+++ b/tests/test_fl_exchange_object.py
@@ -29,7 +29,7 @@ if has_torchvision:
     TEST_INIT_2.append(
         {
             "weights": network.state_dict(),
-            "optim": torch.optim.Adam(lr=1, params=network.parameters()),
+            "optim": torch.optim.Adam(lr=1, params=network.parameters()).state_dict(),
             "metrics": {"accuracy": 1},
             "weight_type": WeightType.WEIGHT_DIFF,
             "statistics": {"some_stat": 1},
@@ -48,6 +48,7 @@ class TestFLExchangeObject(unittest.TestCase):
     def test_init(self, input_params):
         eo = ExchangeObject(**input_params)
         self.assertIsInstance(eo, ExchangeObject)
+        eo.summary()
 
     @parameterized.expand([TEST_FAILURE_METRICS, TEST_FAILURE_STATISTICS, TEST_FAILURE_WEIGHT_TYPE])
     def test_failures(self, input_params):

--- a/tests/test_fl_exchange_object.py
+++ b/tests/test_fl_exchange_object.py
@@ -22,7 +22,7 @@ from tests.utils import SkipIfNoModule
 models, has_torchvision = optional_import("torchvision.models")
 
 
-TEST_INIT_1 = [{"weights": None, "optim": None, "metrics": None, "weight_type": None, "statistics": None}]
+TEST_INIT_1 = [{"weights": None, "optim": None, "metrics": None, "weight_type": None, "statistics": None}, "{}"]
 TEST_INIT_2 = []
 if has_torchvision:
     network = models.resnet18()
@@ -33,8 +33,9 @@ if has_torchvision:
             "metrics": {"accuracy": 1},
             "weight_type": WeightType.WEIGHT_DIFF,
             "statistics": {"some_stat": 1},
-        }
+        },
     )
+    TEST_INIT_2.append("{'weights': 122, 'optim': 2, 'metrics': 1, 'weight_type': fl_weight_diff, 'statistics': 1}")
 
 TEST_FAILURE_METRICS = [{"weights": None, "optim": None, "metrics": 1, "weight_type": None, "statistics": None}]
 TEST_FAILURE_STATISTICS = [{"weights": None, "optim": None, "metrics": None, "weight_type": None, "statistics": 1}]
@@ -45,10 +46,11 @@ TEST_FAILURE_WEIGHT_TYPE = [{"weights": None, "optim": None, "metrics": None, "w
 @SkipIfNoModule("ignite")
 class TestFLExchangeObject(unittest.TestCase):
     @parameterized.expand([TEST_INIT_1, TEST_INIT_2])
-    def test_init(self, input_params):
+    def test_init(self, input_params, expected_str):
         eo = ExchangeObject(**input_params)
         self.assertIsInstance(eo, ExchangeObject)
         eo.summary()
+        self.assertEqual(repr(eo), expected_str)
 
     @parameterized.expand([TEST_FAILURE_METRICS, TEST_FAILURE_STATISTICS, TEST_FAILURE_WEIGHT_TYPE])
     def test_failures(self, input_params):

--- a/tests/test_fl_exchange_object.py
+++ b/tests/test_fl_exchange_object.py
@@ -23,7 +23,7 @@ models, has_torchvision = optional_import("torchvision.models")
 
 
 TEST_INIT_1 = [{"weights": None, "optim": None, "metrics": None, "weight_type": None, "statistics": None}, "{}"]
-TEST_INIT_2 = []
+TEST_INIT_2: list = []
 if has_torchvision:
     network = models.resnet18()
     TEST_INIT_2.append(
@@ -33,7 +33,7 @@ if has_torchvision:
             "metrics": {"accuracy": 1},
             "weight_type": WeightType.WEIGHT_DIFF,
             "statistics": {"some_stat": 1},
-        },
+        }
     )
     TEST_INIT_2.append("{'weights': 122, 'optim': 2, 'metrics': 1, 'weight_type': fl_weight_diff, 'statistics': 1}")
 


### PR DESCRIPTION
Signed-off-by: Holger Roth <hroth@nvidia.com>

Fixes #4924.

### Description

- overwrite the printing function to show summarized content of ExchangeObject better.
- Update the test to include this functionality

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
