### PR TITLE
Add multi-gpu support to MonaiAlgo

### DIFF
--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -287,7 +287,6 @@ class MonaiAlgo(ClientAlgo):
         # get current iteration when a round starts
         self.iter_of_start_time = self.trainer.state.iteration
 
-        # if self.rank == 0:
         _, updated_keys, _ = copy_model_state(src=self.global_weights, dst=self.trainer.network)
         if len(updated_keys) == 0:
             self.logger.warning("No weights loaded!")
@@ -336,7 +335,7 @@ class MonaiAlgo(ClientAlgo):
                     f"Requested model type {model_type} not specified in `model_filepaths`: {self.model_filepaths}"
                 )
         else:
-            if self.trainer:  # and self.rank == 0:
+            if self.trainer:
                 weights = get_state_dict(self.trainer.network)
                 # returned weights will be on the cpu
                 for k in weights.keys():
@@ -404,7 +403,6 @@ class MonaiAlgo(ClientAlgo):
         global_weights, n_converted = convert_global_weights(global_weights=data.weights, local_var_dict=local_var_dict)
         self._check_converted(data.weights, local_var_dict, n_converted)
 
-        # if self.rank == 0:  # Evaluation is only supporting single GPU
         _, updated_keys, _ = copy_model_state(src=global_weights, dst=self.evaluator.network)
         if len(updated_keys) == 0:
             self.logger.warning("No weights loaded!")

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -115,6 +115,7 @@ class MonaiAlgo(ClientAlgo):
             e.g., the aggregator, which is not controlled by this class.
         multi_gpu: whether to run MonaiAlgo in a multi-GPU setting; defaults to `False`.
         backend: backend to use for torch.distributed; defaults to "nccl".
+        init_method: init_method for torch.distributed; defaults to "env://".
     """
 
     def __init__(

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -193,7 +193,7 @@ class MonaiAlgo(ClientAlgo):
             if self.rank > 0:
                 self.logger.setLevel(logging.WARNING)
 
-        if self.seed:  # TODO: adjust for multi-gpu?
+        if self.seed:
             monai.utils.set_determinism(seed=self.seed)
         torch.backends.cudnn.benchmark = self.benchmark
 

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -452,7 +452,7 @@ def copy_model_state(
     dst_prefix="",
     mapping=None,
     exclude_vars=None,
-    inplace=True,
+    inplace=True
 ):
     """
     Compute a module state_dict, of which the keys are the same as `dst`. The values of `dst` are overwritten
@@ -516,6 +516,8 @@ def copy_model_state(
     unchanged_keys = sorted(set(all_keys).difference(updated_keys))
     logger.info(f"'dst' model updated: {len(updated_keys)} of {len(dst_dict)} variables.")
     if inplace and isinstance(dst, torch.nn.Module):
+        if isinstance(dst, (nn.DataParallel, nn.parallel.DistributedDataParallel)):
+            dst = dst.module
         dst.load_state_dict(dst_dict)
     return dst_dict, updated_keys, unchanged_keys
 

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -452,7 +452,7 @@ def copy_model_state(
     dst_prefix="",
     mapping=None,
     exclude_vars=None,
-    inplace=True
+    inplace=True,
 ):
     """
     Compute a module state_dict, of which the keys are the same as `dst`. The values of `dst` are overwritten


### PR DESCRIPTION
Signed-off-by: Holger Roth <hroth@nvidia.com>

Fixes #5195.

### Description

Add support for MonaiAlgo to be run with torchrun for multi-gpu training.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
