### PR TITLE
4929 - enhance the subprocess tests to have detailed outputs

### DIFF
--- a/tests/test_bundle_ckpt_export.py
+++ b/tests/test_bundle_ckpt_export.py
@@ -11,7 +11,6 @@
 
 import json
 import os
-import subprocess
 import tempfile
 import unittest
 
@@ -20,7 +19,7 @@ from parameterized import parameterized
 from monai.bundle import ConfigParser
 from monai.data import load_net_with_metadata
 from monai.networks import save_state
-from tests.utils import skip_if_windows
+from tests.utils import command_line_tests, skip_if_windows
 
 TEST_CASE_1 = [""]
 
@@ -49,7 +48,7 @@ class TestCKPTExport(unittest.TestCase):
             cmd = ["coverage", "run", "-m", "monai.bundle", "ckpt_export", "network_def", "--filepath", ts_file]
             cmd += ["--meta_file", meta_file, "--config_file", f"['{config_file}','{def_args_file}']", "--ckpt_file"]
             cmd += [ckpt_file, "--key_in_ckpt", key_in_ckpt, "--args_file", def_args_file]
-            subprocess.check_call(cmd)
+            command_line_tests(cmd)
             self.assertTrue(os.path.exists(ts_file))
 
             _, metadata, extra_files = load_net_with_metadata(

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -11,7 +11,6 @@
 
 import json
 import os
-import subprocess
 import tempfile
 import unittest
 
@@ -21,7 +20,13 @@ from parameterized import parameterized
 import monai.networks.nets as nets
 from monai.apps import check_hash
 from monai.bundle import ConfigParser, load
-from tests.utils import SkipIfBeforePyTorchVersion, skip_if_downloading_fails, skip_if_quick, skip_if_windows
+from tests.utils import (
+    SkipIfBeforePyTorchVersion,
+    command_line_tests,
+    skip_if_downloading_fails,
+    skip_if_quick,
+    skip_if_windows,
+)
 
 TEST_CASE_1 = [
     ["model.pt", "model.ts", "network.json", "test_output.pt", "test_input.pt"],
@@ -64,7 +69,7 @@ class TestDownload(unittest.TestCase):
             with tempfile.TemporaryDirectory() as tempdir:
                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--name", bundle_name, "--source", "github"]
                 cmd += ["--bundle_dir", tempdir, "--repo", repo, "--progress", "False"]
-                subprocess.check_call(cmd)
+                command_line_tests(cmd)
                 for file in bundle_files:
                     file_path = os.path.join(tempdir, bundle_name, file)
                     self.assertTrue(os.path.exists(file_path))
@@ -83,7 +88,7 @@ class TestDownload(unittest.TestCase):
                 parser.export_config_file(config=def_args, filepath=def_args_file)
                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
                 cmd += ["--url", url]
-                subprocess.check_call(cmd)
+                command_line_tests(cmd)
                 for file in bundle_files:
                     file_path = os.path.join(tempdir, bundle_name, file)
                     self.assertTrue(os.path.exists(file_path))

--- a/tests/test_bundle_init_bundle.py
+++ b/tests/test_bundle_init_bundle.py
@@ -10,14 +10,13 @@
 # limitations under the License.
 
 import os
-import subprocess
 import tempfile
 import unittest
 
 import torch
 
 from monai.networks.nets import UNet
-from tests.utils import skip_if_windows
+from tests.utils import command_line_tests, skip_if_windows
 
 
 @skip_if_windows
@@ -30,7 +29,7 @@ class TestBundleInit(unittest.TestCase):
             bundle_root = tempdir + "/test_bundle"
 
             cmd = ["coverage", "run", "-m", "monai.bundle", "init_bundle", bundle_root, tempdir + "/test.pt"]
-            subprocess.check_call(cmd)
+            command_line_tests(cmd)
 
             self.assertTrue(os.path.exists(bundle_root + "/configs/metadata.json"))
             self.assertTrue(os.path.exists(bundle_root + "/configs/inference.json"))

--- a/tests/test_bundle_utils.py
+++ b/tests/test_bundle_utils.py
@@ -11,7 +11,6 @@
 
 import os
 import shutil
-import subprocess
 import tempfile
 import unittest
 
@@ -19,7 +18,7 @@ import torch
 
 from monai.bundle.utils import load_bundle_config
 from monai.networks.nets import UNet
-from tests.utils import skip_if_windows
+from tests.utils import command_line_tests, skip_if_windows
 
 metadata = """
 {
@@ -104,7 +103,7 @@ class TestLoadBundleConfig(unittest.TestCase):
         cmd += ["--config_file", self.test_name]
         cmd += ["--ckpt_file", self.modelpt_name]
 
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        command_line_tests(cmd)
 
         p = load_bundle_config(self.ts_file, "test.json")
 

--- a/tests/test_bundle_verify_metadata.py
+++ b/tests/test_bundle_verify_metadata.py
@@ -11,14 +11,13 @@
 
 import json
 import os
-import subprocess
 import tempfile
 import unittest
 
 from parameterized import parameterized
 
 from monai.bundle import ConfigParser, verify_metadata
-from tests.utils import download_url_or_skip_test, skip_if_windows, testing_data_config
+from tests.utils import command_line_tests, download_url_or_skip_test, skip_if_windows, testing_data_config
 
 SCHEMA_FILE = os.path.join(os.path.dirname(__file__), "testing_data", "schema.json")
 
@@ -45,7 +44,7 @@ class TestVerifyMetaData(unittest.TestCase):
 
             cmd = ["coverage", "run", "-m", "monai.bundle", "verify_metadata", "--meta_file", meta_file]
             cmd += ["--filepath", schema_file, "--hash_val", self.config["hash_val"], "--args_file", def_args_file]
-            subprocess.check_call(cmd)
+            command_line_tests(cmd)
 
     def test_verify_error(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_bundle_verify_net.py
+++ b/tests/test_bundle_verify_net.py
@@ -10,14 +10,13 @@
 # limitations under the License.
 
 import os
-import subprocess
 import tempfile
 import unittest
 
 from parameterized import parameterized
 
 from monai.bundle import ConfigParser
-from tests.utils import skip_if_windows
+from tests.utils import command_line_tests, skip_if_windows
 
 TEST_CASE_1 = [
     os.path.join(os.path.dirname(__file__), "testing_data", "metadata.json"),
@@ -37,10 +36,7 @@ class TestVerifyNetwork(unittest.TestCase):
             cmd = ["coverage", "run", "-m", "monai.bundle", "verify_net_in_out", "network_def", "--meta_file"]
             cmd += [meta_file, "--config_file", config_file, "-n", "4", "--any", "16", "--args_file", def_args_file]
             cmd += ["--_meta_#network_data_format#inputs#image#spatial_shape", "[16,'*','2**p*n']"]
-
-            test_env = os.environ.copy()
-            print(f"CUDA_VISIBLE_DEVICES in {__file__}", test_env.get("CUDA_VISIBLE_DEVICES"))
-            subprocess.check_call(cmd, env=test_env)
+            command_line_tests(cmd)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration_bundle_run.py
+++ b/tests/test_integration_bundle_run.py
@@ -12,7 +12,6 @@
 import json
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 import unittest
@@ -23,6 +22,7 @@ from parameterized import parameterized
 
 from monai.bundle import ConfigParser
 from monai.transforms import LoadImage
+from tests.utils import command_line_tests
 
 TEST_CASE_1 = [os.path.join(os.path.dirname(__file__), "testing_data", "inference.json"), (128, 128, 128)]
 
@@ -56,7 +56,7 @@ class TestBundleRun(unittest.TestCase):
                 f,
             )
         cmd = ["coverage", "run", "-m", "monai.bundle", "run", "training", "--config_file", config_file]
-        subprocess.check_call(cmd)
+        command_line_tests(cmd)
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     def test_shape(self, config_file, expected_shape):
@@ -96,7 +96,7 @@ class TestBundleRun(unittest.TestCase):
         la = ["coverage", "run"] + cmd.split(" ") + ["--meta_file", meta_file] + ["--config_file", config_file]
         test_env = os.environ.copy()
         print(f"CUDA_VISIBLE_DEVICES in {__file__}", test_env.get("CUDA_VISIBLE_DEVICES"))
-        subprocess.check_call(la + ["--args_file", def_args_file], env=test_env)
+        command_line_tests(la + ["--args_file", def_args_file])
         loader = LoadImage(image_only=True)
         self.assertTupleEqual(loader(os.path.join(tempdir, "image", "image_seg.nii.gz")).shape, expected_shape)
 
@@ -104,7 +104,7 @@ class TestBundleRun(unittest.TestCase):
         cmd = "-m fire monai.bundle.scripts run --runner_id evaluating"
         cmd += f" --evaluator#amp False {override}"
         la = ["coverage", "run"] + cmd.split(" ") + ["--meta_file", meta_file] + ["--config_file", config_file]
-        subprocess.check_call(la, env=test_env)
+        command_line_tests(la)
         self.assertTupleEqual(loader(os.path.join(tempdir, "image", "image_trans.nii.gz")).shape, expected_shape)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,6 +18,7 @@ import operator
 import os
 import queue
 import ssl
+import subprocess
 import sys
 import tempfile
 import time
@@ -741,6 +742,18 @@ def test_local_inversion(invertible_xform, to_invert, im, dict_key=None):
     np.testing.assert_array_equal(im_inv.applied_operations, [])
     assert_allclose(im_inv.shape, im_ref.shape)
     assert_allclose(im_inv.affine, im_ref.affine, atol=1e-3, rtol=1e-3)
+
+
+def command_line_tests(cmd, copy_env=True):
+    test_env = os.environ.copy() if copy_env else os.environ
+    print(f"CUDA_VISIBLE_DEVICES in {__file__}", test_env.get("CUDA_VISIBLE_DEVICES"))
+    try:
+        normal_out = subprocess.run(cmd, env=test_env, check=True, capture_output=True)
+        print(repr(normal_out).replace("\\n", "\n").replace("\\t", "\t"))
+    except subprocess.CalledProcessError as e:
+        output = repr(e.stdout).replace("\\n", "\n").replace("\\t", "\t")
+        errors = repr(e.stderr).replace("\\n", "\n").replace("\\t", "\t")
+        raise RuntimeError(f"subprocess call error {e.returncode}: {errors}, {output}") from e
 
 
 TEST_TORCH_TENSORS: Tuple = (torch.as_tensor,)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

part of #4929


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
