### PR TITLE
Add `new_key` args in `Lambdad`

### DIFF
--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -1032,7 +1032,7 @@ class Lambdad(MapTransform, InvertibleTransform):
             each element corresponds to a key in ``keys``.
         inv_func: Lambda/function of inverse operation if want to invert transforms, default to `lambda x: x`.
             It also can be a sequence of Callable, each element corresponds to a key in ``keys``.
-        overwrite: whether to overwrite the original data in the input dictionary with lambda function output. it 
+        overwrite: whether to overwrite the original data in the input dictionary with lambda function output. it
             can be bool or str, when setting to str, it will create a new key for the output and keep the value of
             key intact. default to True. it also can be a sequence of bool or str, each element corresponds to a key
             in ``keys``.

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -1032,9 +1032,10 @@ class Lambdad(MapTransform, InvertibleTransform):
             each element corresponds to a key in ``keys``.
         inv_func: Lambda/function of inverse operation if want to invert transforms, default to `lambda x: x`.
             It also can be a sequence of Callable, each element corresponds to a key in ``keys``.
-        overwrite: whether to overwrite the original data in the input dictionary with lambda function output. it can
-            be bool or str, when setting to str, it will create a new key for the output and keep the value of key
-            intact. default to True. it also can be a sequence of bool, each element corresponds to a key in ``keys``.
+        overwrite: whether to overwrite the original data in the input dictionary with lambda function output. it 
+            can be bool or str, when setting to str, it will create a new key for the output and keep the value of
+            key intact. default to True. it also can be a sequence of bool or str, each element corresponds to a key
+            in ``keys``.
         allow_missing_keys: don't raise exception if key is missing.
 
     Note: The inverse operation doesn't allow to define `extra_info` or access other information, such as the

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -1032,10 +1032,9 @@ class Lambdad(MapTransform, InvertibleTransform):
             each element corresponds to a key in ``keys``.
         inv_func: Lambda/function of inverse operation if want to invert transforms, default to `lambda x: x`.
             It also can be a sequence of Callable, each element corresponds to a key in ``keys``.
-        overwrite: whether to overwrite the original data in the input dictionary with lambda function output.
-            default to True. it also can be a sequence of bool, each element corresponds to a key in ``keys``.
-        new_key: it will create a new key for the output and keep the value of key intact when overwrite is set
-            to False. default to None. it also can be a sequence of str, each element corresponds to a key in ``keys``.
+        overwrite: whether to overwrite the original data in the input dictionary with lambda function output. it can
+            be bool or str, when setting to str, it will create a new key for the output and keep the value of key
+            intact. default to True. it also can be a sequence of bool, each element corresponds to a key in ``keys``.
         allow_missing_keys: don't raise exception if key is missing.
 
     Note: The inverse operation doesn't allow to define `extra_info` or access other information, such as the
@@ -1050,25 +1049,23 @@ class Lambdad(MapTransform, InvertibleTransform):
         keys: KeysCollection,
         func: Union[Sequence[Callable], Callable],
         inv_func: Union[Sequence[Callable], Callable] = no_collation,
-        overwrite: Union[Sequence[bool], bool] = True,
-        new_key: Union[Sequence[str], str] = None,
+        overwrite: Union[Sequence[bool], bool, Sequence[str], str] = True,
         allow_missing_keys: bool = False,
     ) -> None:
         super().__init__(keys, allow_missing_keys)
         self.func = ensure_tuple_rep(func, len(self.keys))
         self.inv_func = ensure_tuple_rep(inv_func, len(self.keys))
         self.overwrite = ensure_tuple_rep(overwrite, len(self.keys))
-        self.new_key = ensure_tuple_rep(new_key, len(self.keys))
         self._lambd = Lambda()
 
     def __call__(self, data: Mapping[Hashable, torch.Tensor]) -> Dict[Hashable, torch.Tensor]:
         d = dict(data)
-        for key, new_key, func, overwrite in self.key_iterator(d, self.new_key, self.func, self.overwrite):
+        for key, func, overwrite in self.key_iterator(d, self.func, self.overwrite):
             ret = self._lambd(img=d[key], func=func)
-            if overwrite:
+            if overwrite and isinstance(overwrite, bool):
                 d[key] = ret
-            elif new_key is not None:
-                d[new_key] = ret
+            elif isinstance(overwrite, str):
+                d[overwrite] = ret
         return d
 
     def inverse(self, data):

--- a/tests/test_lambdad.py
+++ b/tests/test_lambdad.py
@@ -20,18 +20,16 @@ class TestLambdad(NumpyImageTestCase2D):
     def test_lambdad_identity(self):
         for p in TEST_NDARRAYS:
             img = p(self.imt)
-            data = {"img": img, "prop": 1.0}
+            data = {"img": img, "prop": 1.0, "label": 1.0}
 
             def noise_func(x):
                 return x + 1.0
 
-            expected = {"img": noise_func(data["img"]), "prop": 1.0, "new_prob": 2.0}
-            ret = Lambdad(keys=["img", "prop"], func=noise_func, overwrite=[True, False], new_key=[None, "new_prob"])(
-                data
-            )
+            expected = {"img": noise_func(data["img"]), "prop": 1.0, "new_label": 2.0}
+            ret = Lambdad(keys=["img", "prop", "label"], func=noise_func, overwrite=[True, False, "new_label"])(data)
             assert_allclose(expected["img"], ret["img"], type_test=False)
             assert_allclose(expected["prop"], ret["prop"], type_test=False)
-            assert_allclose(expected["new_prob"], ret["new_prob"], type_test=False)
+            assert_allclose(expected["new_label"], ret["new_label"], type_test=False)
 
     def test_lambdad_slicing(self):
         for p in TEST_NDARRAYS:

--- a/tests/test_lambdad.py
+++ b/tests/test_lambdad.py
@@ -25,10 +25,13 @@ class TestLambdad(NumpyImageTestCase2D):
             def noise_func(x):
                 return x + 1.0
 
-            expected = {"img": noise_func(data["img"]), "prop": 1.0}
-            ret = Lambdad(keys=["img", "prop"], func=noise_func, overwrite=[True, False])(data)
+            expected = {"img": noise_func(data["img"]), "prop": 1.0, "new_prob": 2.0}
+            ret = Lambdad(keys=["img", "prop"], func=noise_func, overwrite=[True, False], new_key=[None, "new_prob"])(
+                data
+            )
             assert_allclose(expected["img"], ret["img"], type_test=False)
             assert_allclose(expected["prop"], ret["prop"], type_test=False)
+            assert_allclose(expected["new_prob"], ret["new_prob"], type_test=False)
 
     def test_lambdad_slicing(self):
         for p in TEST_NDARRAYS:


### PR DESCRIPTION
Signed-off-by: KumoLiu <yunl@nvidia.com>

Fixes #5517.

### Description

Add a `new_key` argument, it will create a new key for the output and keep the value of the key intact when `overwrite` is set to False.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
