### PR TITLE
Fix For RandSmoothDeform Component Order

### DIFF
--- a/monai/data/synthetic.py
+++ b/monai/data/synthetic.py
@@ -48,6 +48,9 @@ def create_test_image_2d(
         channel_dim: if None, create an image without channel dimension, otherwise create
             an image with channel dimension as first dim or last dim. Defaults to `None`.
         random_state: the random generator to use. Defaults to `np.random`.
+
+    Returns:
+        Randomised Numpy array with shape (`width`, `height`) 
     """
 
     if rad_max <= rad_min:
@@ -119,6 +122,9 @@ def create_test_image_3d(
         channel_dim: if None, create an image without channel dimension, otherwise create
             an image with channel dimension as first dim or last dim. Defaults to `None`.
         random_state: the random generator to use. Defaults to `np.random`.
+
+    Returns:
+        Randomised Numpy array with shape (`width`, `height`, `depth`) 
 
     See also:
         :py:meth:`~create_test_image_2d`

--- a/monai/data/synthetic.py
+++ b/monai/data/synthetic.py
@@ -50,7 +50,7 @@ def create_test_image_2d(
         random_state: the random generator to use. Defaults to `np.random`.
 
     Returns:
-        Randomised Numpy array with shape (`width`, `height`) 
+        Randomised Numpy array with shape (`width`, `height`)
     """
 
     if rad_max <= rad_min:
@@ -124,7 +124,7 @@ def create_test_image_3d(
         random_state: the random generator to use. Defaults to `np.random`.
 
     Returns:
-        Randomised Numpy array with shape (`width`, `height`, `depth`) 
+        Randomised Numpy array with shape (`width`, `height`, `depth`)
 
     See also:
         :py:meth:`~create_test_image_2d`

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -42,6 +42,7 @@ __all__ = [
     "save_state",
     "convert_to_torchscript",
     "meshgrid_ij",
+    "meshgrid_xy",
     "replace_modules",
     "replace_modules_temp",
     "look_up_named_module",
@@ -624,13 +625,15 @@ def convert_to_torchscript(
 def meshgrid_ij(*tensors):
     if torch.meshgrid.__kwdefaults__ is not None and "indexing" in torch.meshgrid.__kwdefaults__:
         return torch.meshgrid(*tensors, indexing="ij")  # new api pytorch after 1.10
+        
     return torch.meshgrid(*tensors)
 
 
 def meshgrid_xy(*tensors):
     if torch.meshgrid.__kwdefaults__ is not None and "indexing" in torch.meshgrid.__kwdefaults__:
         return torch.meshgrid(*tensors, indexing="xy")  # new api pytorch after 1.10
-    return torch.meshgrid(*tensors)
+        
+    return torch.meshgrid(tensors[1],tensors[0], *tensors[2:])
 
 
 def _replace_modules(

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -625,15 +625,15 @@ def convert_to_torchscript(
 def meshgrid_ij(*tensors):
     if torch.meshgrid.__kwdefaults__ is not None and "indexing" in torch.meshgrid.__kwdefaults__:
         return torch.meshgrid(*tensors, indexing="ij")  # new api pytorch after 1.10
-        
+
     return torch.meshgrid(*tensors)
 
 
 def meshgrid_xy(*tensors):
     if torch.meshgrid.__kwdefaults__ is not None and "indexing" in torch.meshgrid.__kwdefaults__:
         return torch.meshgrid(*tensors, indexing="xy")  # new api pytorch after 1.10
-        
-    return torch.meshgrid(tensors[1],tensors[0], *tensors[2:])
+
+    return torch.meshgrid(tensors[1], tensors[0], *tensors[2:])
 
 
 def _replace_modules(

--- a/monai/transforms/smooth_field/array.py
+++ b/monai/transforms/smooth_field/array.py
@@ -405,7 +405,7 @@ class RandSmoothDeform(RandomizableTransform):
         )
 
         grid_space = tuple(spatial_size) if spatial_size is not None else self.sfield.field.shape[2:]
-        #grid_space = grid_space[1::-1]+grid_space[2:]
+        # grid_space = grid_space[1::-1]+grid_space[2:]
         grid_ranges = [torch.linspace(-1, 1, d) for d in grid_space]
 
         grid = meshgrid_ij(*grid_ranges)
@@ -447,7 +447,7 @@ class RandSmoothDeform(RandomizableTransform):
 
         dgrid = self.grid + field.to(self.grid_dtype)
         dgrid = moveaxis(dgrid, 1, -1)  # type: ignore
-        dgrid = dgrid[...,list(range(dgrid.shape[-1]-1,-1,-1))]  # invert order of coordinates
+        dgrid = dgrid[..., list(range(dgrid.shape[-1] - 1, -1, -1))]  # invert order of coordinates
 
         img_t = convert_to_tensor(img[None], torch.float32, device)
 
@@ -458,7 +458,7 @@ class RandSmoothDeform(RandomizableTransform):
             align_corners=self.grid_align_corners,
             padding_mode=look_up_option(self.grid_padding_mode, GridSamplePadMode),
         )
-        
+
         out_t, *_ = convert_to_dst_type(out.squeeze(0), img)
 
         return out_t

--- a/monai/transforms/smooth_field/array.py
+++ b/monai/transforms/smooth_field/array.py
@@ -19,7 +19,7 @@ from torch.nn.functional import grid_sample, interpolate
 
 from monai.config.type_definitions import NdarrayOrTensor
 from monai.data.meta_obj import get_track_meta
-from monai.networks.utils import meshgrid_xy
+from monai.networks.utils import meshgrid_ij
 from monai.transforms.transform import Randomizable, RandomizableTransform
 from monai.transforms.utils_pytorch_numpy_unification import moveaxis
 from monai.utils import GridSampleMode, GridSamplePadMode, InterpolateMode
@@ -404,10 +404,11 @@ class RandSmoothDeform(RandomizableTransform):
             device=device,
         )
 
-        grid_space = spatial_size if spatial_size is not None else self.sfield.field.shape[2:]
+        grid_space = tuple(spatial_size) if spatial_size is not None else self.sfield.field.shape[2:]
+        #grid_space = grid_space[1::-1]+grid_space[2:]
         grid_ranges = [torch.linspace(-1, 1, d) for d in grid_space]
 
-        grid = meshgrid_xy(*grid_ranges)
+        grid = meshgrid_ij(*grid_ranges)
 
         self.grid = torch.stack(grid).unsqueeze(0).to(self.device, self.grid_dtype)
 
@@ -446,6 +447,7 @@ class RandSmoothDeform(RandomizableTransform):
 
         dgrid = self.grid + field.to(self.grid_dtype)
         dgrid = moveaxis(dgrid, 1, -1)  # type: ignore
+        dgrid = dgrid[...,list(range(dgrid.shape[-1]-1,-1,-1))]  # invert order of coordinates
 
         img_t = convert_to_tensor(img[None], torch.float32, device)
 
@@ -456,7 +458,7 @@ class RandSmoothDeform(RandomizableTransform):
             align_corners=self.grid_align_corners,
             padding_mode=look_up_option(self.grid_padding_mode, GridSamplePadMode),
         )
-
+        
         out_t, *_ = convert_to_dst_type(out.squeeze(0), img)
 
         return out_t

--- a/tests/test_smooth_field.py
+++ b/tests/test_smooth_field.py
@@ -16,17 +16,17 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.transforms import RandSmoothDeformd, RandSmoothFieldAdjustContrastd, RandSmoothFieldAdjustIntensityd
 from monai.networks.utils import meshgrid_xy
+from monai.transforms import RandSmoothDeformd, RandSmoothFieldAdjustContrastd, RandSmoothFieldAdjustIntensityd
 from tests.utils import TEST_NDARRAYS, assert_allclose, is_tf32_env
 
 _rtol = 5e-3 if is_tf32_env() else 1e-4
 
-x,y=meshgrid_xy(torch.linspace(-1,2,11),torch.linspace(-2.1,1.2,8))
-pattern2d=x.pow(2).add_(y.pow(2)).sqrt_()
+x, y = meshgrid_xy(torch.linspace(-1, 2, 11), torch.linspace(-2.1, 1.2, 8))
+pattern2d = x.pow(2).add_(y.pow(2)).sqrt_()
 
-x,y,z=meshgrid_xy(torch.linspace(-1,2,11),torch.linspace(-2.1,1.2,8),torch.linspace(-0.1,10.2,6))
-pattern3d=x.pow(2).add_(y.pow(2)).add_(z.pow(2)).sqrt_()
+x, y, z = meshgrid_xy(torch.linspace(-1, 2, 11), torch.linspace(-2.1, 1.2, 8), torch.linspace(-0.1, 10.2, 6))
+pattern3d = x.pow(2).add_(y.pow(2)).add_(z.pow(2)).sqrt_()
 
 INPUT_SHAPES = ((1, 8, 8), (1, 12, 7), (2, 8, 8), (2, 13, 8), (1, 8, 8, 8), (3, 7, 4, 5))
 
@@ -138,28 +138,26 @@ class TestSmoothField(unittest.TestCase):
             expected = expected_val[key]
             assert_allclose(result, expected, rtol=_rtol, atol=1e-1, type_test="tensor")
 
-         
     def test_rand_smooth_nodeformd(self):
         """Test input is very close to output when deformation is very low, verifies there's no transposition."""
-        
-        for label,im in zip(("2D", "3D"),(pattern2d, pattern3d)):
+
+        for label, im in zip(("2D", "3D"), (pattern2d, pattern3d)):
             with self.subTest(f"Testing {label} case with shape {im.shape}"):
-                rsize=(3,)*len(im.shape)
+                rsize = (3,) * len(im.shape)
                 g = RandSmoothDeformd(
-                    keys=(KEY,),spatial_size=im.shape,rand_size=rsize,prob=1.0,device=device,def_range=1e-20
+                    keys=(KEY,), spatial_size=im.shape, rand_size=rsize, prob=1.0, device=device, def_range=1e-20
                 )
                 g.set_random_state(123)
-                
-                expected_val={KEY:im[None]}
-        
+
+                expected_val = {KEY: im[None]}
+
                 res = g(expected_val)
                 for key, result in res.items():
                     expected = expected_val[key]
-                    
+
                     self.assertSequenceEqual(tuple(result.shape), tuple(expected.shape))
-                    
+
                     assert_allclose(result, expected, rtol=_rtol, atol=1e-1, type_test="tensor")
-            
 
     def test_rand_smooth_deformd_pad(self):
         input_param, input_data, expected_val = TESTS_DEFORM[0]


### PR DESCRIPTION
Signed-off-by: Eric Kerfoot <eric.kerfoot@kcl.ac.uk>

### Description
One of the issues with `torch.nn.functional.grid_sample` is its definition of grid coordinate space versus dimensional ordering in inputs. The Pytorch ordering is HW or DHW which in coordinate terms is YX or ZYX, this is inverse to what the function actually expects in the  component ordering of the grid given as input. The solution is to reverse the order of the component dimension. Added tests check that an image with a pattern is effectively unchanged with a deformation having almost 0 magnitude to verify images are not transposed in one dimension or another which was occurring without this fix.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
