### PR TITLE
Remove batch dim in `SobelGradients` and `SobelGradientsd`

### DIFF
--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -856,5 +856,5 @@ class SobelGradients(Transform):
         grad_v = apply_filter(image_tensor, kernel_v, padding=self.padding)
         grad_h = apply_filter(image_tensor, kernel_h, padding=self.padding)
         grad = torch.cat([grad_h, grad_v], dim=1)
-        grad, *_ = convert_to_dst_type(grad.squeeze(0), image)
+        grad, *_ = convert_to_dst_type(grad.squeeze(0), image_tensor)
         return grad

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -852,8 +852,9 @@ class SobelGradients(Transform):
         image_tensor = convert_to_tensor(image, track_meta=get_track_meta())
         kernel_v = self.kernel.to(image_tensor.device)
         kernel_h = kernel_v.T
+        image_tensor = image_tensor.unsqueeze(0)  # adds a batch dim
         grad_v = apply_filter(image_tensor, kernel_v, padding=self.padding)
         grad_h = apply_filter(image_tensor, kernel_h, padding=self.padding)
-        grad = torch.cat([grad_h, grad_v])
-
+        grad = torch.cat([grad_h, grad_v], dim=1)
+        grad, *_ = convert_to_dst_type(grad.squeeze(0), image)
         return grad

--- a/tests/test_sobel_gradient.py
+++ b/tests/test_sobel_gradient.py
@@ -17,8 +17,8 @@ from parameterized import parameterized
 from monai.transforms import SobelGradients
 from tests.utils import assert_allclose
 
-IMAGE = torch.zeros(1, 1, 16, 16, dtype=torch.float32)
-IMAGE[0, 0, 8, :] = 1
+IMAGE = torch.zeros(1, 16, 16, dtype=torch.float32)
+IMAGE[0, 8, :] = 1
 OUTPUT_3x3 = torch.zeros(2, 16, 16, dtype=torch.float32)
 OUTPUT_3x3[0, 7, :] = 2.0
 OUTPUT_3x3[0, 9, :] = -2.0
@@ -28,7 +28,6 @@ OUTPUT_3x3[1, 7, 0] = OUTPUT_3x3[1, 9, 0] = 0.5
 OUTPUT_3x3[1, 8, 0] = 1.0
 OUTPUT_3x3[1, 8, -1] = -1.0
 OUTPUT_3x3[1, 7, -1] = OUTPUT_3x3[1, 9, -1] = -0.5
-OUTPUT_3x3 = OUTPUT_3x3.unsqueeze(1)
 
 TEST_CASE_0 = [IMAGE, {"kernel_size": 3, "dtype": torch.float32}, OUTPUT_3x3]
 TEST_CASE_1 = [IMAGE, {"kernel_size": 3, "dtype": torch.float64}, OUTPUT_3x3]

--- a/tests/test_sobel_gradientd.py
+++ b/tests/test_sobel_gradientd.py
@@ -17,8 +17,8 @@ from parameterized import parameterized
 from monai.transforms import SobelGradientsd
 from tests.utils import assert_allclose
 
-IMAGE = torch.zeros(1, 1, 16, 16, dtype=torch.float32)
-IMAGE[0, 0, 8, :] = 1
+IMAGE = torch.zeros(1, 16, 16, dtype=torch.float32)
+IMAGE[0, 8, :] = 1
 OUTPUT_3x3 = torch.zeros(2, 16, 16, dtype=torch.float32)
 OUTPUT_3x3[0, 7, :] = 2.0
 OUTPUT_3x3[0, 9, :] = -2.0
@@ -28,7 +28,6 @@ OUTPUT_3x3[1, 7, 0] = OUTPUT_3x3[1, 9, 0] = 0.5
 OUTPUT_3x3[1, 8, 0] = 1.0
 OUTPUT_3x3[1, 8, -1] = -1.0
 OUTPUT_3x3[1, 7, -1] = OUTPUT_3x3[1, 9, -1] = -0.5
-OUTPUT_3x3 = OUTPUT_3x3.unsqueeze(1)
 
 TEST_CASE_0 = [{"image": IMAGE}, {"keys": "image", "kernel_size": 3, "dtype": torch.float32}, {"image": OUTPUT_3x3}]
 TEST_CASE_1 = [{"image": IMAGE}, {"keys": "image", "kernel_size": 3, "dtype": torch.float64}, {"image": OUTPUT_3x3}]


### PR DESCRIPTION
Signed-off-by: KumoLiu <yunl@nvidia.com>

Fixes #5176.

### Description
Remove batch dim in `SobelGradients` and `SobelGradientsd` to make it consistent with other post transforms.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
