### PR TITLE
5150 fixes integration error  reading stdout visible devices

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -42,7 +42,7 @@ jobs:
         echo "Sleep $LAUNCH_DELAY"
         sleep $LAUNCH_DELAY
         nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils | tail -n 1)
         echo $CUDA_VISIBLE_DEVICES
         trap 'if pgrep python; then pkill python; fi;' ERR
         python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
@@ -85,7 +85,7 @@ jobs:
         echo "Sleep $LAUNCH_DELAY"
         sleep $LAUNCH_DELAY
         nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils | tail -n 1)
         echo $CUDA_VISIBLE_DEVICES
         trap 'if pgrep python; then pkill python; fi;' ERR
         python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
@@ -160,7 +160,7 @@ jobs:
           echo "Sleep $LAUNCH_DELAY"
           sleep $LAUNCH_DELAY
           nvidia-smi
-          export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+          export CUDA_VISIBLE_DEVICES=$(python -m tests.utils | tail -n 1)
           echo $CUDA_VISIBLE_DEVICES
           trap 'if pgrep python; then pkill python; fi;' ERR
           python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
@@ -183,7 +183,7 @@ jobs:
       run: |
         cd /opt/monai
         nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils | tail -n 1)
         echo $CUDA_VISIBLE_DEVICES
         trap 'if pgrep python; then pkill python; fi;' ERR
         python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &
@@ -217,7 +217,7 @@ jobs:
         python -m pip install -r requirements-dev.txt
         BUILD_MONAI=1 python setup.py develop  # install monai
         nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils | tail -n 1)
         echo $CUDA_VISIBLE_DEVICES
         echo "::set-output name=devices::$CUDA_VISIBLE_DEVICES"
     - name: Checkout tutorials and install their requirements

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
     - name: Import
       run: |
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils | tail -n 1)
         echo $CUDA_VISIBLE_DEVICES
         python -c 'import monai; monai.config.print_debug_info()'
         cd /opt/monai

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         python -m pip list
         nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils | tail -n 1)
         echo $CUDA_VISIBLE_DEVICES
         trap 'if pgrep python; then pkill python; fi;' ERR
         python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &

--- a/.github/workflows/pythonapp-gpu.yml
+++ b/.github/workflows/pythonapp-gpu.yml
@@ -129,7 +129,7 @@ jobs:
         export LAUNCH_DELAY=$(python -c "import numpy; print(numpy.random.randint(30) * 10)")
         echo "Sleep $LAUNCH_DELAY"
         sleep $LAUNCH_DELAY
-        export CUDA_VISIBLE_DEVICES=$(coverage run -m tests.utils)
+        export CUDA_VISIBLE_DEVICES=$(coverage run -m tests.utils | tail -n 1)
         echo $CUDA_VISIBLE_DEVICES
         trap 'if pgrep python; then pkill python; fi;' ERR
         python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -53,7 +53,7 @@ jobs:
         echo "Sleep $LAUNCH_DELAY"
         sleep $LAUNCH_DELAY
         nvidia-smi
-        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils)
+        export CUDA_VISIBLE_DEVICES=$(python -m tests.utils | tail -n 1)
         echo $CUDA_VISIBLE_DEVICES
         trap 'if pgrep python; then pkill python; fi;' ERR
         python -c $'import torch\na,b=torch.zeros(1,device="cuda:0"),torch.zeros(1,device="cuda:1");\nwhile True:print(a,b)' > /dev/null &

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,7 +38,7 @@ tifffile; platform_system == "Linux"
 pandas
 requests
 einops
-transformers!=4.22.0
+transformers
 mlflow
 matplotlib!=3.5.0
 tensorboardX

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -778,4 +778,5 @@ if torch.cuda.is_available():
 
 
 if __name__ == "__main__":
-    print(query_memory())
+    print("\n", query_memory())  # print to stdout
+    sys.exit(0)


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5150

### Description
`python -m tests.utils` may print additional contents from 3rd party packages,
only the last line for the stdout should be used

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
