### PR TITLE
5061 align corners and recompute_affine for spacing

### DIFF
--- a/monai/apps/reconstruction/networks/nets/complex_unet.py
+++ b/monai/apps/reconstruction/networks/nets/complex_unet.py
@@ -83,7 +83,8 @@ class ComplexUnet(nn.Module):
             params = [p.shape for p in conv_net.parameters()]
             if params[0][1] != 2:
                 raise ValueError(f"in_channels should be 2 but it's {params[0][1]}.")
-            self.unet = conv_net  # type: ignore
+            self.unet = conv_net
+
         self.pad_factor = pad_factor
 
     def forward(self, x: Tensor) -> Tensor:

--- a/monai/auto3dseg/utils.py
+++ b/monai/auto3dseg/utils.py
@@ -168,7 +168,8 @@ def concat_val_to_np(
     elif ragged:
         return np.concatenate(np_list, **kwargs)  # type: ignore
     else:
-        return np.concatenate([np_list], **kwargs)  # type: ignore
+        return np.concatenate([np_list], **kwargs)
+
 
 
 def concat_multikeys_to_dict(

--- a/monai/auto3dseg/utils.py
+++ b/monai/auto3dseg/utils.py
@@ -171,7 +171,6 @@ def concat_val_to_np(
         return np.concatenate([np_list], **kwargs)
 
 
-
 def concat_multikeys_to_dict(
     data_list: List[Dict], fixed_keys: List[Union[str, int]], keys: List[str], zero_insert: bool = True, **kwargs
 ):

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -855,7 +855,7 @@ def compute_shape_offset(
                 | voxel 1 | voxel 2 | voxel 3 | voxel 4 |
                 |      voxel 1      |      voxel 2      |
 
-            Option 1 may reduce the number of locations the requiring interpolation. Option 2 is more resolution
+            Option 1 may reduce the number of locations that requiring interpolation. Option 2 is more resolution
             agnostic, that is, resampling coordinates depend on the scaling factor, not on the number of voxels.
             Default is False, using option 1 to compute the shape and offset.
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -855,7 +855,10 @@ def compute_shape_offset(
                 | voxel 1 | voxel 2 | voxel 3 | voxel 4 |
                 |      voxel 1      |      voxel 2      |
 
+            Option 1 may reduce the number of locations the requiring interpolation. Option 2 is more resolution
+            agnostic, that is, resampling coordinates depend on the scaling factor, not on the number of voxels.
             Default is False, using option 1 to compute the shape and offset.
+
     """
     shape = np.array(spatial_shape, copy=True, dtype=float)
     sr = len(shape)

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -573,7 +573,6 @@ class AffineTransform(nn.Module):
             )
 
         grid = nn.functional.affine_grid(theta=theta[:, :sr], size=list(dst_size), align_corners=self.align_corners)
-        import pdb; pdb.set_trace()
         dst = nn.functional.grid_sample(
             input=src.contiguous(),
             grid=grid,

--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -573,6 +573,7 @@ class AffineTransform(nn.Module):
             )
 
         grid = nn.functional.affine_grid(theta=theta[:, :sr], size=list(dst_size), align_corners=self.align_corners)
+        import pdb; pdb.set_trace()
         dst = nn.functional.grid_sample(
             input=src.contiguous(),
             grid=grid,

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -195,7 +195,7 @@ def predict_segmentation(logits: torch.Tensor, mutually_exclusive: bool = False,
 
 
 def normalize_transform(
-    shape: Sequence[int],
+    shape,
     device: Optional[torch.device] = None,
     dtype: Optional[torch.dtype] = None,
     align_corners: bool = False,
@@ -212,7 +212,7 @@ def normalize_transform(
         - `align_corners=True`, `zero_centered=True`, normalizing from ``[-(d-1)/2, (d-1)/2]``.
 
     Args:
-        shape: input spatial shape
+        shape: input spatial shape, a sequence of integers.
         device: device on which the returned affine will be allocated.
         dtype: data type of the returned affine
         align_corners: if True, consider -1 and 1 to refer to the centers of the
@@ -221,7 +221,7 @@ def normalize_transform(
         zero_centered: whether the coordinates are normalized from a zero-centered range, default to `False`.
             Setting this flag and `align_corners` will jointly specify the normalization source range.
     """
-    shape = convert_to_tensor(shape, dtype=torch.float64, device=device, wrap_sequence=True, track_meta=False)
+    shape = convert_to_tensor(shape, torch.float64, device=device, wrap_sequence=True, track_meta=False)
     norm = shape.clone().detach().to(dtype=torch.float64, device=device)  # no in-place change
     if align_corners:
         norm[norm <= 1.0] = 2.0
@@ -236,7 +236,7 @@ def normalize_transform(
         norm[:-1, -1] = 1.0 / shape - (0.0 if zero_centered else 1.0)
     norm = norm.unsqueeze(0).to(dtype=dtype)
     norm.requires_grad = False
-    return norm
+    return norm  # type: ignore
 
 
 def to_norm_affine(

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -220,7 +220,10 @@ def normalize_transform(
         zero_centered: whether the coordinates are normalized from a zero-centered range, default to `False`.
             Setting this flag and `align_corners` will jointly specify the normalization source range.
     """
-    norm = torch.tensor(shape, dtype=torch.float64, device=device)  # no in-place change
+    if isinstance(shape, torch.Tensor):
+        norm = shape.clone().detach().to(dtype=torch.float64, device=device)
+    else:
+        norm = torch.tensor(shape, dtype=torch.float64, device=device)  # no in-place change
     if align_corners:
         norm[norm <= 1.0] = 2.0
         norm = 2.0 / (norm - 1.0)
@@ -274,6 +277,7 @@ def to_norm_affine(
 
     src_xform = normalize_transform(src_size, affine.device, affine.dtype, align_corners, zero_centered)
     dst_xform = normalize_transform(dst_size, affine.device, affine.dtype, align_corners, zero_centered)
+    import pdb; pdb.set_trace()
     return src_xform @ affine @ torch.inverse(dst_xform)
 
 

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -277,7 +277,6 @@ def to_norm_affine(
 
     src_xform = normalize_transform(src_size, affine.device, affine.dtype, align_corners, zero_centered)
     dst_xform = normalize_transform(dst_size, affine.device, affine.dtype, align_corners, zero_centered)
-    import pdb; pdb.set_trace()
     return src_xform @ affine @ torch.inverse(dst_xform)
 
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -257,7 +257,7 @@ class SpatialResample(InvertibleTransform):
         if isinstance(spatial_size, int) and (spatial_size == -1):  # using the input spatial size
             spatial_size = in_spatial_size
         elif spatial_size is None and spatial_rank > 1:  # auto spatial size
-            spatial_size, _ = compute_shape_offset(in_spatial_size, src_affine_, dst_affine)  # type: ignore
+            spatial_size, _ = compute_shape_offset(in_spatial_size, src_affine_, dst_affine, align_corners)  # type: ignore
         spatial_size = torch.tensor(fall_back_tuple(ensure_tuple(spatial_size)[:spatial_rank], in_spatial_size))
 
         if (

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -296,7 +296,7 @@ class SpatialResample(InvertibleTransform):
             dst_xform_1 = normalize_transform(spatial_size, xform.device, xform.dtype, True, True)[0]  # to (-1, 1)
             if not align_corners:
                 norm = create_scale(spatial_rank, [(max(d, 2) - 1) / d for d in spatial_size], xform.device, "torch")
-                dst_xform_1 = norm.to(xform.dtype) @ dst_xform_1  # scaling (num_step - 1) / num_step
+                dst_xform_1 = norm.to(xform.dtype) @ dst_xform_1  # type: ignore  # scaling (num_step - 1) / num_step
             dst_xform_d = normalize_transform(spatial_size, xform.device, xform.dtype, align_corners, False)[0]
             xform = xform @ torch.inverse(dst_xform_d) @ dst_xform_1
             affine_xform = Affine(
@@ -307,7 +307,8 @@ class SpatialResample(InvertibleTransform):
         else:
             affine_xform = AffineTransform(
                 normalized=False,
-                mode=mode,  # type: ignore
+                mode=mode,
+
                 padding_mode=padding_mode,
                 align_corners=align_corners,
                 reverse_indexing=True,
@@ -572,7 +573,8 @@ class Spacing(InvertibleTransform):
         # convert to MetaTensor if necessary
         data_array = convert_to_tensor(data_array, track_meta=get_track_meta())
         if isinstance(data_array, MetaTensor):
-            data_array.affine = torch.as_tensor(affine_)  # type: ignore
+            data_array.affine = torch.as_tensor(affine_)
+
 
         # we don't want to track the nested transform otherwise two will be appended
         actual_shape = list(output_shape) if output_spatial_shape is None else output_spatial_shape
@@ -2302,7 +2304,8 @@ class Affine(InvertibleTransform):
             out = MetaTensor(out)
         out.meta = data.meta  # type: ignore
         self.update_meta(out, inv_affine, data.shape[1:], orig_size)
-        return out  # type: ignore
+        return out
+
 
 
 class RandAffine(RandomizableTransform, InvertibleTransform):
@@ -2543,7 +2546,8 @@ class RandAffine(RandomizableTransform, InvertibleTransform):
             out = MetaTensor(out)
         out.meta = data.meta  # type: ignore
         self.update_meta(out, inv_affine, data.shape[1:], orig_size)
-        return out  # type: ignore
+        return out
+
 
 
 class Rand2DElastic(RandomizableTransform):
@@ -2967,7 +2971,8 @@ class GridDistortion(Transform):
         coords = meshgrid_ij(*all_ranges)
         grid = torch.stack([*coords, torch.ones_like(coords[0])])
 
-        return self.resampler(img, grid=grid, mode=mode, padding_mode=padding_mode)  # type: ignore
+        return self.resampler(img, grid=grid, mode=mode, padding_mode=padding_mode)
+
 
 
 class RandGridDistortion(RandomizableTransform):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -308,7 +308,6 @@ class SpatialResample(InvertibleTransform):
             affine_xform = AffineTransform(
                 normalized=False,
                 mode=mode,
-
                 padding_mode=padding_mode,
                 align_corners=align_corners,
                 reverse_indexing=True,
@@ -574,7 +573,6 @@ class Spacing(InvertibleTransform):
         data_array = convert_to_tensor(data_array, track_meta=get_track_meta())
         if isinstance(data_array, MetaTensor):
             data_array.affine = torch.as_tensor(affine_)
-
 
         # we don't want to track the nested transform otherwise two will be appended
         actual_shape = list(output_shape) if output_spatial_shape is None else output_spatial_shape
@@ -2307,7 +2305,6 @@ class Affine(InvertibleTransform):
         return out
 
 
-
 class RandAffine(RandomizableTransform, InvertibleTransform):
     """
     Random affine transform.
@@ -2547,7 +2544,6 @@ class RandAffine(RandomizableTransform, InvertibleTransform):
         out.meta = data.meta  # type: ignore
         self.update_meta(out, inv_affine, data.shape[1:], orig_size)
         return out
-
 
 
 class Rand2DElastic(RandomizableTransform):
@@ -2972,7 +2968,6 @@ class GridDistortion(Transform):
         grid = torch.stack([*coords, torch.ones_like(coords[0])])
 
         return self.resampler(img, grid=grid, mode=mode, padding_mode=padding_mode)
-
 
 
 class RandGridDistortion(RandomizableTransform):

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -479,7 +479,8 @@ class Spacing(InvertibleTransform):
                 the output data type is always ``np.float32``.
             scale_extent: whether the scale is computed based on the spacing or the full extent of voxels,
                 default False. The option is ignored if output spatial size is specified when calling this transform.
-                See also: :py:func:`monai.data.utils.compute_shape_offset`.
+                See also: :py:func:`monai.data.utils.compute_shape_offset`. When this is True, `align_corners`
+                should be `True` because `compute_shape_offset` already provides the corner alignment shift/scaling.
             recompute_affine: whether to recompute affine based on the output shape. The affine computed
                 analytically does not reflect the potential quantization errors in terms of the output shape.
                 Set this flag to True to recompute the output affine based on the actual pixdim. Default to ``False``.
@@ -529,7 +530,8 @@ class Spacing(InvertibleTransform):
                 the output data type is always ``np.float32``.
             scale_extent: whether the scale is computed based on the spacing or the full extent of voxels,
                 The option is ignored if output spatial size is specified when calling this transform.
-                See also: :py:func:`monai.data.utils.compute_shape_offset`.
+                See also: :py:func:`monai.data.utils.compute_shape_offset`. When this is True, `align_corners`
+                should be `True` because `compute_shape_offset` already provides the corner alignment shift/scaling.
             output_spatial_shape: specify the shape of the output data_array. This is typically useful for
                 the inverse of `Spacingd` where sometimes we could not compute the exact shape due to the quantization
                 error with the affine.
@@ -560,6 +562,8 @@ class Spacing(InvertibleTransform):
         if out_d.size < sr:
             out_d = np.append(out_d, [1.0] * (sr - out_d.size))
 
+        if not align_corners and scale_extent:
+            warnings.warn("align_corners=False is not compatible with scale_extent=True.")
         # compute output affine, shape and offset
         new_affine = zoom_affine(affine_, out_d, diagonal=self.diagonal)
         scale_extent = self.scale_extent if scale_extent is None else scale_extent

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -381,7 +381,8 @@ class Spacingd(MapTransform, InvertibleTransform):
                 It also can be a sequence of dtypes, each element corresponds to a key in ``keys``.
             scale_extent: whether the scale is computed based on the spacing or the full extent of voxels,
                 default False. The option is ignored if output spatial size is specified when calling this transform.
-                See also: :py:func:`monai.data.utils.compute_shape_offset`.
+                See also: :py:func:`monai.data.utils.compute_shape_offset`. When this is True, `align_corners`
+                should be `True` because `compute_shape_offset` already provides the corner alignment shift/scaling.
             recompute_affine: whether to recompute affine based on the output shape. The affine computed
                 analytically does not reflect the potential quantization errors in terms of the output shape.
                 Set this flag to True to recompute the output affine based on the actual pixdim. Default to ``False``.

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -331,6 +331,7 @@ class Spacingd(MapTransform, InvertibleTransform):
         padding_mode: SequenceStr = GridSamplePadMode.BORDER,
         align_corners: Union[Sequence[bool], bool] = False,
         dtype: Union[Sequence[DtypeLike], DtypeLike] = np.float64,
+        recompute_affine: bool = False,
         meta_keys: Optional[KeysCollection] = None,
         meta_key_postfix: str = "meta_dict",
         allow_missing_keys: bool = False,
@@ -377,11 +378,14 @@ class Spacingd(MapTransform, InvertibleTransform):
                 If None, use the data type of input data. To be compatible with other modules,
                 the output data type is always ``np.float32``.
                 It also can be a sequence of dtypes, each element corresponds to a key in ``keys``.
+            recompute_affine: whether to recompute affine based on the output shape. The affine computed
+                analytically does not reflect the potential quantization errors in terms of the output shape.
+                Set this flag to True to recompute the output affine based on the actual pixdim. Default to ``False``.
             allow_missing_keys: don't raise exception if key is missing.
 
         """
         super().__init__(keys, allow_missing_keys)
-        self.spacing_transform = Spacing(pixdim, diagonal=diagonal)
+        self.spacing_transform = Spacing(pixdim, diagonal=diagonal, recompute_affine=recompute_affine)
         self.mode = ensure_tuple_rep(mode, len(self.keys))
         self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
         self.align_corners = ensure_tuple_rep(align_corners, len(self.keys))

--- a/tests/test_resample_to_match.py
+++ b/tests/test_resample_to_match.py
@@ -60,8 +60,6 @@ class TestResampleToMatch(unittest.TestCase):
         loader = Compose([LoadImaged(("im1", "im2"), reader=reader), EnsureChannelFirstd(("im1", "im2"))])
         data = loader({"im1": self.fnames[0], "im2": self.fnames[1]})
 
-        with self.assertRaises(ValueError):
-            ResampleToMatch(mode=None)(img=data["im2"], img_dst=data["im1"])
         im_mod = ResampleToMatch()(data["im2"], data["im1"])
         saver = SaveImaged(
             "im3", output_dir=self.tmpdir, output_postfix="", separate_folder=False, writer=writer, resample=False

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -56,7 +56,7 @@ for device in TEST_DEVICES:
     )
     TESTS.append(
         [
-            {"pixdim": (1.0, 0.2, 1.5), "diagonal": False, "padding_mode": "zeros", "align_corners": True},
+            {"pixdim": (1.0, 0.2, 1.5), "diagonal": False, "padding_mode": "zeros", "align_corners": False},
             torch.ones((1, 2, 1, 2)),  # data
             torch.tensor([[2, 1, 0, 4], [-1, -3, 0, 5], [0, 0, 2.0, 5], [0, 0, 0, 1]]),
             {},
@@ -212,7 +212,7 @@ for device in TEST_DEVICES:
     )
     TESTS.append(  # 5D input
         [
-            {"pixdim": [-1, -1, 0.5], "padding_mode": "zeros", "dtype": float, "align_corners": True},
+            {"pixdim": [-1, -1, 0.5], "padding_mode": "zeros", "dtype": float, "align_corners": False},
             torch.ones((1, 2, 2, 2, 1)),  # data
             torch.eye(4),
             {},
@@ -267,7 +267,7 @@ class TestSpacingCase(unittest.TestCase):
         )
         meta = {"fname": "somewhere"}
         img = MetaTensor(img_t, affine=affine, meta=meta)
-        tr = Spacing(pixdim=[1.1, 1.2, 0.9])
+        tr = Spacing(pixdim=[1.1, 1.2, 0.9], recompute_affine=True)
         # check that image and affine have changed
         img = tr(img)
         self.assertNotEqual(img.shape, img_t.shape)

--- a/tests/test_spatial_resample.py
+++ b/tests/test_spatial_resample.py
@@ -168,10 +168,6 @@ class TestSpatialResample(unittest.TestCase):
             img.affine = ill_affine
             dst_affine = torch.eye(4)
             SpatialResample()(img=img, dst_affine=dst_affine)
-        with self.assertRaises(ValueError):
-            img.affine = torch.eye(4)
-            dst_affine = torch.eye(4) * 0.1
-            SpatialResample(mode=None)(img=img, dst_affine=dst_affine)
         if not (optional_import("scipy")[1] and optional_import("cupy")[1]):
             return
         with self.assertRaises(ValueError):  # requires scipy


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5061

### Description
computing output shape considering `align_corners`, recompute the output affine based on output shapes.
a new `scale_extent` parameter is included to choose between the two resampling coordinate conventions.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
