### PR TITLE
Throw error with description when there are no valid user click/signals

### DIFF
--- a/monai/apps/nuclick/transforms.py
+++ b/monai/apps/nuclick/transforms.py
@@ -437,6 +437,8 @@ class AddClickSignalsd(MapTransform):
         cy = [xy[1] for xy in pos]
 
         click_map, bounding_boxes = self.get_clickmap_boundingbox(img, cx=cx, cy=cy, x=x, y=y, bb=self.bb_size)
+        if not bounding_boxes:
+            raise ValueError("Failed to create patches from given click points")
 
         patches = self.get_patches_and_signals(
             img=img, click_map=click_map, bounding_boxes=bounding_boxes, cx=cx, cy=cy, x=x, y=y


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

Fixes # .
Throw error with description when there are no valid user click/signals

### Description
Instead of torch.stack error, provide readable description when the signal is not valid, and no valid bounding boxes could be created based on user click points.

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
