### PR TITLE
UpSample optional kernel_size for deconv mode

### DIFF
--- a/monai/networks/blocks/upsample.py
+++ b/monai/networks/blocks/upsample.py
@@ -40,6 +40,7 @@ class UpSample(nn.Sequential):
         in_channels: Optional[int] = None,
         out_channels: Optional[int] = None,
         scale_factor: Union[Sequence[float], float] = 2,
+        kernel_size: Optional[Union[Sequence[float], float]] = None,
         size: Optional[Union[Tuple[int], int]] = None,
         mode: Union[UpsampleMode, str] = UpsampleMode.DECONV,
         pre_conv: Optional[Union[nn.Module, str]] = "default",
@@ -54,6 +55,7 @@ class UpSample(nn.Sequential):
             in_channels: number of channels of the input image.
             out_channels: number of channels of the output image. Defaults to `in_channels`.
             scale_factor: multiplier for spatial size. Has to match input size if it is a tuple. Defaults to 2.
+            kernel_size: kernel size used during UpsampleMode.DECONV. Defaults to `scale_factor`.
             size: spatial size of the output image.
                 Only used when ``mode`` is ``UpsampleMode.NONTRAINABLE``.
                 In torch.nn.functional.interpolate, only one of `size` or `scale_factor` should be defined,
@@ -83,13 +85,21 @@ class UpSample(nn.Sequential):
         if up_mode == UpsampleMode.DECONV:
             if not in_channels:
                 raise ValueError(f"in_channels needs to be specified in the '{mode}' mode.")
+
+            if not kernel_size:
+                kernel_size = scale_factor
+            kernel_size_ = ensure_tuple_rep(kernel_size, spatial_dims)
+            padding = tuple([(i-1)//2 for i in kernel_size_])
+
             self.add_module(
                 "deconv",
                 Conv[Conv.CONVTRANS, spatial_dims](
                     in_channels=in_channels,
                     out_channels=out_channels or in_channels,
-                    kernel_size=scale_factor_,
+                    kernel_size=kernel_size_,
                     stride=scale_factor_,
+                    padding=padding, 
+                    output_padding=padding,
                     bias=bias,
                 ),
             )


### PR DESCRIPTION
Adds (optional) kernel_size parameter to UpSample, used for deconv (convolution transpose up-sampling). 

This allows to upsample, e.g to upscale to 2x with a kernel_size 3. (currently the default is to upscale to 2x with a kernel size 2)

if this parameter is not set, the behavior is the same as before

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
