### PR TITLE
CacheDataset preserve cache_num 

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -838,16 +838,15 @@ class CacheDataset(Dataset):
 
         if self.runtime_cache in (False, None):  # prepare cache content immediately
             self._cache = self._fill_cache(indices)
-            return
-        if isinstance(self.runtime_cache, str) and "process" in self.runtime_cache:
+        elif isinstance(self.runtime_cache, str) and "process" in self.runtime_cache:
             # this must be in the main process, not in dataloader's workers
             self._cache = Manager().list([None] * self.cache_num)
-            return
-        if (self.runtime_cache is True) or (isinstance(self.runtime_cache, str) and "thread" in self.runtime_cache):
+        elif (self.runtime_cache is True) or (isinstance(self.runtime_cache, str) and "thread" in self.runtime_cache):
             self._cache = [None] * self.cache_num
-            return
-        self._cache = self.runtime_cache  # type: ignore
-        return
+        else:
+            self._cache = self.runtime_cache  # type: ignore
+            if len(self._cache) == 0:
+                self._cache[:] = [None] * self.cache_num
 
     def _fill_cache(self, indices=None) -> List:
         """

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -845,7 +845,7 @@ class CacheDataset(Dataset):
             self._cache = [None] * self.cache_num
         else:
             self._cache = self.runtime_cache  # type: ignore
-            if len(self._cache) == 0:
+            if isinstance(self._cache, (list, ListProxy)) and len(self._cache) == 0:
                 self._cache[:] = [None] * self.cache_num
 
     def _fill_cache(self, indices=None) -> List:


### PR DESCRIPTION
to partially address: https://github.com/Project-MONAI/MONAI/issues/5633

Since CacheDataset accepts a ListProxy object directly now as runtime_cache option
https://github.com/Project-MONAI/MONAI/pull/5630

we need to make sure it's length is "cache_num", (an this length is not always known to a user beforehand), this way a user can provide an empty cache, which will be set to a correct length

```
shared_cache= Manager().list()
CacheDataset(runtime_cache=shared_cache)
```



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
