### PR TITLE
Workflow Fix

### DIFF
--- a/docs/source/engines.rst
+++ b/docs/source/engines.rst
@@ -16,11 +16,6 @@ Workflows
 
 .. currentmodule:: monai.engines
 
-`BaseWorkflow`
-~~~~~~~~~~~~~~
-.. autoclass:: BaseWorkflow
-    :members:
-
 `Workflow`
 ~~~~~~~~~~
 .. autoclass:: Workflow

--- a/monai/engines/__init__.py
+++ b/monai/engines/__init__.py
@@ -23,4 +23,4 @@ from .utils import (
     engine_apply_transform,
     get_devices_spec,
 )
-from .workflow import BaseWorkflow, Workflow
+from .workflow import Workflow

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -249,7 +249,7 @@ class Workflow(IgniteEngine):  # type: ignore[valid-type, misc] # due to optiona
                     )
                     return
 
-                if engine.state.best_metric_epoch == 1 or self.metric_cmp_fn(
+                if engine.state.best_metric_epoch == -1 or self.metric_cmp_fn(
                     current_val_metric, engine.state.best_metric
                 ):
                     self.logger.info(f"Got new best metric of {key_metric_name}: {current_val_metric}")

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import warnings
-from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Sequence, Union
 
 import torch


### PR DESCRIPTION
### Description
Very minor fix to how workflows decide what the best metric result is such that the first epoch always chooses whatever its metric was. `BaseWorkflow` was also removed since it wasn't used anywhere, this can be put back if somewhere else needs it.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
