### PR TITLE
adds dco remediation support

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+allowRemediationCommits:
+  individual: true


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

it's not easy to always keep the dco signing-off line when the pull requests have many commits and rebasing. And the current instructions of rebasing commits for DCO don't work properly in many cases ([example](https://github.com/Project-MONAI/MONAI/pull/5377/checks?check_run_id=9245758301)). This PR set the option https://github.com/dcoapp/app#individual-remediation-commit-support so that the signing-off could be done via follow-up commits retroactively.

the new instructions for signing the PR will be provided similarly to this testing example:
https://github.com/gr2m/sandbox/runs/4221328432 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
