### PR TITLE
adds a debugging flag for bundle parser

### DIFF
--- a/monai/bundle/reference_resolver.py
+++ b/monai/bundle/reference_resolver.py
@@ -9,14 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 import warnings
 from typing import Any, Dict, Optional, Sequence, Set
 
 from monai.bundle.config_item import ConfigComponent, ConfigExpression, ConfigItem
 from monai.bundle.utils import ID_REF_KEY, ID_SEP_KEY
-from monai.utils import look_up_option
+from monai.utils import allow_missing_reference, look_up_option
 
 __all__ = ["ReferenceResolver"]
 
@@ -53,7 +52,7 @@ class ReferenceResolver:
     # match a reference string, e.g. "@id#key", "@id#key#0", "@_target_#key"
     id_matcher = re.compile(rf"{ref}(?:\w*)(?:{sep}\w*)*")
     # if `allow_missing_reference` and can't find a reference ID, will just raise a warning and don't update the config
-    allow_missing_reference = os.environ.get("MONAI_ALLOW_MISSING_REFERENCE", "0") != "0"
+    allow_missing_reference = allow_missing_reference
 
     def __init__(self, items: Optional[Sequence[ConfigItem]] = None):
         # save the items in a dictionary with the `ConfigItem.id` as key

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -81,6 +81,7 @@ from .misc import (
 from .module import (
     InvalidPyTorchVersionError,
     OptionalImportError,
+    allow_missing_reference,
     damerau_levenshtein_distance,
     exact_version,
     export,
@@ -94,6 +95,8 @@ from .module import (
     optional_import,
     pytorch_after,
     require_pkg,
+    run_debug,
+    run_eval,
     version_leq,
 )
 from .nvtx import Range

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -25,6 +25,14 @@ from typing import Any, Callable, Collection, Hashable, Iterable, List, Mapping,
 
 import torch
 
+# bundle config system flags
+# set MONAI_EVAL_EXPR=1 to use 'eval', default value: run_eval=True
+run_eval = os.environ.get("MONAI_EVAL_EXPR", "1") != "0"
+# set MONAI_DEBUG_CONFIG=1 to run in debug mode, default value: run_debug=False
+run_debug = os.environ.get("MONAI_DEBUG_CONFIG", "0") != "0"
+# set MONAI_ALLOW_MISSING_REFERENCE=1 to allow missing references, default value: allow_missing_reference=False
+allow_missing_reference = os.environ.get("MONAI_ALLOW_MISSING_REFERENCE", "0") != "0"
+
 OPTIONAL_IMPORT_MSG_FMT = "{}"
 
 __all__ = [
@@ -220,9 +228,14 @@ def instantiate(path: str, **kwargs):
     if component is None:
         raise ModuleNotFoundError(f"Cannot locate class or function path: '{path}'.")
     try:
-        if kwargs.pop("_debug_", False):
-            print(f"\n\ndebug: instantiating: {component}\n\n")
-            import pdb; pdb.set_trace()
+        if kwargs.pop("_debug_", False) or run_debug:
+            warnings.warn(
+                f"\n\npdb: instantiating component={component}\n"
+                f"See also Debugger commands documentation: https://docs.python.org/3/library/pdb.html\n"
+            )
+            import pdb
+
+            pdb.set_trace()
         if isclass(component):
             return component(**kwargs)
         # support regular function, static method and class method

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -220,6 +220,9 @@ def instantiate(path: str, **kwargs):
     if component is None:
         raise ModuleNotFoundError(f"Cannot locate class or function path: '{path}'.")
     try:
+        if kwargs.pop("_debug_", False):
+            print(f"\n\ndebug: instantiating: {component}\n\n")
+            import pdb; pdb.set_trace()
         if isclass(component):
             return component(**kwargs)
         # support regular function, static method and class method

--- a/tests/test_bundle_verify_net.py
+++ b/tests/test_bundle_verify_net.py
@@ -35,7 +35,7 @@ class TestVerifyNetwork(unittest.TestCase):
 
             cmd = ["coverage", "run", "-m", "monai.bundle", "verify_net_in_out", "network_def", "--meta_file"]
             cmd += [meta_file, "--config_file", config_file, "-n", "4", "--any", "16", "--args_file", def_args_file]
-            cmd += ["--_meta_#network_data_format#inputs#image#spatial_shape", "[16,'*','2**p*n']"]
+            cmd += ["--device", "cpu", "--_meta_#network_data_format#inputs#image#spatial_shape", "[16,'*','2**p*n']"]
             command_line_tests(cmd)
 
 

--- a/tests/test_bundle_verify_net.py
+++ b/tests/test_bundle_verify_net.py
@@ -36,6 +36,7 @@ class TestVerifyNetwork(unittest.TestCase):
             cmd = ["coverage", "run", "-m", "monai.bundle", "verify_net_in_out", "network_def", "--meta_file"]
             cmd += [meta_file, "--config_file", config_file, "-n", "4", "--any", "16", "--args_file", def_args_file]
             cmd += ["--device", "cpu", "--_meta_#network_data_format#inputs#image#spatial_shape", "[16,'*','2**p*n']"]
+            cmd += ["--network_def#_requires_", "$monai.config.print_debug_info()"]
             command_line_tests(cmd)
 
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -22,8 +22,17 @@ from monai.bundle.config_item import ConfigItem
 from monai.data import DataLoader, Dataset
 from monai.transforms import Compose, LoadImaged, RandTorchVisiond
 from monai.utils import min_version, optional_import
+from tests.utils import TimedCall
 
 _, has_tv = optional_import("torchvision", "0.8.0", min_version)
+
+
+@TimedCall(seconds=100, force_quit=True)
+def case_pdb(sarg=None):
+    config = {"transform": {"_target_": "Compose", "transforms": [], "_debug_": True}}
+    parser = ConfigParser(config=config)
+    parser.get_parsed_content()
+
 
 # test the resolved and parsed instances
 TEST_CASE_1 = [
@@ -243,6 +252,10 @@ class TestConfigParser(unittest.TestCase):
         parser = ConfigParser(config=config)
         with self.assertRaises(RuntimeError):
             parser.get_parsed_content("transform", instantiate=True, eval_expr=True)
+
+    def test_pdb(self):
+        with self.assertRaisesRegex(RuntimeError, ".*bdb.BdbQuit.*"):
+            case_pdb()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

### Description
adds a `_debug_` keyword, so that when it's set to true, the program stops at the component init stage and enter the debug mode , usage:

```yaml
inferer:
  _target_: SlidingWindowInferer
  _debug_: true
  roi_size: [96, 96, 96]
  sw_batch_size: 4
  overlap: 0.5
```

alternatively at the CLI set `MONAI_DEBUG_CONFIG=1`, for example:

```bash
MONAI_DEBUG_CONFIG=1 python -m my_test_5 run --config_file=my_test_5.yaml
```

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
