### PR TITLE
5485 torchscript for netadapter

### DIFF
--- a/monai/networks/nets/netadapter.py
+++ b/monai/networks/nets/netadapter.py
@@ -107,7 +107,7 @@ class NetAdapter(torch.nn.Module):
         x = self.features(x)
         if isinstance(x, tuple):
             x = x[0]  # it might be a namedtuple such as torchvision.model.InceptionOutputs
-        elif isinstance(x, dict):
+        elif torch.jit.isinstance(x, Dict[str, torch.Tensor]):
             x = x[self.node_name]  # torchvision create_feature_extractor
         if self.pool is not None:
             x = self.pool(x)

--- a/tests/test_net_adapter.py
+++ b/tests/test_net_adapter.py
@@ -16,6 +16,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import NetAdapter, resnet18
+from tests.utils import test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -49,6 +50,16 @@ class TestNetAdapter(unittest.TestCase):
         with eval_mode(net):
             result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
+
+    @parameterized.expand([TEST_CASE_0])
+    def test_script(self, input_param, input_shape, expected_shape):
+        spatial_dims = input_param["dim"]
+        stride = (1, 2, 2)[:spatial_dims]
+        model = resnet18(spatial_dims=spatial_dims, conv1_t_stride=stride)
+        input_param["model"] = model
+        net = NetAdapter(**input_param).to("cpu")
+        test_data = torch.randn(input_shape).to("cpu")
+        test_script_save(net, test_data)
 
 
 if __name__ == "__main__":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,6 +47,7 @@ from monai.utils.module import pytorch_after, version_leq
 from monai.utils.type_conversion import convert_data_type
 
 nib, _ = optional_import("nibabel")
+http_error, has_requests = optional_import("requests", name="HTTPError")
 
 quick_test_var = "QUICKTEST"
 _tf32_enabled = None
@@ -123,7 +124,7 @@ def assert_allclose(
 def skip_if_downloading_fails():
     try:
         yield
-    except (ContentTooShortError, HTTPError, ConnectionError) as e:
+    except (ContentTooShortError, HTTPError, ConnectionError) + (http_error,) if has_requests else () as e:
         raise unittest.SkipTest(f"error while downloading: {e}") from e
     except ssl.SSLError as ssl_e:
         if "decryption failed" in str(ssl_e):


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5485

### Description
compatibility torchscript for netadapter

also fixes #5487

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
