### PR TITLE
5193 5204 import error msg/warnings

### DIFF
--- a/monai/transforms/signal/array.py
+++ b/monai/transforms/signal/array.py
@@ -13,6 +13,7 @@ A collection of transforms for signal operations
 https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 """
 
+import warnings
 from typing import Any, Optional, Sequence
 
 import numpy as np
@@ -27,7 +28,9 @@ from monai.utils.type_conversion import convert_data_type, convert_to_tensor
 
 shift, has_shift = optional_import("scipy.ndimage.interpolation", name="shift")
 iirnotch, has_iirnotch = optional_import("scipy.signal", name="iirnotch")
-filtfilt, has_filtfilt = optional_import("torchaudio.functional", name="filtfilt")
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", UserWarning)  # project-monai/monai#5204
+    filtfilt, has_filtfilt = optional_import("torchaudio.functional", name="filtfilt")
 central_frequency, has_central_frequency = optional_import("pywt", name="central_frequency")
 cwt, has_cwt = optional_import("pywt", name="cwt")
 

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -202,9 +202,11 @@ def load_submodules(basemod, load_all: bool = True, exclude_pattern: str = "(.*[
             except OptionalImportError:
                 pass  # could not import the optional deps., they are ignored
             except ImportError as e:
-                msg = "\nMultiple versions of MONAI may have been installed?\n" \
-                      "Please see the installation guide: https://docs.monai.io/en/stable/installation.html\n"
-                raise type(e)(f"{e}\n{msg}").with_traceback(e.__traceback__)
+                msg = (
+                    "\nMultiple versions of MONAI may have been installed?\n"
+                    "Please see the installation guide: https://docs.monai.io/en/stable/installation.html\n"
+                )
+                raise type(e)(f"{e}\n{msg}").with_traceback(e.__traceback__) from e  # raise with modified message
 
     return submodules, err_mod
 

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -205,7 +205,7 @@ def load_submodules(basemod, load_all: bool = True, exclude_pattern: str = "(.*[
                 msg = (
                     "\nMultiple versions of MONAI may have been installed?\n"
                     "Please see the installation guide: https://docs.monai.io/en/stable/installation.html\n"
-                )
+                )  # issue project-monai/monai#5193
                 raise type(e)(f"{e}\n{msg}").with_traceback(e.__traceback__) from e  # raise with modified message
 
     return submodules, err_mod

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -202,11 +202,9 @@ def load_submodules(basemod, load_all: bool = True, exclude_pattern: str = "(.*[
             except OptionalImportError:
                 pass  # could not import the optional deps., they are ignored
             except ImportError as e:
-                raise ImportError(
-                    "Multiple versions of MONAI may have been installed,\n"
-                    "please uninstall existing packages (both monai and monai-weekly) and install a version again.\n"
-                    "See also: https://docs.monai.io/en/stable/installation.html\n"
-                ) from e
+                msg = "\nMultiple versions of MONAI may have been installed?\n" \
+                      "Please see the installation guide: https://docs.monai.io/en/stable/installation.html\n"
+                raise type(e)(f"{e}\n{msg}").with_traceback(e.__traceback__)
 
     return submodules, err_mod
 


### PR DESCRIPTION
fixes #5193 
fixes #5204

### Description

revise the import error messages and ignore a torchaudio warning.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
