### PR TITLE
4875 temp location of algo templates 

### DIFF
--- a/monai/apps/auto3dseg/algo_templates/dints/configs/hyper_parameters.yaml
+++ b/monai/apps/auto3dseg/algo_templates/dints/configs/hyper_parameters.yaml
@@ -1,0 +1,61 @@
+---
+# hyper-parameters
+amp: true
+bundle_root: null
+ckpt_path: "$@bundle_root + '/model_fold' + str(@fold)"
+data_file_base_dir: null
+data_list_file_path: null
+determ: false
+fold: 0
+input_channels: null
+learning_rate: 0.025
+num_images_per_batch: 2
+num_iterations: 40000
+num_iterations_per_validation: 500
+num_patches_per_image: 1
+num_sw_batch_size: 2
+output_classes: null
+overlap_ratio: 0.625
+patch_size: null
+patch_size_valid: null
+softmax: true
+
+# training
+loss:
+  _target_: DiceFocalLoss
+  include_background: true
+  to_onehot_y: "$@softmax"
+  softmax: "$@softmax"
+  sigmoid: "$not @softmax"
+  squared_pred: true
+  batch: true
+  smooth_nr: 1.0e-05
+  smooth_dr: 1.0e-05
+optimizer:
+  _target_: torch.optim.SGD
+  lr: "@learning_rate"
+  momentum: 0.9
+  weight_decay: 4.0e-05
+lr_scheduler:
+  _target_: torch.optim.lr_scheduler.StepLR
+  optimizer: "$@optimizer"
+  step_size: "$@num_iterations // 5"
+  gamma: 0.5
+
+# fine-tuning
+finetune:
+  activate: false
+  pretrained_ckpt_name: "$@bundle_root + '/model_fold' + str(@fold) + '/best_metric_model.pt'"
+
+# validation
+validate:
+  ckpt_name: "$@bundle_root + '/model_fold' + str(@fold) + '/best_metric_model.pt'"
+  save_mask: true
+  ouptut_path: "$@bundle_root + '/prediction_fold' + str(@fold)"
+
+# inference
+infer:
+  ckpt_name: "$@bundle_root + '/model_fold' + str(@fold) + '/best_metric_model.pt'"
+  fast: false
+  data_list_key: testing
+  ouptut_path: "$@bundle_root + '/prediction_' + @infer#data_list_key"

--- a/monai/apps/auto3dseg/algo_templates/dints/configs/hyper_parameters_search.yaml
+++ b/monai/apps/auto3dseg/algo_templates/dints/configs/hyper_parameters_search.yaml
@@ -1,0 +1,55 @@
+---
+# hyper-parameters
+amp: true
+bundle_root: null
+arch_path: "$@bundle_root + '/arch_ram' + str(@ram_cost_factor) + '_fold' + str(@fold)"
+data_file_base_dir: null
+data_list_file_path: null
+determ: false
+fold: 0
+input_channels: null
+learning_rate: 0.025
+learning_rate_arch: 0.001
+num_images_per_batch: 2
+num_iterations: 20000
+num_iterations_per_validation: 500
+num_warmup_iterations: 10000
+num_patches_per_image: 1
+num_sw_batch_size: 2
+output_classes: null
+overlap_ratio: 0.625
+patch_size: null
+patch_size_valid: null
+ram_cost_factor: 0.8
+softmax: true
+
+# architecture searching
+loss:
+  _target_: DiceFocalLoss
+  include_background: true
+  to_onehot_y: "$@softmax"
+  softmax: "$@softmax"
+  sigmoid: "$not @softmax"
+  squared_pred: true
+  batch: true
+  smooth_nr: 1.0e-05
+  smooth_dr: 1.0e-05
+optimizer:
+  _target_: torch.optim.SGD
+  lr: "@learning_rate"
+  momentum: 0.9
+  weight_decay: 4.0e-05
+arch_optimizer_a:
+  _target_: torch.optim.Adam
+  lr: "@learning_rate_arch"
+  betas: [0.5, 0.999]
+  weight_decay: 0
+arch_optimizer_c:
+  _target_: torch.optim.Adam
+  lr: "@learning_rate_arch"
+  betas: [0.5, 0.999]
+  weight_decay: 0
+lr_scheduler:
+  _target_: torch.optim.lr_scheduler.StepLR
+  step_size: "$int(float(@num_iterations - @num_warmup_iterations) * 0.4)"
+  gamma: 0.5

--- a/monai/apps/auto3dseg/algo_templates/dints/configs/network.yaml
+++ b/monai/apps/auto3dseg/algo_templates/dints/configs/network.yaml
@@ -1,0 +1,20 @@
+---
+arch_ckpt_path: "$@bundle_root + '/scripts/arch_code.pth'"
+arch_ckpt: "$torch.load(@arch_ckpt_path, map_location=torch.device('cuda'))"
+dints_space:
+  _target_: TopologyInstance
+  channel_mul: 1
+  num_blocks: 12
+  num_depths: 4
+  use_downsample: true
+  arch_code:
+  - "$@arch_ckpt['code_a']"
+  - "$@arch_ckpt['code_c']"
+  device: "$torch.device('cuda')"
+network:
+  _target_: DiNTS
+  dints_space: "$@dints_space"
+  in_channels: "@input_channels"
+  num_classes: "@output_classes"
+  use_downsample: true
+  node_a: "$@arch_ckpt['node_a']"

--- a/monai/apps/auto3dseg/algo_templates/dints/configs/network_search.yaml
+++ b/monai/apps/auto3dseg/algo_templates/dints/configs/network_search.yaml
@@ -1,0 +1,14 @@
+---
+dints_space:
+  _target_: TopologySearch
+  channel_mul: 0.5
+  num_blocks: 12
+  num_depths: 4
+  use_downsample: true
+  device: "$torch.device('cuda')"
+network:
+  _target_: DiNTS
+  dints_space: "$@dints_space"
+  in_channels: "@input_channels"
+  num_classes: "@output_classes"
+  use_downsample: true

--- a/monai/apps/auto3dseg/algo_templates/dints/configs/transforms_infer.yaml
+++ b/monai/apps/auto3dseg/algo_templates/dints/configs/transforms_infer.yaml
@@ -1,0 +1,24 @@
+---
+image_key: image
+transforms_infer:
+  _target_: Compose
+  transforms:
+  - _target_: LoadImaged
+    keys: "@image_key"
+  - _target_: EnsureChannelFirstd
+    keys: "@image_key"
+  - _target_: Orientationd
+    keys: "@image_key"
+    axcodes: RAS
+  - _target_: Spacingd
+    keys: "@image_key"
+    pixdim: null
+    mode: bilinear
+    align_corners: true
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"
+  - PLACEHOLDER_INTENSITY_NORMALIZATION
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"

--- a/monai/apps/auto3dseg/algo_templates/dints/configs/transforms_train.yaml
+++ b/monai/apps/auto3dseg/algo_templates/dints/configs/transforms_train.yaml
@@ -1,0 +1,88 @@
+---
+image_key: image
+label_key: label
+transforms_train:
+  _target_: Compose
+  transforms:
+  - _target_: LoadImaged
+    keys: ["@image_key", "@label_key"]
+  - _target_: EnsureChannelFirstd
+    keys: ["@image_key", "@label_key"]
+  - _target_: Orientationd
+    keys: ["@image_key", "@label_key"]
+    axcodes: RAS
+  - _target_: Spacingd
+    keys: ["@image_key", "@label_key"]
+    pixdim: null
+    mode: [bilinear, nearest]
+    align_corners: [true, true]
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"
+  - PLACEHOLDER_INTENSITY_NORMALIZATION
+  - _target_: CastToTyped
+    keys: ["@image_key", "@label_key"]
+    dtype: ["$np.float16", "$np.uint8"]
+  - _target_: EnsureTyped
+    keys: ["@image_key", "@label_key"]
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"
+  - _target_: SpatialPadd
+    keys: ["@image_key", "@label_key"]
+    spatial_size: "@patch_size"
+    mode: [reflect, constant]
+
+  # data augmentation
+  - _target_: RandCropByLabelClassesd
+    keys: ["@image_key", "@label_key"]
+    label_key: "@label_key"
+    num_classes: "@output_classes"
+    spatial_size: "@patch_size"
+    num_samples: "@num_patches_per_image"
+  - _target_: RandRotated
+    keys: ["@image_key", "@label_key"]
+    range_x: 0.3
+    range_y: 0.3
+    range_z: 0.3
+    mode: [bilinear, nearest]
+    prob: 0.2
+  - _target_: RandZoomd
+    keys: ["@image_key", "@label_key"]
+    min_zoom: 0.8
+    max_zoom: 1.2
+    mode: [trilinear, nearest]
+    prob: 0.16
+  - _target_: RandGaussianSmoothd
+    keys: "@image_key"
+    sigma_x: [0.5, 1.15]
+    sigma_y: [0.5, 1.15]
+    sigma_z: [0.5, 1.15]
+    prob: 0.15
+  - _target_: RandScaleIntensityd
+    keys: "@image_key"
+    factors: 0.3
+    prob: 0.5
+  - _target_: RandShiftIntensityd
+    keys: "@image_key"
+    offsets: 0.1
+    prob: 0.5
+  - _target_: RandGaussianNoised
+    keys: "@image_key"
+    std: 0.01
+    prob: 0.15
+  - _target_: RandFlipd
+    keys: ["@image_key", "@label_key"]
+    spatial_axis: 0
+    prob: 0.5
+  - _target_: RandFlipd
+    keys: ["@image_key", "@label_key"]
+    spatial_axis: 1
+    prob: 0.5
+  - _target_: RandFlipd
+    keys: ["@image_key", "@label_key"]
+    spatial_axis: 2
+    prob: 0.5
+  - _target_: CastToTyped
+    keys: ["@image_key", "@label_key"]
+    dtype: ["$torch.float32", "$torch.uint8"]

--- a/monai/apps/auto3dseg/algo_templates/dints/configs/transforms_validate.yaml
+++ b/monai/apps/auto3dseg/algo_templates/dints/configs/transforms_validate.yaml
@@ -1,0 +1,25 @@
+---
+image_key: image
+label_key: label
+transforms_validate:
+  _target_: Compose
+  transforms:
+  - _target_: LoadImaged
+    keys: ["@image_key", "@label_key"]
+  - _target_: EnsureChannelFirstd
+    keys: ["@image_key", "@label_key"]
+  - _target_: Orientationd
+    keys: ["@image_key", "@label_key"]
+    axcodes: RAS
+  - _target_: Spacingd
+    keys: ["@image_key", "@label_key"]
+    pixdim: null
+    mode: [bilinear, nearest]
+    align_corners: [true, true]
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"
+  - PLACEHOLDER_INTENSITY_NORMALIZATION
+  - _target_: CastToTyped
+    keys: ["@image_key", "@label_key"]
+    dtype: ["$torch.float32", "$torch.uint8"]

--- a/monai/apps/auto3dseg/algo_templates/dints/scripts/algo.py
+++ b/monai/apps/auto3dseg/algo_templates/dints/scripts/algo.py
@@ -1,0 +1,90 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from copy import deepcopy
+
+from monai.apps.auto3dseg import BundleAlgo
+from monai.bundle import ConfigParser
+
+
+class DintsAlgo(BundleAlgo):
+    def fill_template_config(self, data_stats):
+        if data_stats is None:
+            return
+        data_cfg = ConfigParser(globals=False)
+        if os.path.exists(str(data_stats)):
+            data_cfg.read_config(str(data_stats))
+        else:
+            data_cfg.update(data_stats)
+        data_src_cfg = ConfigParser(globals=False)
+        if self.data_list_file is not None and os.path.exists(str(self.data_list_file)):
+            data_src_cfg.read_config(self.data_list_file)
+            self.cfg.update(
+                {
+                    "data_file_base_dir": data_src_cfg["dataroot"],
+                    "data_list_file_path": data_src_cfg["datalist"],
+                    "input_channels": data_cfg["stats_summary#image_stats#channels#max"],
+                    "output_classes": len(data_cfg["stats_summary#label_stats#labels"]),
+                }
+            )
+        patch_size = [128, 128, 96]
+        max_shape = data_cfg["stats_summary#image_stats#shape#max"]
+        patch_size = [
+            max(32, shape_k // 32 * 32) if shape_k < p_k else p_k for p_k, shape_k in zip(patch_size, max_shape)
+        ]
+        # patch_size and patch_size_valid are overridden in scripts/search.py
+        self.cfg["patch_size"], self.cfg["patch_size_valid"] = [96, 96, 96], [96, 96, 96]
+        self.cfg["patch_size#0"], self.cfg["patch_size#1"], self.cfg["patch_size#2"] = patch_size
+        self.cfg["patch_size_valid#0"], self.cfg["patch_size_valid#1"], self.cfg["patch_size_valid#2"] = patch_size
+
+        modality = data_src_cfg.get("modality", "ct").lower()
+        spacing = data_cfg["stats_summary#image_stats#spacing#median"]
+
+        intensity_upper_bound = float(data_cfg["stats_summary#image_foreground_stats#intensity#percentile_99_5"])
+        intensity_lower_bound = float(data_cfg["stats_summary#image_foreground_stats#intensity#percentile_00_5"])
+        ct_intensity_xform = {
+            "_target_": "Compose",
+            "transforms": [
+                {
+                    "_target_": "ScaleIntensityRanged",
+                    "keys": "@image_key",
+                    "a_min": intensity_lower_bound,
+                    "a_max": intensity_upper_bound,
+                    "b_min": 0.0,
+                    "b_max": 1.0,
+                    "clip": True,
+                },
+                {"_target_": "CropForegroundd", "keys": ["@image_key", "@label_key"], "source_key": "@image_key"},
+            ],
+        }
+        mr_intensity_transform = {
+            "_target_": "NormalizeIntensityd",
+            "keys": "@image_key",
+            "nonzero": True,
+            "channel_wise": True,
+        }
+        for key in ["transforms_infer", "transforms_train", "transforms_validate"]:
+            for idx, xform in enumerate(self.cfg[f"{key}#transforms"]):
+                if isinstance(xform, dict) and xform.get("_target_", "").startswith("Spacing"):
+                    xform["pixdim"] = deepcopy(spacing)
+                elif isinstance(xform, str) and xform.startswith("PLACEHOLDER_INTENSITY_NORMALIZATION"):
+                    if modality.startswith("ct"):
+                        self.cfg[f"{key}#transforms#{idx}"] = deepcopy(ct_intensity_xform)
+                    else:
+                        self.cfg[f"{key}#transforms#{idx}"] = deepcopy(mr_intensity_transform)
+
+
+if __name__ == "__main__":
+    from monai.utils import optional_import
+
+    fire, _ = optional_import("fire")
+    fire.Fire({"DintsAlgo": DintsAlgo})

--- a/monai/apps/auto3dseg/algo_templates/dints/scripts/infer.py
+++ b/monai/apps/auto3dseg/algo_templates/dints/scripts/infer.py
@@ -1,0 +1,192 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import os
+import sys
+from typing import Optional, Sequence, Union
+
+import torch
+
+import monai
+from monai import transforms
+from monai.bundle import ConfigParser
+from monai.bundle.scripts import _pop_args, _update_args
+from monai.data import ThreadDataLoader, decollate_batch, list_data_collate
+from monai.inferers import sliding_window_inference
+
+
+class InferClass:
+    def __init__(self, config_file: Optional[Union[str, Sequence[str]]] = None, **override):
+        logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+        _args = _update_args(config_file=config_file, **override)
+        config_file_ = _pop_args(_args, "config_file")[0]
+
+        parser = ConfigParser()
+        parser.read_config(config_file_)
+        parser.update(pairs=_args)
+
+        data_file_base_dir = parser.get_parsed_content("data_file_base_dir")
+        data_list_file_path = parser.get_parsed_content("data_list_file_path")
+        self.fast = parser.get_parsed_content("infer")["fast"]
+        self.num_sw_batch_size = parser.get_parsed_content("num_sw_batch_size")
+        self.overlap_ratio = parser.get_parsed_content("overlap_ratio")
+        self.patch_size_valid = parser.get_parsed_content("patch_size_valid")
+        softmax = parser.get_parsed_content("softmax")
+
+        ckpt_name = parser.get_parsed_content("infer")["ckpt_name"]
+        data_list_key = parser.get_parsed_content("infer")["data_list_key"]
+        output_path = parser.get_parsed_content("infer")["ouptut_path"]
+
+        if not os.path.exists(output_path):
+            os.makedirs(output_path, exist_ok=True)
+
+        self.infer_transforms = parser.get_parsed_content("transforms_infer")
+
+        with open(data_list_file_path) as f:
+            json_data = json.load(f)
+
+        list_data = []
+        for item in json_data[data_list_key]:
+            list_data.append(item)
+
+        files = []
+        for _i in range(len(list_data)):
+            str_img = os.path.join(data_file_base_dir, list_data[_i]["image"])
+
+            if not os.path.exists(str_img):
+                continue
+
+            files.append({"image": str_img})
+
+        self.infer_files = files
+
+        self.infer_loader = None
+        if self.fast:
+            infer_ds = monai.data.Dataset(data=self.infer_files, transform=self.infer_transforms)
+            self.infer_loader = ThreadDataLoader(infer_ds, num_workers=8, batch_size=1, shuffle=False)
+
+        self.device = torch.device("cuda:0")
+        torch.cuda.set_device(self.device)
+
+        self.model = parser.get_parsed_content("network")
+        self.model = self.model.to(self.device)
+        self.model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(self.model)
+
+        pretrained_ckpt = torch.load(ckpt_name, map_location=self.device)
+        self.model.load_state_dict(pretrained_ckpt)
+        print(f"[info] checkpoint {ckpt_name:s} loaded")
+
+        post_transforms = [
+            transforms.Invertd(
+                keys="pred",
+                transform=self.infer_transforms,
+                orig_keys="image",
+                meta_keys="pred_meta_dict",
+                orig_meta_keys="image_meta_dict",
+                meta_key_postfix="meta_dict",
+                nearest_interp=False,
+                to_tensor=True,
+            ),
+            transforms.Activationsd(keys="pred", softmax=softmax, sigmoid=not softmax),
+            transforms.CopyItemsd(keys="pred", times=1, names="pred_final"),
+        ]
+
+        if softmax:
+            post_transforms += [transforms.AsDiscreted(keys="pred_final", argmax=True)]
+        else:
+            post_transforms += [transforms.AsDiscreted(keys="pred_final", threshold=0.5)]
+
+        post_transforms += [
+            transforms.SaveImaged(
+                keys="pred_final",
+                meta_keys="pred_meta_dict",
+                output_dir=output_path,
+                output_postfix="seg",
+                resample=False,
+            )
+        ]
+        self.post_transforms = transforms.Compose(post_transforms)
+
+        return
+
+    @torch.no_grad()
+    def infer(self, image_file):
+        self.model.eval()
+
+        batch_data = self.infer_transforms(image_file)
+        batch_data = list_data_collate([batch_data])
+        infer_image = batch_data["image"].to(self.device)
+
+        with torch.cuda.amp.autocast():
+            batch_data["pred"] = sliding_window_inference(
+                infer_image,
+                self.patch_size_valid,
+                self.num_sw_batch_size,
+                self.model,
+                mode="gaussian",
+                overlap=self.overlap_ratio,
+            )
+
+        batch_data = [self.post_transforms(i) for i in decollate_batch(batch_data)]
+
+        return batch_data[0]["pred"]
+
+    def infer_all(self):
+        for _i in range(len(self.infer_files)):
+            infer_filename = self.infer_files[_i]
+            _ = self.infer(infer_filename)
+
+        return
+
+    @torch.no_grad()
+    def batch_infer(self):
+        self.model.eval()
+        with torch.no_grad():
+            for d in self.infer_loader:
+                torch.cuda.empty_cache()
+
+                infer_images = d["image"].to(self.device)
+
+                with torch.cuda.amp.autocast():
+                    d["pred"] = sliding_window_inference(
+                        infer_images,
+                        self.patch_size_valid,
+                        self.num_sw_batch_size,
+                        self.model,
+                        mode="gaussian",
+                        overlap=self.overlap_ratio,
+                    )
+
+                d = [self.post_transforms(i) for i in decollate_batch(d)]
+
+        return
+
+
+def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
+    infer_instance = InferClass(config_file, **override)
+    if infer_instance.fast:
+        print("[info] fast mode")
+        infer_instance.batch_infer()
+    else:
+        print("[info] slow mode")
+        infer_instance.infer_all()
+
+    return
+
+
+if __name__ == "__main__":
+    from monai.utils import optional_import
+
+    fire, _ = optional_import("fire")
+    fire.Fire()

--- a/monai/apps/auto3dseg/algo_templates/dints/scripts/search.py
+++ b/monai/apps/auto3dseg/algo_templates/dints/scripts/search.py
@@ -1,0 +1,550 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import math
+import os
+import random
+import sys
+import time
+from datetime import datetime
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+import yaml
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.tensorboard import SummaryWriter
+
+import monai
+from monai import transforms
+from monai.bundle import ConfigParser
+from monai.bundle.scripts import _pop_args, _update_args
+from monai.data import ThreadDataLoader, partition_dataset
+from monai.inferers import sliding_window_inference
+from monai.metrics import compute_meandice
+from monai.utils import set_determinism
+
+
+def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    _args = _update_args(config_file=config_file, **override)
+    config_file_ = _pop_args(_args, "config_file")[0]
+
+    parser = ConfigParser()
+    parser.read_config(config_file_)
+    parser.update(pairs=_args)
+
+    parser["patch_size"] = [96, 96, 96]
+    parser["patch_size_valid"] = [96, 96, 96]
+    amp = parser.get_parsed_content("amp")
+    arch_path = parser.get_parsed_content("arch_path")
+    data_file_base_dir = parser.get_parsed_content("data_file_base_dir")
+    data_list_file_path = parser.get_parsed_content("data_list_file_path")
+    determ = parser.get_parsed_content("determ")
+    fold = parser.get_parsed_content("fold")
+    num_images_per_batch = parser.get_parsed_content("num_images_per_batch")
+    num_iterations = parser.get_parsed_content("num_iterations")
+    num_iterations_per_validation = parser.get_parsed_content("num_iterations_per_validation")
+    num_warmup_iterations = parser.get_parsed_content("num_warmup_iterations")
+    num_sw_batch_size = parser.get_parsed_content("num_sw_batch_size")
+    output_classes = parser.get_parsed_content("output_classes")
+    overlap_ratio = parser.get_parsed_content("overlap_ratio")
+    patch_size_valid = parser.get_parsed_content("patch_size_valid")
+    ram_cost_factor = parser.get_parsed_content("ram_cost_factor")
+    softmax = parser.get_parsed_content("softmax")
+
+    train_transforms = parser.get_parsed_content("transforms_train")
+    val_transforms = parser.get_parsed_content("transforms_validate")
+
+    if not os.path.exists(arch_path):
+        os.makedirs(arch_path, exist_ok=True)
+
+    if determ:
+        set_determinism(seed=0)
+
+    print("[info] number of GPUs:", torch.cuda.device_count())
+    if torch.cuda.device_count() > 1:
+        dist.init_process_group(backend="nccl", init_method="env://")
+        world_size = dist.get_world_size()
+    else:
+        world_size = 1
+    print("[info] world_size:", world_size)
+
+    with open(data_list_file_path) as f:
+        json_data = json.load(f)
+
+    list_train = []
+    list_valid = []
+    for item in json_data["training"]:
+        if item["fold"] == fold:
+            item.pop("fold", None)
+            list_valid.append(item)
+        else:
+            item.pop("fold", None)
+            list_train.append(item)
+
+    files = []
+    for _i in range(len(list_train)):
+        str_img = os.path.join(data_file_base_dir, list_train[_i]["image"])
+        str_seg = os.path.join(data_file_base_dir, list_train[_i]["label"])
+
+        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
+            continue
+
+        files.append({"image": str_img, "label": str_seg})
+
+    train_files = files
+    random.shuffle(train_files)
+
+    train_files_w = train_files[: len(train_files) // 2]
+    if torch.cuda.device_count() > 1:
+        train_files_w = partition_dataset(
+            data=train_files_w, shuffle=True, num_partitions=world_size, even_divisible=True
+        )[dist.get_rank()]
+    print("train_files_w:", len(train_files_w))
+
+    train_files_a = train_files[len(train_files) // 2 :]
+    if torch.cuda.device_count() > 1:
+        train_files_a = partition_dataset(
+            data=train_files_a, shuffle=True, num_partitions=world_size, even_divisible=True
+        )[dist.get_rank()]
+    print("train_files_a:", len(train_files_a))
+
+    files = []
+    for _i in range(len(list_valid)):
+        str_img = os.path.join(data_file_base_dir, list_valid[_i]["image"])
+        str_seg = os.path.join(data_file_base_dir, list_valid[_i]["label"])
+
+        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
+            continue
+
+        files.append({"image": str_img, "label": str_seg})
+
+    val_files = files
+
+    if torch.cuda.device_count() > 1:
+        if len(val_files) < world_size:
+            val_files = val_files * math.ceil(float(world_size) / float(len(val_files)))
+
+        val_files = partition_dataset(data=val_files, shuffle=False, num_partitions=world_size, even_divisible=False)[
+            dist.get_rank()
+        ]
+    print("val_files:", len(val_files))
+
+    if torch.cuda.device_count() >= 4:
+        train_ds_a = monai.data.CacheDataset(
+            data=train_files_a, transform=train_transforms, cache_rate=1.0, num_workers=8
+        )
+        train_ds_w = monai.data.CacheDataset(
+            data=train_files_w, transform=train_transforms, cache_rate=1.0, num_workers=8
+        )
+        val_ds = monai.data.CacheDataset(data=val_files, transform=val_transforms, cache_rate=1.0, num_workers=2)
+    else:
+        train_ds_a = monai.data.CacheDataset(
+            data=train_files_a,
+            transform=train_transforms,
+            cache_rate=float(torch.cuda.device_count()) / 4.0,
+            num_workers=8,
+        )
+        train_ds_w = monai.data.CacheDataset(
+            data=train_files_w,
+            transform=train_transforms,
+            cache_rate=float(torch.cuda.device_count()) / 4.0,
+            num_workers=8,
+        )
+        val_ds = monai.data.CacheDataset(
+            data=val_files, transform=val_transforms, cache_rate=float(torch.cuda.device_count()) / 4.0, num_workers=2
+        )
+
+    train_loader_a = ThreadDataLoader(train_ds_a, num_workers=6, batch_size=num_images_per_batch, shuffle=True)
+    train_loader_w = ThreadDataLoader(train_ds_w, num_workers=6, batch_size=num_images_per_batch, shuffle=True)
+    val_loader = ThreadDataLoader(val_ds, num_workers=0, batch_size=1, shuffle=False)
+
+    device = torch.device(f"cuda:{dist.get_rank()}") if torch.cuda.device_count() > 1 else torch.device("cuda:0")
+    torch.cuda.set_device(device)
+
+    dints_space = parser.get_parsed_content("dints_space")
+    model = parser.get_parsed_content("network")
+    model = model.to(device)
+    model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+
+    if softmax:
+        post_pred = transforms.Compose(
+            [transforms.EnsureType(), transforms.AsDiscrete(argmax=True, to_onehot=output_classes)]
+        )
+        post_label = transforms.Compose([transforms.EnsureType(), transforms.AsDiscrete(to_onehot=output_classes)])
+    else:
+        post_pred = transforms.Compose(
+            [transforms.EnsureType(), transforms.Activations(sigmoid=True), transforms.AsDiscrete(threshold=0.5)]
+        )
+
+    loss_function = parser.get_parsed_content("loss")
+
+    optimizer_part = parser.get_parsed_content("optimizer", instantiate=False)
+    optimizer = optimizer_part.instantiate(params=model.parameters())
+
+    arch_optimizer_a_part = parser.get_parsed_content("arch_optimizer_a", instantiate=False)
+    arch_optimizer_a = arch_optimizer_a_part.instantiate(params=[dints_space.log_alpha_a])
+
+    arch_optimizer_c_part = parser.get_parsed_content("arch_optimizer_c", instantiate=False)
+    arch_optimizer_c = arch_optimizer_c_part.instantiate(params=[dints_space.log_alpha_c])
+
+    num_epochs_per_validation = num_iterations_per_validation // len(train_loader_a)
+    num_epochs_per_validation = max(num_epochs_per_validation, 1)
+    num_epochs = num_epochs_per_validation * (num_iterations // num_iterations_per_validation)
+    num_epochs_warmup = num_epochs_per_validation * (num_warmup_iterations // num_iterations_per_validation)
+
+    if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+        print("num_epochs", num_epochs)
+        print("num_epochs_warmup", num_epochs_warmup)
+        print("num_epochs_per_validation", num_epochs_per_validation)
+
+    lr_scheduler_part = parser.get_parsed_content("lr_scheduler", instantiate=False)
+    lr_scheduler = lr_scheduler_part.instantiate(optimizer=optimizer)
+
+    if torch.cuda.device_count() > 1:
+        model = DistributedDataParallel(model, device_ids=[device], find_unused_parameters=True)
+
+    if amp:
+        from torch.cuda.amp import GradScaler, autocast
+
+        scaler = GradScaler()
+        if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+            print("[info] amp enabled")
+
+    val_interval = num_epochs_per_validation
+    best_metric = -1
+    best_metric_epoch = -1
+    idx_iter = 0
+    metric_dim = output_classes - 1 if softmax else output_classes
+
+    if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+        writer = SummaryWriter(log_dir=os.path.join(arch_path, "Events"))
+
+        with open(os.path.join(arch_path, "accuracy_history.csv"), "a") as f:
+            f.write("epoch\tmetric\tloss\tlr\ttime\titer\n")
+
+    dataloader_a_iterator = iter(train_loader_a)
+
+    start_time = time.time()
+    for epoch in range(num_epochs):
+        lr = lr_scheduler.get_last_lr()[0]
+        if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+            print("-" * 10)
+            print(f"epoch {epoch + 1}/{num_epochs}")
+            print(f"learning rate is set to {lr}")
+
+        model.train()
+        epoch_loss = 0
+        loss_torch = torch.zeros(2, dtype=torch.float, device=device)
+        epoch_loss_arch = 0
+        loss_torch_arch = torch.zeros(2, dtype=torch.float, device=device)
+        step = 0
+
+        for batch_data in train_loader_w:
+            step += 1
+            inputs, labels = batch_data["image"].to(device), batch_data["label"].to(device)
+
+            if world_size == 1:
+                for _ in model.weight_parameters():
+                    _.requires_grad = True
+            else:
+                for _ in model.module.weight_parameters():
+                    _.requires_grad = True
+
+            dints_space.log_alpha_a.requires_grad = False
+            dints_space.log_alpha_c.requires_grad = False
+
+            for param in model.parameters():
+                param.grad = None
+
+            if amp:
+                with autocast():
+                    outputs = model(inputs)
+                    loss = loss_function(outputs.float(), labels)
+
+                scaler.scale(loss).backward()
+                scaler.unscale_(optimizer)
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5)
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                outputs = model(inputs)
+                loss = loss_function(outputs.float(), labels)
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5)
+                optimizer.step()
+
+            epoch_loss += loss.item()
+            loss_torch[0] += loss.item()
+            loss_torch[1] += 1.0
+            epoch_len = len(train_loader_w)
+            idx_iter += 1
+
+            if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+                print(f"[{str(datetime.now())[:19]}] " + f"{step}/{epoch_len}, train_loss: {loss.item():.4f}")
+                writer.add_scalar("Loss/train", loss.item(), epoch_len * epoch + step)
+
+            if epoch < num_epochs_warmup:
+                continue
+
+            try:
+                sample_a = next(dataloader_a_iterator)
+            except StopIteration:
+                dataloader_a_iterator = iter(train_loader_a)
+                sample_a = next(dataloader_a_iterator)
+
+            inputs_search, labels_search = (sample_a["image"].to(device), sample_a["label"].to(device))
+            if world_size == 1:
+                for _ in model.weight_parameters():
+                    _.requires_grad = False
+            else:
+                for _ in model.module.weight_parameters():
+                    _.requires_grad = False
+
+            dints_space.log_alpha_a.requires_grad = True
+            dints_space.log_alpha_c.requires_grad = True
+
+            entropy_alpha_c = torch.tensor(0.0).to(device)
+            entropy_alpha_a = torch.tensor(0.0).to(device)
+            ram_cost_full = torch.tensor(0.0).to(device)
+            ram_cost_usage = torch.tensor(0.0).to(device)
+            ram_cost_loss = torch.tensor(0.0).to(device)
+            topology_loss = torch.tensor(0.0).to(device)
+
+            probs_a, arch_code_prob_a = dints_space.get_prob_a(child=True)
+            entropy_alpha_a = -((probs_a) * torch.log(probs_a + 1e-5)).mean()
+            entropy_alpha_c = -(
+                F.softmax(dints_space.log_alpha_c, dim=-1) * F.log_softmax(dints_space.log_alpha_c, dim=-1)
+            ).mean()
+            topology_loss = dints_space.get_topology_entropy(probs_a)
+
+            ram_cost_full = dints_space.get_ram_cost_usage(inputs.shape, full=True)
+            ram_cost_usage = dints_space.get_ram_cost_usage(inputs.shape)
+            ram_cost_loss = torch.abs(ram_cost_factor - ram_cost_usage / ram_cost_full)
+
+            arch_optimizer_a.zero_grad()
+            arch_optimizer_c.zero_grad()
+
+            combination_weights = (epoch - num_epochs_warmup) / (num_epochs - num_epochs_warmup)
+
+            if amp:
+                with autocast():
+                    outputs_search = model(inputs_search)
+                    loss = loss_function(outputs_search.float(), labels_search)
+                    loss += combination_weights * (
+                        (entropy_alpha_a + entropy_alpha_c) + ram_cost_loss + 0.001 * topology_loss
+                    )
+
+                scaler.scale(loss).backward()
+                scaler.unscale_(arch_optimizer_a)
+                scaler.unscale_(arch_optimizer_c)
+                torch.nn.utils.clip_grad_norm_([dints_space.log_alpha_a], 0.5)
+                torch.nn.utils.clip_grad_norm_([dints_space.log_alpha_c], 0.5)
+                scaler.step(arch_optimizer_a)
+                scaler.step(arch_optimizer_c)
+                scaler.update()
+            else:
+                outputs_search = model(inputs_search)
+                loss = loss_function(outputs_search.float(), labels_search)
+                loss += combination_weights * (
+                    (entropy_alpha_a + entropy_alpha_c) + ram_cost_loss + 0.001 * topology_loss
+                )
+
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_([dints_space.log_alpha_a], 0.5)
+                torch.nn.utils.clip_grad_norm_([dints_space.log_alpha_c], 0.5)
+                arch_optimizer_a.step()
+                arch_optimizer_c.step()
+
+            epoch_loss_arch += loss.item()
+            loss_torch_arch[0] += loss.item()
+            loss_torch_arch[1] += 1.0
+
+            if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+                print(f"[{str(datetime.now())[:19]}] " + f"{step}/{epoch_len}, train_loss_arch: {loss.item():.4f}")
+                writer.add_scalar("train_loss_arch", loss.item(), epoch_len * epoch + step)
+
+            lr_scheduler.step()
+
+        if torch.cuda.device_count() > 1:
+            dist.barrier()
+            dist.all_reduce(loss_torch, op=torch.distributed.ReduceOp.SUM)
+
+        loss_torch = loss_torch.tolist()
+        loss_torch_arch = loss_torch_arch.tolist()
+        if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+            loss_torch_epoch = loss_torch[0] / loss_torch[1]
+            print(
+                f"epoch {epoch + 1} average loss: {loss_torch_epoch:.4f}, "
+                f"best mean dice: {best_metric:.4f} at epoch {best_metric_epoch}"
+            )
+
+            if epoch >= num_epochs_warmup:
+                loss_torch_arch_epoch = loss_torch_arch[0] / loss_torch_arch[1]
+                print(
+                    f"epoch {epoch + 1} average arch loss: {loss_torch_arch_epoch:.4f}, "
+                    f"best mean dice: {best_metric:.4f} at epoch {best_metric_epoch}"
+                )
+
+        if (epoch + 1) % val_interval == 0 or (epoch + 1) == num_epochs:
+            torch.cuda.empty_cache()
+            model.eval()
+            with torch.no_grad():
+                metric = torch.zeros(metric_dim * 2, dtype=torch.float, device=device)
+                metric_sum = 0.0
+                metric_count = 0
+                metric_mat = []
+                val_images = None
+                val_labels = None
+                val_outputs = None
+
+                _index = 0
+                for val_data in val_loader:
+                    val_images = val_data["image"].to(device)
+                    val_labels = val_data["label"].to(device)
+
+                    with torch.cuda.amp.autocast(enabled=amp):
+                        val_outputs = sliding_window_inference(
+                            val_images,
+                            patch_size_valid,
+                            num_sw_batch_size,
+                            model,
+                            mode="gaussian",
+                            overlap=overlap_ratio,
+                        )
+
+                    val_outputs = post_pred(val_outputs[0, ...])
+                    val_outputs = val_outputs[None, ...]
+
+                    if softmax:
+                        val_labels = post_label(val_labels[0, ...])
+                        val_labels = val_labels[None, ...]
+
+                    value = compute_meandice(y_pred=val_outputs, y=val_labels, include_background=not softmax)
+
+                    print(_index + 1, "/", len(val_loader), value)
+
+                    metric_count += len(value)
+                    metric_sum += value.sum().item()
+                    metric_vals = value.cpu().numpy()
+                    if len(metric_mat) == 0:
+                        metric_mat = metric_vals
+                    else:
+                        metric_mat = np.concatenate((metric_mat, metric_vals), axis=0)
+
+                    for _c in range(metric_dim):
+                        val0 = torch.nan_to_num(value[0, _c], nan=0.0)
+                        val1 = 1.0 - torch.isnan(value[0, 0]).float()
+                        metric[2 * _c] += val0 * val1
+                        metric[2 * _c + 1] += val1
+
+                    _index += 1
+
+                if torch.cuda.device_count() > 1:
+                    dist.barrier()
+                    dist.all_reduce(metric, op=torch.distributed.ReduceOp.SUM)
+
+                metric = metric.tolist()
+                if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+                    for _c in range(metric_dim):
+                        print(f"evaluation metric - class {_c + 1:d}:", metric[2 * _c] / metric[2 * _c + 1])
+                    avg_metric = 0
+                    for _c in range(metric_dim):
+                        avg_metric += metric[2 * _c] / metric[2 * _c + 1]
+                    avg_metric = avg_metric / float(metric_dim)
+                    print("avg_metric", avg_metric)
+
+                    if avg_metric > best_metric:
+                        best_metric = avg_metric
+                        best_metric_epoch = epoch + 1
+                        best_metric_iterations = idx_iter
+
+                    (node_a_d, arch_code_a_d, arch_code_c_d, arch_code_a_max_d) = dints_space.decode()
+
+                    torch.save(
+                        {
+                            "arch_code_a": arch_code_a_d,
+                            "arch_code_a_max": arch_code_a_max_d,
+                            "arch_code_c": arch_code_c_d,
+                            "best_dsc": best_metric,
+                            "best_path": best_metric_iterations,
+                            "dsc": avg_metric,
+                            "epochs": epoch + 1,
+                            "iter_num": idx_iter,
+                            "node_a": node_a_d,
+                        },
+                        os.path.join(arch_path, "search_code_" + str(idx_iter) + ".pt"),
+                    )
+
+                    torch.save(
+                        {
+                            "arch_code_a": arch_code_a_d,
+                            "arch_code_a_max": arch_code_a_max_d,
+                            "arch_code_c": arch_code_c_d,
+                            "best_dsc": best_metric,
+                            "best_path": best_metric_iterations,
+                            "dsc": avg_metric,
+                            "epochs": epoch + 1,
+                            "iter_num": idx_iter,
+                            "node_a": node_a_d,
+                        },
+                        os.path.join(arch_path, "search_code_latest.pt"),
+                    )
+                    print("saved new best metric model")
+
+                    dict_file = {}
+                    dict_file["best_avg_dice_score"] = float(best_metric)
+                    dict_file["best_avg_dice_score_epoch"] = int(best_metric_epoch)
+                    dict_file["best_avg_dice_score_iteration"] = int(idx_iter)
+                    with open(os.path.join(arch_path, "progress.yaml"), "a") as out_file:
+                        _ = yaml.dump(dict_file, stream=out_file)
+
+                    print(
+                        "current epoch: {} current mean dice: {:.4f} best mean dice: {:.4f} at epoch {}".format(
+                            epoch + 1, avg_metric, best_metric, best_metric_epoch
+                        )
+                    )
+
+                    current_time = time.time()
+                    elapsed_time = (current_time - start_time) / 60.0
+                    with open(os.path.join(arch_path, "accuracy_history.csv"), "a") as f:
+                        f.write(
+                            "{:d}\t{:.5f}\t{:.5f}\t{:.5f}\t{:.1f}\t{:d}\n".format(
+                                epoch + 1, avg_metric, loss_torch_epoch, lr, elapsed_time, idx_iter
+                            )
+                        )
+
+                if torch.cuda.device_count() > 1:
+                    dist.barrier()
+
+            torch.cuda.empty_cache()
+
+    print(f"train completed, best_metric: {best_metric:.4f} at epoch: {best_metric_epoch}")
+
+    if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+        writer.flush()
+        writer.close()
+
+    if torch.cuda.device_count() > 1:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    from monai.utils import optional_import
+
+    fire, _ = optional_import("fire")
+    fire.Fire()

--- a/monai/apps/auto3dseg/algo_templates/dints/scripts/train.py
+++ b/monai/apps/auto3dseg/algo_templates/dints/scripts/train.py
@@ -1,0 +1,400 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import math
+import os
+import random
+import sys
+import time
+from datetime import datetime
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import yaml
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.tensorboard import SummaryWriter
+
+import monai
+from monai import transforms
+from monai.bundle import ConfigParser
+from monai.bundle.scripts import _pop_args, _update_args
+from monai.data import DataLoader, partition_dataset
+from monai.inferers import sliding_window_inference
+from monai.metrics import compute_meandice
+from monai.utils import set_determinism
+
+
+def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    _args = _update_args(config_file=config_file, **override)
+    config_file_ = _pop_args(_args, "config_file")[0]
+
+    parser = ConfigParser()
+    parser.read_config(config_file_)
+    parser.update(pairs=_args)
+
+    amp = parser.get_parsed_content("amp")
+    ckpt_path = parser.get_parsed_content("ckpt_path")
+    data_file_base_dir = parser.get_parsed_content("data_file_base_dir")
+    data_list_file_path = parser.get_parsed_content("data_list_file_path")
+    determ = parser.get_parsed_content("determ")
+    finetune = parser.get_parsed_content("finetune")
+    fold = parser.get_parsed_content("fold")
+    num_images_per_batch = parser.get_parsed_content("num_images_per_batch")
+    num_iterations = parser.get_parsed_content("num_iterations")
+    num_iterations_per_validation = parser.get_parsed_content("num_iterations_per_validation")
+    num_sw_batch_size = parser.get_parsed_content("num_sw_batch_size")
+    output_classes = parser.get_parsed_content("output_classes")
+    overlap_ratio = parser.get_parsed_content("overlap_ratio")
+    patch_size_valid = parser.get_parsed_content("patch_size_valid")
+    softmax = parser.get_parsed_content("softmax")
+
+    train_transforms = parser.get_parsed_content("transforms_train")
+    val_transforms = parser.get_parsed_content("transforms_validate")
+
+    if not os.path.exists(ckpt_path):
+        os.makedirs(ckpt_path, exist_ok=True)
+
+    if determ:
+        set_determinism(seed=0)
+
+    print("[info] number of GPUs:", torch.cuda.device_count())
+    if torch.cuda.device_count() > 1:
+        dist.init_process_group(backend="nccl", init_method="env://")
+        world_size = dist.get_world_size()
+    else:
+        world_size = 1
+    print("[info] world_size:", world_size)
+
+    with open(data_list_file_path) as f:
+        json_data = json.load(f)
+
+    list_train = []
+    list_valid = []
+    for item in json_data["training"]:
+        if item["fold"] == fold:
+            item.pop("fold", None)
+            list_valid.append(item)
+        else:
+            item.pop("fold", None)
+            list_train.append(item)
+
+    files = []
+    for _i in range(len(list_train)):
+        str_img = os.path.join(data_file_base_dir, list_train[_i]["image"])
+        str_seg = os.path.join(data_file_base_dir, list_train[_i]["label"])
+
+        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
+            continue
+
+        files.append({"image": str_img, "label": str_seg})
+
+    train_files = files
+    random.shuffle(train_files)
+
+    if torch.cuda.device_count() > 1:
+        train_files = partition_dataset(data=train_files, shuffle=True, num_partitions=world_size, even_divisible=True)[
+            dist.get_rank()
+        ]
+    print("train_files:", len(train_files))
+
+    files = []
+    for _i in range(len(list_valid)):
+        str_img = os.path.join(data_file_base_dir, list_valid[_i]["image"])
+        str_seg = os.path.join(data_file_base_dir, list_valid[_i]["label"])
+
+        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
+            continue
+
+        files.append({"image": str_img, "label": str_seg})
+
+    val_files = files
+
+    if torch.cuda.device_count() > 1:
+        if len(val_files) < world_size:
+            val_files = val_files * math.ceil(float(world_size) / float(len(val_files)))
+
+        val_files = partition_dataset(data=val_files, shuffle=False, num_partitions=world_size, even_divisible=False)[
+            dist.get_rank()
+        ]
+    print("val_files:", len(val_files))
+
+    if torch.cuda.device_count() >= 4:
+        train_ds = monai.data.CacheDataset(data=train_files, transform=train_transforms, cache_rate=1.0, num_workers=8)
+        val_ds = monai.data.CacheDataset(data=val_files, transform=val_transforms, cache_rate=1.0, num_workers=2)
+    else:
+        train_ds = monai.data.CacheDataset(
+            data=train_files,
+            transform=train_transforms,
+            cache_rate=float(torch.cuda.device_count()) / 4.0,
+            num_workers=8,
+        )
+        val_ds = monai.data.CacheDataset(
+            data=val_files, transform=val_transforms, cache_rate=float(torch.cuda.device_count()) / 4.0, num_workers=2
+        )
+
+    train_loader = DataLoader(train_ds, num_workers=8, batch_size=num_images_per_batch, shuffle=True)
+    val_loader = DataLoader(val_ds, num_workers=0, batch_size=1, shuffle=False)
+
+    device = torch.device(f"cuda:{dist.get_rank()}") if torch.cuda.device_count() > 1 else torch.device("cuda:0")
+    torch.cuda.set_device(device)
+
+    model = parser.get_parsed_content("network")
+    model = model.to(device)
+    model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+
+    if softmax:
+        post_pred = transforms.Compose(
+            [transforms.EnsureType(), transforms.AsDiscrete(argmax=True, to_onehot=output_classes)]
+        )
+        post_label = transforms.Compose([transforms.EnsureType(), transforms.AsDiscrete(to_onehot=output_classes)])
+    else:
+        post_pred = transforms.Compose(
+            [transforms.EnsureType(), transforms.Activations(sigmoid=True), transforms.AsDiscrete(threshold=0.5)]
+        )
+
+    loss_function = parser.get_parsed_content("loss")
+
+    optimizer_part = parser.get_parsed_content("optimizer", instantiate=False)
+    optimizer = optimizer_part.instantiate(params=model.parameters())
+
+    num_epochs_per_validation = num_iterations_per_validation // len(train_loader)
+    num_epochs_per_validation = max(num_epochs_per_validation, 1)
+    num_epochs = num_epochs_per_validation * (num_iterations // num_iterations_per_validation)
+
+    if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+        print("num_epochs", num_epochs)
+        print("num_epochs_per_validation", num_epochs_per_validation)
+
+    lr_scheduler_part = parser.get_parsed_content("lr_scheduler", instantiate=False)
+    lr_scheduler = lr_scheduler_part.instantiate(optimizer=optimizer)
+
+    if torch.cuda.device_count() > 1:
+        model = DistributedDataParallel(model, device_ids=[device], find_unused_parameters=True)
+
+    if finetune["activate"] and os.path.isfile(finetune["pretrained_ckpt_name"]):
+        print("[info] fine-tuning pre-trained checkpoint {:s}".format(finetune["pretrained_ckpt_name"]))
+        if torch.cuda.device_count() > 1:
+            model.module.load_state_dict(torch.load(finetune["pretrained_ckpt_name"], map_location=device))
+        else:
+            model.load_state_dict(torch.load(finetune["pretrained_ckpt_name"], map_location=device))
+    else:
+        print("[info] training from scratch")
+
+    if amp:
+        from torch.cuda.amp import GradScaler, autocast
+
+        scaler = GradScaler()
+        if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+            print("[info] amp enabled")
+
+    val_interval = num_epochs_per_validation
+    best_metric = -1
+    best_metric_epoch = -1
+    idx_iter = 0
+    metric_dim = output_classes - 1 if softmax else output_classes
+
+    if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+        writer = SummaryWriter(log_dir=os.path.join(ckpt_path, "Events"))
+
+        with open(os.path.join(ckpt_path, "accuracy_history.csv"), "a") as f:
+            f.write("epoch\tmetric\tloss\tlr\ttime\titer\n")
+
+    start_time = time.time()
+    for epoch in range(num_epochs):
+        lr = lr_scheduler.get_last_lr()[0]
+        if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+            print("-" * 10)
+            print(f"epoch {epoch + 1}/{num_epochs}")
+            print(f"learning rate is set to {lr}")
+
+        model.train()
+        epoch_loss = 0
+        loss_torch = torch.zeros(2, dtype=torch.float, device=device)
+        step = 0
+
+        for batch_data in train_loader:
+            step += 1
+            inputs, labels = batch_data["image"].to(device), batch_data["label"].to(device)
+
+            for param in model.parameters():
+                param.grad = None
+
+            if amp:
+                with autocast():
+                    outputs = model(inputs)
+                    loss = loss_function(outputs.float(), labels)
+
+                scaler.scale(loss).backward()
+                scaler.unscale_(optimizer)
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5)
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                outputs = model(inputs)
+                loss = loss_function(outputs.float(), labels)
+
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5)
+                optimizer.step()
+
+            epoch_loss += loss.item()
+            loss_torch[0] += loss.item()
+            loss_torch[1] += 1.0
+            epoch_len = len(train_loader)
+            idx_iter += 1
+
+            if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+                print(f"[{str(datetime.now())[:19]}] " + f"{step}/{epoch_len}, train_loss: {loss.item():.4f}")
+                writer.add_scalar("Loss/train", loss.item(), epoch_len * epoch + step)
+
+            lr_scheduler.step()
+
+        if torch.cuda.device_count() > 1:
+            dist.barrier()
+            dist.all_reduce(loss_torch, op=torch.distributed.ReduceOp.SUM)
+
+        loss_torch = loss_torch.tolist()
+        if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+            loss_torch_epoch = loss_torch[0] / loss_torch[1]
+            print(
+                f"epoch {epoch + 1} average loss: {loss_torch_epoch:.4f}, "
+                f"best mean dice: {best_metric:.4f} at epoch {best_metric_epoch}"
+            )
+
+        if (epoch + 1) % val_interval == 0 or (epoch + 1) == num_epochs:
+            torch.cuda.empty_cache()
+            model.eval()
+            with torch.no_grad():
+                metric = torch.zeros(metric_dim * 2, dtype=torch.float, device=device)
+                metric_sum = 0.0
+                metric_count = 0
+                metric_mat = []
+                val_images = None
+                val_labels = None
+                val_outputs = None
+
+                _index = 0
+                for val_data in val_loader:
+                    val_images = val_data["image"].to(device)
+                    val_labels = val_data["label"].to(device)
+
+                    with torch.cuda.amp.autocast(enabled=amp):
+                        val_outputs = sliding_window_inference(
+                            val_images,
+                            patch_size_valid,
+                            num_sw_batch_size,
+                            model,
+                            mode="gaussian",
+                            overlap=overlap_ratio,
+                        )
+
+                    val_outputs = post_pred(val_outputs[0, ...])
+                    val_outputs = val_outputs[None, ...]
+
+                    if softmax:
+                        val_labels = post_label(val_labels[0, ...])
+                        val_labels = val_labels[None, ...]
+
+                    value = compute_meandice(y_pred=val_outputs, y=val_labels, include_background=not softmax)
+
+                    print(_index + 1, "/", len(val_loader), value)
+
+                    metric_count += len(value)
+                    metric_sum += value.sum().item()
+                    metric_vals = value.cpu().numpy()
+                    if len(metric_mat) == 0:
+                        metric_mat = metric_vals
+                    else:
+                        metric_mat = np.concatenate((metric_mat, metric_vals), axis=0)
+
+                    for _c in range(metric_dim):
+                        val0 = torch.nan_to_num(value[0, _c], nan=0.0)
+                        val1 = 1.0 - torch.isnan(value[0, 0]).float()
+                        metric[2 * _c] += val0 * val1
+                        metric[2 * _c + 1] += val1
+
+                    _index += 1
+
+                if torch.cuda.device_count() > 1:
+                    dist.barrier()
+                    dist.all_reduce(metric, op=torch.distributed.ReduceOp.SUM)
+
+                metric = metric.tolist()
+                if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+                    for _c in range(metric_dim):
+                        print(f"evaluation metric - class {_c + 1:d}:", metric[2 * _c] / metric[2 * _c + 1])
+                    avg_metric = 0
+                    for _c in range(metric_dim):
+                        avg_metric += metric[2 * _c] / metric[2 * _c + 1]
+                    avg_metric = avg_metric / float(metric_dim)
+                    print("avg_metric", avg_metric)
+
+                    writer.add_scalar("Accuracy/validation", avg_metric, epoch)
+
+                    if avg_metric > best_metric:
+                        best_metric = avg_metric
+                        best_metric_epoch = epoch + 1
+                        if torch.cuda.device_count() > 1:
+                            torch.save(model.module.state_dict(), os.path.join(ckpt_path, "best_metric_model.pt"))
+                        else:
+                            torch.save(model.state_dict(), os.path.join(ckpt_path, "best_metric_model.pt"))
+                        print("saved new best metric model")
+
+                        dict_file = {}
+                        dict_file["best_avg_dice_score"] = float(best_metric)
+                        dict_file["best_avg_dice_score_epoch"] = int(best_metric_epoch)
+                        dict_file["best_avg_dice_score_iteration"] = int(idx_iter)
+                        with open(os.path.join(ckpt_path, "progress.yaml"), "a") as out_file:
+                            yaml.dump(dict_file, stream=out_file)
+
+                    print(
+                        "current epoch: {} current mean dice: {:.4f} best mean dice: {:.4f} at epoch {}".format(
+                            epoch + 1, avg_metric, best_metric, best_metric_epoch
+                        )
+                    )
+
+                    current_time = time.time()
+                    elapsed_time = (current_time - start_time) / 60.0
+                    with open(os.path.join(ckpt_path, "accuracy_history.csv"), "a") as f:
+                        f.write(
+                            "{:d}\t{:.5f}\t{:.5f}\t{:.5f}\t{:.1f}\t{:d}\n".format(
+                                epoch + 1, avg_metric, loss_torch_epoch, lr, elapsed_time, idx_iter
+                            )
+                        )
+
+                if torch.cuda.device_count() > 1:
+                    dist.barrier()
+
+            torch.cuda.empty_cache()
+
+    print(f"train completed, best_metric: {best_metric:.4f} at epoch: {best_metric_epoch}")
+
+    if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+        writer.flush()
+        writer.close()
+
+    if torch.cuda.device_count() > 1:
+        dist.destroy_process_group()
+
+    return best_metric
+
+
+if __name__ == "__main__":
+    from monai.utils import optional_import
+
+    fire, _ = optional_import("fire")
+    fire.Fire()

--- a/monai/apps/auto3dseg/algo_templates/dints/scripts/validate.py
+++ b/monai/apps/auto3dseg/algo_templates/dints/scripts/validate.py
@@ -1,0 +1,236 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import csv
+import json
+import logging
+import os
+import sys
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import torch
+import yaml
+
+import monai
+from monai import transforms
+from monai.bundle import ConfigParser
+from monai.bundle.scripts import _pop_args, _update_args
+from monai.data import ThreadDataLoader, decollate_batch
+from monai.inferers import sliding_window_inference
+from monai.metrics import compute_meandice
+
+
+def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    _args = _update_args(config_file=config_file, **override)
+    config_file_ = _pop_args(_args, "config_file")[0]
+
+    parser = ConfigParser()
+    parser.read_config(config_file_)
+    parser.update(pairs=_args)
+
+    data_file_base_dir = parser.get_parsed_content("data_file_base_dir")
+    data_list_file_path = parser.get_parsed_content("data_list_file_path")
+    fold = parser.get_parsed_content("fold")
+    num_sw_batch_size = parser.get_parsed_content("num_sw_batch_size")
+    output_classes = parser.get_parsed_content("output_classes")
+    overlap_ratio = parser.get_parsed_content("overlap_ratio")
+    patch_size_valid = parser.get_parsed_content("patch_size_valid")
+    softmax = parser.get_parsed_content("softmax")
+
+    ckpt_name = parser.get_parsed_content("validate")["ckpt_name"]
+    output_path = parser.get_parsed_content("validate")["ouptut_path"]
+    save_mask = parser.get_parsed_content("validate")["save_mask"]
+
+    if not os.path.exists(output_path):
+        os.makedirs(output_path, exist_ok=True)
+
+    infer_transforms = parser.get_parsed_content("transforms_infer")
+    validate_transforms = transforms.Compose(
+        [
+            infer_transforms,
+            transforms.LoadImaged(keys="label"),
+            transforms.EnsureChannelFirstd(keys="label"),
+            transforms.EnsureTyped(keys="label"),
+        ]
+    )
+
+    with open(data_list_file_path) as f:
+        json_data = json.load(f)
+
+    list_valid = []
+    for item in json_data["training"]:
+        if item["fold"] == fold:
+            item.pop("fold", None)
+            list_valid.append(item)
+
+    files = []
+    for _i in range(len(list_valid)):
+        str_img = os.path.join(data_file_base_dir, list_valid[_i]["image"])
+        str_seg = os.path.join(data_file_base_dir, list_valid[_i]["label"])
+
+        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
+            continue
+
+        files.append({"image": str_img, "label": str_seg})
+
+    val_files = files
+
+    val_ds = monai.data.Dataset(data=val_files, transform=validate_transforms)
+    val_loader = ThreadDataLoader(val_ds, num_workers=2, batch_size=1, shuffle=False)
+
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+
+    model = parser.get_parsed_content("network")
+    model = model.to(device)
+    model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+
+    pretrained_ckpt = torch.load(ckpt_name, map_location=device)
+    model.load_state_dict(pretrained_ckpt)
+    print(f"[info] checkpoint {ckpt_name:s} loaded")
+
+    if softmax:
+        post_pred = transforms.Compose([transforms.EnsureType(), transforms.AsDiscrete(to_onehot=output_classes)])
+    else:
+        post_pred = transforms.Compose([transforms.EnsureType()])
+
+    post_transforms = [
+        transforms.Invertd(
+            keys="pred",
+            transform=validate_transforms,
+            orig_keys="image",
+            meta_keys="pred_meta_dict",
+            orig_meta_keys="image_meta_dict",
+            meta_key_postfix="meta_dict",
+            nearest_interp=False,
+            to_tensor=True,
+        )
+    ]
+
+    if softmax:
+        post_transforms += [transforms.AsDiscreted(keys="pred", argmax=True)]
+    else:
+        post_transforms += [transforms.AsDiscreted(keys="pred", threshold=0.5)]
+
+    if save_mask:
+        post_transforms += [
+            transforms.SaveImaged(
+                keys="pred", meta_keys="pred_meta_dict", output_dir=output_path, output_postfix="seg", resample=False
+            )
+        ]
+
+    post_transforms = transforms.Compose(post_transforms)
+
+    metric_dim = output_classes - 1 if softmax else output_classes
+    metric_sum = 0.0
+    metric_count = 0
+    metric_mat = []
+
+    row = ["case_name"]
+    for _i in range(metric_dim):
+        row.append("class_" + str(_i + 1))
+
+    with open(os.path.join(output_path, "raw.csv"), "w", encoding="UTF8") as f:
+        writer = csv.writer(f)
+        writer.writerow(row)
+
+    model.eval()
+    with torch.no_grad():
+        metric = torch.zeros(metric_dim * 2, dtype=torch.float)
+
+        _index = 0
+        for d in val_loader:
+            torch.cuda.empty_cache()
+
+            val_images = d["image"].to(device)
+            val_labels = d["label"]
+
+            with torch.cuda.amp.autocast():
+                d["pred"] = sliding_window_inference(
+                    val_images, patch_size_valid, num_sw_batch_size, model, mode="gaussian", overlap=overlap_ratio
+                )
+
+            d = [post_transforms(i) for i in decollate_batch(d)]
+
+            val_outputs = post_pred(d[0]["pred"])
+            val_outputs = val_outputs[None, ...]
+
+            if softmax:
+                val_labels = post_pred(val_labels[0, ...])
+                val_labels = val_labels[None, ...]
+
+            value = compute_meandice(y_pred=val_outputs, y=val_labels, include_background=not softmax)
+
+            metric_count += len(value)
+            metric_sum += value.sum().item()
+            metric_vals = value.cpu().numpy()
+            if len(metric_mat) == 0:
+                metric_mat = metric_vals
+            else:
+                metric_mat = np.concatenate((metric_mat, metric_vals), axis=0)
+
+            print_message = ""
+            print_message += str(_index + 1)
+            print_message += ", "
+            print_message += d[0]["pred"].meta["filename_or_obj"]
+            print_message += ", "
+            for _k in range(metric_dim):
+                if output_classes == 2:
+                    print_message += f"{metric_vals.squeeze():.5f}"
+                else:
+                    print_message += f"{metric_vals.squeeze()[_k]:.5f}"
+                print_message += ", "
+            print(print_message)
+
+            row = [d[0]["pred"].meta["filename_or_obj"]]
+            for _i in range(metric_dim):
+                row.append(metric_vals[0, _i])
+
+            with open(os.path.join(output_path, "raw.csv"), "a", encoding="UTF8") as f:
+                writer = csv.writer(f)
+                writer.writerow(row)
+
+            for _c in range(metric_dim):
+                val0 = torch.nan_to_num(value[0, _c], nan=0.0)
+                val1 = 1.0 - torch.isnan(value[0, 0]).float()
+                metric[2 * _c] += val0 * val1
+                metric[2 * _c + 1] += val1
+
+            _index += 1
+
+        metric = metric.tolist()
+        for _c in range(metric_dim):
+            print(f"evaluation metric - class {_c + 1:d}:", metric[2 * _c] / metric[2 * _c + 1])
+        avg_metric = 0
+        for _c in range(metric_dim):
+            avg_metric += metric[2 * _c] / metric[2 * _c + 1]
+        avg_metric = avg_metric / float(metric_dim)
+        print("avg_metric", avg_metric)
+
+        dict_file = {}
+        dict_file["acc"] = float(avg_metric)
+        for _c in range(metric_dim):
+            dict_file["acc_class" + str(_c + 1)] = metric[2 * _c] / metric[2 * _c + 1]
+
+        with open(os.path.join(output_path, "summary.yaml"), "w") as out_file:
+            yaml.dump(dict_file, stream=out_file)
+
+    return
+
+
+if __name__ == "__main__":
+    from monai.utils import optional_import
+
+    fire, _ = optional_import("fire")
+    fire.Fire()

--- a/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/hyper_parameters.yaml
+++ b/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/hyper_parameters.yaml
@@ -1,0 +1,62 @@
+---
+# hyper-parameters
+amp: true
+bundle_root: null
+ckpt_path: "$@bundle_root + '/model_fold' + str(@fold)"
+data_file_base_dir: null
+data_list_file_path: null
+determ: false
+fold: 0
+input_channels: null
+learning_rate: 0.025
+num_adjacent_slices: 1
+num_images_per_batch: 2
+num_iterations: 40000
+num_iterations_per_validation: 500
+num_patches_per_image: 1
+num_sw_batch_size: 2
+output_classes: null
+overlap_ratio: 0.625
+patch_size: [-1, -1, "$@num_adjacent_slices * 2 + 1"]
+patch_size_valid: [-1, -1, "$@num_adjacent_slices * 2 + 1"]
+softmax: true
+
+# training
+loss:
+  _target_: DiceFocalLoss
+  include_background: true
+  to_onehot_y: "$@softmax"
+  softmax: "$@softmax"
+  sigmoid: "$not @softmax"
+  squared_pred: true
+  batch: true
+  smooth_nr: 1.0e-05
+  smooth_dr: 1.0e-05
+optimizer:
+  _target_: torch.optim.SGD
+  lr: "@learning_rate"
+  momentum: 0.9
+  weight_decay: 4.0e-05
+lr_scheduler:
+  _target_: torch.optim.lr_scheduler.StepLR
+  optimizer: "$@optimizer"
+  step_size: "$@num_iterations // 5"
+  gamma: 0.5
+
+# fine-tuning
+finetune:
+  activate: false
+  pretrained_ckpt_name: "$@bundle_root + '/model_fold' + str(@fold) + '/best_metric_model.pt'"
+
+# validation
+validate:
+  ckpt_name: "$@bundle_root + '/model_fold' + str(@fold) + '/best_metric_model.pt'"
+  save_mask: true
+  ouptut_path: "$@bundle_root + '/prediction_fold' + str(@fold)"
+
+# inference
+infer:
+  ckpt_name: "$@bundle_root + '/model_fold' + str(@fold) + '/best_metric_model.pt'"
+  fast: false
+  data_list_key: testing
+  ouptut_path: "$@bundle_root + '/prediction_' + @infer#data_list_key"

--- a/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/network.yaml
+++ b/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/network.yaml
@@ -1,0 +1,8 @@
+---
+network:
+  _target_: SegResNet
+  spatial_dims: 2
+  init_filters: 32
+  in_channels: "$@input_channels * (2 * @num_adjacent_slices + 1)"
+  out_channels: "@output_classes"
+  dropout_prob: 0.1

--- a/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/transforms_infer.yaml
+++ b/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/transforms_infer.yaml
@@ -1,0 +1,24 @@
+---
+image_key: image
+transforms_infer:
+  _target_: Compose
+  transforms:
+  - _target_: LoadImaged
+    keys: "@image_key"
+  - _target_: EnsureChannelFirstd
+    keys: "@image_key"
+  - _target_: Orientationd
+    keys: "@image_key"
+    axcodes: RAS
+  - _target_: Spacingd
+    keys: "@image_key"
+    pixdim: null
+    mode: bilinear
+    align_corners: true
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"
+  - PLACEHOLDER_INTENSITY_NORMALIZATION
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"

--- a/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/transforms_train.yaml
+++ b/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/transforms_train.yaml
@@ -1,0 +1,84 @@
+---
+image_key: image
+label_key: label
+transforms_train:
+  _target_: Compose
+  transforms:
+  - _target_: LoadImaged
+    keys: ["@image_key", "@label_key"]
+  - _target_: EnsureChannelFirstd
+    keys: ["@image_key", "@label_key"]
+  - _target_: Orientationd
+    keys: ["@image_key", "@label_key"]
+    axcodes: RAS
+  - _target_: Spacingd
+    keys: ["@image_key", "@label_key"]
+    pixdim: null
+    mode: [bilinear, nearest]
+    align_corners: [true, true]
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"
+  - PLACEHOLDER_INTENSITY_NORMALIZATION
+  - _target_: CastToTyped
+    keys: ["@image_key", "@label_key"]
+    dtype: ["$np.float16", "$np.uint8"]
+  - _target_: EnsureTyped
+    keys: ["@image_key", "@label_key"]
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"
+  - _target_: SpatialPadd
+    keys: ["@image_key", "@label_key"]
+    spatial_size: "@patch_size"
+    mode: [reflect, constant]
+
+  # data augmentation
+  - _target_: RandCropByLabelClassesd
+    keys: ["@image_key", "@label_key"]
+    label_key: "@label_key"
+    num_classes: "@output_classes"
+    spatial_size: "@patch_size"
+    num_samples: "@num_patches_per_image"
+  - _target_: RandRotated
+    keys: ["@image_key", "@label_key"]
+    range_x: 0.3
+    range_y: 0.3
+    range_z: 0.0
+    mode: [bilinear, nearest]
+    prob: 0.2
+  - _target_: RandZoomd
+    keys: ["@image_key", "@label_key"]
+    min_zoom: [0.8, 0.8, 1.0]
+    max_zoom: [1.2, 1.2, 1.0]
+    mode: [trilinear, nearest]
+    prob: 0.16
+  - _target_: RandGaussianSmoothd
+    keys: "@image_key"
+    sigma_x: [0.5, 1.15]
+    sigma_y: [0.5, 1.15]
+    sigma_z: [0.5, 1.15]
+    prob: 0.15
+  - _target_: RandScaleIntensityd
+    keys: "@image_key"
+    factors: 0.3
+    prob: 0.5
+  - _target_: RandShiftIntensityd
+    keys: "@image_key"
+    offsets: 0.1
+    prob: 0.5
+  - _target_: RandGaussianNoised
+    keys: "@image_key"
+    std: 0.01
+    prob: 0.15
+  - _target_: RandFlipd
+    keys: ["@image_key", "@label_key"]
+    spatial_axis: 0
+    prob: 0.5
+  - _target_: RandFlipd
+    keys: ["@image_key", "@label_key"]
+    spatial_axis: 1
+    prob: 0.5
+  - _target_: CastToTyped
+    keys: ["@image_key", "@label_key"]
+    dtype: ["$torch.float32", "$torch.uint8"]

--- a/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/transforms_validate.yaml
+++ b/monai/apps/auto3dseg/algo_templates/segresnet2d/configs/transforms_validate.yaml
@@ -1,0 +1,25 @@
+---
+image_key: image
+label_key: label
+transforms_validate:
+  _target_: Compose
+  transforms:
+  - _target_: LoadImaged
+    keys: ["@image_key", "@label_key"]
+  - _target_: EnsureChannelFirstd
+    keys: ["@image_key", "@label_key"]
+  - _target_: Orientationd
+    keys: ["@image_key", "@label_key"]
+    axcodes: RAS
+  - _target_: Spacingd
+    keys: ["@image_key", "@label_key"]
+    pixdim: null
+    mode: [bilinear, nearest]
+    align_corners: [true, true]
+  - _target_: CastToTyped
+    keys: "@image_key"
+    dtype: "$torch.float32"
+  - PLACEHOLDER_INTENSITY_NORMALIZATION
+  - _target_: CastToTyped
+    keys: ["@image_key", "@label_key"]
+    dtype: ["$torch.float32", "$torch.uint8"]

--- a/monai/apps/auto3dseg/algo_templates/segresnet2d/scripts/algo.py
+++ b/monai/apps/auto3dseg/algo_templates/segresnet2d/scripts/algo.py
@@ -1,0 +1,88 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from copy import deepcopy
+
+from monai.apps.auto3dseg import BundleAlgo
+from monai.bundle import ConfigParser
+
+
+class Segresnet2DAlgo(BundleAlgo):
+    def fill_template_config(self, data_stats):
+        if data_stats is None:
+            return
+        data_cfg = ConfigParser(globals=False)
+        if os.path.exists(str(data_stats)):
+            data_cfg.read_config(str(data_stats))
+        else:
+            data_cfg.update(data_stats)
+        patch_size = [320, 320]
+        max_shape = data_cfg["stats_summary#image_stats#shape#max"]
+        patch_size = [
+            max(32, shape_k // 32 * 32) if shape_k < p_k else p_k for p_k, shape_k in zip(patch_size, max_shape)
+        ]
+        self.cfg["patch_size#0"], self.cfg["patch_size#1"] = patch_size
+        self.cfg["patch_size_valid#0"], self.cfg["patch_size_valid#1"] = patch_size
+        data_src_cfg = ConfigParser(globals=False)
+        if self.data_list_file is not None and os.path.exists(str(self.data_list_file)):
+            data_src_cfg.read_config(self.data_list_file)
+            self.cfg.update(
+                {
+                    "data_file_base_dir": data_src_cfg["dataroot"],
+                    "data_list_file_path": data_src_cfg["datalist"],
+                    "input_channels": data_cfg["stats_summary#image_stats#channels#max"],
+                    "output_classes": len(data_cfg["stats_summary#label_stats#labels"]),
+                }
+            )
+        modality = data_src_cfg.get("modality", "ct").lower()
+        spacing = data_cfg["stats_summary#image_stats#spacing#median"]
+        spacing[-1] = -1.0
+
+        intensity_upper_bound = float(data_cfg["stats_summary#image_foreground_stats#intensity#percentile_99_5"])
+        intensity_lower_bound = float(data_cfg["stats_summary#image_foreground_stats#intensity#percentile_00_5"])
+        ct_intensity_xform = {
+            "_target_": "Compose",
+            "transforms": [
+                {
+                    "_target_": "ScaleIntensityRanged",
+                    "keys": "@image_key",
+                    "a_min": intensity_lower_bound,
+                    "a_max": intensity_upper_bound,
+                    "b_min": 0.0,
+                    "b_max": 1.0,
+                    "clip": True,
+                },
+                {"_target_": "CropForegroundd", "keys": ["@image_key", "@label_key"], "source_key": "@image_key"},
+            ],
+        }
+        mr_intensity_transform = {
+            "_target_": "NormalizeIntensityd",
+            "keys": "@image_key",
+            "nonzero": True,
+            "channel_wise": True,
+        }
+        for key in ["transforms_infer", "transforms_train", "transforms_validate"]:
+            for idx, xform in enumerate(self.cfg[f"{key}#transforms"]):
+                if isinstance(xform, dict) and xform.get("_target_", "").startswith("Spacing"):
+                    xform["pixdim"] = deepcopy(spacing)
+                elif isinstance(xform, str) and xform.startswith("PLACEHOLDER_INTENSITY_NORMALIZATION"):
+                    if modality.startswith("ct"):
+                        self.cfg[f"{key}#transforms#{idx}"] = deepcopy(ct_intensity_xform)
+                    else:
+                        self.cfg[f"{key}#transforms#{idx}"] = deepcopy(mr_intensity_transform)
+
+
+if __name__ == "__main__":
+    from monai.utils import optional_import
+
+    fire, _ = optional_import("fire")
+    fire.Fire({"Segresnet2DAlgo": Segresnet2DAlgo})

--- a/monai/apps/auto3dseg/algo_templates/segresnet2d/scripts/infer.py
+++ b/monai/apps/auto3dseg/algo_templates/segresnet2d/scripts/infer.py
@@ -1,0 +1,252 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import os
+import sys
+from typing import Optional, Sequence, Union
+
+import torch
+
+import monai
+from monai import transforms
+from monai.bundle import ConfigParser
+from monai.bundle.scripts import _pop_args, _update_args
+from monai.data import ThreadDataLoader, decollate_batch, list_data_collate
+from monai.inferers import sliding_window_inference
+
+
+class InferClass:
+    def __init__(self, config_file: Optional[Union[str, Sequence[str]]] = None, **override):
+        logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+        _args = _update_args(config_file=config_file, **override)
+        config_file_ = _pop_args(_args, "config_file")[0]
+
+        parser = ConfigParser()
+        parser.read_config(config_file_)
+        parser.update(pairs=_args)
+
+        data_file_base_dir = parser.get_parsed_content("data_file_base_dir")
+        data_list_file_path = parser.get_parsed_content("data_list_file_path")
+        self.fast = parser.get_parsed_content("infer")["fast"]
+        self.num_adjacent_slices = parser.get_parsed_content("num_adjacent_slices")
+        self.num_sw_batch_size = parser.get_parsed_content("num_sw_batch_size")
+        self.output_classes = parser.get_parsed_content("output_classes")
+        self.overlap_ratio = parser.get_parsed_content("overlap_ratio")
+        self.patch_size_valid = parser.get_parsed_content("patch_size_valid")
+        softmax = parser.get_parsed_content("softmax")
+
+        ckpt_name = parser.get_parsed_content("infer")["ckpt_name"]
+        data_list_key = parser.get_parsed_content("infer")["data_list_key"]
+        output_path = parser.get_parsed_content("infer")["ouptut_path"]
+
+        if not os.path.exists(output_path):
+            os.makedirs(output_path, exist_ok=True)
+
+        self.infer_transforms = parser.get_parsed_content("transforms_infer")
+
+        with open(data_list_file_path) as f:
+            json_data = json.load(f)
+
+        list_data = []
+        for item in json_data[data_list_key]:
+            list_data.append(item)
+
+        files = []
+        for _i in range(len(list_data)):
+            str_img = os.path.join(data_file_base_dir, list_data[_i]["image"])
+
+            if not os.path.exists(str_img):
+                continue
+
+            files.append({"image": str_img})
+
+        self.infer_files = files
+
+        self.infer_loader = None
+        if self.fast:
+            infer_ds = monai.data.Dataset(data=self.infer_files, transform=self.infer_transforms)
+            self.infer_loader = ThreadDataLoader(infer_ds, num_workers=8, batch_size=1, shuffle=False)
+
+        self.device = torch.device("cuda:0")
+        torch.cuda.set_device(self.device)
+
+        self.model = parser.get_parsed_content("network")
+        self.model = self.model.to(self.device)
+        self.model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(self.model)
+
+        pretrained_ckpt = torch.load(ckpt_name, map_location=self.device)
+        self.model.load_state_dict(pretrained_ckpt)
+        print(f"[info] checkpoint {ckpt_name:s} loaded")
+
+        post_transforms = [
+            transforms.Invertd(
+                keys="pred",
+                transform=self.infer_transforms,
+                orig_keys="image",
+                meta_keys="pred_meta_dict",
+                orig_meta_keys="image_meta_dict",
+                meta_key_postfix="meta_dict",
+                nearest_interp=False,
+                to_tensor=True,
+            ),
+            transforms.Activationsd(keys="pred", softmax=softmax, sigmoid=not softmax),
+            transforms.CopyItemsd(keys="pred", times=1, names="pred_final"),
+        ]
+
+        if softmax:
+            post_transforms += [transforms.AsDiscreted(keys="pred_final", argmax=True)]
+        else:
+            post_transforms += [transforms.AsDiscreted(keys="pred_final", threshold=0.5)]
+
+        post_transforms += [
+            transforms.SaveImaged(
+                keys="pred_final",
+                meta_keys="pred_meta_dict",
+                output_dir=output_path,
+                output_postfix="seg",
+                resample=False,
+            )
+        ]
+        self.post_transforms = transforms.Compose(post_transforms)
+
+        return
+
+    @torch.no_grad()
+    def infer(self, image_file):
+        self.model.eval()
+
+        batch_data = self.infer_transforms(image_file)
+        batch_data = list_data_collate([batch_data])
+        infer_images = batch_data["image"].to(self.device)
+
+        img_size = infer_images.size()
+        infer_outputs = torch.zeros((1, self.output_classes, img_size[-3], img_size[-2], img_size[-1])).to(self.device)
+
+        with torch.cuda.amp.autocast():
+            for _k in range(img_size[-1]):
+                if _k < self.num_adjacent_slices:
+                    infer_images_slices = torch.stack(
+                        [infer_images[..., 0]] * self.num_adjacent_slices
+                        + [infer_images[..., _r] for _r in range(self.num_adjacent_slices + 1)],
+                        dim=-1,
+                    )
+                elif _k >= img_size[-1] - self.num_adjacent_slices:
+                    infer_images_slices = torch.stack(
+                        [
+                            infer_images[..., _r - self.num_adjacent_slices - 1]
+                            for _r in range(self.num_adjacent_slices + 1)
+                        ]
+                        + [infer_images[..., -1]] * self.num_adjacent_slices,
+                        dim=-1,
+                    )
+                else:
+                    infer_images_slices = infer_images[
+                        ..., _k - self.num_adjacent_slices : _k + self.num_adjacent_slices + 1,
+                    ]
+                infer_images_slices = infer_images_slices.permute(0, 1, 4, 2, 3).flatten(1, 2)
+
+                infer_outputs[..., :, :, _k] = sliding_window_inference(
+                    infer_images_slices,
+                    self.patch_size_valid[:2],
+                    self.num_sw_batch_size,
+                    self.model,
+                    mode="gaussian",
+                    overlap=self.overlap_ratio,
+                    padding_mode="reflect",
+                )
+
+            batch_data["pred"] = monai.utils.convert_to_dst_type(infer_outputs, infer_images)[0]
+
+        batch_data = [self.post_transforms(i) for i in decollate_batch(batch_data)]
+
+        return batch_data[0]["pred"]
+
+    def infer_all(self):
+        for _i in range(len(self.infer_files)):
+            infer_filename = self.infer_files[_i]
+            _ = self.infer(infer_filename)
+
+        return
+
+    @torch.no_grad()
+    def batch_infer(self):
+        self.model.eval()
+        with torch.no_grad():
+            for d in self.infer_loader:
+                torch.cuda.empty_cache()
+
+                infer_images = d["image"].to(self.device)
+
+                img_size = infer_images.size()
+                infer_outputs = torch.zeros((1, self.output_classes, img_size[-3], img_size[-2], img_size[-1])).to(
+                    self.device
+                )
+
+                with torch.cuda.amp.autocast():
+                    for _k in range(img_size[-1]):
+                        if _k < self.num_adjacent_slices:
+                            infer_images_slices = torch.stack(
+                                [infer_images[..., 0]] * self.num_adjacent_slices
+                                + [infer_images[..., _r] for _r in range(self.num_adjacent_slices + 1)],
+                                dim=-1,
+                            )
+                        elif _k >= img_size[-1] - self.num_adjacent_slices:
+                            infer_images_slices = torch.stack(
+                                [
+                                    infer_images[..., _r - self.num_adjacent_slices - 1]
+                                    for _r in range(self.num_adjacent_slices + 1)
+                                ]
+                                + [infer_images[..., -1]] * self.num_adjacent_slices,
+                                dim=-1,
+                            )
+                        else:
+                            infer_images_slices = infer_images[
+                                ..., _k - self.num_adjacent_slices : _k + self.num_adjacent_slices + 1,
+                            ]
+                        infer_images_slices = infer_images_slices.permute(0, 1, 4, 2, 3).flatten(1, 2)
+
+                        infer_outputs[..., :, :, _k] = sliding_window_inference(
+                            infer_images_slices,
+                            self.patch_size_valid[:2],
+                            self.num_sw_batch_size,
+                            self.model,
+                            mode="gaussian",
+                            overlap=self.overlap_ratio,
+                            padding_mode="reflect",
+                        )
+
+                    d["pred"] = monai.utils.convert_to_dst_type(infer_outputs, infer_images)[0]
+
+                d = [self.post_transforms(i) for i in decollate_batch(d)]
+
+        return
+
+
+def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
+    infer_instance = InferClass(config_file, **override)
+    if infer_instance.fast:
+        print("[info] fast mode")
+        infer_instance.batch_infer()
+    else:
+        print("[info] slow mode")
+        infer_instance.infer_all()
+
+    return
+
+
+if __name__ == "__main__":
+    from monai.utils import optional_import
+
+    fire, _ = optional_import("fire")
+    fire.Fire()

--- a/monai/apps/auto3dseg/algo_templates/segresnet2d/scripts/train.py
+++ b/monai/apps/auto3dseg/algo_templates/segresnet2d/scripts/train.py
@@ -1,0 +1,430 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import math
+import os
+import random
+import sys
+import time
+from datetime import datetime
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import yaml
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.tensorboard import SummaryWriter
+
+import monai
+from monai import transforms
+from monai.bundle import ConfigParser
+from monai.bundle.scripts import _pop_args, _update_args
+from monai.data import DataLoader, partition_dataset
+from monai.inferers import sliding_window_inference
+from monai.metrics import compute_meandice
+from monai.utils import set_determinism
+
+
+def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    _args = _update_args(config_file=config_file, **override)
+    config_file_ = _pop_args(_args, "config_file")[0]
+
+    parser = ConfigParser()
+    parser.read_config(config_file_)
+    parser.update(pairs=_args)
+
+    amp = parser.get_parsed_content("amp")
+    ckpt_path = parser.get_parsed_content("ckpt_path")
+    data_file_base_dir = parser.get_parsed_content("data_file_base_dir")
+    data_list_file_path = parser.get_parsed_content("data_list_file_path")
+    determ = parser.get_parsed_content("determ")
+    finetune = parser.get_parsed_content("finetune")
+    fold = parser.get_parsed_content("fold")
+    num_adjacent_slices = parser.get_parsed_content("num_adjacent_slices")
+    num_images_per_batch = parser.get_parsed_content("num_images_per_batch")
+    num_iterations = parser.get_parsed_content("num_iterations")
+    num_iterations_per_validation = parser.get_parsed_content("num_iterations_per_validation")
+    num_sw_batch_size = parser.get_parsed_content("num_sw_batch_size")
+    output_classes = parser.get_parsed_content("output_classes")
+    overlap_ratio = parser.get_parsed_content("overlap_ratio")
+    patch_size_valid = parser.get_parsed_content("patch_size_valid")
+    softmax = parser.get_parsed_content("softmax")
+
+    train_transforms = parser.get_parsed_content("transforms_train")
+    val_transforms = parser.get_parsed_content("transforms_validate")
+
+    if not os.path.exists(ckpt_path):
+        os.makedirs(ckpt_path, exist_ok=True)
+
+    if determ:
+        set_determinism(seed=0)
+
+    print("[info] number of GPUs:", torch.cuda.device_count())
+    if torch.cuda.device_count() > 1:
+        dist.init_process_group(backend="nccl", init_method="env://")
+        world_size = dist.get_world_size()
+    else:
+        world_size = 1
+    print("[info] world_size:", world_size)
+
+    with open(data_list_file_path) as f:
+        json_data = json.load(f)
+
+    list_train = []
+    list_valid = []
+    for item in json_data["training"]:
+        if item["fold"] == fold:
+            item.pop("fold", None)
+            list_valid.append(item)
+        else:
+            item.pop("fold", None)
+            list_train.append(item)
+
+    files = []
+    for _i in range(len(list_train)):
+        str_img = os.path.join(data_file_base_dir, list_train[_i]["image"])
+        str_seg = os.path.join(data_file_base_dir, list_train[_i]["label"])
+
+        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
+            continue
+
+        files.append({"image": str_img, "label": str_seg})
+
+    train_files = files
+    random.shuffle(train_files)
+
+    if torch.cuda.device_count() > 1:
+        train_files = partition_dataset(data=train_files, shuffle=True, num_partitions=world_size, even_divisible=True)[
+            dist.get_rank()
+        ]
+    print("train_files:", len(train_files))
+
+    files = []
+    for _i in range(len(list_valid)):
+        str_img = os.path.join(data_file_base_dir, list_valid[_i]["image"])
+        str_seg = os.path.join(data_file_base_dir, list_valid[_i]["label"])
+
+        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
+            continue
+
+        files.append({"image": str_img, "label": str_seg})
+
+    val_files = files
+
+    if torch.cuda.device_count() > 1:
+        if len(val_files) < world_size:
+            val_files = val_files * math.ceil(float(world_size) / float(len(val_files)))
+
+        val_files = partition_dataset(data=val_files, shuffle=False, num_partitions=world_size, even_divisible=False)[
+            dist.get_rank()
+        ]
+    print("val_files:", len(val_files))
+
+    if torch.cuda.device_count() >= 4:
+        train_ds = monai.data.CacheDataset(data=train_files, transform=train_transforms, cache_rate=1.0, num_workers=8)
+        val_ds = monai.data.CacheDataset(data=val_files, transform=val_transforms, cache_rate=1.0, num_workers=2)
+    else:
+        train_ds = monai.data.CacheDataset(
+            data=train_files,
+            transform=train_transforms,
+            cache_rate=float(torch.cuda.device_count()) / 4.0,
+            num_workers=8,
+        )
+        val_ds = monai.data.CacheDataset(
+            data=val_files, transform=val_transforms, cache_rate=float(torch.cuda.device_count()) / 4.0, num_workers=2
+        )
+
+    train_loader = DataLoader(train_ds, num_workers=8, batch_size=num_images_per_batch, shuffle=True)
+    val_loader = DataLoader(val_ds, num_workers=0, batch_size=1, shuffle=False)
+
+    device = torch.device(f"cuda:{dist.get_rank()}") if torch.cuda.device_count() > 1 else torch.device("cuda:0")
+    torch.cuda.set_device(device)
+
+    model = parser.get_parsed_content("network")
+    model = model.to(device)
+    model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+
+    if softmax:
+        post_pred = transforms.Compose(
+            [transforms.EnsureType(), transforms.AsDiscrete(argmax=True, to_onehot=output_classes)]
+        )
+        post_label = transforms.Compose([transforms.EnsureType(), transforms.AsDiscrete(to_onehot=output_classes)])
+    else:
+        post_pred = transforms.Compose(
+            [transforms.EnsureType(), transforms.Activations(sigmoid=True), transforms.AsDiscrete(threshold=0.5)]
+        )
+
+    loss_function = parser.get_parsed_content("loss")
+
+    optimizer_part = parser.get_parsed_content("optimizer", instantiate=False)
+    optimizer = optimizer_part.instantiate(params=model.parameters())
+
+    num_epochs_per_validation = num_iterations_per_validation // len(train_loader)
+    num_epochs_per_validation = max(num_epochs_per_validation, 1)
+    num_epochs = num_epochs_per_validation * (num_iterations // num_iterations_per_validation)
+
+    if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+        print("num_epochs", num_epochs)
+        print("num_epochs_per_validation", num_epochs_per_validation)
+
+    lr_scheduler_part = parser.get_parsed_content("lr_scheduler", instantiate=False)
+    lr_scheduler = lr_scheduler_part.instantiate(optimizer=optimizer)
+
+    if torch.cuda.device_count() > 1:
+        model = DistributedDataParallel(model, device_ids=[device], find_unused_parameters=True)
+
+    if finetune["activate"] and os.path.isfile(finetune["pretrained_ckpt_name"]):
+        print("[info] fine-tuning pre-trained checkpoint {:s}".format(finetune["pretrained_ckpt_name"]))
+        if torch.cuda.device_count() > 1:
+            model.module.load_state_dict(torch.load(finetune["pretrained_ckpt_name"], map_location=device))
+        else:
+            model.load_state_dict(torch.load(finetune["pretrained_ckpt_name"], map_location=device))
+    else:
+        print("[info] training from scratch")
+
+    if amp:
+        from torch.cuda.amp import GradScaler, autocast
+
+        scaler = GradScaler()
+        if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+            print("[info] amp enabled")
+
+    val_interval = num_epochs_per_validation
+    best_metric = -1
+    best_metric_epoch = -1
+    idx_iter = 0
+    metric_dim = output_classes - 1 if softmax else output_classes
+
+    if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+        writer = SummaryWriter(log_dir=os.path.join(ckpt_path, "Events"))
+
+        with open(os.path.join(ckpt_path, "accuracy_history.csv"), "a") as f:
+            f.write("epoch\tmetric\tloss\tlr\ttime\titer\n")
+
+    start_time = time.time()
+    for epoch in range(num_epochs):
+        lr = lr_scheduler.get_last_lr()[0]
+        if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+            print("-" * 10)
+            print(f"epoch {epoch + 1}/{num_epochs}")
+            print(f"learning rate is set to {lr}")
+
+        model.train()
+        epoch_loss = 0
+        loss_torch = torch.zeros(2, dtype=torch.float, device=device)
+        step = 0
+
+        for batch_data in train_loader:
+            step += 1
+            inputs, labels = batch_data["image"].to(device), batch_data["label"].to(device)
+
+            inputs = inputs.permute(0, 1, 4, 2, 3).flatten(1, 2)
+            labels = labels[..., num_adjacent_slices]
+
+            for param in model.parameters():
+                param.grad = None
+
+            if amp:
+                with autocast():
+                    outputs = model(inputs)
+                    loss = loss_function(outputs.float(), labels)
+
+                scaler.scale(loss).backward()
+                scaler.unscale_(optimizer)
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5)
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                outputs = model(inputs)
+                loss = loss_function(outputs.float(), labels)
+
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 0.5)
+                optimizer.step()
+
+            epoch_loss += loss.item()
+            loss_torch[0] += loss.item()
+            loss_torch[1] += 1.0
+            epoch_len = len(train_loader)
+            idx_iter += 1
+
+            if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+                print(f"[{str(datetime.now())[:19]}] " + f"{step}/{epoch_len}, train_loss: {loss.item():.4f}")
+                writer.add_scalar("Loss/train", loss.item(), epoch_len * epoch + step)
+
+            lr_scheduler.step()
+
+        if torch.cuda.device_count() > 1:
+            dist.barrier()
+            dist.all_reduce(loss_torch, op=torch.distributed.ReduceOp.SUM)
+
+        loss_torch = loss_torch.tolist()
+        if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+            loss_torch_epoch = loss_torch[0] / loss_torch[1]
+            print(
+                f"epoch {epoch + 1} average loss: {loss_torch_epoch:.4f}, "
+                f"best mean dice: {best_metric:.4f} at epoch {best_metric_epoch}"
+            )
+
+        if (epoch + 1) % val_interval == 0 or (epoch + 1) == num_epochs:
+            torch.cuda.empty_cache()
+            model.eval()
+            with torch.no_grad():
+                metric = torch.zeros(metric_dim * 2, dtype=torch.float, device=device)
+                metric_sum = 0.0
+                metric_count = 0
+                metric_mat = []
+                val_images = None
+                val_labels = None
+                val_outputs = None
+
+                _index = 0
+                for val_data in val_loader:
+                    val_images = val_data["image"].to(device)
+                    val_labels = val_data["label"].to(device)
+
+                    img_size = val_images.size()
+                    val_outputs = torch.zeros((1, output_classes, img_size[-3], img_size[-2], img_size[-1])).to(device)
+
+                    with torch.cuda.amp.autocast(enabled=amp):
+                        for _k in range(val_images.size()[-1]):
+                            if _k < num_adjacent_slices:
+                                val_images_slices = torch.stack(
+                                    [val_images[..., 0]] * num_adjacent_slices
+                                    + [val_images[..., _r] for _r in range(num_adjacent_slices + 1)],
+                                    dim=-1,
+                                )
+                            elif _k >= val_images.size()[-1] - num_adjacent_slices:
+                                val_images_slices = torch.stack(
+                                    [
+                                        val_images[..., _r - num_adjacent_slices - 1]
+                                        for _r in range(num_adjacent_slices + 1)
+                                    ]
+                                    + [val_images[..., -1]] * num_adjacent_slices,
+                                    dim=-1,
+                                )
+                            else:
+                                val_images_slices = val_images[
+                                    ..., _k - num_adjacent_slices : _k + num_adjacent_slices + 1,
+                                ]
+                            val_images_slices = val_images_slices.permute(0, 1, 4, 2, 3).flatten(1, 2)
+
+                            val_outputs[..., :, :, _k] = sliding_window_inference(
+                                val_images_slices,
+                                patch_size_valid[:2],
+                                num_sw_batch_size,
+                                model,
+                                mode="gaussian",
+                                overlap=overlap_ratio,
+                                padding_mode="reflect",
+                            )
+
+                    val_outputs = post_pred(val_outputs[0, ...])
+                    val_outputs = val_outputs[None, ...]
+
+                    if softmax:
+                        val_labels = post_label(val_labels[0, ...])
+                        val_labels = val_labels[None, ...]
+
+                    value = compute_meandice(y_pred=val_outputs, y=val_labels, include_background=not softmax)
+
+                    print(_index + 1, "/", len(val_loader), value)
+
+                    metric_count += len(value)
+                    metric_sum += value.sum().item()
+                    metric_vals = value.cpu().numpy()
+                    if len(metric_mat) == 0:
+                        metric_mat = metric_vals
+                    else:
+                        metric_mat = np.concatenate((metric_mat, metric_vals), axis=0)
+
+                    for _c in range(metric_dim):
+                        val0 = torch.nan_to_num(value[0, _c], nan=0.0)
+                        val1 = 1.0 - torch.isnan(value[0, 0]).float()
+                        metric[2 * _c] += val0 * val1
+                        metric[2 * _c + 1] += val1
+
+                    _index += 1
+
+                if torch.cuda.device_count() > 1:
+                    dist.barrier()
+                    dist.all_reduce(metric, op=torch.distributed.ReduceOp.SUM)
+
+                metric = metric.tolist()
+                if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+                    for _c in range(metric_dim):
+                        print(f"evaluation metric - class {_c + 1:d}:", metric[2 * _c] / metric[2 * _c + 1])
+                    avg_metric = 0
+                    for _c in range(metric_dim):
+                        avg_metric += metric[2 * _c] / metric[2 * _c + 1]
+                    avg_metric = avg_metric / float(metric_dim)
+                    print("avg_metric", avg_metric)
+
+                    writer.add_scalar("Accuracy/validation", avg_metric, epoch)
+
+                    if avg_metric > best_metric:
+                        best_metric = avg_metric
+                        best_metric_epoch = epoch + 1
+                        if torch.cuda.device_count() > 1:
+                            torch.save(model.module.state_dict(), os.path.join(ckpt_path, "best_metric_model.pt"))
+                        else:
+                            torch.save(model.state_dict(), os.path.join(ckpt_path, "best_metric_model.pt"))
+                        print("saved new best metric model")
+
+                        dict_file = {}
+                        dict_file["best_avg_dice_score"] = float(best_metric)
+                        dict_file["best_avg_dice_score_epoch"] = int(best_metric_epoch)
+                        dict_file["best_avg_dice_score_iteration"] = int(idx_iter)
+                        with open(os.path.join(ckpt_path, "progress.yaml"), "a") as out_file:
+                            yaml.dump(dict_file, stream=out_file)
+
+                    print(
+                        "current epoch: {} current mean dice: {:.4f} best mean dice: {:.4f} at epoch {}".format(
+                            epoch + 1, avg_metric, best_metric, best_metric_epoch
+                        )
+                    )
+
+                    current_time = time.time()
+                    elapsed_time = (current_time - start_time) / 60.0
+                    with open(os.path.join(ckpt_path, "accuracy_history.csv"), "a") as f:
+                        f.write(
+                            "{:d}\t{:.5f}\t{:.5f}\t{:.5f}\t{:.1f}\t{:d}\n".format(
+                                epoch + 1, avg_metric, loss_torch_epoch, lr, elapsed_time, idx_iter
+                            )
+                        )
+
+                if torch.cuda.device_count() > 1:
+                    dist.barrier()
+
+            torch.cuda.empty_cache()
+
+    print(f"train completed, best_metric: {best_metric:.4f} at epoch: {best_metric_epoch}")
+
+    if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
+        writer.flush()
+        writer.close()
+
+    if torch.cuda.device_count() > 1:
+        dist.destroy_process_group()
+
+    return best_metric
+
+
+if __name__ == "__main__":
+    from monai.utils import optional_import
+
+    fire, _ = optional_import("fire")
+    fire.Fire()

--- a/monai/apps/auto3dseg/algo_templates/segresnet2d/scripts/validate.py
+++ b/monai/apps/auto3dseg/algo_templates/segresnet2d/scripts/validate.py
@@ -1,0 +1,265 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import csv
+import json
+import logging
+import os
+import sys
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import torch
+import yaml
+
+import monai
+from monai import transforms
+from monai.bundle import ConfigParser
+from monai.bundle.scripts import _pop_args, _update_args
+from monai.data import ThreadDataLoader, decollate_batch
+from monai.inferers import sliding_window_inference
+from monai.metrics import compute_meandice
+
+
+def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+    _args = _update_args(config_file=config_file, **override)
+    config_file_ = _pop_args(_args, "config_file")[0]
+
+    parser = ConfigParser()
+    parser.read_config(config_file_)
+    parser.update(pairs=_args)
+
+    data_file_base_dir = parser.get_parsed_content("data_file_base_dir")
+    data_list_file_path = parser.get_parsed_content("data_list_file_path")
+    fold = parser.get_parsed_content("fold")
+    num_adjacent_slices = parser.get_parsed_content("num_adjacent_slices")
+    num_sw_batch_size = parser.get_parsed_content("num_sw_batch_size")
+    output_classes = parser.get_parsed_content("output_classes")
+    overlap_ratio = parser.get_parsed_content("overlap_ratio")
+    patch_size_valid = parser.get_parsed_content("patch_size_valid")
+    softmax = parser.get_parsed_content("softmax")
+
+    ckpt_name = parser.get_parsed_content("validate")["ckpt_name"]
+    output_path = parser.get_parsed_content("validate")["ouptut_path"]
+    save_mask = parser.get_parsed_content("validate")["save_mask"]
+
+    if not os.path.exists(output_path):
+        os.makedirs(output_path, exist_ok=True)
+
+    infer_transforms = parser.get_parsed_content("transforms_infer")
+    validate_transforms = transforms.Compose(
+        [
+            infer_transforms,
+            transforms.LoadImaged(keys="label"),
+            transforms.EnsureChannelFirstd(keys="label"),
+            transforms.EnsureTyped(keys="label"),
+        ]
+    )
+
+    with open(data_list_file_path) as f:
+        json_data = json.load(f)
+
+    list_valid = []
+    for item in json_data["training"]:
+        if item["fold"] == fold:
+            item.pop("fold", None)
+            list_valid.append(item)
+
+    files = []
+    for _i in range(len(list_valid)):
+        str_img = os.path.join(data_file_base_dir, list_valid[_i]["image"])
+        str_seg = os.path.join(data_file_base_dir, list_valid[_i]["label"])
+
+        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
+            continue
+
+        files.append({"image": str_img, "label": str_seg})
+
+    val_files = files
+
+    val_ds = monai.data.Dataset(data=val_files, transform=validate_transforms)
+    val_loader = ThreadDataLoader(val_ds, num_workers=2, batch_size=1, shuffle=False)
+
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+
+    model = parser.get_parsed_content("network")
+    model = model.to(device)
+    model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+
+    pretrained_ckpt = torch.load(ckpt_name, map_location=device)
+    model.load_state_dict(pretrained_ckpt)
+    print(f"[info] checkpoint {ckpt_name:s} loaded")
+
+    if softmax:
+        post_pred = transforms.Compose([transforms.EnsureType(), transforms.AsDiscrete(to_onehot=output_classes)])
+    else:
+        post_pred = transforms.Compose([transforms.EnsureType()])
+
+    post_transforms = [
+        transforms.Invertd(
+            keys="pred",
+            transform=validate_transforms,
+            orig_keys="image",
+            meta_keys="pred_meta_dict",
+            orig_meta_keys="image_meta_dict",
+            meta_key_postfix="meta_dict",
+            nearest_interp=False,
+            to_tensor=True,
+        )
+    ]
+
+    if softmax:
+        post_transforms += [transforms.AsDiscreted(keys="pred", argmax=True)]
+    else:
+        post_transforms += [transforms.AsDiscreted(keys="pred", threshold=0.5)]
+
+    if save_mask:
+        post_transforms += [
+            transforms.SaveImaged(
+                keys="pred", meta_keys="pred_meta_dict", output_dir=output_path, output_postfix="seg", resample=False
+            )
+        ]
+
+    post_transforms = transforms.Compose(post_transforms)
+
+    metric_dim = output_classes - 1 if softmax else output_classes
+    metric_sum = 0.0
+    metric_count = 0
+    metric_mat = []
+
+    row = ["case_name"]
+    for _i in range(metric_dim):
+        row.append("class_" + str(_i + 1))
+
+    with open(os.path.join(output_path, "raw.csv"), "w", encoding="UTF8") as f:
+        writer = csv.writer(f)
+        writer.writerow(row)
+
+    model.eval()
+    with torch.no_grad():
+        metric = torch.zeros(metric_dim * 2, dtype=torch.float)
+
+        _index = 0
+        for d in val_loader:
+            torch.cuda.empty_cache()
+
+            val_images = d["image"].to(device)
+            val_labels = d["label"]
+
+            img_size = val_images.size()
+            val_outputs = torch.zeros((1, output_classes, img_size[-3], img_size[-2], img_size[-1])).to(device)
+
+            with torch.cuda.amp.autocast():
+                for _k in range(img_size[-1]):
+                    if _k < num_adjacent_slices:
+                        val_images_slices = torch.stack(
+                            [val_images[..., 0]] * num_adjacent_slices
+                            + [val_images[..., _r] for _r in range(num_adjacent_slices + 1)],
+                            dim=-1,
+                        )
+                    elif _k >= img_size[-1] - num_adjacent_slices:
+                        val_images_slices = torch.stack(
+                            [val_images[..., _r - num_adjacent_slices - 1] for _r in range(num_adjacent_slices + 1)]
+                            + [val_images[..., -1]] * num_adjacent_slices,
+                            dim=-1,
+                        )
+                    else:
+                        val_images_slices = val_images[..., _k - num_adjacent_slices : _k + num_adjacent_slices + 1]
+                    val_images_slices = val_images_slices.permute(0, 1, 4, 2, 3).flatten(1, 2)
+
+                    val_outputs[..., :, :, _k] = sliding_window_inference(
+                        val_images_slices,
+                        patch_size_valid[:2],
+                        num_sw_batch_size,
+                        model,
+                        mode="gaussian",
+                        overlap=overlap_ratio,
+                        padding_mode="reflect",
+                    )
+
+                d["pred"] = monai.utils.convert_to_dst_type(val_outputs, val_images)[0]
+
+            d = [post_transforms(i) for i in decollate_batch(d)]
+
+            val_outputs = post_pred(d[0]["pred"])
+            val_outputs = val_outputs[None, ...]
+
+            if softmax:
+                val_labels = post_pred(val_labels[0, ...])
+                val_labels = val_labels[None, ...]
+
+            value = compute_meandice(y_pred=val_outputs, y=val_labels, include_background=not softmax)
+
+            metric_count += len(value)
+            metric_sum += value.sum().item()
+            metric_vals = value.cpu().numpy()
+            if len(metric_mat) == 0:
+                metric_mat = metric_vals
+            else:
+                metric_mat = np.concatenate((metric_mat, metric_vals), axis=0)
+
+            print_message = ""
+            print_message += str(_index + 1)
+            print_message += ", "
+            print_message += d[0]["pred"].meta["filename_or_obj"]
+            print_message += ", "
+            for _k in range(metric_dim):
+                if output_classes == 2:
+                    print_message += f"{metric_vals.squeeze():.5f}"
+                else:
+                    print_message += f"{metric_vals.squeeze()[_k]:.5f}"
+                print_message += ", "
+            print(print_message)
+
+            row = [d[0]["pred"].meta["filename_or_obj"]]
+            for _i in range(metric_dim):
+                row.append(metric_vals[0, _i])
+
+            with open(os.path.join(output_path, "raw.csv"), "a", encoding="UTF8") as f:
+                writer = csv.writer(f)
+                writer.writerow(row)
+
+            for _c in range(metric_dim):
+                val0 = torch.nan_to_num(value[0, _c], nan=0.0)
+                val1 = 1.0 - torch.isnan(value[0, 0]).float()
+                metric[2 * _c] += val0 * val1
+                metric[2 * _c + 1] += val1
+
+            _index += 1
+
+        metric = metric.tolist()
+        for _c in range(metric_dim):
+            print(f"evaluation metric - class {_c + 1:d}:", metric[2 * _c] / metric[2 * _c + 1])
+        avg_metric = 0
+        for _c in range(metric_dim):
+            avg_metric += metric[2 * _c] / metric[2 * _c + 1]
+        avg_metric = avg_metric / float(metric_dim)
+        print("avg_metric", avg_metric)
+
+        dict_file = {}
+        dict_file["acc"] = float(avg_metric)
+        for _c in range(metric_dim):
+            dict_file["acc_class" + str(_c + 1)] = metric[2 * _c] / metric[2 * _c + 1]
+
+        with open(os.path.join(output_path, "summary.yaml"), "w") as out_file:
+            yaml.dump(dict_file, stream=out_file)
+
+    return
+
+
+if __name__ == "__main__":
+    from monai.utils import optional_import
+
+    fire, _ = optional_import("fire")
+    fire.Fire()


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

minor refactoring of #4875 
this is a temporary PR as a demo of algo templates



### Status
**Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
