### PR TITLE
Improve MonaiAlgo

### DIFF
--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -102,9 +102,8 @@ class MonaiAlgo(ClientAlgo):
         config_evaluate_filename: bundle evaluation config path relative to bundle_root; defaults to "configs/evaluate.json".
         config_filters_filename: filter configuration file.
         disable_ckpt_loader: do not use CheckpointLoader if defined in train/evaluate configs; defaults to `True`.
-        model_filepaths: dict of locations of best & final model checkpoints;
-            defaults "model/model.pt" and "models/model_final.pt" relative to `bundle_root`
-            for the best and final model, respectively.
+        best_model_filepath: location of best model checkpoint; defaults "models/model.pt" relative to `bundle_root`.
+        final_model_filepath: location of final model checkpoint; defaults "models/model_final.pt" relative to `bundle_root`.
         seed: set random seed for modules to enable or disable deterministic training; defaults to `None`,
             i.e., non-deterministic training.
         benchmark: set benchmark to `False` for full deterministic behavior in cuDNN components.
@@ -121,10 +120,8 @@ class MonaiAlgo(ClientAlgo):
         config_evaluate_filename: Optional[str] = "configs/evaluate.json",
         config_filters_filename: Optional[str] = None,
         disable_ckpt_loader: bool = True,
-        model_filepaths: Optional[dict] = {
-            ModelType.BEST_MODEL: "models/model.pt",
-            ModelType.FINAL_MODEL: "models/model_final.pt",
-        },
+        best_model_filepath: Optional[str] = "models/model.pt",
+        final_model_filepath: Optional[str] = "models/model_final.pt",
         seed: Optional[int] = None,
         benchmark: bool = True,
     ):
@@ -137,7 +134,7 @@ class MonaiAlgo(ClientAlgo):
         self.config_evaluate_filename = config_evaluate_filename
         self.config_filters_filename = config_filters_filename
         self.disable_ckpt_loader = disable_ckpt_loader
-        self.model_filepaths = model_filepaths
+        self.model_filepaths = {ModelType.BEST_MODEL: best_model_filepath, ModelType.FINAL_MODEL: final_model_filepath}
         self.seed = seed
         self.benchmark = benchmark
 
@@ -172,7 +169,7 @@ class MonaiAlgo(ClientAlgo):
 
         if self.seed:
             monai.utils.set_determinism(seed=self.seed)
-        setattr(torch.backends.cudnn, "benchmark", self.benchmark)
+        torch.backends.cudnn.benchmark = self.benchmark
 
         # FL platform needs to provide filepath to configuration files
         self.app_root = extra.get(ExtraItems.APP_ROOT, "")

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -102,9 +102,10 @@ class MonaiAlgo(ClientAlgo):
         bundle_root: path of bundle.
         local_epochs: number of local epochs to execute during each round of local training; defaults to 1.
         send_weight_diff: whether to send weight differences rather than full weights; defaults to `True`.
-        config_train_filename: bundle training config path relative to bundle_root; defaults to "configs/train.json"
-        config_evaluate_filename: bundle evaluation config path relative to bundle_root; defaults to "configs/evaluate.json"
+        config_train_filename: bundle training config path relative to bundle_root; defaults to "configs/train.json".
+        config_evaluate_filename: bundle evaluation config path relative to bundle_root; defaults to "configs/evaluate.json".
         config_filters_filename: filter configuration file.
+        disable_ckpt_loader: do not use CheckpointLoader if defined in train/evaluate configs; defaults to True.
     """
 
     def __init__(

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -18,7 +18,7 @@ import torch
 
 import monai
 from monai.bundle import ConfigParser
-from monai.bundle.config_item import ConfigItem
+from monai.bundle.config_item import ConfigItem, ConfigComponent
 from monai.config import IgniteInfo
 from monai.fl.client.client_algo import ClientAlgo
 from monai.fl.utils.constants import (
@@ -83,15 +83,10 @@ def check_bundle_config(parser):
 
 def remove_ckpt_loader(parser):
     if BundleKeys.VALIDATE_HANDLERS in parser:
-        _handlers = parser.get(BundleKeys.VALIDATE_HANDLERS)
-        _filtered_handlers = []
-        for _h in _handlers:
-            if isinstance(_h, dict):
-                if "_target_" in _h:
-                    if "CheckpointLoader" in _h.get("_target_"):
-                        continue
-                _filtered_handlers.append(_h)
-        parser[BundleKeys.VALIDATE_HANDLERS] = _filtered_handlers
+        for h in parser[BundleKeys.VALIDATE_HANDLERS]:
+            if ConfigComponent.is_instantiable(h):
+                if "CheckpointLoader" in h["_target_"]:
+                    h["_disabled_"] = True
 
 
 class MonaiAlgo(ClientAlgo):

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -233,7 +233,9 @@ class MonaiAlgo(ClientAlgo):
         # get current iteration when a round starts
         self.iter_of_start_time = self.trainer.state.iteration
 
-        copy_model_state(src=self.global_weights, dst=self.trainer.network)
+        _, updated_keys, _ = copy_model_state(src=self.global_weights, dst=self.trainer.network)
+        if len(updated_keys) == 0:
+            self.logger.warning("No weights loaded!")
         self.logger.info(f"Start {self.client_name} training...")
         self.trainer.run()
 
@@ -311,7 +313,9 @@ class MonaiAlgo(ClientAlgo):
             global_weights=data.weights, local_var_dict=get_state_dict(self.evaluator.network)
         )
 
-        copy_model_state(src=global_weights, dst=self.evaluator.network)
+        _, updated_keys, _ = copy_model_state(src=global_weights, dst=self.evaluator.network)
+        if len(updated_keys) == 0:
+            self.logger.warning("No weights loaded!")
         self.logger.info(f"Start {self.client_name} evaluating...")
         if isinstance(self.trainer, monai.engines.Trainer):
             self.evaluator.run(self.trainer.state.epoch + 1)

--- a/monai/fl/utils/constants.py
+++ b/monai/fl/utils/constants.py
@@ -17,9 +17,14 @@ class WeightType(StrEnum):
     WEIGHT_DIFF = "fl_weight_diff"
 
 
+class ModelType(StrEnum):
+    BEST_MODEL = "fl_best_model"
+    FINAL_MODEL = "fl_final_model"
+
+
 class ExtraItems(StrEnum):
     ABORT = "fl_abort"
-    MODEL_NAME = "fl_model_name"
+    MODEL_TYPE = "fl_model_type"
     CLIENT_NAME = "fl_client_name"
     APP_ROOT = "fl_app_root"
 

--- a/monai/fl/utils/constants.py
+++ b/monai/fl/utils/constants.py
@@ -43,6 +43,7 @@ class BundleKeys(StrEnum):
     TRAINER = "train#trainer"
     EVALUATOR = "validate#evaluator"
     TRAIN_TRAINER_MAX_EPOCHS = "train#trainer#max_epochs"
+    VALIDATE_HANDLERS = "validate#handlers"
 
 
 class FiltersType(StrEnum):


### PR DESCRIPTION
Fixes #4982.

### Description
Several improvements to MonaiAlgo:

1. warn if no weights were loaded
2. disable checkpoint loaders by default if defined in train/evaluate configs
3. send best checkpoint if requested
4. allow deterministic training

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
