### PR TITLE
Slight Fix For Type Conversion

### DIFF
--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -129,7 +129,7 @@ def convert_to_tensor(
         if not isinstance(tensor, torch.Tensor):
             # certain numpy types are not supported as being directly convertible to Pytorch tensors
             if isinstance(tensor, np.ndarray) and tensor.dtype in UNSUPPORTED_TYPES:
-                tensor = tensor.view(dtype=UNSUPPORTED_TYPES[tensor.dtype])
+                tensor = tensor.astype(UNSUPPORTED_TYPES[tensor.dtype])
 
             # if input data is not Tensor, convert it to Tensor first
             tensor = torch.as_tensor(tensor, **kwargs)

--- a/tests/test_convert_data_type.py
+++ b/tests/test_convert_data_type.py
@@ -66,7 +66,7 @@ class TestConvertDataType(unittest.TestCase):
 
     @parameterized.expand(list(UNSUPPORTED_TYPES.items()))
     def test_unsupported_np_types(self, np_type, pt_type):
-        in_image = np.ones(2, dtype=np_type)
+        in_image = np.ones(13, dtype=np_type)  # choose a prime size so as to be indivisible by the size of any dtype 
         converted_im, orig_type, orig_device = convert_data_type(in_image, torch.Tensor)
 
         self.assertEqual(converted_im.dtype, pt_type)

--- a/tests/test_convert_data_type.py
+++ b/tests/test_convert_data_type.py
@@ -66,7 +66,7 @@ class TestConvertDataType(unittest.TestCase):
 
     @parameterized.expand(list(UNSUPPORTED_TYPES.items()))
     def test_unsupported_np_types(self, np_type, pt_type):
-        in_image = np.ones(13, dtype=np_type)  # choose a prime size so as to be indivisible by the size of any dtype 
+        in_image = np.ones(13, dtype=np_type)  # choose a prime size so as to be indivisible by the size of any dtype
         converted_im, orig_type, orig_device = convert_data_type(in_image, torch.Tensor)
 
         self.assertEqual(converted_im.dtype, pt_type)


### PR DESCRIPTION
Signed-off-by: Eric Kerfoot <eric.kerfoot@kcl.ac.uk>

### Description
Using `view` to avoid copying doesn't actually work as intended in the type conversion to use `astype`.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
