### PR TITLE
AverageMeter utility 

### DIFF
--- a/monai/metrics/__init__.py
+++ b/monai/metrics/__init__.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 from .active_learning_metrics import LabelQualityScore, VarianceMetric, compute_variance, label_quality_score
+from .average_meter import AverageMeter
 from .confusion_matrix import ConfusionMatrixMetric, compute_confusion_matrix_metric, get_confusion_matrix
 from .cumulative_average import CumulativeAverage
 from .froc import compute_fp_tp_probs, compute_froc_curve_data, compute_froc_score

--- a/monai/metrics/average_meter.py
+++ b/monai/metrics/average_meter.py
@@ -151,9 +151,10 @@ class AverageMeter:
         if torch.any(nfin):
             # non-finite numbers may indicate some errors in the user code
             print("non-finite numbers received", val, count)
-            val = torch.where(nfin, 0, val)
-            count = torch.where(nfin, 0, count)
-            val_count = torch.where(nfin, 0, val_count)
+            zero = torch.tensor(0).to(val)
+            val = torch.where(nfin, zero, val)
+            count = torch.where(nfin, zero, count)
+            val_count = torch.where(nfin, zero, val_count)
 
         self.val = val
         self.count += count

--- a/monai/metrics/average_meter.py
+++ b/monai/metrics/average_meter.py
@@ -1,0 +1,160 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.distributed as dist
+
+__all__ = ["AverageMeter"]
+
+
+class AverageMeter:
+    """
+    A utility class to keep track of average values. For example during training/validation loop,
+    we need to accumulate the per-batch metrics and calculate the final average value for the whole dataset.
+    When training in multi-gpu environment, with DistributedDataParallel, it will average across the processes.
+
+    Example:
+
+    .. code-block:: python
+
+        from monai.metrics import AverageMeter
+
+        run_avg = AverageMeter()
+        for i in range(len(train_set)):
+            ...
+            val = calc_metric(x,y) #some metric value
+            run_avg.update(val)
+
+        val_avg = run_avg.get_avg() #average value
+
+    """
+
+    def __init__(self, ensure_cpu_group: bool = False) -> None:
+        """
+        Args:
+            ensure_cpu_group: applies only to multi-gpu distributed setup. Optionally request to operate on CPU,
+                even if the default DistributedDataParallel group is on GPU. This will create an additional
+                CPU group with GLOO backend to reduce across processes on CPU (and maintain all intermediate data on CPU).
+                Defaults to False: use the default process group created during DistributedDataParallel initialization.
+        """
+
+        self.is_distributed = dist.is_available() and dist.is_initialized()
+        self.group = None
+        self.device = None
+
+        if self.is_distributed:
+            dist_cuda = dist.get_backend() == dist.Backend.NCCL
+            if ensure_cpu_group and dist_cuda:
+                self.group = dist.new_group(backend="gloo")  # create a new cpu group
+            elif dist_cuda:
+                self.device = torch.device("cuda", dist.get_rank())
+
+        self.val = 0
+        self.sum = 0
+        self.count = 0
+
+    def proper_tensor(self, x) -> torch.Tensor:
+        """
+        Ensure torch.Tensor float format and optionally copy to the proper gpu device
+        """
+        x = x.detach() if isinstance(x, torch.Tensor) else torch.tensor(x)
+
+        if self.device is not None:
+            x = x.to(device=self.device)
+        else:
+            x = x.cpu()
+
+        return x.float()
+
+    def reduce(self, x: torch.Tensor, avg: bool = False) -> torch.Tensor:
+        """
+        Reduce across processes if in DDP
+        """
+        if self.is_distributed:
+            if avg:
+                x = x / dist.get_world_size()
+            else:
+                x = x.clone()
+            dist.all_reduce(x, group=self.group)
+
+        return x
+
+    def get_current(self, np: bool = True):
+        """
+        return most recent value (averaged across processes)
+        """
+        x = self.reduce(self.val, avg=True)
+        if np:
+            x = x.cpu().numpy()
+        return x
+
+    def get_avg(self, np: bool = True):
+        """
+        return total average value (averaged across processes)
+        """
+        sum = self.reduce(self.sum)
+        count = self.reduce(self.count)
+
+        x = torch.where(count > 0, sum / count, sum)
+        if np:
+            x = x.cpu().numpy()
+        return x
+
+    def update(self, val, count=1) -> None:
+        """
+        Update with a new value, and an optional count
+
+        Args:
+            val: new value (e.g. constant, list, numpy array or Tensor) to keep track of.
+            count: new count (e.g. constant, list, numpy array or Tensor), to update the contribution count
+
+        For example:
+            # a simple constant tracking
+            avg_meter= AverageMeter()
+            avg_meter.update(0.6)
+            avg_meter.update(0.8)
+            print(avg_meter.get_avg()) #prints 0.7
+
+            # an array tracking, e.g. metrics from 3 classes
+            avg_meter= AverageMeter()
+            avg_meter.update([0.2, 0.4, 0.4])
+            avg_meter.update([0.4, 0.6, 0.4])
+            print(avg_meter.get_avg()) #prints [0.3, 0.5. 0.4]
+
+            # different contributions / counts
+            avg_meter= AverageMeter()
+            avg_meter.update(1, count=4) #avg metric 1 coming from a batch of 4
+            avg_meter.update(2, count=6) #avg metric 2 coming from a batch of 6
+            print(avg_meter.get_avg()) #prints 1.6 == (1*4 +2*6)/(4+6)
+
+            # different contributions / counts
+            avg_meter= AverageMeter()
+            avg_meter.update([0.5, 0.5, 0], count=[1, 1, 0]) # last elements count is zero to ignore it
+            avg_meter.update([0.5, 0.5, 0.5], count=[1, 1, 1]) #
+            print(avg_meter.get_avg()) #prints [0.5, 0.5, 0,5] == ([0.5, 0.5, 0] + [0.5, 0.5, 0.5]) / ([1, 1, 0] + [1, 1, 1])
+
+        """
+
+        val = self.proper_tensor(val)
+        count = self.proper_tensor(count)
+
+        val_count = val * count
+        nfin = ~torch.isfinite(val_count)
+        if torch.any(nfin):
+            # non-finite numbers may indicate some errors in the user code
+            print("non-finite numbers received", val, count)
+            val = torch.where(nfin, 0, val)
+            count = torch.where(nfin, 0, count)
+            val_count = torch.where(nfin, 0, val_count)
+
+        self.val = val
+        self.count += count
+        self.sum += val_count

--- a/tests/test_average_meter.py
+++ b/tests/test_average_meter.py
@@ -1,0 +1,103 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from parameterized import parameterized
+
+from monai.metrics import AverageMeter
+
+# from tests.utils import assert_allclose
+
+# single class value
+TEST_CASE_1 = []
+TEST_CASE_1.append([{"vals": [1, 2, 3], "avg": 2}])
+TEST_CASE_1.append([{"vals": [[1, 1, 1], [2, 2, 2], [3, 6, 9]], "avg": [2, 3, 4]}])
+
+TEST_CASE_1.append([{"vals": [2, 4, 6], "counts": [2, 1, 2], "avg": 4}])
+TEST_CASE_1.append(
+    [{"vals": [[3, 2, 1], [2, 3, 2], [0, 0, 9]], "counts": [[4, 4, 4], [4, 4, 4], [2, 2, 2]], "avg": [2, 2, 3]}]
+)
+
+TEST_CASE_1.append([{"vals": [1, 2, float("nan")], "avg": 1.5}])
+
+
+class TestAverageMeter(unittest.TestCase):
+    @parameterized.expand(TEST_CASE_1)
+    def test_value_all(self, data):
+
+        # test orig
+        self.run_test(data)
+
+        # test in numpy
+        data["vals"] = np.array(data["vals"])
+        data["avg"] = np.array(data["avg"])
+        self.run_test(data)
+
+        # test as Tensors
+        data["vals"] = torch.tensor(data["vals"])
+        data["avg"] = torch.tensor(data["avg"], dtype=torch.float)
+        self.run_test(data)
+
+    def run_test(self, data):
+        vals = data["vals"]
+        avg = data["avg"]
+
+        counts = data.get("counts", None)
+        if counts is not None and not isinstance(counts, list) and isinstance(vals, list):
+            counts = [counts] * len(vals)
+
+        avg_meter = AverageMeter()
+        for i in range(len(vals)):
+            if counts is not None:
+                avg_meter.update(vals[i], counts[i])
+            else:
+                avg_meter.update(vals[i])
+
+        np.testing.assert_equal(avg_meter.get_avg(), avg)
+
+
+def main_worker(rank, nprocs):
+
+    has_cuda = torch.cuda.is_available() and torch.cuda.device_count() > 1
+    backend = "nccl" if has_cuda else "gloo"
+
+    dist.init_process_group(backend=backend, init_method="tcp://127.0.0.1:12345", world_size=nprocs, rank=rank)
+
+    avg_meter = AverageMeter()  # each process rank has it's own AverageMeter
+    n_iter = 10
+    for i in range(n_iter):
+        val = rank + i
+        avg_meter.update(val=val)
+
+    avg_val = avg_meter.get_avg()  # average across all processes
+    expected_val = sum(sum(list(range(rank_i, rank_i + n_iter))) for rank_i in range(nprocs)) / (n_iter * nprocs)
+    np.testing.assert_equal(avg_val, expected_val)
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+class TestDDP(unittest.TestCase):
+    def test_ddp_ops(self):
+        if torch.cuda.is_available() and torch.cuda.device_count() > 1:
+            nprocs = torch.cuda.device_count()
+        else:
+            nprocs = 2
+
+        torch.multiprocessing.spawn(main_worker, nprocs=nprocs, args=(nprocs,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_average_meter.py
+++ b/tests/test_average_meter.py
@@ -17,8 +17,7 @@ import torch.distributed as dist
 from parameterized import parameterized
 
 from monai.metrics import AverageMeter
-
-# from tests.utils import assert_allclose
+from tests.utils import SkipIfBeforePyTorchVersion
 
 # single class value
 TEST_CASE_1 = []
@@ -88,7 +87,7 @@ def main_worker(rank, nprocs):
     if dist.is_initialized():
         dist.destroy_process_group()
 
-
+@SkipIfBeforePyTorchVersion((1, 8))
 class TestDDP(unittest.TestCase):
     def test_ddp_ops(self):
         if torch.cuda.is_available() and torch.cuda.device_count() > 1:

--- a/tests/test_average_meter.py
+++ b/tests/test_average_meter.py
@@ -87,6 +87,7 @@ def main_worker(rank, nprocs):
     if dist.is_initialized():
         dist.destroy_process_group()
 
+
 @SkipIfBeforePyTorchVersion((1, 8))
 class TestDDP(unittest.TestCase):
     def test_ddp_ops(self):


### PR DESCRIPTION
Adds a a utility class AverageMeter to keep track of average accumulating values. For example during training/validation loop, we need to accumulate the per-batch metrics and calculate the final average value for the whole dataset. When training in multi-gpu environment, with DistributedDataParallel, it will average across the multi-gpu processes.

```
from monai.metrics import AverageMeter

run_avg = AverageMeter()
for i in range(len(train_set)):
    ...
    val = calc_metric(x,y) #some metric value
    run_avg.update(val)

val_avg = run_avg.get_avg() #average value

```

it supports input in various formats as constant, lists, arrays

   ```
  # a simple constant tracking
  avg_meter= AverageMeter()
  avg_meter.update(0.6)
  avg_meter.update(0.8)
  print(avg_meter.get_avg()) #prints 0.7

  # an array tracking, e.g. metrics from 3 classes
  avg_meter= AverageMeter()
  avg_meter.update([0.2, 0.4, 0.4])
  avg_meter.update([0.4, 0.6, 0.4])
  print(avg_meter.get_avg()) #prints [0.3, 0.5. 0.4]

  # different contributions / counts
  avg_meter= AverageMeter()
  avg_meter.update(1, count=4) #avg metric 1 coming from a batch of 4
  avg_meter.update(2, count=6) #avg metric 2 coming from a batch of 6
  print(avg_meter.get_avg()) #prints 1.6 == (1*4 +2*6)/(4+6)

  # different contributions / counts
  avg_meter= AverageMeter()
  avg_meter.update([0.5, 0.5, 0], count=[1, 1, 0]) # last elements count is zero to ignore it
  avg_meter.update([0.5, 0.5, 0.5], count=[1, 1, 1]) #
  print(avg_meter.get_avg()) #prints [0.5, 0.5, 0,5] == ([0.5, 0.5, 0] + [0.5, 0.5, 0.5]) / ([1, 1, 0] + [1, 1, 1])

```

This class is of general purpose.  Some monai metrics (e.g. DiceMetric) support reduction across gpu (by being a subclass of Cumulative that maintains gpu buffers for all data points).  But there are multiple issues with such approach  https://github.com/Project-MONAI/MONAI/issues/5378 , and for any new custom metric (that is not in monai) a user will have to write their own multi-gpu reduction or try to sublclass from Cumulative, which is not straightforward. 

This class adds a utility function for arbitrary custom metric to compute proper average (on one or more gpus/processes).  And for existing monai metrics, it could help (in the future) to disentangle the logic of metric computation from the multi-gpu reduction handling.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
