### PR TITLE
Denseblock Class

### DIFF
--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -89,6 +89,11 @@ Blocks
 .. autoclass:: UnetOutBlock
     :members:
 
+`DenseBlock`
+~~~~~~~~~~~~~
+.. autoclass:: DenseBlock
+   :members:
+
 `SegResnet Block`
 ~~~~~~~~~~~~~~~~~
 .. autoclass:: ResBlock
@@ -237,7 +242,6 @@ Blocks
 ~~~~~~~~~~~~~
 .. autoclass:: monai.apps.reconstruction.networks.blocks.varnetblock.VarNetBlock
    :members:
-
 
 N-Dim Fourier Transform
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/monai/networks/blocks/__init__.py
+++ b/monai/networks/blocks/__init__.py
@@ -15,6 +15,7 @@ from .aspp import SimpleASPP
 from .backbone_fpn_utils import BackboneWithFPN
 from .convolutions import Convolution, ResidualUnit
 from .crf import CRF
+from .denseblock import ConvDenseBlock, DenseBlock
 from .dints_block import ActiConvNormBlock, FactorizedIncreaseBlock, FactorizedReduceBlock, P3DActiConvNormBlock
 from .downsample import MaxAvgPool
 from .dynunet_block import UnetBasicBlock, UnetOutBlock, UnetResBlock, UnetUpBlock, get_output_padding, get_padding

--- a/monai/networks/blocks/denseblock.py
+++ b/monai/networks/blocks/denseblock.py
@@ -1,0 +1,127 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Sequence, Tuple, Union
+
+import torch
+import torch.nn as nn
+
+from monai.networks.blocks import Convolution, ResidualUnit
+from monai.networks.layers.factories import Act, Norm
+
+__ALL__ = ["DenseBlock", "ConvDenseBlock"]
+
+
+class DenseBlock(nn.Sequential):
+    """
+    A DenseBlock is a sequence of layers where each layer's outputs are concatenated with their inputs. This has the
+    effect of accumulating outputs from previous layers as inputs to later ones and as the final output of the block.
+
+    Args:
+        layers: sequence of nn.Module objects to define the individual layers of the dense block
+    """
+
+    def __init__(self, layers: Sequence[nn.Module]):
+        super().__init__()
+        for i, l in enumerate(layers):
+            self.add_module(f"layers{i}", l)
+
+    def forward(self, x):
+        for l in self.children():
+            result = l(x)
+            x = torch.cat([x, result], 1)
+
+        return x
+
+
+class ConvDenseBlock(DenseBlock):
+    """
+    This dense block is defined as a sequence of `Convolution` or `ResidualUnit` blocks. The `_get_layer` method returns
+    an object for each layer and can be overridden to change the composition of the block.
+
+    Args:
+        spatial_dims: number of spatial dimensions.
+        in_channels: number of input channels.
+        channels: output channels for each layer.
+        dilations: dilation value for each layer.
+        kernel_size: convolution kernel size. Defaults to 3.
+        num_res_units: number of convolutions. Defaults to 2.
+        adn_ordering: a string representing the ordering of activation, normalization, and dropout. Defaults to "NDA".
+        act: activation type and arguments. Defaults to PReLU.
+        norm: feature normalization type and arguments. Defaults to instance norm.
+        dropout: dropout ratio. Defaults to no dropout.
+        bias: whether to have a bias term. Defaults to True.
+    """
+
+    def __init__(
+        self,
+        spatial_dims: int,
+        in_channels: int,
+        channels: Sequence[int],
+        dilations: Sequence[int] = None,
+        kernel_size: Union[Sequence[int], int] = 3,
+        num_res_units: int = 0,
+        adn_ordering: str = "NDA",
+        act: Optional[Union[Tuple, str]] = Act.PRELU,
+        norm: Optional[Union[Tuple, str]] = Norm.INSTANCE,
+        dropout: Optional[int] = None,
+        bias: bool = True,
+    ):
+
+        self.spatial_dims = spatial_dims
+        self.kernel_size = kernel_size
+        self.num_res_units = num_res_units
+        self.adn_ordering = adn_ordering
+        self.act = act
+        self.norm = norm
+        self.dropout = dropout
+        self.bias = bias
+
+        l_channels = in_channels
+        dilations = dilations or ([1] * len(channels))
+        layers = []
+
+        for c, d in zip(channels, dilations):
+            layer = self._get_layer(l_channels, c, d)
+            layers.append(layer)
+            l_channels += c
+
+        super().__init__(layers)
+
+    def _get_layer(self, in_channels, out_channels, dilation):
+        if self.num_res_units > 0:
+            return ResidualUnit(
+                spatial_dims=self.spatial_dims,
+                in_channels=in_channels,
+                out_channels=out_channels,
+                strides=1,
+                kernel_size=self.kernel_size,
+                subunits=self.num_res_units,
+                adn_ordering=self.adn_ordering,
+                act=self.act,
+                norm=self.norm,
+                dropout=self.dropout,
+                dilation=dilation,
+                bias=self.bias,
+            )
+        else:
+            return Convolution(
+                spatial_dims=self.spatial_dims,
+                in_channels=in_channels,
+                out_channels=out_channels,
+                strides=1,
+                kernel_size=self.kernel_size,
+                act=self.act,
+                norm=self.norm,
+                dropout=self.dropout,
+                dilation=dilation,
+                bias=self.bias,
+            )

--- a/monai/networks/blocks/denseblock.py
+++ b/monai/networks/blocks/denseblock.py
@@ -88,7 +88,7 @@ class ConvDenseBlock(DenseBlock):
         l_channels = in_channels
         dilations = dilations if dilations is not None else ([1] * len(channels))
         layers = []
-        
+
         if len(channels) != len(dilations):
             raise ValueError("Length of `channels` and `dilations` must match")
 

--- a/monai/networks/blocks/denseblock.py
+++ b/monai/networks/blocks/denseblock.py
@@ -66,7 +66,7 @@ class ConvDenseBlock(DenseBlock):
         spatial_dims: int,
         in_channels: int,
         channels: Sequence[int],
-        dilations: Sequence[int] = None,
+        dilations: Optional[Sequence[int]] = None,
         kernel_size: Union[Sequence[int], int] = 3,
         num_res_units: int = 0,
         adn_ordering: str = "NDA",
@@ -86,8 +86,11 @@ class ConvDenseBlock(DenseBlock):
         self.bias = bias
 
         l_channels = in_channels
-        dilations = dilations or ([1] * len(channels))
+        dilations = dilations if dilations is not None else ([1] * len(channels))
         layers = []
+        
+        if len(channels) != len(dilations):
+            raise ValueError("Length of `channels` and `dilations` must match")
 
         for c, d in zip(channels, dilations):
             layer = self._get_layer(l_channels, c, d)

--- a/tests/test_denseblock.py
+++ b/tests/test_denseblock.py
@@ -13,32 +13,39 @@ import unittest
 
 import torch.nn as nn
 
-from monai.networks.blocks import DenseBlock, ConvDenseBlock
+from monai.networks.blocks import ConvDenseBlock, DenseBlock
 from tests.utils import TorchImageTestCase2D, TorchImageTestCase3D
+
 
 class TestDenseBlock2D(TorchImageTestCase2D):
     def test_block_empty(self):
-        block=DenseBlock([])
+        block = DenseBlock([])
         out = block(self.imt)
         expected_shape = self.imt.shape
         self.assertEqual(out.shape, expected_shape)
-        
+
     def test_block_conv(self):
-        conv1=nn.Conv2d(self.input_channels, self.output_channels,3,padding=1)
-        conv2=nn.Conv2d(self.input_channels+self.output_channels, self.input_channels,3,padding=1)
-        block=DenseBlock([conv1,conv2])
-        out=block(self.imt)
-        expected_shape = (1, self.output_channels+self.input_channels*2, self.im_shape[0], self.im_shape[1])
+        conv1 = nn.Conv2d(self.input_channels, self.output_channels, 3, padding=1)
+        conv2 = nn.Conv2d(self.input_channels + self.output_channels, self.input_channels, 3, padding=1)
+        block = DenseBlock([conv1, conv2])
+        out = block(self.imt)
+        expected_shape = (1, self.output_channels + self.input_channels * 2, self.im_shape[0], self.im_shape[1])
         self.assertEqual(out.shape, expected_shape)
-        
-        
+
+
 class TestDenseBlock3D(TorchImageTestCase3D):
     def test_block_conv(self):
-        conv1=nn.Conv3d(self.input_channels, self.output_channels,3,padding=1)
-        conv2=nn.Conv3d(self.input_channels+self.output_channels, self.input_channels,3,padding=1)
-        block=DenseBlock([conv1,conv2])
-        out=block(self.imt)
-        expected_shape = (1, self.output_channels+self.input_channels*2, self.im_shape[1], self.im_shape[0], self.im_shape[2])
+        conv1 = nn.Conv3d(self.input_channels, self.output_channels, 3, padding=1)
+        conv2 = nn.Conv3d(self.input_channels + self.output_channels, self.input_channels, 3, padding=1)
+        block = DenseBlock([conv1, conv2])
+        out = block(self.imt)
+        expected_shape = (
+            1,
+            self.output_channels + self.input_channels * 2,
+            self.im_shape[1],
+            self.im_shape[0],
+            self.im_shape[2],
+        )
         self.assertEqual(out.shape, expected_shape)
 
 
@@ -48,44 +55,49 @@ class TestConvDenseBlock2D(TorchImageTestCase2D):
         out = conv(self.imt)
         expected_shape = self.imt.shape
         self.assertEqual(out.shape, expected_shape)
-        
+
+    def test_except(self):
+        with self.assertRaises(ValueError):
+            _ = ConvDenseBlock(spatial_dims=2, in_channels=self.input_channels, channels=[1, 2], dilations=[1, 2, 3])
+
     def test_block1(self):
-        channels=[2,4]
+        channels = [2, 4]
         conv = ConvDenseBlock(spatial_dims=2, in_channels=self.input_channels, channels=channels)
         out = conv(self.imt)
-        expected_shape = (1, self.input_channels+sum(channels), self.im_shape[0], self.im_shape[1])
+        expected_shape = (1, self.input_channels + sum(channels), self.im_shape[0], self.im_shape[1])
         self.assertEqual(out.shape, expected_shape)
 
     def test_block2(self):
-        channels=[2,4]
-        dilations=[1,2]
-        conv = ConvDenseBlock(spatial_dims=2, in_channels=self.input_channels, channels=channels,dilations=dilations)
+        channels = [2, 4]
+        dilations = [1, 2]
+        conv = ConvDenseBlock(spatial_dims=2, in_channels=self.input_channels, channels=channels, dilations=dilations)
         out = conv(self.imt)
-        expected_shape = (1, self.input_channels+sum(channels), self.im_shape[0], self.im_shape[1])
+        expected_shape = (1, self.input_channels + sum(channels), self.im_shape[0], self.im_shape[1])
         self.assertEqual(out.shape, expected_shape)
 
-    
+
 class TestConvDenseBlock3D(TorchImageTestCase3D):
     def test_block_empty(self):
         conv = ConvDenseBlock(spatial_dims=3, in_channels=self.input_channels, channels=[])
         out = conv(self.imt)
         expected_shape = self.imt.shape
         self.assertEqual(out.shape, expected_shape)
-        
+
     def test_block1(self):
-        channels=[2,4]
+        channels = [2, 4]
         conv = ConvDenseBlock(spatial_dims=3, in_channels=self.input_channels, channels=channels)
         out = conv(self.imt)
-        expected_shape = (1, self.input_channels+sum(channels), self.im_shape[1], self.im_shape[0], self.im_shape[2])
+        expected_shape = (1, self.input_channels + sum(channels), self.im_shape[1], self.im_shape[0], self.im_shape[2])
         self.assertEqual(out.shape, expected_shape)
 
     def test_block2(self):
-        channels=[2,4]
-        dilations=[1,2]
-        conv = ConvDenseBlock(spatial_dims=3, in_channels=self.input_channels, channels=channels,dilations=dilations)
+        channels = [2, 4]
+        dilations = [1, 2]
+        conv = ConvDenseBlock(spatial_dims=3, in_channels=self.input_channels, channels=channels, dilations=dilations)
         out = conv(self.imt)
-        expected_shape = (1, self.input_channels+sum(channels), self.im_shape[1], self.im_shape[0], self.im_shape[2])
+        expected_shape = (1, self.input_channels + sum(channels), self.im_shape[1], self.im_shape[0], self.im_shape[2])
         self.assertEqual(out.shape, expected_shape)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_denseblock.py
+++ b/tests/test_denseblock.py
@@ -1,0 +1,91 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch.nn as nn
+
+from monai.networks.blocks import DenseBlock, ConvDenseBlock
+from tests.utils import TorchImageTestCase2D, TorchImageTestCase3D
+
+class TestDenseBlock2D(TorchImageTestCase2D):
+    def test_block_empty(self):
+        block=DenseBlock([])
+        out = block(self.imt)
+        expected_shape = self.imt.shape
+        self.assertEqual(out.shape, expected_shape)
+        
+    def test_block_conv(self):
+        conv1=nn.Conv2d(self.input_channels, self.output_channels,3,padding=1)
+        conv2=nn.Conv2d(self.input_channels+self.output_channels, self.input_channels,3,padding=1)
+        block=DenseBlock([conv1,conv2])
+        out=block(self.imt)
+        expected_shape = (1, self.output_channels+self.input_channels*2, self.im_shape[0], self.im_shape[1])
+        self.assertEqual(out.shape, expected_shape)
+        
+        
+class TestDenseBlock3D(TorchImageTestCase3D):
+    def test_block_conv(self):
+        conv1=nn.Conv3d(self.input_channels, self.output_channels,3,padding=1)
+        conv2=nn.Conv3d(self.input_channels+self.output_channels, self.input_channels,3,padding=1)
+        block=DenseBlock([conv1,conv2])
+        out=block(self.imt)
+        expected_shape = (1, self.output_channels+self.input_channels*2, self.im_shape[1], self.im_shape[0], self.im_shape[2])
+        self.assertEqual(out.shape, expected_shape)
+
+
+class TestConvDenseBlock2D(TorchImageTestCase2D):
+    def test_block_empty(self):
+        conv = ConvDenseBlock(spatial_dims=2, in_channels=self.input_channels, channels=[])
+        out = conv(self.imt)
+        expected_shape = self.imt.shape
+        self.assertEqual(out.shape, expected_shape)
+        
+    def test_block1(self):
+        channels=[2,4]
+        conv = ConvDenseBlock(spatial_dims=2, in_channels=self.input_channels, channels=channels)
+        out = conv(self.imt)
+        expected_shape = (1, self.input_channels+sum(channels), self.im_shape[0], self.im_shape[1])
+        self.assertEqual(out.shape, expected_shape)
+
+    def test_block2(self):
+        channels=[2,4]
+        dilations=[1,2]
+        conv = ConvDenseBlock(spatial_dims=2, in_channels=self.input_channels, channels=channels,dilations=dilations)
+        out = conv(self.imt)
+        expected_shape = (1, self.input_channels+sum(channels), self.im_shape[0], self.im_shape[1])
+        self.assertEqual(out.shape, expected_shape)
+
+    
+class TestConvDenseBlock3D(TorchImageTestCase3D):
+    def test_block_empty(self):
+        conv = ConvDenseBlock(spatial_dims=3, in_channels=self.input_channels, channels=[])
+        out = conv(self.imt)
+        expected_shape = self.imt.shape
+        self.assertEqual(out.shape, expected_shape)
+        
+    def test_block1(self):
+        channels=[2,4]
+        conv = ConvDenseBlock(spatial_dims=3, in_channels=self.input_channels, channels=channels)
+        out = conv(self.imt)
+        expected_shape = (1, self.input_channels+sum(channels), self.im_shape[1], self.im_shape[0], self.im_shape[2])
+        self.assertEqual(out.shape, expected_shape)
+
+    def test_block2(self):
+        channels=[2,4]
+        dilations=[1,2]
+        conv = ConvDenseBlock(spatial_dims=3, in_channels=self.input_channels, channels=channels,dilations=dilations)
+        out = conv(self.imt)
+        expected_shape = (1, self.input_channels+sum(channels), self.im_shape[1], self.im_shape[0], self.im_shape[2])
+        self.assertEqual(out.shape, expected_shape)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description
This defines an abstract dense block class and a convolutional dense block using `Convolution` or `ResidualUnit` classes. A number of existing networks use dense blocks but have their own implementations that should be left as-is since these are reference implementations, but further definitions should use a common definition. I will have a network to submit as a bundle that uses this.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
