### PR TITLE
5425 conda tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -5,9 +5,6 @@ on:
     - cron: "0 3 * * *"  # at 03:00 UTC
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  push:
-    branches:
-      - 5425-conda-tests
 
 concurrency:
   # automatically cancel the previously triggered workflows when there's a newer version

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 3 * * *"  # at 03:00 UTC
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  push:
+    branches:
+      - 5425-conda-tests
 
 concurrency:
   # automatically cancel the previously triggered workflows when there's a newer version

--- a/tests/test_nifti_rw.py
+++ b/tests/test_nifti_rw.py
@@ -157,8 +157,8 @@ class TestNiftiLoadRead(unittest.TestCase):
                 writer_obj.set_metadata({"affine": np.diag([1, 1, 1]), "original_affine": np.diag([1.4, 1, 1])})
                 writer_obj.write(image_name, verbose=True)
                 out = nib.load(image_name)
-                np.testing.assert_allclose(out.get_fdata(), [[0, 1, 2], [3.0, 4, 5]])
-                np.testing.assert_allclose(out.affine, np.diag([1.4, 1, 1, 1]))
+                np.testing.assert_allclose(out.get_fdata(), [[0, 1, 2], [3.0, 4, 5]], atol=1e-4, rtol=1e-4)
+                np.testing.assert_allclose(out.affine, np.diag([1.4, 1, 1, 1]), atol=1e-4, rtol=1e-4)
 
                 image_name = os.path.join(out_dir, "test1.nii.gz")
                 img = np.arange(5).reshape((1, 5))
@@ -168,8 +168,8 @@ class TestNiftiLoadRead(unittest.TestCase):
                 )
                 writer_obj.write(image_name, verbose=True)
                 out = nib.load(image_name)
-                np.testing.assert_allclose(out.get_fdata(), [[0, 2, 4]])
-                np.testing.assert_allclose(out.affine, np.diag([1.4, 2, 1, 1]))
+                np.testing.assert_allclose(out.get_fdata(), [[0, 2, 4]], atol=1e-4, rtol=1e-4)
+                np.testing.assert_allclose(out.affine, np.diag([1.4, 2, 1, 1]), atol=1e-4, rtol=1e-4)
 
     def test_write_3d(self):
         with tempfile.TemporaryDirectory() as out_dir:
@@ -192,8 +192,8 @@ class TestNiftiLoadRead(unittest.TestCase):
                 )
                 writer_obj.write(image_name, verbose=True)
                 out = nib.load(image_name)
-                np.testing.assert_allclose(out.get_fdata(), [[[0, 2, 4]]])
-                np.testing.assert_allclose(out.affine, np.diag([1.4, 2, 2, 1]))
+                np.testing.assert_allclose(out.get_fdata(), [[[0, 2, 4]]], atol=1e-4, rtol=1e-4)
+                np.testing.assert_allclose(out.affine, np.diag([1.4, 2, 2, 1]), atol=1e-4, rtol=1e-4)
 
     def test_write_4d(self):
         with tempfile.TemporaryDirectory() as out_dir:
@@ -216,8 +216,8 @@ class TestNiftiLoadRead(unittest.TestCase):
                 )
                 writer_obj.write(image_name, verbose=True)
                 out = nib.load(image_name)
-                np.testing.assert_allclose(out.get_fdata(), [[[[0], [2], [4]]]])
-                np.testing.assert_allclose(out.affine, np.diag([1.4, 2, 2, 1]))
+                np.testing.assert_allclose(out.get_fdata(), [[[[0], [2], [4]]]], atol=1e-4, rtol=1e-4)
+                np.testing.assert_allclose(out.affine, np.diag([1.4, 2, 2, 1]), atol=1e-4, rtol=1e-4)
 
     def test_write_5d(self):
         with tempfile.TemporaryDirectory() as out_dir:
@@ -241,8 +241,10 @@ class TestNiftiLoadRead(unittest.TestCase):
                 writer_obj.set_metadata({"affine": np.diag([1, 1, 1, 3]), "original_affine": np.diag([1.4, 2.0, 2, 3])})
                 writer_obj.write(image_name, verbose=True)
                 out = nib.load(image_name)
-                np.testing.assert_allclose(out.get_fdata(), np.array([[[[[0.0, 2.0]], [[4.0, 5.0]], [[7.0, 9.0]]]]]))
-                np.testing.assert_allclose(out.affine, np.diag([1.4, 2, 2, 1]))
+                np.testing.assert_allclose(
+                    out.get_fdata(), np.array([[[[[0.0, 2.0]], [[4.0, 5.0]], [[7.0, 9.0]]]]]), atol=1e-4, rtol=1e-4
+                )
+                np.testing.assert_allclose(out.affine, np.diag([1.4, 2, 2, 1]), atol=1e-4, rtol=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #5425

tested: https://github.com/Project-MONAI/MONAI/actions/runs/3344552788

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
