### PR TITLE
Fix to `ToTensord`

### DIFF
--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -19,8 +19,8 @@ import warnings
 from copy import deepcopy
 from typing import Any, Callable, Dict, Hashable, Iterable, List, Mapping, Optional, Sequence, Union
 
-import torch
 import numpy as np
+import torch
 
 from monai import config
 from monai.config.type_definitions import KeysCollection, NdarrayOrTensor, PathLike
@@ -690,7 +690,7 @@ class Invertd(MapTransform):
             else:
                 inverted_data = inverted[orig_key]
             if isinstance(inverted_data, np.ndarray) and device != "cpu":
-                raise ValueError(f"Inverted data with type of 'numpy.ndarray' do not support GPU.")
+                raise ValueError("Inverted data with type of 'numpy.ndarray' do not support GPU.")
             elif isinstance(inverted_data, torch.Tensor):
                 d[key] = post_func(inverted_data.to(device))
             else:

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -689,7 +689,7 @@ class Invertd(MapTransform):
                 inverted_data = self._totensor(inverted[orig_key])
             else:
                 inverted_data = inverted[orig_key]
-            if isinstance(inverted_data, np.ndarray) and device != "cpu":
+            if isinstance(inverted_data, np.ndarray) and torch.device(device).type != "cpu":
                 raise ValueError("Inverted data with type of 'numpy.ndarray' do not support GPU.")
             elif isinstance(inverted_data, torch.Tensor):
                 d[key] = post_func(inverted_data.to(device))

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -536,19 +536,19 @@ class ToTensord(MapTransform, InvertibleTransform):
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
         d = dict(data)
         for key in self.key_iterator(d):
-            self.push_transform(d, key)
             d[key] = self.converter(d[key])
+            self.push_transform(d, key)
         return d
 
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
         d = dict(data)
         for key in self.key_iterator(d):
+            # Remove the applied transform
+            self.pop_transform(d, key)
             # Create inverse transform
             inverse_transform = ToNumpy()
             # Apply inverse
             d[key] = inverse_transform(d[key])
-            # Remove the applied transform
-            self.pop_transform(d, key)
         return d
 
 

--- a/tests/test_to_tensord.py
+++ b/tests/test_to_tensord.py
@@ -11,8 +11,8 @@
 
 import unittest
 
-import torch
 import numpy as np
+import torch
 from parameterized import parameterized
 
 from monai.transforms import ToTensord
@@ -31,39 +31,39 @@ TESTS_SINGLE = [[5]]
 for p in TEST_NDARRAYS:
     TESTS_SINGLE.append([p(5)])
 
+
 class TestToTensord(unittest.TestCase):
     @parameterized.expand(TESTS)
     def test_array_input(self, test_data, expected_shape):
-        test_data = {'img': test_data}
+        test_data = {"img": test_data}
         to_tensord = ToTensord(keys="img", dtype=torch.float32, device="cpu", wrap_sequence=True)
         result = to_tensord(test_data)
-        out_img = result['img']
+        out_img = result["img"]
         self.assertTrue(isinstance(out_img, torch.Tensor))
-        assert_allclose(out_img, test_data['img'], type_test=False)
+        assert_allclose(out_img, test_data["img"], type_test=False)
         self.assertTupleEqual(out_img.shape, expected_shape)
 
         # test inverse
         inv_data = to_tensord.inverse(result)
-        self.assertTrue(isinstance(inv_data['img'], np.ndarray))
-        assert_allclose(test_data['img'], inv_data['img'], type_test=False)
+        self.assertTrue(isinstance(inv_data["img"], np.ndarray))
+        assert_allclose(test_data["img"], inv_data["img"], type_test=False)
 
     @parameterized.expand(TESTS_SINGLE)
     def test_single_input(self, test_data):
-        test_data = {'img': test_data}
+        test_data = {"img": test_data}
         result = ToTensord(keys="img", track_meta=True)(test_data)
-        out_img = result['img']
+        out_img = result["img"]
         self.assertTrue(isinstance(out_img, torch.Tensor))
-        assert_allclose(out_img, test_data['img'], type_test=False)
+        assert_allclose(out_img, test_data["img"], type_test=False)
         self.assertEqual(out_img.ndim, 0)
 
     @unittest.skipUnless(HAS_CUPY, "CuPy is required.")
     def test_cupy(self):
         test_data = [[1, 2], [3, 4]]
         cupy_array = cp.ascontiguousarray(cp.asarray(test_data))
-        result = ToTensord(keys="img")({'img': cupy_array})
-        self.assertTrue(isinstance(result['img'], torch.Tensor))
-        assert_allclose(result['img'], test_data, type_test=False)
-    
+        result = ToTensord(keys="img")({"img": cupy_array})
+        self.assertTrue(isinstance(result["img"], torch.Tensor))
+        assert_allclose(result["img"], test_data, type_test=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_to_tensord.py
+++ b/tests/test_to_tensord.py
@@ -1,0 +1,70 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+import numpy as np
+from parameterized import parameterized
+
+from monai.transforms import ToTensord
+from tests.utils import HAS_CUPY, TEST_NDARRAYS, assert_allclose, optional_import
+
+cp, _ = optional_import("cupy")
+
+
+im = [[1, 2], [3, 4]]
+
+TESTS = [(im, (2, 2))]
+for p in TEST_NDARRAYS:
+    TESTS.append((p(im), (2, 2)))
+
+TESTS_SINGLE = [[5]]
+for p in TEST_NDARRAYS:
+    TESTS_SINGLE.append([p(5)])
+
+class TestToTensord(unittest.TestCase):
+    @parameterized.expand(TESTS)
+    def test_array_input(self, test_data, expected_shape):
+        test_data = {'img': test_data}
+        to_tensord = ToTensord(keys="img", dtype=torch.float32, device="cpu", wrap_sequence=True)
+        result = to_tensord(test_data)
+        out_img = result['img']
+        self.assertTrue(isinstance(out_img, torch.Tensor))
+        assert_allclose(out_img, test_data['img'], type_test=False)
+        self.assertTupleEqual(out_img.shape, expected_shape)
+
+        # test inverse
+        inv_data = to_tensord.inverse(result)
+        self.assertTrue(isinstance(inv_data['img'], np.ndarray))
+        assert_allclose(test_data['img'], inv_data['img'], type_test=False)
+
+    @parameterized.expand(TESTS_SINGLE)
+    def test_single_input(self, test_data):
+        test_data = {'img': test_data}
+        result = ToTensord(keys="img", track_meta=True)(test_data)
+        out_img = result['img']
+        self.assertTrue(isinstance(out_img, torch.Tensor))
+        assert_allclose(out_img, test_data['img'], type_test=False)
+        self.assertEqual(out_img.ndim, 0)
+
+    @unittest.skipUnless(HAS_CUPY, "CuPy is required.")
+    def test_cupy(self):
+        test_data = [[1, 2], [3, 4]]
+        cupy_array = cp.ascontiguousarray(cp.asarray(test_data))
+        result = ToTensord(keys="img")({'img': cupy_array})
+        self.assertTrue(isinstance(result['img'], torch.Tensor))
+        assert_allclose(result['img'], test_data, type_test=False)
+    
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #5392.

### Description
fix `inverse` bug in `ToTensord`
raise an error when `inverted_data` is numpy.ndarray and the device is 'cuda'

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
