### PR TITLE
Versions as strings, not numbers, so that 3.1 != 3.10, etc.

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -59,7 +59,7 @@ jobs:
       #- name: Setup java
       #  uses: actions/setup-java@v1
       #  with:
-      #    java-version: 1.8
+      #    java-version: '1.8'
 
       # add blackduck properties https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/631308372/Methods+for+Configuring+Analysis#Using-a-configuration-file
       #- name: Setup blackduck properties

--- a/.github/workflows/cron-mmar.yml
+++ b/.github/workflows/cron-mmar.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: cache weekly timestamp
       id: pip-cache
       run: echo "datew=$(date '+%Y-%V')" >> $GITHUB_OUTPUT

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, common]
     strategy:
       matrix:
-        pytorch-version: [1.7.1, 1.8.1, 1.9.1, 1.10.2, latest]
+        pytorch-version: ['1.7.1', '1.8.1', '1.9.1', '1.10.2', 'latest']
     steps:
     - uses: actions/checkout@v3
     - name: Install the dependencies

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - shell: bash
         run: |
           git describe

--- a/.github/workflows/pythonapp-min.yml
+++ b/.github/workflows/pythonapp-min.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: Prepare pip wheel
       run: |
         which python
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v3
@@ -119,14 +119,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pytorch-version: [1.7.1, 1.8.2, 1.9.1, 1.10.2, 1.11.0, latest]
+        pytorch-version: ['1.7.1', '1.8.2', '1.9.1', '1.10.2', '1.11.0', 'latest']
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: Prepare pip wheel
       run: |
         which python

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: cache weekly timestamp
       id: pip-cache
       run: |
@@ -67,7 +67,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: Prepare pip wheel
       run: |
         which python
@@ -123,7 +123,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: cache weekly timestamp
       id: pip-cache
       run: |
@@ -204,7 +204,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: cache weekly timestamp
       id: pip-cache
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v3
       with:
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - shell: bash
         run: |
           git describe

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v3
       with:
@@ -122,7 +122,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: cache weekly timestamp
       id: pip-cache
       run: |

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version:  3.8
+        python-version: '3.8'
     - name: Install setuptools
       run: |
         python -m pip install --user --upgrade setuptools wheel


### PR DESCRIPTION
Signed-off-by: Lee Newberg <lee.newberg@kitware.com>

### Description

Re-writes version numbers as strings rather than numbers because 3.1 != 3.10, etc.  Nothing is broken at present but in the future as, e.g., the Python version for some things goes from 3.8 to 3.9 to 3.10, this could end up being an unexpected problem.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
