### PR TITLE
Improve data type conversion performance in convert_to_numpy

### DIFF
--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -175,6 +175,13 @@ def convert_to_numpy(data, dtype: DtypeLike = None, wrap_sequence: bool = False)
     elif has_cp and isinstance(data, cp_ndarray):
         data = cp.asnumpy(data).astype(dtype, copy=False)
     elif isinstance(data, (np.ndarray, float, int, bool)):
+        # Convert into a contiguous array first if the current dtype's size is smaller than the target dtype's size.
+        # This help improve the performance because (convert to contiguous array) -> (convert dtype) is faster
+        # than (convert dtype) -> (convert to contiguous array) when src dtype (e.g., uint8) is smaller than
+        # target dtype(e.g., float32) and we are going to convert it to contiguous array anyway later in this
+        # method.
+        if data.ndim > 0 and data.dtype.itemsize < np.dtype(dtype).itemsize:
+            data = np.ascontiguousarray(data)
         data = np.asarray(data, dtype=dtype)
     elif isinstance(data, list):
         list_ret = [convert_to_numpy(i, dtype=dtype) for i in data]

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -180,7 +180,7 @@ def convert_to_numpy(data, dtype: DtypeLike = None, wrap_sequence: bool = False)
         # than (convert dtype) -> (convert to contiguous array) when src dtype (e.g., uint8) is smaller than
         # target dtype(e.g., float32) and we are going to convert it to contiguous array anyway later in this
         # method.
-        if data.ndim > 0 and data.dtype.itemsize < np.dtype(dtype).itemsize:
+        if isinstance(data, np.ndarray) and data.ndim > 0 and data.dtype.itemsize < np.dtype(dtype).itemsize:
             data = np.ascontiguousarray(data)
         data = np.asarray(data, dtype=dtype)
     elif isinstance(data, list):


### PR DESCRIPTION
Signed-off-by: Gigon Bae <gbae@nvidia.com>

#4900

### Description

Improve type conversion(`convert_to_numpy()`) performance by converting to contiguous array first.

```bash
# Without patch
  Thread elapsed time (cucim loader) : 14.059558755951002
    type: <class 'monai.data.meta_tensor.MetaTensor'>, shape: (3, 60797, 34007), dtype: torch.float32

# With patch
  Thread elapsed time (cucim loader) : 10.268190009985119
    type: <class 'monai.data.meta_tensor.MetaTensor'>, shape: (3, 60797, 34007), dtype: torch.float32
```

test code
```python
from contextlib import ContextDecorator
from time import perf_counter

import monai
from monai.transforms import LoadImage

loader_cucim = LoadImage(
    reader=monai.data.wsi_reader.WSIReader, backend="cucim", image_only=True)


class Timer(ContextDecorator):
    def __init__(self, message):
        self.message = message
        self.end = None

    def elapsed_time(self):
        self.end = perf_counter()
        return self.end - self.start

    def __enter__(self):
        self.start = perf_counter()
        return self

    def __exit__(self, exc_type, exc, exc_tb):
        if not self.end:
            self.elapsed_time()
        print("{} : {}".format(self.message, self.end - self.start))


image_file = "/home/gbae/repo/cucim/notebooks/input/006388_0.tif"

with Timer("  Thread elapsed time (cucim loader)") as timer:
    image = loader_cucim(image_file)
print(f"    type: {type(image)}, shape: {image.shape}, dtype: {image.dtype}")
```

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
