### PR TITLE
4931- provide an initial channel dim 

### DIFF
--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -238,7 +238,7 @@ class EnsureChannelFirst(Transform):
         if isinstance(img, MetaTensor):
             meta_dict = img.meta
 
-        channel_dim = meta_dict.get("original_channel_dim")  # type: ignore
+        channel_dim = meta_dict.get("original_channel_dim", None)  # type: ignore
 
         if channel_dim is None:
             if self.input_channel_dim is None:

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -238,7 +238,7 @@ class EnsureChannelFirst(Transform):
         if isinstance(img, MetaTensor):
             meta_dict = img.meta
 
-        channel_dim = meta_dict.get("original_channel_dim", None)  # type: ignore
+        channel_dim = meta_dict.get("original_channel_dim", None) if isinstance(meta_dict, Mapping) else None
 
         if channel_dim is None:
             if self.input_channel_dim is None:
@@ -247,7 +247,9 @@ class EnsureChannelFirst(Transform):
                     raise ValueError(msg)
                 warnings.warn(msg)
                 return img
-            meta_dict["original_channel_dim"] = channel_dim = self.input_channel_dim  # type: ignore
+            channel_dim = self.input_channel_dim
+            if isinstance(meta_dict, dict):
+                meta_dict["original_channel_dim"] = self.input_channel_dim
 
         if channel_dim == "no_channel":
             result = img[None]

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -201,7 +201,7 @@ class AddChannel(Transform):
 
 class EnsureChannelFirst(Transform):
     """
-    Automatically adjust or add the channel dimension of input data to ensure `channel_first` shape.
+    Adjust or add the channel dimension of input data to ensure `channel_first` shape.
 
     This extracts the `original_channel_dim` info from provided meta_data dictionary or MetaTensor input. This value
     should state which dimension is the channel dimension so that it can be moved forward, or contain "no_channel" to
@@ -212,7 +212,7 @@ class EnsureChannelFirst(Transform):
         channel_dim: If the input image `img` is not a MetaTensor or `meta_dict` is not given,
             this argument can be used to specify the original channel dimension (integer) of the input array.
             If the input array doesn't have a channel dim, this value should be ``'no_channel'`` (default).
-            If this is set to `None`, rely on the input `img` or `meta_dict` to provide the channel dimension.
+            If this is set to `None`, this class relies on `img` or `meta_dict` to provide the channel dimension.
     """
 
     backend = [TransformBackends.TORCH, TransformBackends.NUMPY]

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -301,7 +301,7 @@ class EnsureChannelFirstd(MapTransform):
         meta_key_postfix: str = DEFAULT_POST_FIX,
         strict_check: bool = True,
         allow_missing_keys: bool = False,
-        add_channel_default=True,
+        channel_dim="no_channel",
     ) -> None:
         """
         Args:
@@ -309,11 +309,13 @@ class EnsureChannelFirstd(MapTransform):
                 See also: :py:class:`monai.transforms.compose.MapTransform`
             strict_check: whether to raise an error when the meta information is insufficient.
             allow_missing_keys: don't raise exception if key is missing.
-            add_channel_default: If True and the input image `img` is not a MetaTensor and `meta_dict` is not given,
-                or `img` is a MetaTensor but doesn't specify channel dimension, use the value is `no_channel`
+            channel_dim: If the input image `img` is not a MetaTensor or `meta_dict` is not given,
+                this argument can be used to specify the original channel dimension (integer) of the input array.
+                If the input array doesn't have a channel dim, this value should be ``'no_channel'`` (default).
+                If this is set to `None`, rely on the input `img` or `meta_dict` to provide the channel dimension.
         """
         super().__init__(keys, allow_missing_keys)
-        self.adjuster = EnsureChannelFirst(strict_check=strict_check, add_channel_default=add_channel_default)
+        self.adjuster = EnsureChannelFirst(strict_check=strict_check, channel_dim=channel_dim)
         self.meta_keys = ensure_tuple_rep(meta_keys, len(self.keys))
         self.meta_key_postfix = ensure_tuple_rep(meta_key_postfix, len(self.keys))
 

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -312,7 +312,7 @@ class EnsureChannelFirstd(MapTransform):
             channel_dim: If the input image `img` is not a MetaTensor or `meta_dict` is not given,
                 this argument can be used to specify the original channel dimension (integer) of the input array.
                 If the input array doesn't have a channel dim, this value should be ``'no_channel'`` (default).
-                If this is set to `None`, rely on the input `img` or `meta_dict` to provide the channel dimension.
+                If this is set to `None`, this class relies on `img` or `meta_dict` to provide the channel dimension.
         """
         super().__init__(keys, allow_missing_keys)
         self.adjuster = EnsureChannelFirst(strict_check=strict_check, channel_dim=channel_dim)

--- a/tests/test_ensure_channel_first.py
+++ b/tests/test_ensure_channel_first.py
@@ -45,9 +45,9 @@ class TestEnsureChannelFirst(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5, TEST_CASE_6])
     def test_load_nifti(self, input_param, filenames, original_channel_dim):
         if original_channel_dim is None:
-            test_image = np.random.rand(128, 128, 128)
+            test_image = np.random.rand(8, 8, 8)
         elif original_channel_dim == -1:
-            test_image = np.random.rand(128, 128, 128, 1)
+            test_image = np.random.rand(8, 8, 8, 1)
 
         with tempfile.TemporaryDirectory() as tempdir:
             for i, name in enumerate(filenames):
@@ -65,8 +65,8 @@ class TestEnsureChannelFirst(unittest.TestCase):
         self.assertEqual(result.shape[0], 1)
 
     def test_load_png(self):
-        spatial_size = (256, 256, 3)
-        test_image = np.random.randint(0, 256, size=spatial_size)
+        spatial_size = (6, 6, 3)
+        test_image = np.random.randint(0, 6, size=spatial_size)
         with tempfile.TemporaryDirectory() as tempdir:
             filename = os.path.join(tempdir, "test_image.png")
             Image.fromarray(test_image.astype("uint8")).save(filename)
@@ -79,21 +79,21 @@ class TestEnsureChannelFirst(unittest.TestCase):
         im_nodim = MetaTensor(im, meta={"original_channel_dim": None})
 
         with self.assertRaises(ValueError):  # not MetaTensor
-            EnsureChannelFirst(add_channel_default=False)(im)
+            EnsureChannelFirst(channel_dim=None)(im)
         with self.assertRaises(ValueError):  # no meta
-            EnsureChannelFirst(add_channel_default=False)(MetaTensor(im))
+            EnsureChannelFirst(channel_dim=None)(MetaTensor(im))
         with self.assertRaises(ValueError):  # no meta channel
-            EnsureChannelFirst(add_channel_default=False)(im_nodim)
+            EnsureChannelFirst(channel_dim=None)(im_nodim)
 
         with self.assertWarns(Warning):
-            EnsureChannelFirst(strict_check=False, add_channel_default=False)(im)
+            EnsureChannelFirst(strict_check=False, channel_dim=None)(im)
 
         with self.assertWarns(Warning):
-            EnsureChannelFirst(strict_check=False, add_channel_default=False)(im_nodim)
+            EnsureChannelFirst(strict_check=False, channel_dim=None)(im_nodim)
 
     def test_default_channel_first(self):
         im = torch.rand(4, 4)
-        result = EnsureChannelFirst(add_channel_default=True)(im)
+        result = EnsureChannelFirst(channel_dim="no_channel")(im)
 
         self.assertEqual(result.shape, (1, 4, 4))
 

--- a/tests/test_ensure_channel_firstd.py
+++ b/tests/test_ensure_channel_firstd.py
@@ -33,9 +33,9 @@ class TestEnsureChannelFirstd(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_load_nifti(self, input_param, filenames, original_channel_dim):
         if original_channel_dim is None:
-            test_image = np.random.rand(128, 128, 128)
+            test_image = np.random.rand(8, 8, 8)
         elif original_channel_dim == -1:
-            test_image = np.random.rand(128, 128, 128, 1)
+            test_image = np.random.rand(8, 8, 8, 1)
 
         with tempfile.TemporaryDirectory() as tempdir:
             for i, name in enumerate(filenames):
@@ -46,7 +46,7 @@ class TestEnsureChannelFirstd(unittest.TestCase):
             self.assertEqual(result["img"].shape[0], len(filenames))
 
     def test_load_png(self):
-        spatial_size = (256, 256, 3)
+        spatial_size = (6, 6, 3)
         test_image = np.random.randint(0, 256, size=spatial_size)
         with tempfile.TemporaryDirectory() as tempdir:
             filename = os.path.join(tempdir, "test_image.png")
@@ -60,19 +60,19 @@ class TestEnsureChannelFirstd(unittest.TestCase):
         im_nodim = MetaTensor(im, meta={"original_channel_dim": None})
 
         with self.assertRaises(ValueError):  # no meta
-            EnsureChannelFirstd("img", add_channel_default=False)({"img": im})
+            EnsureChannelFirstd("img", channel_dim=None)({"img": im})
         with self.assertRaises(ValueError):  # no meta channel
-            EnsureChannelFirstd("img", add_channel_default=False)({"img": im_nodim})
+            EnsureChannelFirstd("img", channel_dim=None)({"img": im_nodim})
 
         with self.assertWarns(Warning):
-            EnsureChannelFirstd("img", strict_check=False, add_channel_default=False)({"img": im})
+            EnsureChannelFirstd("img", strict_check=False, channel_dim=None)({"img": im})
 
         with self.assertWarns(Warning):
-            EnsureChannelFirstd("img", strict_check=False, add_channel_default=False)({"img": im_nodim})
+            EnsureChannelFirstd("img", strict_check=False, channel_dim=None)({"img": im_nodim})
 
     def test_default_channel_first(self):
         im = torch.rand(4, 4)
-        result = EnsureChannelFirstd("img", add_channel_default=True)({"img": im})
+        result = EnsureChannelFirstd("img", channel_dim="no_channel")({"img": im})
 
         self.assertEqual(result["img"].shape, (1, 4, 4))
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #4931

### Description
adds the flexibility of providing a channel dim.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
