### PR TITLE
Fix wrong algorithm folder name parsing in ensemble after HPO in Auto3DSeg

### DIFF
--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -222,7 +222,8 @@ class AlgoEnsembleBestByFold(AlgoEnsemble):
             best_score = -1.0
             best_model: Optional[BundleAlgo] = None
             for algo in self.algos:
-                identifier = algo[AlgoEnsembleKeys.ID].split("_")[-1]
+                # algorithm folder: {net}_{fold_index}_{other}
+                identifier = algo[AlgoEnsembleKeys.ID].split("_")[1]
                 try:
                     algo_id = int(identifier)
                 except ValueError as err:


### PR DESCRIPTION
Signed-off-by: Mingxin Zheng <18563433+mingxin-zheng@users.noreply.github.com>

Fixes #5558 .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `python tests/test_integration_autorunner.py`.
