### PR TITLE
Fix AutoRunner Update Integration Test Errors

### DIFF
--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -64,7 +64,6 @@ class AutoRunner:
         work_dir: working directory to save the intermediate and final results.
         input: the configuration dictionary or the file path to the configuration in form of YAML.
             The configuration should contain datalist, dataroot, modality, multigpu, and class_names info.
-        algos: optionally specify a list of algorithms to use
         analyze: on/off switch to run DataAnalyzer and generate a datastats report. Defaults to None, to automatically
             decide based on cache, and run data analysis only if we have not completed this step yet.
         algo_gen: on/off switch to run AlgoGen and generate templated BundleAlgos. Defaults to None, to automatically
@@ -79,6 +78,7 @@ class AutoRunner:
             datasets.
         not_use_cache: if the value is True, it will ignore all cached results in data analysis,
             algorithm generation, or training, and start the pipeline from scratch.
+        algos: optionally specify a list of algorithms to use.
         kwargs: image writing parameters for the ensemble inference. The kwargs format follows the SaveImage
             transform. For more information, check https://docs.monai.io/en/stable/transforms.html#saveimage.
 

--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -181,7 +181,6 @@ class AutoRunner:
         self,
         work_dir: str = "./work_dir",
         input: Union[Dict[str, Any], str, None] = None,
-        algos: Optional[Union[Tuple, List]] = None,
         analyze: Optional[bool] = None,
         algo_gen: Optional[bool] = None,
         train: Optional[bool] = None,
@@ -189,6 +188,7 @@ class AutoRunner:
         hpo_backend: str = "nni",
         ensemble: bool = True,
         not_use_cache: bool = False,
+        algos: Optional[Union[Tuple, List]] = None,
         **kwargs,
     ):
 
@@ -235,6 +235,7 @@ class AutoRunner:
         self.train = not self.cache["train"] if train is None else train
         self.ensemble = ensemble  # last step, no need to check
 
+        self.ensemble_method_name = "AlgoEnsembleBestByFold"
         # intermediate variables
         self.set_num_fold(num_fold=5)
         self.set_training_params()
@@ -243,7 +244,7 @@ class AutoRunner:
 
         self.save_image = self.set_image_save_transform(kwargs)
         self.ensemble_method: AlgoEnsemble
-        self.set_ensemble_method(ensemble_method_name="AlgoEnsembleBestByFold")
+        self.set_ensemble_method(ensemble_method_name=self.ensemble_method_name)
 
         # hpo
         if hpo_backend.lower() != "nni":
@@ -309,6 +310,8 @@ class AutoRunner:
         if num_fold <= 0:
             raise ValueError(f"num_fold is expected to be an integer greater than zero. Now it gets {num_fold}")
         self.num_fold = num_fold
+        # ensemble methods may require an update if the num_fold is changed
+        self.set_ensemble_method(ensemble_method_name=self.ensemble_method_name)
 
     def set_training_params(self, params: Optional[Dict[str, Any]] = None):
         """

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -231,7 +231,8 @@ class AlgoEnsembleBestByFold(AlgoEnsemble):
             best_score = -1.0
             best_model: Optional[BundleAlgo] = None
             for algo in self.algos:
-                identifier = algo[AlgoEnsembleKeys.ID].split("_")[-1]
+                # algo folder naming is {net_name}_{fold_index}_{other}
+                identifier = algo[AlgoEnsembleKeys.ID].split("_")[1]
                 try:
                     algo_id = int(identifier)
                 except ValueError as err:


### PR DESCRIPTION
Signed-off-by: Mingxin Zheng <18563433+mingxin-zheng@users.noreply.github.com>

Fixes #5555 .

The following command fails after the update.
```python
python tests/test_integration_autorunner.py
```

### Description

- fix identifier naming bug for HPO AutoRunner runs
- fix NoneType elements in the ensemble algorithm lists
- move optional argument `algos` to the end of the argument list (this is still up for more discussion I think)


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).


