### PR TITLE
5127 fixes dtypes in randomized transforms

### DIFF
--- a/monai/apps/auto3dseg/hpo_gen.py
+++ b/monai/apps/auto3dseg/hpo_gen.py
@@ -38,7 +38,8 @@ class HPOGen(AlgoGen):
         raise NotImplementedError
 
     @abstractmethod
-    def update_params(self, *args, **kwargs):  # type: ignore
+    def update_params(self, *args, **kwargs):
+
         """Update Algo parameters according to the hyperparameters to be evaluated."""
         raise NotImplementedError
 
@@ -48,7 +49,8 @@ class HPOGen(AlgoGen):
         raise NotImplementedError
 
     @abstractmethod
-    def run_algo(self, *args, **kwargs):  # type: ignore
+    def run_algo(self, *args, **kwargs):
+
         """Interface for launch the training given the fetched hyperparameters."""
         raise NotImplementedError
 

--- a/monai/auto3dseg/utils.py
+++ b/monai/auto3dseg/utils.py
@@ -174,7 +174,7 @@ def concat_val_to_np(
     elif ragged:
         return np.concatenate(np_list, **kwargs)  # type: ignore
     else:
-        return np.concatenate([np_list], **kwargs)  # type: ignore
+        return np.concatenate([np_list], **kwargs)
 
 
 def concat_multikeys_to_dict(

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -189,14 +189,13 @@ class RandRicianNoise(RandomizableTransform):
         """
         Apply the transform to `img`.
         """
-        img = convert_to_tensor(img, track_meta=get_track_meta())
+        img = convert_to_tensor(img, track_meta=get_track_meta(), dtype=self.dtype)
         if randomize:
             super().randomize(None)
 
         if not self._do_transform:
             return img
 
-        img, *_ = convert_data_type(img, dtype=self.dtype)
         if self.channel_wise:
             _mean = ensure_tuple_rep(self.mean, len(img))
             _std = ensure_tuple_rep(self.std, len(img))
@@ -335,9 +334,7 @@ class StdShiftIntensity(Transform):
         """
         Apply the transform to `img`.
         """
-        img = convert_to_tensor(img, track_meta=get_track_meta())
-        if self.dtype is not None:
-            img, *_ = convert_data_type(img, dtype=self.dtype)
+        img = convert_to_tensor(img, track_meta=get_track_meta(), dtype=self.dtype)
         if self.channel_wise:
             for i, d in enumerate(img):
                 img[i] = self._stdshift(d)  # type: ignore
@@ -394,7 +391,7 @@ class RandStdShiftIntensity(RandomizableTransform):
         """
         Apply the transform to `img`.
         """
-        img = convert_to_tensor(img, track_meta=get_track_meta())
+        img = convert_to_tensor(img, track_meta=get_track_meta(), dtype=self.dtype)
         if randomize:
             self.randomize()
 
@@ -506,7 +503,7 @@ class RandScaleIntensity(RandomizableTransform):
             self.randomize()
 
         if not self._do_transform:
-            return img
+            return convert_data_type(img, dtype=self.dtype)[0]
 
         return ScaleIntensity(minv=None, maxv=None, factor=self.factor, dtype=self.dtype)(img)
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -138,9 +138,9 @@ class SpatialResample(InvertibleTransform):
                 When `mode` is an integer, using numpy/cupy backends, this argument accepts
                 {'reflect', 'grid-mirror', 'constant', 'grid-constant', 'nearest', 'mirror', 'grid-wrap', 'wrap'}.
                 See also: https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.map_coordinates.html
-            dtype: data type for resampling computation. Defaults to ``np.float64`` for best precision.
+            dtype: data type for resampling computation. Defaults to ``float64`` for best precision.
                 If ``None``, use the data type of input data. To be compatible with other modules,
-                the output data type is always ``np.float32``.
+                the output data type is always ``float32``.
         """
         self.mode = mode
         self.padding_mode = padding_mode
@@ -160,7 +160,7 @@ class SpatialResample(InvertibleTransform):
         """
         Small fn to simplify returning data. If `MetaTensor`, update affine. Elif
         tracking metadata is desired, create `MetaTensor` with affine. Else, return
-        image as `torch.Tensor`. Output type is always `torch.float32`.
+        image as `torch.Tensor`. Output type is always `float32`.
 
         Also append the transform to the stack.
         """
@@ -473,9 +473,9 @@ class Spacing(InvertibleTransform):
                 See also: https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.map_coordinates.html
             align_corners: Geometrically, we consider the pixels of the input as squares rather than points.
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
-            dtype: data type for resampling computation. Defaults to ``np.float64`` for best precision.
+            dtype: data type for resampling computation. Defaults to ``float64`` for best precision.
                 If None, use the data type of input data. To be compatible with other modules,
-                the output data type is always ``np.float32``.
+                the output data type is always ``float32``.
             scale_extent: whether the scale is computed based on the spacing or the full extent of voxels,
                 default False. The option is ignored if output spatial size is specified when calling this transform.
                 See also: :py:func:`monai.data.utils.compute_shape_offset`. When this is True, `align_corners`
@@ -526,7 +526,7 @@ class Spacing(InvertibleTransform):
                 Defaults to ``None``, effectively using the value of `self.align_corners`.
             dtype: data type for resampling computation. Defaults to ``self.dtype``.
                 If None, use the data type of input data. To be compatible with other modules,
-                the output data type is always ``np.float32``.
+                the output data type is always ``float32``.
             scale_extent: whether the scale is computed based on the spacing or the full extent of voxels,
                 The option is ignored if output spatial size is specified when calling this transform.
                 See also: :py:func:`monai.data.utils.compute_shape_offset`. When this is True, `align_corners`
@@ -961,9 +961,9 @@ class Rotate(InvertibleTransform):
             See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
         align_corners: Defaults to False.
             See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
-        dtype: data type for resampling computation. Defaults to ``np.float32``.
+        dtype: data type for resampling computation. Defaults to ``float32``.
             If None, use the data type of input data. To be compatible with other modules,
-            the output data type is always ``np.float32``.
+            the output data type is always ``float32``.
     """
 
     backend = [TransformBackends.TORCH]
@@ -975,7 +975,7 @@ class Rotate(InvertibleTransform):
         mode: str = GridSampleMode.BILINEAR,
         padding_mode: str = GridSamplePadMode.BORDER,
         align_corners: bool = False,
-        dtype: Union[DtypeLike, torch.dtype] = np.float32,
+        dtype: Union[DtypeLike, torch.dtype] = torch.float32,
     ) -> None:
         self.angle = angle
         self.keep_size = keep_size
@@ -1007,7 +1007,7 @@ class Rotate(InvertibleTransform):
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
             dtype: data type for resampling computation. Defaults to ``self.dtype``.
                 If None, use the data type of input data. To be compatible with other modules,
-                the output data type is always ``np.float32``.
+                the output data type is always ``float32``.
 
         Raises:
             ValueError: When ``img`` spatially is not one of [2D, 3D].
@@ -1388,9 +1388,9 @@ class RandRotate(RandomizableTransform, InvertibleTransform):
             See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
         align_corners: Defaults to False.
             See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
-        dtype: data type for resampling computation. Defaults to ``np.float32``.
+        dtype: data type for resampling computation. Defaults to ``float32``.
             If None, use the data type of input data. To be compatible with other modules,
-            the output data type is always ``np.float32``.
+            the output data type is always ``float32``.
     """
 
     backend = Rotate.backend
@@ -1460,7 +1460,7 @@ class RandRotate(RandomizableTransform, InvertibleTransform):
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
             dtype: data type for resampling computation. Defaults to ``self.dtype``.
                 If None, use the data type of input data. To be compatible with other modules,
-                the output data type is always ``np.float32``.
+                the output data type is always ``float32``.
             randomize: whether to execute `randomize()` function first, default to True.
         """
         if randomize:
@@ -1477,7 +1477,7 @@ class RandRotate(RandomizableTransform, InvertibleTransform):
             )
             out = rotator(img)
         else:
-            out = convert_to_tensor(img, track_meta=get_track_meta())
+            out = convert_to_tensor(img, track_meta=get_track_meta(), dtype=torch.float32)
         if get_track_meta():
             rot_info = self.pop_transform(out, check=False) if self._do_transform else {}
             self.push_transform(out, extra_info=rot_info)
@@ -1688,7 +1688,7 @@ class RandZoom(RandomizableTransform, InvertibleTransform):
             self.randomize(img=img)
 
         if not self._do_transform:
-            out = convert_to_tensor(img, track_meta=get_track_meta())
+            out = convert_to_tensor(img, track_meta=get_track_meta(), dtype=torch.float32)
         else:
             out = Zoom(
                 self._zoom,
@@ -1731,7 +1731,7 @@ class AffineGrid(Transform):
             pixel/voxel relative to the center of the input image. Defaults to no translation.
         scale_params: scale factor for every spatial dims. a tuple of 2 floats for 2D,
             a tuple of 3 floats for 3D. Defaults to `1.0`.
-        dtype: data type for the grid computation. Defaults to ``np.float32``.
+        dtype: data type for the grid computation. Defaults to ``float32``.
             If ``None``, use the data type of input data (if `grid` is provided).
         device: device on which the tensor will be allocated, if a new grid is generated.
         affine: If applied, ignore the params (`rotate_params`, etc.) and use the
@@ -2007,7 +2007,7 @@ class Resample(Transform):
                 `[-1, 1]` (for torch ``grid_sample`` implementation) to be compatible with the underlying
                 resampling API.
             device: device on which the tensor will be allocated.
-            dtype: data type for resampling computation. Defaults to ``np.float64`` for best precision.
+            dtype: data type for resampling computation. Defaults to ``float64`` for best precision.
                 If ``None``, use the data type of input data. To be compatible with other modules,
                 the output data type is always `float32`.
 
@@ -2199,7 +2199,7 @@ class Affine(InvertibleTransform):
                 If `normalized=False`, additional coordinate normalization will be applied before resampling.
                 See also: :py:func:`monai.networks.utils.normalize_transform`.
             device: device on which the tensor will be allocated.
-            dtype: data type for resampling computation. Defaults to ``np.float32``.
+            dtype: data type for resampling computation. Defaults to ``float32``.
                 If ``None``, use the data type of input data. To be compatible with other modules,
                 the output data type is always `float32`.
             image_only: if True return only the image volume, otherwise return (image, affine).

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -192,9 +192,9 @@ class SpatialResampled(MapTransform, InvertibleTransform):
             align_corners: Geometrically, we consider the pixels of the input as squares rather than points.
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
                 It also can be a sequence of bool, each element corresponds to a key in ``keys``.
-            dtype: data type for resampling computation. Defaults to ``np.float64`` for best precision.
+            dtype: data type for resampling computation. Defaults to ``float64`` for best precision.
                 If None, use the data type of input data. To be compatible with other modules,
-                the output data type is always ``np.float32``.
+                the output data type is always ``float32``.
                 It also can be a sequence of dtypes, each element corresponds to a key in ``keys``.
             dst_keys: the key of the corresponding ``dst_affine`` in the metadata dictionary.
             allow_missing_keys: don't raise exception if key is missing.
@@ -268,9 +268,9 @@ class ResampleToMatchd(MapTransform, InvertibleTransform):
             align_corners: Geometrically, we consider the pixels of the input as squares rather than points.
                 See also: https://pytorch.org/docs/stable/nn.functional.html#grid-sample
                 It also can be a sequence of bool, each element corresponds to a key in ``keys``.
-            dtype: data type for resampling computation. Defaults to ``np.float64`` for best precision.
+            dtype: data type for resampling computation. Defaults to ``float64`` for best precision.
                 If None, use the data type of input data. To be compatible with other modules,
-                the output data type is always ``np.float32``.
+                the output data type is always ``float32``.
                 It also can be a sequence of dtypes, each element corresponds to a key in ``keys``.
             allow_missing_keys: don't raise exception if key is missing.
         """
@@ -375,9 +375,9 @@ class Spacingd(MapTransform, InvertibleTransform):
             align_corners: Geometrically, we consider the pixels of the input as squares rather than points.
                 See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
                 It also can be a sequence of bool, each element corresponds to a key in ``keys``.
-            dtype: data type for resampling computation. Defaults to ``np.float64`` for best precision.
+            dtype: data type for resampling computation. Defaults to ``float64`` for best precision.
                 If None, use the data type of input data. To be compatible with other modules,
-                the output data type is always ``np.float32``.
+                the output data type is always ``float32``.
                 It also can be a sequence of dtypes, each element corresponds to a key in ``keys``.
             scale_extent: whether the scale is computed based on the spacing or the full extent of voxels,
                 default False. The option is ignored if output spatial size is specified when calling this transform.
@@ -696,7 +696,7 @@ class Affined(MapTransform, InvertibleTransform):
                 See also: https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.map_coordinates.html
                 It also can be a sequence, each element corresponds to a key in ``keys``.
             device: device on which the tensor will be allocated.
-            dtype: data type for resampling computation. Defaults to ``np.float32``.
+            dtype: data type for resampling computation. Defaults to ``float32``.
                 If ``None``, use the data type of input data. To be compatible with other modules,
                 the output data type is always `float32`.
             allow_missing_keys: don't raise exception if key is missing.
@@ -861,6 +861,8 @@ class RandAffined(RandomizableTransform, MapTransform, InvertibleTransform):
             # do the transform
             if do_resampling:
                 d[key] = self.rand_affine(d[key], mode=mode, padding_mode=padding_mode, grid=grid)  # type: ignore
+            else:
+                d[key] = convert_to_tensor(d[key], track_meta=get_track_meta(), dtype=torch.float32)
             if get_track_meta():
                 xform = self.pop_transform(d[key], check=False) if do_resampling else {}
                 self.push_transform(d[key], extra_info={"do_resampling": do_resampling, "rand_affine_info": xform})
@@ -1320,9 +1322,9 @@ class Rotated(MapTransform, InvertibleTransform):
         align_corners: Defaults to False.
             See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html
             It also can be a sequence of bool, each element corresponds to a key in ``keys``.
-        dtype: data type for resampling computation. Defaults to ``np.float32``.
+        dtype: data type for resampling computation. Defaults to ``float32``.
             If None, use the data type of input data. To be compatible with other modules,
-            the output data type is always ``np.float32``.
+            the output data type is always ``float32``.
             It also can be a sequence of dtype or None, each element corresponds to a key in ``keys``.
         allow_missing_keys: don't raise exception if key is missing.
     """
@@ -1393,9 +1395,9 @@ class RandRotated(RandomizableTransform, MapTransform, InvertibleTransform):
         align_corners: Defaults to False.
             See also: https://pytorch.org/docs/stable/generated/torch.nn.functional.interpolate.html
             It also can be a sequence of bool, each element corresponds to a key in ``keys``.
-        dtype: data type for resampling computation. Defaults to ``np.float64`` for best precision.
+        dtype: data type for resampling computation. Defaults to ``float64`` for best precision.
             If None, use the data type of input data. To be compatible with other modules,
-            the output data type is always ``np.float32``.
+            the output data type is always ``float32``.
             It also can be a sequence of dtype or None, each element corresponds to a key in ``keys``.
         allow_missing_keys: don't raise exception if key is missing.
     """
@@ -1450,7 +1452,7 @@ class RandRotated(RandomizableTransform, MapTransform, InvertibleTransform):
                     randomize=False,
                 )
             else:
-                d[key] = convert_to_tensor(d[key], track_meta=get_track_meta())
+                d[key] = convert_to_tensor(d[key], track_meta=get_track_meta(), dtype=torch.float32)
             if get_track_meta():
                 rot_info = self.pop_transform(d[key], check=False) if self._do_transform else {}
                 self.push_transform(d[key], extra_info=rot_info)
@@ -1618,7 +1620,7 @@ class RandZoomd(RandomizableTransform, MapTransform, InvertibleTransform):
                     d[key], mode=mode, padding_mode=padding_mode, align_corners=align_corners, randomize=False
                 )
             else:
-                d[key] = convert_to_tensor(d[key], track_meta=get_track_meta())
+                d[key] = convert_to_tensor(d[key], track_meta=get_track_meta(), dtype=torch.float32)
             if get_track_meta():
                 xform = self.pop_transform(d[key], check=False) if self._do_transform else {}
                 self.push_transform(d[key], extra_info=xform)

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -102,7 +102,7 @@ def get_dtype(data: Any):
 
 def convert_to_tensor(
     data,
-    dtype: Optional[torch.dtype] = None,
+    dtype: Union[DtypeLike, torch.dtype] = None,
     device: Union[None, str, torch.device] = None,
     wrap_sequence: bool = False,
     track_meta: bool = False,

--- a/tests/test_rand_rician_noise.py
+++ b/tests/test_rand_rician_noise.py
@@ -32,6 +32,8 @@ class TestRandRicianNoise(NumpyImageTestCase2D):
         rician_fn.set_random_state(seed)
         im = in_type(self.imt)
         noised = rician_fn(im)
+        if isinstance(im, torch.Tensor):
+            self.assertEqual(im.dtype, noised.dtype)
         np.random.seed(seed)
         np.random.random()
         _std = np.random.uniform(0, std)

--- a/tests/test_rand_rotate.py
+++ b/tests/test_rand_rotate.py
@@ -127,5 +127,22 @@ class TestRandRotate3D(NumpyImageTestCase3D):
         set_track_meta(True)
 
 
+class TestRandRotateDtype(NumpyImageTestCase2D):
+    @parameterized.expand(TEST_CASES_2D)
+    def test_correct_results(self, im_type, degrees, keep_size, mode, padding_mode, align_corners):
+        rotate_fn = RandRotate(
+            range_x=1.0,
+            prob=0.5,
+            keep_size=keep_size,
+            mode=mode,
+            padding_mode=padding_mode,
+            align_corners=align_corners,
+            dtype=np.float64,
+        )
+        im = im_type(self.imt[0])
+        rotated = rotate_fn(im)
+        self.assertEqual(rotated.dtype, torch.float32)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rand_rotated.py
+++ b/tests/test_rand_rotated.py
@@ -145,7 +145,7 @@ class TestRandRotated3D(NumpyImageTestCase3D):
     @parameterized.expand(TEST_CASES_3D)
     def test_correct_shapes(self, im_type, x, y, z, keep_size, mode, padding_mode, align_corners, expected):
         rotate_fn = RandRotated(
-            "img",
+            ("img", "seg"),
             range_x=x,
             range_y=y,
             range_z=z,
@@ -159,6 +159,10 @@ class TestRandRotated3D(NumpyImageTestCase3D):
         rotate_fn.set_random_state(243)
         rotated = rotate_fn({"img": im_type(self.imt[0]), "seg": im_type(self.segn[0])})
         np.testing.assert_allclose(rotated["img"].shape, expected)
+
+        rotate_fn.prob = 0.0
+        rotated = rotate_fn({"img": im_type(self.imt[0]), "seg": im_type(self.segn[0])})
+        self.assertEqual(rotated["seg"].dtype, torch.float32)
 
 
 if __name__ == "__main__":

--- a/tests/test_rand_std_shift_intensity.py
+++ b/tests/test_rand_std_shift_intensity.py
@@ -12,6 +12,7 @@
 import unittest
 
 import numpy as np
+import torch
 from parameterized import parameterized
 
 from monai.transforms import RandStdShiftIntensity
@@ -29,7 +30,10 @@ class TestRandStdShiftIntensity(NumpyImageTestCase2D):
         expected = p(self.imt + offset)
         shifter = RandStdShiftIntensity(factors=1.0, prob=1.0)
         shifter.set_random_state(seed=0)
-        result = shifter(p(self.imt))
+        _imt = p(self.imt)
+        result = shifter(_imt)
+        if isinstance(_imt, torch.Tensor):
+            self.assertEqual(result.dtype, _imt.dtype)
         assert_allclose(result, expected, atol=0, rtol=1e-5, type_test="tensor")
 
 

--- a/tests/test_rand_zoom.py
+++ b/tests/test_rand_zoom.py
@@ -12,6 +12,7 @@
 import unittest
 
 import numpy as np
+import torch
 from parameterized import parameterized
 from scipy.ndimage import zoom as zoom_scipy
 
@@ -51,6 +52,8 @@ class TestRandZoom(NumpyImageTestCase2D):
             self.assertTrue(np.array_equal(zoomed.shape, self.imt.shape[1:]))
             zoomed = random_zoom(im)
             self.assertTrue(np.array_equal(zoomed.shape, self.imt.shape[1:]))
+            random_zoom.prob = 0.0
+            self.assertEqual(random_zoom(im).dtype, torch.float32)
 
     @parameterized.expand(
         [("no_min_zoom", None, 1.1, "bilinear", TypeError), ("invalid_mode", 0.9, 1.1, "s", ValueError)]

--- a/tests/test_rand_zoomd.py
+++ b/tests/test_rand_zoomd.py
@@ -12,6 +12,7 @@
 import unittest
 
 import numpy as np
+import torch
 from parameterized import parameterized
 from scipy.ndimage import zoom as zoom_scipy
 
@@ -58,6 +59,8 @@ class TestRandZoomd(NumpyImageTestCase2D):
             zoomed = random_zoom({key: im})
             test_local_inversion(random_zoom, zoomed, {key: im}, key)
             np.testing.assert_array_equal(zoomed[key].shape, self.imt.shape[1:])
+        random_zoom.prob = 0.0
+        self.assertEqual(random_zoom({key: p(self.imt[0])})[key].dtype, torch.float32)
 
     @parameterized.expand(
         [("no_min_zoom", None, 1.1, "bilinear", TypeError), ("invalid_order", 0.9, 1.1, "s", ValueError)]


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5127 

### Description
still does the dtype converting if self._do_transform is False


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
