### PR TITLE
get_norm_layer default to affine=True

### DIFF
--- a/monai/networks/layers/utils.py
+++ b/monai/networks/layers/utils.py
@@ -47,6 +47,8 @@ def get_norm_layer(name: Union[Tuple, str], spatial_dims: Optional[int] = 1, cha
         kw_args["num_features"] = channels
     if has_option(norm_type, "num_channels") and "num_channels" not in kw_args:
         kw_args["num_channels"] = channels
+    if has_option(norm_type, "affine") and "affine" not in kw_args:
+        kw_args["affine"] = True
     return norm_type(**kw_args)
 
 


### PR DESCRIPTION
https://github.com/Project-MONAI/MONAI/issues/5222

Sets the default normalization parameter (affine) to True. 

Most normalizations in pytorch by default estimates the affine parameters (e.g. Batchnorm, Groupnorm). 
One notable exception is Instancenorm (for which default is affine=False), and if we don't specify it manually, it won't estimate these parameters, e.g. this won't have any learnable parameters
``
get_norm_layer(name="instance", spatial_dims=2)
``
and one needs to use a verbose input
``
get_norm_layer(name=("instance", {"affine":True}, spatial_dims=2)
``

this change makes affine (parameters) default to True for all normalizations, unless it's explicitly set to False. 
This is the preferred way and  should be the default for all segmentation/classification tasks.


### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
