### PR TITLE
3844 flexible min/max_pixdim options for Spacing

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -15,6 +15,7 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 import warnings
 from copy import deepcopy
 from enum import Enum
+from itertools import zip_longest
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -24,7 +25,7 @@ from monai.config import USE_COMPILED, DtypeLike
 from monai.config.type_definitions import NdarrayOrTensor
 from monai.data.meta_obj import get_track_meta
 from monai.data.meta_tensor import MetaTensor
-from monai.data.utils import AFFINE_TOL, compute_shape_offset, iter_patch, to_affine_nd, zoom_affine
+from monai.data.utils import AFFINE_TOL, affine_to_spacing, compute_shape_offset, iter_patch, to_affine_nd, zoom_affine
 from monai.networks.layers import AffineTransform, GaussianFilter, grid_pull
 from monai.networks.utils import meshgrid_ij, normalize_transform
 from monai.transforms.croppad.array import CenterSpatialCrop, ResizeWithPadOrCrop
@@ -437,6 +438,8 @@ class Spacing(InvertibleTransform):
         dtype: DtypeLike = np.float64,
         scale_extent: bool = False,
         recompute_affine: bool = False,
+        min_pixdim: Union[Sequence[float], float, np.ndarray, None] = None,
+        max_pixdim: Union[Sequence[float], float, np.ndarray, None] = None,
         image_only: bool = False,
     ) -> None:
         """
@@ -483,12 +486,22 @@ class Spacing(InvertibleTransform):
             recompute_affine: whether to recompute affine based on the output shape. The affine computed
                 analytically does not reflect the potential quantization errors in terms of the output shape.
                 Set this flag to True to recompute the output affine based on the actual pixdim. Default to ``False``.
+            min_pixdim: minimally allowed input spacing. If provided, input image with a larger spacing than this value
+                will be kept the same (not be resampled to `pixdim`) by this transform, default to `None`.
+            max_pixdim: maximally allowed input spacing. If provided, input image with a smaller spacing than this value
+                will be kept the same (not be resampled to `pixdim`) by this transform, default to `None`.
 
         """
         self.pixdim = np.array(ensure_tuple(pixdim), dtype=np.float64)
+        self.min_pixdim = np.array(ensure_tuple(min_pixdim), dtype=np.float64)
+        self.max_pixdim = np.array(ensure_tuple(max_pixdim), dtype=np.float64)
         self.diagonal = diagonal
         self.scale_extent = scale_extent
         self.recompute_affine = recompute_affine
+
+        for mn, mx in zip(self.min_pixdim, self.max_pixdim):
+            if (not np.isnan(mn)) and (not np.isnan(mx)) and (mx < mn):
+                raise ValueError(f"min_pixdim {self.min_pixdim} must be smaller than the max {self.max_pixdim}.")
 
         self.sp_resample = SpatialResample(
             mode=mode, padding_mode=padding_mode, align_corners=align_corners, dtype=dtype
@@ -560,6 +573,19 @@ class Spacing(InvertibleTransform):
         out_d = self.pixdim[:sr]
         if out_d.size < sr:
             out_d = np.append(out_d, [1.0] * (sr - out_d.size))
+        orig_d = affine_to_spacing(affine_, sr, out_d.dtype)
+        for idx, (_d, mn, mx) in enumerate(
+            zip_longest(orig_d, self.min_pixdim[:sr], self.max_pixdim[:sr], fillvalue=np.nan)
+        ):
+            target = out_d[idx]
+            if np.isnan(mn) and np.isnan(mx):
+                continue
+            elif not np.isnan(mn) and np.isnan(mx):
+                out_d[idx] = _d if _d > mn else target
+            elif not np.isnan(mx) and np.isnan(mn):
+                out_d[idx] = _d if _d < mx else target
+            else:
+                out_d[idx] = _d if mn < _d < mx else target
 
         if not align_corners and scale_extent:
             warnings.warn("align_corners=False is not compatible with scale_extent=True.")

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -388,10 +388,12 @@ class Spacingd(MapTransform, InvertibleTransform):
             recompute_affine: whether to recompute affine based on the output shape. The affine computed
                 analytically does not reflect the potential quantization errors in terms of the output shape.
                 Set this flag to True to recompute the output affine based on the actual pixdim. Default to ``False``.
-            min_pixdim: minimally allowed input spacing. If provided, input image with a larger spacing than this value
-                will be kept the same (not be resampled to `pixdim`) by this transform, default to `None`.
-            max_pixdim: maximally allowed input spacing. If provided, input image with a smaller spacing than this value
-                will be kept the same (not be resampled to `pixdim`) by this transform, default to `None`.
+            min_pixdim: minimal input spacing to be resampled. If provided, input image with a larger spacing than this
+                value will be kept in its original spacing (not be resampled to `pixdim`). Set it to `None` to use the
+                value of `pixdim`. Default to `None`.
+            max_pixdim: maximal input spacing to be resampled. If provided, input image with a smaller spacing than this
+                value will be kept in its original spacing (not be resampled to `pixdim`). Set it to `None` to use the
+                value of `pixdim`. Default to `None`.
             allow_missing_keys: don't raise exception if key is missing.
 
         """

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -335,6 +335,8 @@ class Spacingd(MapTransform, InvertibleTransform):
         recompute_affine: bool = False,
         meta_keys: Optional[KeysCollection] = None,
         meta_key_postfix: str = "meta_dict",
+        min_pixdim: Union[Sequence[float], float, None] = None,
+        max_pixdim: Union[Sequence[float], float, None] = None,
         allow_missing_keys: bool = False,
     ) -> None:
         """
@@ -386,11 +388,17 @@ class Spacingd(MapTransform, InvertibleTransform):
             recompute_affine: whether to recompute affine based on the output shape. The affine computed
                 analytically does not reflect the potential quantization errors in terms of the output shape.
                 Set this flag to True to recompute the output affine based on the actual pixdim. Default to ``False``.
+            min_pixdim: minimally allowed input spacing. If provided, input image with a larger spacing than this value
+                will be kept the same (not be resampled to `pixdim`) by this transform, default to `None`.
+            max_pixdim: maximally allowed input spacing. If provided, input image with a smaller spacing than this value
+                will be kept the same (not be resampled to `pixdim`) by this transform, default to `None`.
             allow_missing_keys: don't raise exception if key is missing.
 
         """
         super().__init__(keys, allow_missing_keys)
-        self.spacing_transform = Spacing(pixdim, diagonal=diagonal, recompute_affine=recompute_affine)
+        self.spacing_transform = Spacing(
+            pixdim, diagonal=diagonal, recompute_affine=recompute_affine, min_pixdim=min_pixdim, max_pixdim=max_pixdim
+        )
         self.mode = ensure_tuple_rep(mode, len(self.keys))
         self.padding_mode = ensure_tuple_rep(padding_mode, len(self.keys))
         self.align_corners = ensure_tuple_rep(align_corners, len(self.keys))

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -19,7 +19,7 @@ from monai.data.meta_obj import set_track_meta
 from monai.data.meta_tensor import MetaTensor
 from monai.data.utils import affine_to_spacing
 from monai.transforms import Spacing
-from monai.utils import ensure_tuple, fall_back_tuple
+from monai.utils import fall_back_tuple
 from tests.utils import TEST_DEVICES, TEST_NDARRAYS_ALL, assert_allclose
 
 TESTS = []
@@ -245,7 +245,6 @@ class TestSpacingCase(unittest.TestCase):
         sr = min(len(res.shape) - 1, 3)
         if isinstance(init_param["pixdim"], float):
             init_param["pixdim"] = [init_param["pixdim"]] * sr
-        init_pixdim = ensure_tuple(init_param["pixdim"])
         init_pixdim = init_param["pixdim"][:sr]
         norm = affine_to_spacing(res.affine, sr).cpu().numpy()
         assert_allclose(fall_back_tuple(init_pixdim, norm), norm, type_test=False)
@@ -286,6 +285,33 @@ class TestSpacingCase(unittest.TestCase):
         self.assertEqual(img.shape, img_t.shape)
         l2_norm_affine = ((affine - img.affine) ** 2).sum() ** 0.5
         self.assertLess(l2_norm_affine, 5e-2)
+
+    @parameterized.expand(TEST_INVERSE)
+    def test_inverse_mn_mx(self, device, recompute, align, scale_extent):
+        img_t = torch.rand((1, 10, 9, 8), dtype=torch.float32, device=device)
+        affine = torch.tensor(
+            [[0, 0, -1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]], dtype=torch.float32, device="cpu"
+        )
+        img = MetaTensor(img_t, affine=affine, meta={"fname": "somewhere"})
+        choices = [(None, None), [1.2, None], [None, 0.7], [0.7, 0.9]]
+        idx = np.random.choice(range(len(choices)), size=1)[0]
+        tr = Spacing(
+            pixdim=[1.1, 1.2, 0.9],
+            recompute_affine=recompute,
+            align_corners=align,
+            scale_extent=scale_extent,
+            min_pixdim=[0.9, None, choices[idx][0]],
+            max_pixdim=[1.1, 1.1, choices[idx][1]],
+        )
+        img_out = tr(img)
+        if isinstance(img_out, MetaTensor):
+            assert_allclose(
+                img_out.pixdim, [1.0, 1.0, 0.888889] if recompute else [1.0, 1.0, 0.9], type_test=False, rtol=1e-4
+            )
+        img_out = tr.inverse(img_out)
+        self.assertEqual(img_out.applied_operations, [])
+        self.assertEqual(img_out.shape, img_t.shape)
+        self.assertLess(((affine - img_out.affine) ** 2).sum() ** 0.5, 5e-2)
 
 
 if __name__ == "__main__":

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -306,7 +306,7 @@ class TestSpacingCase(unittest.TestCase):
         img_out = tr(img)
         if isinstance(img_out, MetaTensor):
             assert_allclose(
-                img_out.pixdim, [1.0, 1.0, 0.888889] if recompute else [1.0, 1.0, 0.9], type_test=False, rtol=1e-4
+                img_out.pixdim, [1.0, 1.125, 0.888889] if recompute else [1.0, 1.2, 0.9], type_test=False, rtol=1e-4
             )
         img_out = tr.inverse(img_out)
         self.assertEqual(img_out.applied_operations, [])


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #3844

### Description
adding the flexibility for skipping the transform if the pixdim is in the specified range

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
