### PR TITLE
Fix deepgrow prepare data for 2D/3D

### DIFF
--- a/tests/test_deepgrow_dataset.py
+++ b/tests/test_deepgrow_dataset.py
@@ -29,20 +29,20 @@ TEST_CASE_3 = [{"dimension": 2, "pixdim": (1, 1)}, {"length": 1}, 3, 1]
 
 TEST_CASE_4 = [{"dimension": 3, "pixdim": (1, 1, 1)}, {"length": 1}, 1, 1]
 
-TEST_CASE_5 = [{"dimension": 3, "pixdim": (1, 1, 1)}, {"length": 1, "image_channel": 4}, 1, 1]
+TEST_CASE_5 = [{"dimension": 3, "pixdim": (1, 1, 1)}, {"length": 1, "image_channel": 1}, 1, 1]
 
-TEST_CASE_6 = [{"dimension": 2, "pixdim": (1, 1)}, {"length": 1, "image_channel": 4}, 3, 1]
+TEST_CASE_6 = [{"dimension": 2, "pixdim": (1, 1)}, {"length": 1, "image_channel": 1}, 3, 1]
 
 TEST_CASE_7 = [
     {"dimension": 2, "pixdim": (1, 1), "label_key": None},
-    {"length": 1, "image_channel": 4, "with_label": False},
+    {"length": 1, "image_channel": 1, "with_label": False},
     40,
     None,
 ]
 
 TEST_CASE_8 = [
     {"dimension": 3, "pixdim": (1, 1, 1), "label_key": None},
-    {"length": 1, "image_channel": 4, "with_label": False},
+    {"length": 1, "image_channel": 1, "with_label": False},
     1,
     None,
 ]


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

Fixes # 
Fix data preparation for Deepgrow 2D/3D training

### Description

Removing deprecated transform caused incorrect functionality for data-preparation step.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
