### PR TITLE
5515 Adjust freeze encoder of hovernet

### DIFF
--- a/monai/data/image_writer.py
+++ b/monai/data/image_writer.py
@@ -421,7 +421,7 @@ class ITKWriter(ImageWriter):
                 defaulting to ``bilinear``, ``border``, ``False``, and ``np.float64`` respectively.
         """
         original_affine, affine, spatial_shape = self.get_meta_info(meta_dict)
-        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):  # pylint: disable=E0203
+        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):  # type: ignore # pylint: disable=E0203
             self.output_dtype = self.data_obj.dtype
         self.data_obj, self.affine = self.resample_if_needed(
             data_array=self.data_obj,
@@ -576,7 +576,7 @@ class NibabelWriter(ImageWriter):
                 defaulting to ``bilinear``, ``border``, ``False``, and ``np.float64`` respectively.
         """
         original_affine, affine, spatial_shape = self.get_meta_info(meta_dict)
-        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):  # pylint: disable=E0203
+        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):  # type: ignore # pylint: disable=E0203
             self.output_dtype = self.data_obj.dtype
         self.data_obj, self.affine = self.resample_if_needed(
             data_array=self.data_obj,
@@ -721,7 +721,7 @@ class PILWriter(ImageWriter):
                 currently support ``mode``, defaulting to ``bicubic``.
         """
         spatial_shape = self.get_meta_info(meta_dict)
-        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):  # pylint: disable=E0203
+        if self.output_dtype is None and hasattr(self.data_obj, "dtype"):  # type: ignore  # pylint: disable=E0203
             self.output_dtype = self.data_obj.dtype
         self.data_obj = self.resample_and_clip(
             data_array=self.data_obj,

--- a/monai/metrics/f_beta_score.py
+++ b/monai/metrics/f_beta_score.py
@@ -33,7 +33,7 @@ class FBetaScore(CumulativeIterationMetric):
         self.reduction = reduction
         self.get_not_nans = get_not_nans
 
-    def _compute_tensor(self, y_pred: torch.Tensor, y: torch.Tensor):  #
+    def _compute_tensor(self, y_pred: torch.Tensor, y: torch.Tensor):  # type: ignore
         is_binary_tensor(y_pred, "y_pred")
         is_binary_tensor(y, "y")
 

--- a/monai/metrics/regression.py
+++ b/monai/metrics/regression.py
@@ -305,9 +305,7 @@ class SSIMMetric(RegressionMetric):
         """
         ssim_value = torch.empty((1), dtype=torch.float)
         if x.shape[0] == 1:
-            ssim_value: torch.Tensor = 1 - SSIMLoss(self.win_size, self.k1, self.k2, self.spatial_dims)(
-                x, y, self.data_range
-            )
+            ssim_value = 1 - SSIMLoss(self.win_size, self.k1, self.k2, self.spatial_dims)(x, y, self.data_range)
         elif x.shape[0] > 1:
 
             for i in range(x.shape[0]):

--- a/monai/networks/blocks/feature_pyramid_network.py
+++ b/monai/networks/blocks/feature_pyramid_network.py
@@ -68,7 +68,7 @@ class ExtraFPNBlock(nn.Module):
     Same code as https://github.com/pytorch/vision/blob/release/0.12/torchvision/ops/feature_pyramid_network.py
     """
 
-    def forward(self, results: List[Tensor], x: List[Tensor], names: List[str]) -> Tuple[List[Tensor], List[str]]:
+    def forward(self, results: List[Tensor], x: List[Tensor], names: List[str]):
         """
         Compute extended set of results of the FPN and their names.
 

--- a/monai/networks/nets/dints.py
+++ b/monai/networks/nets/dints.py
@@ -38,16 +38,16 @@ __all__ = ["DiNTS", "TopologyConstruction", "TopologyInstance", "TopologySearch"
 class CellInterface(torch.nn.Module):
     """interface for torchscriptable Cell"""
 
-    def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-        pass
+    def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:  # type: ignore
+        pass  # type: ignore
 
 
 @torch.jit.interface
 class StemInterface(torch.nn.Module):
     """interface for torchscriptable Stem"""
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        pass
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore
+        pass  # type: ignore
 
 
 class StemTS(StemInterface):

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -319,7 +319,7 @@ class Cropd(MapTransform, InvertibleTransform):
         return d
 
 
-class RandCropd(Cropd, Randomizable):
+class RandCropd(Cropd, Randomizable):  # type: ignore
     """
     Base class for random crop transform.
 

--- a/tests/test_hovernet.py
+++ b/tests/test_hovernet.py
@@ -14,8 +14,9 @@ import unittest
 import torch
 from parameterized import parameterized
 
-from monai.networks import eval_mode
+from monai.networks import eval_mode, train_mode
 from monai.networks.nets import HoVerNet
+from monai.networks.nets.hovernet import _DenseLayerDecoder
 from tests.utils import test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -66,7 +67,7 @@ def check_branch(branch, mode):
     if branch.decoderblock1.convf.kernel_size != (1, 1):
         return True
     for block in branch.decoderblock1:
-        if isinstance(block, HoVerNet._DenseLayerDecoder):
+        if isinstance(block, _DenseLayerDecoder):
             if block.layers.conv1.kernel_size != (1, 1) or block.layers.conv2.kernel_size != (ksize, ksize):
                 return True
 
@@ -76,7 +77,7 @@ def check_branch(branch, mode):
         return True
 
     for block in branch.decoderblock2:
-        if isinstance(block, HoVerNet._DenseLayerDecoder):
+        if isinstance(block, _DenseLayerDecoder):
             if block.layers.conv1.kernel_size != (1, 1) or block.layers.conv2.kernel_size != (ksize, ksize):
                 return True
 
@@ -93,6 +94,8 @@ def check_output(out_block, mode):
         return True
     if out_block.decoderblock4.conv.kernel_size != (1, 1) or out_block.decoderblock4.conv.stride != (1, 1):
         return True
+
+    return False
 
 
 def check_kernels(net, mode):
@@ -145,6 +148,8 @@ def check_kernels(net, mode):
     if check_output(net.type_prediction.output_features, mode):
         return True
 
+    return False
+
 
 class TestHoverNet(unittest.TestCase):
     @parameterized.expand(CASES)
@@ -183,14 +188,23 @@ class TestHoverNet(unittest.TestCase):
             with self.assertRaises(ValueError):
                 net.forward(torch.randn(1, 3, 270, 260))
 
-    def check_kernels_strides(self):
-        net = HoVerNet(mode=HoVerNet.Mode.FAST)
+    def test_kernels_strides(self):
+        net = HoVerNet(mode=HoVerNet.Mode.FAST, out_classes=2)
         with eval_mode(net):
             self.assertEqual(check_kernels(net, HoVerNet.Mode.FAST), False)
 
-        net = HoVerNet(mode=HoVerNet.Mode.ORIGINAL)
+        net = HoVerNet(mode=HoVerNet.Mode.ORIGINAL, out_classes=2)
         with eval_mode(net):
             self.assertEqual(check_kernels(net, HoVerNet.Mode.ORIGINAL), False)
+
+    def test_freeze_encoder(self):
+        net = HoVerNet(mode=HoVerNet.Mode.FAST, freeze_encoder=True)
+        with train_mode(net):
+            for _, param in net.res_blocks[1:].named_parameters():
+                self.assertFalse(param.requires_grad)
+            for name, param in net.res_blocks[0].named_parameters():
+                if param.requires_grad is True:
+                    self.assertTrue("bna_block" or "shortcut" in name)
 
     @parameterized.expand(ILL_CASES)
     def test_ill_input_hyper_params(self, input_param):


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #5515  .

### Description

This PR adjusts the freeze encoder function, and also fix the issue of un-trigger some of the unit tests.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
