### PR TITLE
Skip HoVerNet Loss for pytorch 1.9.1 and older

### DIFF
--- a/tests/test_hovernet_loss.py
+++ b/tests/test_hovernet_loss.py
@@ -169,7 +169,7 @@ ILL_CASES = [
 ]
 
 
-@SkipIfBeforePyTorchVersion((1, 9))
+@SkipIfBeforePyTorchVersion((1, 10))
 class TestHoverNetLoss(unittest.TestCase):
     @parameterized.expand(CASES)
     def test_shape(self, input_param, expected_loss):


### PR DESCRIPTION
Fixes #5393 

### Description

HoVerNet Loss works with PyTorch 1.10 and newer

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
