### PR TITLE
4938 improve SpatialResample default values and fixes bugs

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -295,7 +295,7 @@ class SpatialResample(InvertibleTransform):
             for idx, d_dst in enumerate(spatial_size[:spatial_rank]):
                 _t_r[idx, -1] = (max(d_dst, 2) - 1.0) / 2.0
             xform = xform @ _t_r
-            if not USE_COMPILED:
+            if not USE_COMPILED and not isinstance(mode, int):
                 _t_l = normalize_transform(
                     in_spatial_size, xform.device, xform.dtype, align_corners=True  # type: ignore
                 )[0]

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -195,7 +195,7 @@ class SpatialResample(InvertibleTransform):
         spatial_size: Optional[Union[Sequence[int], torch.Tensor, int]] = None,
         mode: Union[str, int, None] = None,
         padding_mode: Optional[str] = None,
-        align_corners: Optional[bool] = False,
+        align_corners: Optional[bool] = None,
         dtype: DtypeLike = None,
     ) -> torch.Tensor:
         """
@@ -224,6 +224,7 @@ class SpatialResample(InvertibleTransform):
                 See also: https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.map_coordinates.html
             align_corners: Geometrically, we consider the pixels of the input as squares rather than points.
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
+                Defaults to ``None``, effectively using the value of `self.align_corners`.
             dtype: data type for resampling computation. Defaults to ``self.dtype`` or
                 ``np.float64`` (for best precision). If ``None``, use the data type of input data.
                 To be compatible with other modules, the output data type is always `float32`.
@@ -365,7 +366,7 @@ class ResampleToMatch(SpatialResample):
         dst_meta: Optional[Dict] = None,
         mode: Union[str, int, None] = None,
         padding_mode: Optional[str] = None,
-        align_corners: Optional[bool] = False,
+        align_corners: Optional[bool] = None,
         dtype: DtypeLike = None,
     ) -> torch.Tensor:
         """
@@ -393,7 +394,7 @@ class ResampleToMatch(SpatialResample):
                 {'reflect', 'grid-mirror', 'constant', 'grid-constant', 'nearest', 'mirror', 'grid-wrap', 'wrap'}.
                 See also: https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.map_coordinates.html
             align_corners: Geometrically, we consider the pixels of the input as squares rather than points.
-                Defaults to ``False``.
+                Defaults to ``None``, effectively using the value of `self.align_corners`.
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
             dtype: data type for resampling computation. Defaults to ``self.dtype`` or
                 ``np.float64`` (for best precision). If ``None``, use the data type of input data.
@@ -513,6 +514,7 @@ class Spacing(InvertibleTransform):
                 See also: https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.map_coordinates.html
             align_corners: Geometrically, we consider the pixels of the input as squares rather than points.
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
+                Defaults to ``None``, effectively using the value of `self.align_corners`.
             dtype: data type for resampling computation. Defaults to ``self.dtype``.
                 If None, use the data type of input data. To be compatible with other modules,
                 the output data type is always ``np.float32``.

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -172,7 +172,7 @@ class TestSpatialResample(unittest.TestCase):
             img.affine = torch.eye(4)
             dst_affine = torch.eye(4) * 0.1
             SpatialResample(mode=None)(img=img, dst_affine=dst_affine)
-        if not optional_import("scipy")[1]:
+        if not (optional_import("scipy")[1] and optional_import("cupy")[1]):
             return
         with self.assertRaises(ValueError):  # requires scipy
             SpatialResample(mode=1, align_corners=True)(img=img, dst_affine=dst_affine)

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import unittest
+from copy import deepcopy
 
 import numpy as np
 import torch
@@ -19,6 +20,7 @@ from monai.data.meta_obj import set_track_meta
 from monai.data.meta_tensor import MetaTensor
 from monai.data.utils import to_affine_nd
 from monai.transforms import SpatialResample
+from monai.utils import optional_import
 from tests.utils import TEST_DEVICES, TEST_NDARRAYS_ALL, assert_allclose
 
 TESTS = []
@@ -53,6 +55,9 @@ for dst, expct in zip(destinations_3d, expected_3d):
                             expct,
                         ]
                     )
+if optional_import("cupy")[1] and optional_import("scipy.ndimage")[1]:
+    TESTS.append(deepcopy(TESTS[-1]))
+    TESTS[-1][2].update({"align_corners": True, "mode": 1, "padding_mode": "reflect"})  # type: ignore
 
 
 destinations_2d = [

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -152,7 +152,7 @@ class TestSpatialResample(unittest.TestCase):
 
         dst = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, -1.0, 1.5], [0.0, 0.0, 0.0, 1.0]])
         dst = dst.to(dtype)
-        out = SpatialResample(dtype=dtype)(img=img, dst_affine=dst)
+        out = SpatialResample(dtype=dtype, align_corners=True)(img=img, dst_affine=dst, align_corners=False)
         assert_allclose(out, expected_data[None], rtol=1e-2, atol=1e-2)
         assert_allclose(out.affine, dst.to(torch.float32), rtol=1e-2, atol=1e-2)
 
@@ -172,6 +172,10 @@ class TestSpatialResample(unittest.TestCase):
             img.affine = torch.eye(4)
             dst_affine = torch.eye(4) * 0.1
             SpatialResample(mode=None)(img=img, dst_affine=dst_affine)
+        with self.assertRaises(ValueError):
+            SpatialResample(mode=1, align_corners=True)(img=img, dst_affine=dst_affine)
+        with self.assertRaises(ValueError):
+            SpatialResample(mode=1, align_corners=False)(img=img, dst_affine=dst_affine)
 
     @parameterized.expand(TEST_TORCH_INPUT)
     def test_input_torch(self, new_shape, tile, device, dtype, expected_data, track_meta):

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -172,7 +172,9 @@ class TestSpatialResample(unittest.TestCase):
             img.affine = torch.eye(4)
             dst_affine = torch.eye(4) * 0.1
             SpatialResample(mode=None)(img=img, dst_affine=dst_affine)
-        with self.assertRaises(ValueError):
+        if not optional_import("scipy")[1]:
+            return
+        with self.assertRaises(ValueError):  # requires scipy
             SpatialResample(mode=1, align_corners=True)(img=img, dst_affine=dst_affine)
         with self.assertRaises(ValueError):
             SpatialResample(mode=1, align_corners=False)(img=img, dst_affine=dst_affine)


### PR DESCRIPTION
Fixes #4938

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
