### PR TITLE
4971 support of missing indexing in config parser (including minor patches for 4975, 4979)

### DIFF
--- a/monai/apps/detection/utils/ATSS_matcher.py
+++ b/monai/apps/detection/utils/ATSS_matcher.py
@@ -74,7 +74,7 @@ These are the changes compared with nndetection:
 """
 
 import logging
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Callable, Sequence, Tuple, TypeVar
 
 import torch
@@ -139,6 +139,7 @@ class Matcher(ABC):
             num_anchors_per_loc=num_anchors_per_loc,
         )
 
+    @abstractmethod
     def compute_matches(
         self, boxes: torch.Tensor, anchors: torch.Tensor, num_anchors_per_level: Sequence[int], num_anchors_per_loc: int
     ) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/monai/apps/detection/utils/hard_negative_sampler.py
+++ b/monai/apps/detection/utils/hard_negative_sampler.py
@@ -31,14 +31,13 @@ https://github.com/MIC-DKFZ/nnDetection/blob/main/nndet/core/boxes/sampler.py
 """
 
 import logging
-from abc import ABC
 from typing import List, Tuple
 
 import torch
 from torch import Tensor
 
 
-class HardNegativeSamplerBase(ABC):
+class HardNegativeSamplerBase:
     """
     Base class of hard negative sampler.
 

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -173,7 +173,7 @@ class ConfigParser:
         """
         try:
             return self[id]
-        except KeyError:
+        except (KeyError, IndexError):  # Index error for integer indexing
             return default
 
     def set(self, config: Any, id: str = ""):
@@ -209,7 +209,7 @@ class ConfigParser:
         try:
             _ = self[id]
             return True
-        except KeyError:
+        except (KeyError, IndexError):  # Index error for integer indexing
             return False
 
     def parse(self, reset: bool = True):

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 import torch
 import torch.nn as nn
 
+from monai.apps.utils import get_logger
 from monai.config import PathLike
 from monai.utils.deprecate_utils import deprecated, deprecated_arg
 from monai.utils.misc import ensure_tuple, save_obj, set_determinism
@@ -48,6 +49,8 @@ __all__ = [
     "look_up_named_module",
     "set_named_module",
 ]
+
+logger = get_logger(module_name=__name__)
 
 
 def look_up_named_module(name: str, mod, print_all_options=False):
@@ -519,7 +522,7 @@ def copy_model_state(
 
     updated_keys = sorted(set(updated_keys))
     unchanged_keys = sorted(set(all_keys).difference(updated_keys))
-    print(f"'dst' model updated: {len(updated_keys)} of {len(dst_dict)} variables.")
+    logger.info(f"'dst' model updated: {len(updated_keys)} of {len(dst_dict)} variables.")
     if inplace and isinstance(dst, torch.nn.Module):
         dst.load_state_dict(dst_dict)
     return dst_dict, updated_keys, unchanged_keys

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -131,7 +131,7 @@ class ThreadUnsafe:
     pass
 
 
-class Randomizable(ABC, ThreadUnsafe):
+class Randomizable(ThreadUnsafe):
     """
     An interface for handling random state locally, currently based on a class
     variable `R`, which is an instance of `np.random.RandomState`.  This
@@ -179,7 +179,6 @@ class Randomizable(ABC, ThreadUnsafe):
         self.R = np.random.RandomState()
         return self
 
-    @abstractmethod
     def randomize(self, data: Any) -> None:
         """
         Within this method, :py:attr:`self.R` should be used, instead of `np.random`, to introduce random factors.

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -179,6 +179,7 @@ class Randomizable(ABC, ThreadUnsafe):
         self.R = np.random.RandomState()
         return self
 
+    @abstractmethod
     def randomize(self, data: Any) -> None:
         """
         Within this method, :py:attr:`self.R` should be used, instead of `np.random`, to introduce random factors.

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -204,7 +204,7 @@ class TestConfigParser(unittest.TestCase):
         empty_parser = ConfigParser({})
         empty_parser.parse()
 
-        parser = ConfigParser({"value": 1, "entry": "string content"})
+        parser = ConfigParser({"value": 1, "entry": "string content", "array": [1, 2]})
         parser.parse()
 
         with self.subTest("Testing empty parser"):
@@ -215,6 +215,7 @@ class TestConfigParser(unittest.TestCase):
             self.assertFalse("value1" in parser)
             self.assertTrue("entry" in parser)
             self.assertFalse("entr" in parser)
+            self.assertFalse("array#2" in parser)
 
     def test_lambda_reference(self):
         configs = {


### PR DESCRIPTION
Fixes #4971 
fixes #4975
fixes #4979 



### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
