### PR TITLE
5497 Update init bundle function

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -799,6 +799,7 @@ def init_bundle(
     bundle_dir: PathLike,
     ckpt_file: Optional[PathLike] = None,
     network: Optional[torch.nn.Module] = None,
+    dataset_license: bool = False,
     metadata_str: Union[Dict, str] = DEFAULT_METADATA,
     inference_str: Union[Dict, str] = DEFAULT_INFERENCE,
 ):
@@ -815,6 +816,7 @@ def init_bundle(
         bundle_dir: directory name to create, must not exist but parent direct must exist
         ckpt_file: optional checkpoint file to copy into bundle
         network: if given instead of ckpt_file this network's weights will be stored in bundle
+        dataset_license: if `True`, a default incense file "data_license.txt" will be produced.
     """
 
     bundle_dir = Path(bundle_dir).absolute()
@@ -863,8 +865,12 @@ def init_bundle(
 
         o.write(dedent(readme))
 
-    with open(str(docs_dir / "license.txt"), "w") as o:
+    with open(str(bundle_dir / "LICENSE"), "w") as o:
         o.write("Select a license and place its terms here\n")
+
+    if dataset_license is True:
+        with open(str(docs_dir / "data_license.txt"), "w") as o:
+            o.write("Select a license for dataset and place its terms here\n")
 
     if ckpt_file is not None:
         copyfile(str(ckpt_file), str(models_dir / "model.pt"))

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -816,7 +816,8 @@ def init_bundle(
         bundle_dir: directory name to create, must not exist but parent direct must exist
         ckpt_file: optional checkpoint file to copy into bundle
         network: if given instead of ckpt_file this network's weights will be stored in bundle
-        dataset_license: if `True`, a default incense file "data_license.txt" will be produced.
+        dataset_license: if `True`, a default license file called "data_license.txt" will be produced. This
+            file is required if there are any license conditions stated for data your bundle uses.
     """
 
     bundle_dir = Path(bundle_dir).absolute()

--- a/tests/test_bundle_init_bundle.py
+++ b/tests/test_bundle_init_bundle.py
@@ -28,12 +28,25 @@ class TestBundleInit(unittest.TestCase):
 
             bundle_root = tempdir + "/test_bundle"
 
-            cmd = ["coverage", "run", "-m", "monai.bundle", "init_bundle", bundle_root, tempdir + "/test.pt"]
+            cmd = [
+                "coverage",
+                "run",
+                "-m",
+                "monai.bundle",
+                "init_bundle",
+                bundle_root,
+                tempdir + "/test.pt",
+                "--dataset_license",
+                "True",
+            ]
             command_line_tests(cmd)
 
             self.assertTrue(os.path.exists(bundle_root + "/configs/metadata.json"))
             self.assertTrue(os.path.exists(bundle_root + "/configs/inference.json"))
             self.assertTrue(os.path.exists(bundle_root + "/models/model.pt"))
+            self.assertTrue(os.path.exists(bundle_root + "/LICENSE"))
+            self.assertTrue(os.path.exists(bundle_root + "/docs/README.md"))
+            self.assertTrue(os.path.exists(bundle_root + "/docs/data_license.txt"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #5497 .

### Description

This PR updates the init bundle function to match up with https://github.com/Project-MONAI/model-zoo/blob/dev/CONTRIBUTING.md

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
