### PR TITLE
5510 flexible device in Invert

### DIFF
--- a/tests/test_invert.py
+++ b/tests/test_invert.py
@@ -64,7 +64,9 @@ class TestInvert(unittest.TestCase):
         dataset = Dataset(data, transform=transform)
         self.assertIsInstance(transform.inverse(dataset[0]), MetaTensor)
         loader = DataLoader(dataset, num_workers=num_workers, batch_size=1)
-        inverter = Invert(transform=transform, nearest_interp=True, device="cpu")
+        inverter = Invert(
+            transform=transform, nearest_interp=True, device="cpu", post_func=lambda x: torch.as_tensor(x)
+        )
 
         for d in loader:
             d = decollate_batch(d)

--- a/tests/test_invertd.py
+++ b/tests/test_invertd.py
@@ -77,7 +77,8 @@ class TestInvertd(unittest.TestCase):
             transform=transform,
             orig_keys=["label", "label"],
             nearest_interp=True,
-            device="cpu",
+            device=None,
+            post_func=lambda x: torch.as_tensor(x),
         )
 
         inverter_1 = Invertd(


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5510

### Description
this makes `device` and `post_func` optional 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
