### PR TITLE
Install dependencies on Mac

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,8 +33,8 @@ sphinx-autodoc-typehints==1.11.1
 sphinx-rtd-theme==0.5.2
 cucim==22.8.1; platform_system == "Linux"
 openslide-python==1.1.2
-imagecodecs; platform_system == "Linux"
-tifffile; platform_system == "Linux"
+imagecodecs; platform_system == "Linux" or platform_system == "Darwin"
+tifffile; platform_system == "Linux" or platform_system == "Darwin"
 pandas
 requests
 einops


### PR DESCRIPTION
### Description

Few MONAI dependencies are flagged to be installed only on a Linux system while they are available on Macintosh systems too. This PR fix that to include `imagecodecs` and `tifffile`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
