### PR TITLE
Fix installation verification command

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -139,7 +139,7 @@ and the codebase is ready to use (without the additional features of MONAI C++/C
 ## Validating the install
 You can verify the installation by:
 ```bash
-python -c 'import monai; monai.config.print_config()'
+python -c "import monai; monai.config.print_config()"
 ```
 If the installation is successful, this command will print out the MONAI version information, and this confirms the core
 modules of MONAI are ready-to-use.


### PR DESCRIPTION
Current command did not work on my machine:

```batch
M:\Dev\MONAI>python -c 'import monai; monai.config.print_config()'
  File "<string>", line 1
    'import
           ^
SyntaxError: EOL while scanning string literal

M:\Dev\MONAI>python -c "import monai; monai.config.print_config()"
MONAI version: 1.0.0+39.g9355f1c2
Numpy version: 1.23.4
Pytorch version: 1.12.1+cu113
MONAI flags: HAS_EXT = False, USE_COMPILED = False, USE_META_DICT = False
MONAI rev id: 9355f1c264c7e69e28b005b8e8eb65c26e0c4ab0
MONAI __file__: M:\Dev\MONAI\monai\__init__.py

Optional dependencies:
Pytorch Ignite version: NOT INSTALLED or UNKNOWN VERSION.
Nibabel version: NOT INSTALLED or UNKNOWN VERSION.
scikit-image version: NOT INSTALLED or UNKNOWN VERSION.
Pillow version: 9.2.0
Tensorboard version: NOT INSTALLED or UNKNOWN VERSION.
gdown version: NOT INSTALLED or UNKNOWN VERSION.
TorchVision version: 0.13.1+cu113
tqdm version: NOT INSTALLED or UNKNOWN VERSION.
lmdb version: NOT INSTALLED or UNKNOWN VERSION.
psutil version: NOT INSTALLED or UNKNOWN VERSION.
pandas version: NOT INSTALLED or UNKNOWN VERSION.
einops version: NOT INSTALLED or UNKNOWN VERSION.
transformers version: NOT INSTALLED or UNKNOWN VERSION.
mlflow version: NOT INSTALLED or UNKNOWN VERSION.
pynrrd version: NOT INSTALLED or UNKNOWN VERSION.

For details about installing the optional dependencies, please visit:
    https://docs.monai.io/en/latest/installation.html#installing-the-recommended-dependencies

M:\Dev\MONAI>
```
