### PR TITLE
AutoRunner small updates

### DIFF
--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -15,6 +15,7 @@ import subprocess
 from copy import deepcopy
 from time import sleep
 from typing import Any, Dict, List, Optional, Tuple, Union
+import numpy as np
 
 import torch
 
@@ -429,9 +430,12 @@ class AutoRunner:
             os.makedirs(output_dir)
             logger.info(f"Directory {output_dir} is created to save ensemble predictions")
 
-        output_postfix = kwargs.pop("output_postfix", "ensemble")
         self.output_dir = output_dir
-        return SaveImage(output_dir=output_dir, output_postfix=output_postfix, **kwargs)
+        output_postfix = kwargs.pop("output_postfix", "ensemble")
+        output_dtype = kwargs.pop("output_dtype", np.uint8)
+        resample = kwargs.pop("resample", False)
+
+        return SaveImage(output_dir=output_dir, output_postfix=output_postfix, output_dtype=output_dtype, resample=resample, **kwargs)
 
     def set_ensemble_method(self, ensemble_method_name: str = "AlgoEnsembleBestByFold", **kwargs):
         """

--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -15,8 +15,8 @@ import subprocess
 from copy import deepcopy
 from time import sleep
 from typing import Any, Dict, List, Optional, Tuple, Union
-import numpy as np
 
+import numpy as np
 import torch
 
 from monai.apps.auto3dseg.bundle_gen import BundleGen
@@ -435,7 +435,9 @@ class AutoRunner:
         output_dtype = kwargs.pop("output_dtype", np.uint8)
         resample = kwargs.pop("resample", False)
 
-        return SaveImage(output_dir=output_dir, output_postfix=output_postfix, output_dtype=output_dtype, resample=resample, **kwargs)
+        return SaveImage(
+            output_dir=output_dir, output_postfix=output_postfix, output_dtype=output_dtype, resample=resample, **kwargs
+        )
 
     def set_ensemble_method(self, ensemble_method_name: str = "AlgoEnsembleBestByFold", **kwargs):
         """

--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -12,7 +12,6 @@
 import os
 import shutil
 import subprocess
-import sys
 from copy import deepcopy
 from time import sleep
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -64,7 +63,7 @@ class AutoRunner:
         work_dir: working directory to save the intermediate and final results.
         input: the configuration dictionary or the file path to the configuration in form of YAML.
             The configuration should contain datalist, dataroot, modality, multigpu, and class_names info.
-        algos: optionally specify a list of algorithms to use 
+        algos: optionally specify a list of algorithms to use
         analyze: on/off switch to run DataAnalyzer and generate a datastats report. Defaults to None, to automatically
             decide based on cache, and run data analysis only if we have not completed this step yet.
         algo_gen: on/off switch to run AlgoGen and generate templated BundleAlgos. Defaults to None, to automatically
@@ -216,7 +215,7 @@ class AutoRunner:
         else:
             raise ValueError(f"{input} is not a valid file or dict")
 
-        missing_keys = set(["dataroot", "datalist", "modality"]).difference(self.data_src_cfg.keys())
+        missing_keys = {"dataroot", "datalist", "modality"}.difference(self.data_src_cfg.keys())
         if len(missing_keys) > 0:
             raise ValueError(f"Config keys are missing {missing_keys}")
 

--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -184,10 +184,10 @@ class AutoRunner:
         analyze: Optional[bool] = None,
         algo_gen: Optional[bool] = None,
         train: Optional[bool] = None,
-        ensemble: bool = True,
-        not_use_cache: bool = False,
         hpo: bool = False,
         hpo_backend: str = "nni",
+        ensemble: bool = True,
+        not_use_cache: bool = False,
         **kwargs,
     ):
 

--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -321,7 +321,7 @@ class AutoRunner:
             raise ValueError(f"num_fold is expected to be an integer greater than zero. Now it gets {num_fold}")
         self.num_fold = num_fold
 
-    def set_training_params(self, params: Dict[str, Any] = {}):
+    def set_training_params(self, params: Optional[Dict[str, Any]] = None):
         """
         Set the training params for all algos.
 
@@ -334,9 +334,9 @@ class AutoRunner:
                 {"num_iterations": 8, "num_iterations_per_validation": 4}
 
         """
-        self.train_params = deepcopy(params)
+        self.train_params = deepcopy(params) if params is not None else {}
 
-    def set_prediction_params(self, params: Dict[str, Any] = {}):
+    def set_prediction_params(self, params: Optional[Dict[str, Any]] = None):
         """
         Set the prediction params for all algos.
 
@@ -350,7 +350,7 @@ class AutoRunner:
                 two files in the testing datalist {"file_slices": slice(0, 2)}
 
         """
-        self.pred_params = deepcopy(params)
+        self.pred_params = deepcopy(params) if params is not None else {}
 
     def set_analyze_params(self, params: Optional[Dict[str, Any]] = None):
         """

--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -590,14 +590,16 @@ class AutoRunner:
             history = import_bundle_algo_history(self.work_dir, only_trained=True)
             builder = AlgoEnsembleBuilder(history, self.data_src_cfg_name)
             builder.set_ensemble_method(self.ensemble_method)
-            ensembler = builder.get_ensemble()
-            preds = ensembler(pred_param=self.pred_params)  # apply sigmoid to binarize the prediction
-            print("Auto3Dseg picked the following networks to ensemble:")
-            for algo in ensembler.get_algo_ensemble():
-                print(algo[AlgoEnsembleKeys.ID])
 
-            for pred in preds:
-                self.save_image(pred)
-            logger.info(f"Auto3Dseg ensemble prediction outputs are saved in {self.output_dir}.")
+            ensembler = builder.get_ensemble()
+            preds = ensembler(pred_param=self.pred_params)
+            if len(preds) > 0:
+                print("Auto3Dseg picked the following networks to ensemble:")
+                for algo in ensembler.get_algo_ensemble():
+                    print(algo[AlgoEnsembleKeys.ID])
+
+                for pred in preds:
+                    self.save_image(pred)
+                logger.info(f"Auto3Dseg ensemble prediction outputs are saved in {self.output_dir}.")
 
         logger.info("Auto3Dseg pipeline is complete successfully.")

--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -183,7 +183,6 @@ class BundleAlgo(Algo):
         if devices_info:
             ps_environ["CUDA_VISIBLE_DEVICES"] = devices_info
         normal_out = subprocess.run(cmd.split(), env=ps_environ, check=True)
-        logger.info(repr(normal_out).replace("\\n", "\n").replace("\\t", "\t"))
 
         return normal_out
 

--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -327,24 +327,24 @@ class BundleGen(AlgoGen):
 
         if isinstance(algos, dict):
             for algo_name, algo_params in algos.items():
+
+                template_path = os.path.dirname(algo_params.get("template_path", "."))
+                if len(template_path) > 0 and template_path not in sys.path:
+                    sys.path.append(template_path)
+
                 try:
                     self.algos.append(ConfigParser(algo_params).get_parsed_content())
                 except RuntimeError as e:
-                    if "ModuleNotFoundError" in str(e):
-                        msg = """Please make sure the folder structure of an Algo Template follows
-                            [algo_name]
-                            ├── configs
-                            │   ├── hyperparameters.yaml  # automatically generated yaml from a set of ``template_configs``
-                            │   ├── network.yaml  # automatically generated network yaml from a set of ``template_configs``
-                            │   ├── transforms_train.yaml  # automatically generated yaml to define transforms for training
-                            │   ├── transforms_validate.yaml  # automatically generated yaml to define transforms for validation
-                            │   └── transforms_infer.yaml  # automatically generated yaml to define transforms for inference
-                            └── scripts
-                                ├── test.py
-                                ├── __init__.py
-                                └── validate.py
-                        """
-                        raise RuntimeError(msg) from e
+                    msg = """Please make sure the folder structure of an Algo Template follows
+                        [algo_name]
+                        ├── configs
+                        │   ├── hyper_parameters.yaml  # automatically generated yaml from a set of ``template_configs``
+                        └── scripts
+                            ├── test.py
+                            ├── __init__.py
+                            └── validate.py
+                    """
+                    raise RuntimeError(msg) from e
                 self.algos[-1].name = algo_name
         else:
             self.algos = ensure_tuple(algos)

--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -177,17 +177,14 @@ class BundleAlgo(Algo):
         Execute the training command with target devices information.
 
         """
-        try:
-            logger.info(f"Launching: {cmd}")
-            ps_environ = os.environ.copy()
-            if devices_info:
-                ps_environ["CUDA_VISIBLE_DEVICES"] = devices_info
-            normal_out = subprocess.run(cmd.split(), env=ps_environ, check=True, capture_output=True)
-            logger.info(repr(normal_out).replace("\\n", "\n").replace("\\t", "\t"))
-        except subprocess.CalledProcessError as e:
-            output = repr(e.stdout).replace("\\n", "\n").replace("\\t", "\t")
-            errors = repr(e.stderr).replace("\\n", "\n").replace("\\t", "\t")
-            raise RuntimeError(f"subprocess call error {e.returncode}: {errors}, {output}") from e
+
+        logger.info(f"Launching: {cmd}")
+        ps_environ = os.environ.copy()
+        if devices_info:
+            ps_environ["CUDA_VISIBLE_DEVICES"] = devices_info
+        normal_out = subprocess.run(cmd.split(), env=ps_environ, check=True)
+        logger.info(repr(normal_out).replace("\\n", "\n").replace("\\t", "\t"))
+
         return normal_out
 
     def train(self, train_params=None):

--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -252,13 +252,12 @@ class BundleAlgo(Algo):
         spec.loader.exec_module(infer_class)
         return infer_class.InferClass(configs_path, *args, **kwargs)
 
-    def predict(self, predict_params=None):
+    def predict(self, predict_files: list, predict_params=None):
         """
-        Use the trained model to predict the outputs with a given input image. Path to input image is in the params
-        dict in a form of {"files", ["path_to_image_1", "path_to_image_2"]}. If it is not specified, then the
-        prediction will use the test images predefined in the bundle config.
+        Use the trained model to predict the outputs with a given input image.
 
         Args:
+            predict_files: a list of paths to files to run inference on ["path_to_image_1", "path_to_image_2"]
             predict_params: a dict to override the parameters in the bundle config (including the files to predict).
 
         """
@@ -267,9 +266,8 @@ class BundleAlgo(Algo):
         else:
             params = deepcopy(predict_params)
 
-        files = params.pop("files", ".")
         inferer = self.get_inferer(**params)
-        return [inferer.infer(f) for f in ensure_tuple(files)]
+        return [inferer.infer(f) for f in ensure_tuple(predict_files)]
 
     def get_output_path(self):
         """Returns the algo output paths to find the algo scripts and configs."""

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -81,13 +81,14 @@ class AlgoEnsemble(ABC):
         for d in datalist[data_key]:
             self.infer_files.append({"image": os.path.join(dataroot, d["image"])})
 
-    def ensemble_pred(self, preds, sigmoid=True):
+    def ensemble_pred(self, preds, sigmoid=False):
         """
         ensemble the results using either "mean" or "vote" method
 
         Args:
             preds: a list of probability prediction in Tensor-Like format.
-            sigmoid: use the sigmoid function to threshold probability one-hot map.
+            sigmoid: use the sigmoid function to threshold probability one-hot map,
+                otherwise argmax is used. Defaults to False
 
         Returns:
             a tensor which is the ensembled prediction.
@@ -113,7 +114,7 @@ class AlgoEnsemble(ABC):
                     make prediction on the infer_files[file_slices].
                 'mode': ensemble mode. Currently "mean" and "vote" (majority voting) schemes are supported.
                 'sigmoid': use the sigmoid function (e.g. x>0.5) to convert the prediction probability map to
-                    the label class prediction.
+                    the label class prediction, otherwise argmax(x) is used.
 
         Returns:
             A list of tensors.
@@ -132,10 +133,7 @@ class AlgoEnsemble(ABC):
             mode = param.pop("mode")
             self.mode = look_up_option(mode, supported=["mean", "vote"])
 
-        sigmoid = True
-        if "sigmoid" in param:
-            sigmoid = param.pop("sigmoid")
-            sigmoid = look_up_option(sigmoid, supported=[True, False])
+        sigmoid = param.pop("sigmoid", False)
 
         outputs = []
         for i in range(len(files)):

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -21,6 +21,7 @@ import numpy as np
 from monai.apps.auto3dseg.bundle_gen import BundleAlgo
 from monai.apps.utils import get_logger
 from monai.auto3dseg import concat_val_to_np
+from monai.auto3dseg.utils import datafold_read
 from monai.bundle import ConfigParser
 from monai.transforms import MeanEnsemble, VoteEnsemble
 from monai.utils.enums import AlgoEnsembleKeys
@@ -75,11 +76,8 @@ class AlgoEnsemble(ABC):
             dataroot: the path of the files
             data_src_cfg_file: the data source file path
         """
-        with open(data_list_file_path) as f:
-            datalist = json.load(f)
 
-        for d in datalist[data_key]:
-            self.infer_files.append({"image": os.path.join(dataroot, d["image"])})
+        self.infer_files, _ = datafold_read(datalist=data_list_file_path, basedir=dataroot, fold=-1, key=data_key)
 
     def ensemble_pred(self, preds, sigmoid=False):
         """

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -85,7 +85,8 @@ class AlgoEnsemble(ABC):
             if data_key in datalist:
                 self.infer_files, _ = datafold_read(datalist=datalist, basedir=dataroot, fold=-1, key=data_key)
             else:
-                print(f"Datalist file has no testing key {data_key}. No data for inference is specified")
+                logger.info(f"Datalist file has no testing key - {data_key}. No data for inference is specified")
+
         else:
             raise ValueError("Unsupported parameter type")
 

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
 from abc import ABC, abstractmethod
 from copy import deepcopy

--- a/monai/apps/auto3dseg/utils.py
+++ b/monai/apps/auto3dseg/utils.py
@@ -31,7 +31,7 @@ def import_bundle_algo_history(
 
     history = []
 
-    for name in os.listdir(output_folder):
+    for name in sorted(os.listdir(output_folder)):
         write_path = os.path.join(output_folder, name)
 
         if not os.path.isdir(write_path):

--- a/monai/auto3dseg/algo_gen.py
+++ b/monai/auto3dseg/algo_gen.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from monai.transforms import Randomizable
 
 
@@ -31,12 +33,13 @@ class Algo:
         """
         pass
 
-    def predict(self, params: dict):
+    def predict(self, predict_files: list, predict_params: Optional[dict] = None):
         """
         Read test data and output model predictions.
 
         Args:
-            params: key-value pairs of input parameters for the predicting pipeline.
+            predict_files: list of files for the predicting pipeline.
+            predict_params: key-value pairs of input parameters for the predicting pipeline.
         """
         pass
 


### PR DESCRIPTION
AutoRunner() non-breaking class updates, to add more options 

- adding and option self.algos to manually specify algorithms to run (instead of always downloading a zip)
- Input options train, algo_gen, analyze will default to None, indicating to automatically decide whether this step is necessary based on cache (history). 
- default ensemble method is changed to AlgoEnsembleBestByFold
- added method set_analyze_params() to set DataAnalyser parameters (e.g. run it on gpu)
- changed self.cache dict to be a single level (since it only has 4 items), instead of a nested dictionary
- removed default setting sigmoid=True in set_prediction_params(), since it's somewhat arbitrary

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
