### PR TITLE
Enhancement for WarmupCosineSchedule to specify the beginning fraction of the linear warmup

### DIFF
--- a/tests/test_lr_scheduler.py
+++ b/tests/test_lr_scheduler.py
@@ -56,7 +56,7 @@ class TestLRSCHEDULER(unittest.TestCase):
         net = SchedulerTestNet()
         optimizer = torch.optim.Adam(net.parameters(), lr=1.0)
         with self.assertRaises(ValueError):
-            scheduler = WarmupCosineSchedule(optimizer, warmup_steps=2, t_total=10, warmup_multiplier=-1)
+            WarmupCosineSchedule(optimizer, warmup_steps=2, t_total=10, warmup_multiplier=-1)
 
 
 if __name__ == "__main__":

--- a/tests/test_lr_scheduler.py
+++ b/tests/test_lr_scheduler.py
@@ -28,7 +28,11 @@ class SchedulerTestNet(torch.nn.Module):
 
 
 TEST_CASE_LRSCHEDULER = [
-    [{"warmup_steps": 2, "t_total": 10}, [0.000, 0.500, 1.00, 0.962, 0.854, 0.691, 0.500, 0.309, 0.146, 0.038]]
+    [{"warmup_steps": 2, "t_total": 10}, [0.000, 0.500, 1.00, 0.962, 0.854, 0.691, 0.500, 0.309, 0.146, 0.038]],
+    [
+        {"warmup_steps": 2, "t_total": 10, "warmup_multiplier": 0.1},
+        [0.1, 0.55, 1.00, 0.962, 0.854, 0.691, 0.500, 0.309, 0.146, 0.038],
+    ],
 ]
 
 
@@ -46,6 +50,13 @@ class TestLRSCHEDULER(unittest.TestCase):
             scheduler.step()
         for a, b in zip(lrs_1, expected_lr):
             self.assertEqual(a, b, msg=f"LR is wrong ! expected {b}, got {a}")
+
+    def test_error(self):
+        """Should fail because warmup_multiplier is outside 0..1"""
+        net = SchedulerTestNet()
+        optimizer = torch.optim.Adam(net.parameters(), lr=1.0)
+        with self.assertRaises(ValueError):
+            scheduler = WarmupCosineSchedule(optimizer, warmup_steps=2, t_total=10, warmup_multiplier=-1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
small enhancement to WarmupCosineSchedule input, to optionally specify the beginning of the linear warmup from something above 0 ( e.g from a fraction 0.1 * initial_lr). 

a unit test is added too.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
