### PR TITLE
5505 - option for preserving input dtypes Load/Save

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -33,6 +33,7 @@ from monai.utils import (
     SpaceKeys,
     TraceKeys,
     deprecated,
+    deprecated_arg,
     ensure_tuple,
     ensure_tuple_rep,
     optional_import,
@@ -871,12 +872,12 @@ class NibabelReader(ImageReader):
             this is used to set original_channel_dim in the metadata, EnsureChannelFirstD reads this field.
             if None, `original_channel_dim` will be either `no_channel` or `-1`.
             most Nifti files are usually "channel last", no need to specify this argument for them.
-        dtype: dtype of the output data array when loading with Nibabel library.
         kwargs: additional args for `nibabel.load` API. more details about available args:
             https://github.com/nipy/nibabel/blob/master/nibabel/loadsave.py
 
     """
 
+    @deprecated_arg("dtype", since="1.0", msg_suffix="please modify dtype of the returned by ``get_data`` instead.")
     def __init__(
         self,
         channel_dim: Optional[int] = None,
@@ -889,7 +890,7 @@ class NibabelReader(ImageReader):
         self.channel_dim = channel_dim
         self.as_closest_canonical = as_closest_canonical
         self.squeeze_non_spatial_dims = squeeze_non_spatial_dims
-        self.dtype = dtype
+        self.dtype = dtype  # deprecated
         self.kwargs = kwargs
 
     def verify_suffix(self, filename: Union[Sequence[PathLike], PathLike]) -> bool:
@@ -1027,9 +1028,7 @@ class NibabelReader(ImageReader):
             img: a Nibabel image object loaded from an image file.
 
         """
-        _array = np.array(img.get_fdata(dtype=self.dtype))
-        img.uncache()
-        return _array
+        return np.asanyarray(img.dataobj)
 
 
 class NumpyReader(ImageReader):

--- a/monai/data/image_writer.py
+++ b/monai/data/image_writer.py
@@ -421,7 +421,7 @@ class ITKWriter(ImageWriter):
                 defaulting to ``bilinear``, ``border``, ``False``, and ``np.float64`` respectively.
         """
         original_affine, affine, spatial_shape = self.get_meta_info(meta_dict)
-        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):
+        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):  # pylint: disable=E0203
             self.output_dtype = self.data_obj.dtype
         self.data_obj, self.affine = self.resample_if_needed(
             data_array=self.data_obj,
@@ -494,9 +494,7 @@ class ITKWriter(ImageWriter):
         _is_vec = channel_dim is not None
         if _is_vec:
             data_array = np.moveaxis(data_array, -1, 0)  # from channel last to channel first
-        if dtype is not None:
-            dtype = get_equivalent_dtype(dtype, np.ndarray)
-        data_array = data_array.T.astype(dtype, copy=True, order="C")
+        data_array = data_array.T.astype(get_equivalent_dtype(dtype, np.ndarray), copy=True, order="C")
         itk_obj = itk.GetImageFromArray(data_array, is_vector=_is_vec, ttype=kwargs.pop("ttype", None))
 
         d = len(itk.size(itk_obj))
@@ -578,7 +576,7 @@ class NibabelWriter(ImageWriter):
                 defaulting to ``bilinear``, ``border``, ``False``, and ``np.float64`` respectively.
         """
         original_affine, affine, spatial_shape = self.get_meta_info(meta_dict)
-        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):
+        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):  # pylint: disable=E0203
             self.output_dtype = self.data_obj.dtype
         self.data_obj, self.affine = self.resample_if_needed(
             data_array=self.data_obj,
@@ -723,7 +721,7 @@ class PILWriter(ImageWriter):
                 currently support ``mode``, defaulting to ``bicubic``.
         """
         spatial_shape = self.get_meta_info(meta_dict)
-        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):
+        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):  # pylint: disable=E0203
             self.output_dtype = self.data_obj.dtype
         self.data_obj = self.resample_and_clip(
             data_array=self.data_obj,

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -113,7 +113,7 @@ class LoadImage(Transform):
         self,
         reader=None,
         image_only: bool = False,
-        dtype: DtypeLike = np.float32,
+        dtype: Optional[DtypeLike] = np.float32,
         ensure_channel_first: bool = False,
         simple_keys: bool = False,
         prune_meta_pattern: Optional[str] = None,
@@ -293,7 +293,7 @@ class SaveImage(Transform):
         output_dir: output image directory.
         output_postfix: a string appended to all output file names, default to `trans`.
         output_ext: output file extension name.
-        output_dtype: data type for saving data. Defaults to ``np.float32``.
+        output_dtype: data type (if not None) for saving data. Defaults to ``np.float32``.
         resample: whether to resample image (if needed) before saving the data array,
             based on the `spatial_shape` (and `original_affine`) from metadata.
         mode: This option is used when ``resample=True``. Defaults to ``"nearest"``.
@@ -310,7 +310,7 @@ class SaveImage(Transform):
         scale: {``255``, ``65535``} postprocess data by clipping to [0, 1] and scaling
             [0, 255] (uint8) or [0, 65535] (uint16). Default is `None` (no scaling).
         dtype: data type during resampling computation. Defaults to ``np.float64`` for best precision.
-            if None, use the data type of input data. To be compatible with other modules,
+            if None, use the data type of input data. To set the output data type, use `output_dtype`.
         squeeze_end_dims: if True, any trailing singleton dimensions will be removed (after the channel
             has been moved to the end). So if input is (C,H,W,D), this will be altered to (H,W,D,C), and
             then if C==1, it will be saved as (H,W,D). If D is also 1, it will be saved as (H,W). If `false`,
@@ -347,7 +347,7 @@ class SaveImage(Transform):
         output_dir: PathLike = "./",
         output_postfix: str = "trans",
         output_ext: str = ".nii.gz",
-        output_dtype: DtypeLike = np.float32,
+        output_dtype: Optional[DtypeLike] = np.float32,
         resample: bool = True,
         mode: str = "nearest",
         padding_mode: str = GridSamplePadMode.BORDER,
@@ -382,9 +382,9 @@ class SaveImage(Transform):
         self.writer_obj = None
 
         _output_dtype = output_dtype
-        if self.output_ext == ".png" and _output_dtype not in (np.uint8, np.uint16):
+        if self.output_ext == ".png" and _output_dtype not in (np.uint8, np.uint16, None):
             _output_dtype = np.uint8
-        if self.output_ext == ".dcm" and _output_dtype not in (np.uint8, np.uint16):
+        if self.output_ext == ".dcm" and _output_dtype not in (np.uint8, np.uint16, None):
             _output_dtype = np.uint8
         self.init_kwargs = {"output_dtype": _output_dtype, "scale": scale}
         self.data_kwargs = {"squeeze_end_dims": squeeze_end_dims, "channel_dim": channel_dim}

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -173,7 +173,7 @@ class SaveImaged(MapTransform):
 
     Note:
         Image should be channel-first shape: [C,H,W,[D]].
-        If the data is a patch of big image, will append the patch index to filename.
+        If the data is a patch of an image, the patch index will be appended to the filename.
 
     Args:
         keys: keys of the corresponding items to be transformed.
@@ -187,7 +187,6 @@ class SaveImaged(MapTransform):
         output_dir: output image directory.
         output_postfix: a string appended to all output file names, default to `trans`.
         output_ext: output file extension name, available extensions: `.nii.gz`, `.nii`, `.png`.
-        output_dtype: data type for saving data. Defaults to ``np.float32``.
         resample: whether to resample image (if needed) before saving the data array,
             based on the `spatial_shape` (and `original_affine`) from metadata.
         mode: This option is used when ``resample=True``. Defaults to ``"nearest"``.
@@ -204,9 +203,8 @@ class SaveImaged(MapTransform):
         scale: {``255``, ``65535``} postprocess data by clipping to [0, 1] and scaling
             [0, 255] (uint8) or [0, 65535] (uint16). Default is `None` (no scaling).
         dtype: data type during resampling computation. Defaults to ``np.float64`` for best precision.
-            if None, use the data type of input data. To be compatible with other modules,
+            if None, use the data type of input data. To set the output data type, use `output_dtype`.
         output_dtype: data type for saving data. Defaults to ``np.float32``.
-            it's used for NIfTI format only.
         allow_missing_keys: don't raise exception if key is missing.
         squeeze_end_dims: if True, any trailing singleton dimensions will be removed (after the channel
             has been moved to the end). So if input is (C,H,W,D), this will be altered to (H,W,D,C), and
@@ -251,7 +249,7 @@ class SaveImaged(MapTransform):
         padding_mode: str = GridSamplePadMode.BORDER,
         scale: Optional[int] = None,
         dtype: DtypeLike = np.float64,
-        output_dtype: DtypeLike = np.float32,
+        output_dtype: Optional[DtypeLike] = np.float32,
         allow_missing_keys: bool = False,
         squeeze_end_dims: bool = True,
         data_root_dir: str = "",

--- a/tests/test_image_rw.py
+++ b/tests/test_image_rw.py
@@ -44,7 +44,12 @@ class TestLoadSaveNifti(unittest.TestCase):
             output_ext = ".nii.gz"
             filepath = f"testfile_{ndim}d"
             saver = SaveImage(
-                output_dir=self.test_dir, output_ext=output_ext, resample=resample, separate_folder=False, writer=writer
+                output_dir=self.test_dir,
+                output_ext=output_ext,
+                output_dtype=None,
+                resample=resample,
+                separate_folder=False,
+                writer=writer,
             )
             meta_dict = {
                 "filename_or_obj": f"{filepath}.png",
@@ -56,8 +61,9 @@ class TestLoadSaveNifti(unittest.TestCase):
             saver(test_data)
             saved_path = os.path.join(self.test_dir, filepath + "_trans" + output_ext)
             self.assertTrue(os.path.exists(saved_path))
-            loader = LoadImage(image_only=True, reader=reader, squeeze_non_spatial_dims=True)
+            loader = LoadImage(image_only=True, reader=reader, squeeze_non_spatial_dims=True, dtype=None)
             data = loader(saved_path)
+            self.assertIn(dtype.__name__, str(data.dtype))
             meta = data.meta
             if meta["original_channel_dim"] == -1:
                 _test_data = moveaxis(test_data, 0, -1)
@@ -84,7 +90,7 @@ class TestLoadSaveNifti(unittest.TestCase):
     @parameterized.expand(itertools.product([NibabelReader, ITKReader], ["NibabelWriter", ITKWriter]))
     def test_4d(self, reader, writer):
         test_data = np.arange(48, dtype=np.uint8).reshape(2, 1, 3, 8)
-        self.nifti_rw(test_data, reader, writer, np.float16)
+        self.nifti_rw(test_data, reader, writer, np.float64)
 
 
 @unittest.skipUnless(has_itk, "itk not installed")

--- a/tests/test_image_rw.py
+++ b/tests/test_image_rw.py
@@ -84,8 +84,8 @@ class TestLoadSaveNifti(unittest.TestCase):
     @parameterized.expand(itertools.product([NibabelReader, ITKReader], [NibabelWriter, ITKWriter]))
     def test_3d(self, reader, writer):
         test_data = np.arange(48, dtype=np.uint8).reshape(1, 2, 3, 8)
-        self.nifti_rw(test_data, reader, writer, int)
-        self.nifti_rw(test_data, reader, writer, int, False)
+        self.nifti_rw(test_data, reader, writer, np.int16)
+        self.nifti_rw(test_data, reader, writer, float, False)
 
     @parameterized.expand(itertools.product([NibabelReader, ITKReader], ["NibabelWriter", ITKWriter]))
     def test_4d(self, reader, writer):


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5505

### Description
- provides an option to preserve the input dtype when:
  - `LoadImge(dtype=None, ...)`
  - `SaveImage(output_dtype=None, ...)`

- deprecate `dtype` in `NibabelReader`, so the readers always preserve the dtype

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
