### PR TITLE
4456 optional import issue on top-level modules -- monai.handlers/monai.engines

### DIFF
--- a/monai/__init__.py
+++ b/monai/__init__.py
@@ -11,7 +11,6 @@
 
 import os
 import sys
-import types
 
 from ._version import get_versions
 
@@ -46,18 +45,7 @@ excludes = "(^(monai.handlers))|(^(monai.bundle))|(^(monai.fl))|((\\.so)$)|(^(mo
 load_submodules(sys.modules[__name__], False, exclude_pattern=excludes)
 
 # load all modules, this will trigger all export decorations
-_, err_mod = load_submodules(sys.modules[__name__], True, exclude_pattern=excludes)
-
-if isinstance(sys.modules.get("monai", ""), types.ModuleType) and err_mod:  # project-monai/monai#4456
-    for x in err_mod:
-        if x.startswith("monai.") and "utils" not in x:
-            from monai.utils.module import optional_import
-
-            name = x.split(".", 1)
-            if len(name) != 2:
-                continue  # don't understand more than one dot in the erroneous module name
-            setattr(sys.modules["monai"], name[1], optional_import(x)[0])
-
+load_submodules(sys.modules[__name__], True, exclude_pattern=excludes)
 
 __all__ = [
     "apps",

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from ignite.engine import EventEnum
 else:
     EventEnum, _ = optional_import(
-        "ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "EventEnum", as_type=True
+        "ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "EventEnum", as_type="base"
     )
 
 __all__ = [

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -22,7 +22,9 @@ from monai.utils.enums import CommonKeys, GanKeys
 if TYPE_CHECKING:
     from ignite.engine import EventEnum
 else:
-    EventEnum, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "EventEnum")
+    EventEnum, _ = optional_import(
+        "ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "EventEnum", as_type=True
+    )
 
 __all__ = [
     "IterationEvents",

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -24,7 +24,7 @@ from monai.utils import ensure_tuple, is_scalar, min_version, optional_import
 
 from .utils import engine_apply_transform
 
-IgniteEngine, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Engine")
+IgniteEngine, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Engine", as_type=True)
 State, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "State")
 Events, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Events")
 

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -24,7 +24,7 @@ from monai.utils import ensure_tuple, is_scalar, min_version, optional_import
 
 from .utils import engine_apply_transform
 
-IgniteEngine, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Engine", as_type=True)
+IgniteEngine, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Engine", as_type="")
 State, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "State")
 Events, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Events")
 

--- a/monai/handlers/ignite_metric.py
+++ b/monai/handlers/ignite_metric.py
@@ -19,9 +19,9 @@ from monai.metrics import CumulativeIterationMetric
 from monai.utils import min_version, optional_import
 
 idist, _ = optional_import("ignite", IgniteInfo.OPT_IMPORT_VERSION, min_version, "distributed")
-Metric, _ = optional_import("ignite.metrics", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Metric", as_type=True)
+Metric, _ = optional_import("ignite.metrics", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Metric", as_type="base")
 reinit__is_reduced, _ = optional_import(
-    "ignite.metrics.metric", IgniteInfo.OPT_IMPORT_VERSION, min_version, "reinit__is_reduced", as_type=True
+    "ignite.metrics.metric", IgniteInfo.OPT_IMPORT_VERSION, min_version, "reinit__is_reduced", as_type="decorator"
 )
 if TYPE_CHECKING:
     from ignite.engine import Engine

--- a/monai/handlers/ignite_metric.py
+++ b/monai/handlers/ignite_metric.py
@@ -19,9 +19,9 @@ from monai.metrics import CumulativeIterationMetric
 from monai.utils import min_version, optional_import
 
 idist, _ = optional_import("ignite", IgniteInfo.OPT_IMPORT_VERSION, min_version, "distributed")
-Metric, _ = optional_import("ignite.metrics", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Metric")
+Metric, _ = optional_import("ignite.metrics", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Metric", as_type=True)
 reinit__is_reduced, _ = optional_import(
-    "ignite.metrics.metric", IgniteInfo.OPT_IMPORT_VERSION, min_version, "reinit__is_reduced"
+    "ignite.metrics.metric", IgniteInfo.OPT_IMPORT_VERSION, min_version, "reinit__is_reduced", as_type=True
 )
 if TYPE_CHECKING:
     from ignite.engine import Engine

--- a/monai/handlers/parameter_scheduler.py
+++ b/monai/handlers/parameter_scheduler.py
@@ -45,10 +45,10 @@ class ParamSchedulerHandler:
         vc_kwargs: Dict,
         epoch_level: bool = False,
         name: Optional[str] = None,
-        event=Events.ITERATION_COMPLETED,
+        event=None,
     ):
         self.epoch_level = epoch_level
-        self.event = event
+        self.event = event if event is not None else Events.ITERATION_COMPLETED
 
         self._calculators = {
             "linear": self._linear,

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -309,6 +309,7 @@ def optional_import(
     descriptor: str = OPTIONAL_IMPORT_MSG_FMT,
     version_args=None,
     allow_namespace_pkg: bool = False,
+    as_type: bool = False,
 ) -> Tuple[Any, bool]:
     """
     Imports an optional module specified by `module` string.
@@ -323,6 +324,8 @@ def optional_import(
         descriptor: a format string for the final error message when using a not imported module.
         version_args: additional parameters to the version checker.
         allow_namespace_pkg: whether importing a namespace package is allowed. Defaults to False.
+        as_type: whether the imported object will be used as a type, so that it can be used as a lazy base class.
+            default to False.
 
     Returns:
         The imported module and a boolean flag indicating whether the import is successful.
@@ -409,6 +412,8 @@ def optional_import(
             """
             raise self._exception
 
+    if as_type:
+        return _LazyRaise, False
     return _LazyRaise(), False
 
 

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -414,6 +414,12 @@ def optional_import(
             """
             raise self._exception
 
+        def __getitem__(self, item):
+            raise self._exception
+
+        def __iter__(self):
+            raise self._exception
+
     if as_type == "default":
         return _LazyRaise(), False
 

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -324,7 +324,7 @@ def optional_import(
         descriptor: a format string for the final error message when using a not imported module.
         version_args: additional parameters to the version checker.
         allow_namespace_pkg: whether importing a namespace package is allowed. Defaults to False.
-        as_type: whether the imported object will be used as a type, so that it can be used as a lazy base class.
+        as_type: whether to return a lazy class type instead of instance, so that it can be used as a lazy base class.
             default to False.
 
     Returns:

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -209,14 +209,14 @@ if __name__ == "__main__":
     try:
         import monai.engines
 
-        print(monai.engines.test_attribute)
+        print(monai.engines.test_attribute)  # type: ignore
     except OptionalImportError as e:
         print(f"expected {e}")
 
     try:
         import monai.handlers
 
-        print(monai.handlers.test_attribute)
+        print(monai.handlers.test_attribute)  # type: ignore
     except OptionalImportError as e:
         print(f"expected {e}")
 

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -204,7 +204,21 @@ def run_testsuit():
 if __name__ == "__main__":
 
     # testing import submodules
-    from monai.utils.module import load_submodules
+    from monai.utils.module import OptionalImportError, load_submodules
+
+    try:
+        import monai.engines
+
+        print(monai.engines.test_attribute)
+    except OptionalImportError as e:
+        print(f"expected {e}")
+
+    try:
+        import monai.handlers
+
+        print(monai.handlers.test_attribute)
+    except OptionalImportError as e:
+        print(f"expected {e}")
 
     _, err_mod = load_submodules(sys.modules["monai"], True)
     if err_mod:

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -204,27 +204,10 @@ def run_testsuit():
 if __name__ == "__main__":
 
     # testing import submodules
-    from monai.utils.module import OptionalImportError, load_submodules
-
-    try:
-        import monai.engines
-
-        print(monai.engines.test_attribute)  # type: ignore
-    except OptionalImportError as e:
-        print(f"expected {e}")
-
-    try:
-        import monai.handlers
-
-        print(monai.handlers.test_attribute)  # type: ignore
-    except OptionalImportError as e:
-        print(f"expected {e}")
+    from monai.utils.module import load_submodules
 
     _, err_mod = load_submodules(sys.modules["monai"], True)
-    if err_mod:
-        print(err_mod)
-        # expecting that only engines and handlers are not imported
-        assert sorted(err_mod) == ["monai.engines", "monai.handlers"]
+    assert not err_mod
 
     # testing all modules
     test_runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=2)


### PR DESCRIPTION
Fixes #4456

### Description
make sure that if the top-level modules miss dependencies, the optional import error raises properly.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
