### PR TITLE
5140 Add update time information for bundle API

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -346,6 +346,8 @@ def _get_all_bundles_info(repo: str = "Project-MONAI/model-zoo", tag: str = "hos
                     "size": asset["size"],
                     "download_count": asset["download_count"],
                     "browser_download_url": asset["browser_download_url"],
+                    "created_at": asset["created_at"],
+                    "updated_at": asset["updated_at"],
                 }
             return bundles_info
     return bundles_info
@@ -405,7 +407,8 @@ def get_bundle_info(
     tag: str = "hosting_storage_v1",
 ):
     """
-    Get all information (include "id", "name", "size", "download_count", "browser_download_url") of a bundle
+    Get all information
+    (include "id", "name", "size", "download_count", "browser_download_url", "created_at", "updated_at") of a bundle
     with the specified bundle name and version.
 
     Args:


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #5140 

### Description

This PR is used to add `created_at` (the create time of a bundle) and `update_at` (the update time of a bundle) information in 
bundle API. It is helpful for showing the corresponding information in model zoo website.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
