### PR TITLE
Upsample mode deconvgroup

### DIFF
--- a/monai/networks/blocks/upsample.py
+++ b/monai/networks/blocks/upsample.py
@@ -27,6 +27,7 @@ class UpSample(nn.Sequential):
     Supported modes are:
 
         - "deconv": uses a transposed convolution.
+        - "deconvgroup": uses a transposed group convolution.
         - "nontrainable": uses :py:class:`torch.nn.Upsample`.
         - "pixelshuffle": uses :py:class:`monai.networks.blocks.SubpixelUpsample`.
 
@@ -55,13 +56,13 @@ class UpSample(nn.Sequential):
             in_channels: number of channels of the input image.
             out_channels: number of channels of the output image. Defaults to `in_channels`.
             scale_factor: multiplier for spatial size. Has to match input size if it is a tuple. Defaults to 2.
-            kernel_size: kernel size used during UpsampleMode.DECONV. Defaults to `scale_factor`.
+            kernel_size: kernel size used during transposed convolutions. Defaults to `scale_factor`.
             size: spatial size of the output image.
                 Only used when ``mode`` is ``UpsampleMode.NONTRAINABLE``.
                 In torch.nn.functional.interpolate, only one of `size` or `scale_factor` should be defined,
                 thus if size is defined, `scale_factor` will not be used.
                 Defaults to None.
-            mode: {``"deconv"``, ``"nontrainable"``, ``"pixelshuffle"``}. Defaults to ``"deconv"``.
+            mode: {``"deconv"``, ``"deconvgroup"``, ``"nontrainable"``, ``"pixelshuffle"``}. Defaults to ``"deconv"``.
             pre_conv: a conv block applied before upsampling. Defaults to "default".
                 When ``conv_block`` is ``"default"``, one reserved conv layer will be utilized when
                 Only used in the "nontrainable" or "pixelshuffle" mode.

--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -169,6 +169,7 @@ class UpsampleMode(StrEnum):
     """
 
     DECONV = "deconv"
+    DECONVGROUP = "deconvgroup"
     NONTRAINABLE = "nontrainable"  # e.g. using torch.nn.Upsample
     PIXELSHUFFLE = "pixelshuffle"
 

--- a/tests/test_upsample_block.py
+++ b/tests/test_upsample_block.py
@@ -67,6 +67,16 @@ TEST_CASES = [
         (16, 1, 10, 15, 20),
         (16, 3, 20, 30, 40),
     ],  # 1-channel 3D, batch 16, pre_conv
+    [
+        {"spatial_dims": 3, "in_channels": 8, "out_channels": 4, "mode": "deconvgroup"},
+        (16, 8, 16, 16, 16),
+        (16, 4, 32, 32, 32),
+    ],  # 8-channel 3D, batch 16
+    [
+        {"spatial_dims": 2, "in_channels": 32, "out_channels": 16, "mode": "deconvgroup", "scale_factor": 2},
+        (8, 32, 16, 16),
+        (8, 16, 32, 32),
+    ],  # 32-channel 2D, batch 8
 ]
 
 TEST_CASES_EQ = []


### PR DESCRIPTION
This adds an additional UpSample mode DECONVGROUP to upsample with groupwise convolution transpose. 
Unit tests are passed too. 
 

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
