### PR TITLE
fixing broadcast_object_list during torchrun

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -829,9 +829,9 @@ class CacheDataset(Dataset):
                 if self._is_dist:
                     # ensure each process has the same authkey, otherwise broadcast_object_list fails
                     authkey = bytearray(mp.current_process().authkey).ljust(32)[:32]
-                    ak_tensor = torch.frombuffer(authkey, dtype=torch.uint8)
-                    if dist.get_backend()==dist.Backend.NCCL:
-                        ak_tensor=ak_tensor.cuda(torch.cuda.current_device())
+                    ak_tensor = torch.from_numpy(np.frombuffer(authkey, dtype=np.uint8))
+                    if dist.get_backend() == dist.Backend.NCCL:
+                        ak_tensor = ak_tensor.cuda(torch.cuda.current_device())
                     dist.broadcast(ak_tensor, src=0)
                     mp.current_process().authkey = ak_tensor.cpu().numpy().tobytes()
 

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -829,7 +829,9 @@ class CacheDataset(Dataset):
                 if self._is_dist:
                     # ensure each process has the same authkey, otherwise broadcast_object_list fails
                     authkey = bytearray(mp.current_process().authkey).ljust(32)[:32]
-                    ak_tensor = torch.frombuffer(authkey, dtype=torch.uint8).cuda(torch.cuda.current_device())
+                    ak_tensor = torch.frombuffer(authkey, dtype=torch.uint8)
+                    if dist.get_backend()==dist.Backend.NCCL:
+                        ak_tensor=ak_tensor.cuda(torch.cuda.current_device())
                     dist.broadcast(ak_tensor, src=0)
                     mp.current_process().authkey = ak_tensor.cpu().numpy().tobytes()
 

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -828,12 +828,7 @@ class CacheDataset(Dataset):
                 cache = Manager().list([None for _ in range(self.cache_num)])
                 if self._is_dist:
                     # ensure each process has the same authkey, otherwise broadcast_object_list fails
-                    authkey = bytearray(mp.current_process().authkey).ljust(32)[:32]
-                    ak_tensor = torch.from_numpy(np.frombuffer(authkey, dtype=np.uint8))
-                    if dist.get_backend() == dist.Backend.NCCL:
-                        ak_tensor = ak_tensor.cuda(torch.cuda.current_device())
-                    dist.broadcast(ak_tensor, src=0)
-                    mp.current_process().authkey = ak_tensor.cpu().numpy().tobytes()
+                    mp.current_process().authkey = np.arange(32, dtype=np.uint8).tobytes()
 
                     obj_list = [cache]
                     # broadcast the ProxyList to all the ranks, then share the same cache content at runtime

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -825,11 +825,12 @@ class CacheDataset(Dataset):
 
         def _compute_cache(indices=None):
             if self.runtime_cache:
-                cache = Manager().list([None for _ in range(self.cache_num)])
                 if self._is_dist:
                     # ensure each process has the same authkey, otherwise broadcast_object_list fails
                     mp.current_process().authkey = np.arange(32, dtype=np.uint8).tobytes()
 
+                cache = Manager().list([None for _ in range(self.cache_num)])
+                if self._is_dist:
                     obj_list = [cache]
                     # broadcast the ProxyList to all the ranks, then share the same cache content at runtime
                     dist.broadcast_object_list(obj_list, src=0)


### PR DESCRIPTION
Fixes # https://github.com/Project-MONAI/MONAI/issues/5613

This ensures that each process has the same authkey (same as processes 0) during torchrun multi-gpu, to be able to call broadcast_object_list for shared memory.
Here we broadcast the key from the 0 process  too all other processes.  


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
