### PR TITLE
5251 replace None type metadict content with 'none'

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -28,7 +28,16 @@ from monai.data.utils import (
     orientation_ras_lps,
 )
 from monai.transforms.utility.array import EnsureChannelFirst
-from monai.utils import MetaKeys, SpaceKeys, deprecated, ensure_tuple, ensure_tuple_rep, optional_import, require_pkg
+from monai.utils import (
+    MetaKeys,
+    SpaceKeys,
+    TraceKeys,
+    deprecated,
+    ensure_tuple,
+    ensure_tuple_rep,
+    optional_import,
+    require_pkg,
+)
 
 if TYPE_CHECKING:
     import itk
@@ -131,7 +140,7 @@ def _copy_compatible_dict(from_dict: Dict, to_dict: Dict):
             datum = from_dict[key]
             if isinstance(datum, np.ndarray) and np_str_obj_array_pattern.search(datum.dtype.str) is not None:
                 continue
-            to_dict[key] = datum
+            to_dict[key] = str(TraceKeys.NONE) if datum is None else datum  # NoneType to string for default_collate
     else:
         affine_key, shape_key = MetaKeys.AFFINE, MetaKeys.SPATIAL_SHAPE
         if affine_key in from_dict and not np.allclose(from_dict[affine_key], to_dict[affine_key]):

--- a/monai/visualize/occlusion_sensitivity.py
+++ b/monai/visualize/occlusion_sensitivity.py
@@ -155,7 +155,8 @@ class OcclusionSensitivity:
             [GaussianSmooth(sigma=[b * sigma for b in spatial_shape]), Lambda(lambda x: -x), ScaleIntensity()]
         )
         # transform and add batch
-        mul: torch.Tensor = gaussian(kernel)[None]  # type: ignore
+        mul: torch.Tensor = gaussian(kernel)[None]
+
         return mul, 0
 
     @staticmethod

--- a/tests/test_pil_reader.py
+++ b/tests/test_pil_reader.py
@@ -64,6 +64,7 @@ class TestPNGReader(unittest.TestCase):
                 Image.fromarray(test_image.astype("uint8")).save(filenames[i])
             reader = PILReader(converter=lambda image: image.convert("LA"))
             result = reader.get_data(reader.read(filenames, mode="r"))
+            self.assertEqual(result[1]["format"], "none")  # project-monai/monai issue#5251
             # load image by PIL and compare the result
             test_image = np.asarray(Image.open(filenames[0]).convert("LA"))
 


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5251

### Description
replace `None` with `"none"` in the readers

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
