### PR TITLE
Add channel dim in `ComputeHoVerMaps` and `ComputeHoVerMapsd`

### DIFF
--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -2311,6 +2311,7 @@ class ComputeHoVerMaps(Transform):
 
         h_map = instance_mask.astype(self.dtype, copy=True)
         v_map = instance_mask.astype(self.dtype, copy=True)
+        instance_mask = instance_mask.squeeze(0)  # remove channel dim
 
         for region in skimage.measure.regionprops(instance_mask):
             v_dist = region.coords[:, 0] - region.centroid[0]
@@ -2325,5 +2326,5 @@ class ComputeHoVerMaps(Transform):
             h_map[h_map == region.label] = h_dist
             v_map[v_map == region.label] = v_dist
 
-        hv_maps = convert_to_tensor(np.stack([h_map, v_map]), track_meta=get_track_meta())
+        hv_maps = convert_to_tensor(np.concatenate([h_map, v_map]), track_meta=get_track_meta())
         return hv_maps

--- a/tests/test_compute_ho_ver_maps.py
+++ b/tests/test_compute_ho_ver_maps.py
@@ -22,11 +22,11 @@ from tests.utils import TEST_NDARRAYS, assert_allclose
 _, has_skimage = optional_import("skimage", "0.19.0", min_version)
 
 
-INSTANCE_MASK = np.zeros((16, 16), dtype="int16")
-INSTANCE_MASK[5:8, 4:11] = 1
-INSTANCE_MASK[3:5, 6:9] = 1
-INSTANCE_MASK[8:10, 6:9] = 1
-INSTANCE_MASK[13:, 13:] = 2
+INSTANCE_MASK = np.zeros((1, 16, 16), dtype="int16")
+INSTANCE_MASK[:, 5:8, 4:11] = 1
+INSTANCE_MASK[:, 3:5, 6:9] = 1
+INSTANCE_MASK[:, 8:10, 6:9] = 1
+INSTANCE_MASK[:, 13:, 13:] = 2
 H_MAP = torch.zeros((16, 16), dtype=torch.float32)
 H_MAP[5:8, 4] = -1.0
 H_MAP[5:8, 5] = -2.0 / 3.0

--- a/tests/test_compute_ho_ver_maps_d.py
+++ b/tests/test_compute_ho_ver_maps_d.py
@@ -22,11 +22,11 @@ from tests.utils import TEST_NDARRAYS, assert_allclose
 _, has_skimage = optional_import("skimage", "0.19.0", min_version)
 
 
-INSTANCE_MASK = np.zeros((16, 16), dtype="int16")
-INSTANCE_MASK[5:8, 4:11] = 1
-INSTANCE_MASK[3:5, 6:9] = 1
-INSTANCE_MASK[8:10, 6:9] = 1
-INSTANCE_MASK[13:, 13:] = 2
+INSTANCE_MASK = np.zeros((1, 16, 16), dtype="int16")
+INSTANCE_MASK[:, 5:8, 4:11] = 1
+INSTANCE_MASK[:, 3:5, 6:9] = 1
+INSTANCE_MASK[:, 8:10, 6:9] = 1
+INSTANCE_MASK[:, 13:, 13:] = 2
 H_MAP = torch.zeros((16, 16), dtype=torch.float32)
 H_MAP[5:8, 4] = -1.0
 H_MAP[5:8, 5] = -2.0 / 3.0


### PR DESCRIPTION
Signed-off-by: KumoLiu <yunl@nvidia.com>

Fixes #5177.

### Description

Add channel dim in `ComputeHoVerMaps` and `ComputeHoVerMapsd` to make it consistent with other transforms.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
