### PR TITLE
Fix missing type annotations

### DIFF
--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -221,7 +221,7 @@ class AlgoEnsembleBestByFold(AlgoEnsemble):
         super().__init__()
         self.n_fold = n_fold
 
-    def collect_algos(self):
+    def collect_algos(self) -> None:
         """
         Rank the algos by finding the best model in each cross-validation fold
         """

--- a/monai/apps/auto3dseg/hpo_gen.py
+++ b/monai/apps/auto3dseg/hpo_gen.py
@@ -12,6 +12,7 @@
 import os
 from abc import abstractmethod
 from copy import deepcopy
+from typing import Optional
 from warnings import warn
 
 from monai.apps.auto3dseg.bundle_gen import BundleAlgo
@@ -96,7 +97,7 @@ class NNIGen(HPOGen):
         NNI command manually.
     """
 
-    def __init__(self, algo=None, params=None):
+    def __init__(self, algo: Optional[Algo] = None, params=None):
         self.algo: Algo
         self.hint = ""
         self.obj_filename = ""
@@ -115,7 +116,7 @@ class NNIGen(HPOGen):
             else:
                 self.algo = algo
 
-            if isinstance(algo, BundleAlgo):
+            if isinstance(self.algo, BundleAlgo):
                 self.obj_filename = algo_to_pickle(self.algo, template_path=self.algo.template_path)
                 self.print_bundle_algo_instruction()
             else:
@@ -271,7 +272,7 @@ class OptunaGen(HPOGen):
 
     """
 
-    def __init__(self, algo=None, params=None):
+    def __init__(self, algo: Optional[Algo] = None, params=None) -> None:
         self.algo: Algo
         self.obj_filename = ""
 
@@ -289,7 +290,7 @@ class OptunaGen(HPOGen):
             else:
                 self.algo = algo
 
-            if isinstance(algo, BundleAlgo):
+            if isinstance(self.algo, BundleAlgo):
                 self.obj_filename = algo_to_pickle(self.algo, template_path=self.algo.template_path)
             else:
                 self.obj_filename = algo_to_pickle(self.algo)

--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -870,7 +870,7 @@ class RestoreLabeld(MapTransform):
 
             if np.any(np.not_equal(current_size, spatial_size)):
                 resizer = Resize(spatial_size=spatial_size, mode=mode)
-                result = resizer(result, mode=mode, align_corners=align_corners) # type: ignore
+                result = resizer(result, mode=mode, align_corners=align_corners)  # type: ignore
 
             # Undo Slicing
             slice_idx = meta_dict.get("slice_idx")

--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -852,7 +852,7 @@ class RestoreLabeld(MapTransform):
 
             # Undo Crop
             original_shape = meta_dict[self.original_shape_key]
-            result = torch.zeros(original_shape, dtype=torch.float32)
+            result = np.zeros(original_shape, dtype=np.float32)
             box_start = meta_dict[self.start_coord_key]
             box_end = meta_dict[self.end_coord_key]
 
@@ -870,7 +870,7 @@ class RestoreLabeld(MapTransform):
 
             if np.any(np.not_equal(current_size, spatial_size)):
                 resizer = Resize(spatial_size=spatial_size, mode=mode)
-                result = resizer(result, mode=mode, align_corners=align_corners)
+                result = resizer(result, mode=mode, align_corners=align_corners) # type: ignore
 
             # Undo Slicing
             slice_idx = meta_dict.get("slice_idx")

--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-from typing import Any, Callable, Dict, Hashable, List, Optional, Sequence, Union
+from typing import Callable, Dict, Hashable, Optional, Sequence, Union
 
 import numpy as np
 import torch

--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -9,12 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-from typing import Callable, Dict, Hashable, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Hashable, List, Optional, Sequence, Union
 
 import numpy as np
 import torch
 
-from monai.config import IndexSelection, KeysCollection
+from monai.config import IndexSelection, KeysCollection, NdarrayOrTensor
 from monai.networks.layers import GaussianFilter
 from monai.transforms import Resize, SpatialCrop
 from monai.transforms.transform import MapTransform, Randomizable, Transform
@@ -50,7 +50,7 @@ class FindAllValidSlicesd(Transform):
                 sids.append(sid)
         return np.asarray(sids)
 
-    def __call__(self, data):
+    def __call__(self, data) -> Dict:
         d: Dict = dict(data)
         label = d[self.label].numpy() if isinstance(data[self.label], torch.Tensor) else data[self.label]
         if label.shape[0] != 1:
@@ -654,7 +654,7 @@ class SpatialCropGuidanced(MapTransform):
             box_start[di], box_end[di] = min_d, max_d
         return box_start, box_end
 
-    def __call__(self, data):
+    def __call__(self, data) -> Dict:
         d: Dict = dict(data)
         first_key: Hashable = self.first_key(d)
         if first_key == ():
@@ -741,7 +741,7 @@ class ResizeGuidanced(Transform):
         self.meta_key_postfix = meta_key_postfix
         self.cropped_shape_key = cropped_shape_key
 
-    def __call__(self, data):
+    def __call__(self, data) -> Dict:
         d = dict(data)
         guidance = d[self.guidance]
         meta_dict: Dict = d[self.meta_keys or f"{self.ref_image}_{self.meta_key_postfix}"]
@@ -836,7 +836,7 @@ class RestoreLabeld(MapTransform):
         self.original_shape_key = original_shape_key
         self.cropped_shape_key = cropped_shape_key
 
-    def __call__(self, data):
+    def __call__(self, data) -> Dict:
         d = dict(data)
         meta_dict: Dict = d[f"{self.ref_image}_{self.meta_key_postfix}"]
 
@@ -852,13 +852,14 @@ class RestoreLabeld(MapTransform):
 
             # Undo Crop
             original_shape = meta_dict[self.original_shape_key]
-            result = np.zeros(original_shape, dtype=np.float32)
+            result = torch.zeros(original_shape, dtype=torch.float32)
             box_start = meta_dict[self.start_coord_key]
             box_end = meta_dict[self.end_coord_key]
 
             spatial_dims = min(len(box_start), len(image.shape[1:]))
-            slices = [slice(None)] + [slice(s, e) for s, e in zip(box_start[:spatial_dims], box_end[:spatial_dims])]
-            slices = tuple(slices)
+            slices = tuple(
+                [slice(None)] + [slice(s, e) for s, e in zip(box_start[:spatial_dims], box_end[:spatial_dims])]
+            )
             result[slices] = image
 
             # Undo Spacing
@@ -873,6 +874,7 @@ class RestoreLabeld(MapTransform):
 
             # Undo Slicing
             slice_idx = meta_dict.get("slice_idx")
+            final_result: NdarrayOrTensor
             if slice_idx is None or self.slice_only:
                 final_result = result if len(result.shape) <= 3 else result[0]
             else:

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -1075,7 +1075,7 @@ class SmartCacheDataset(Randomizable, CacheDataset):
         except TypeError as e:
             warnings.warn(f"input data can't be shuffled in SmartCacheDataset with numpy.random.shuffle(): {e}.")
 
-    def _compute_data_idx(self):
+    def _compute_data_idx(self) -> None:
         """
         Update the replacement data position in the total data.
 
@@ -1209,7 +1209,7 @@ class SmartCacheDataset(Randomizable, CacheDataset):
                 self._compute_replacements()
             return False, self._round
 
-    def manage_replacement(self):
+    def manage_replacement(self) -> None:
         """
         Background thread for replacement.
 

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -277,7 +277,7 @@ class ITKReader(ImageReader):
                 img_.append(itk.imread(name, **kwargs_))
         return img_ if len(filenames) > 1 else img_[0]
 
-    def get_data(self, img):
+    def get_data(self, img) -> Tuple[np.ndarray, Dict]:
         """
         Extract data array and metadata from loaded image and return them.
         This function returns two objects, first is numpy array of image data, second is dict of metadata.
@@ -564,7 +564,7 @@ class PydicomReader(ImageReader):
 
         return stack_array, stack_metadata
 
-    def get_data(self, data):
+    def get_data(self, data) -> Tuple[np.ndarray, Dict]:
         """
         Extract data array and metadata from loaded image and return them.
         This function returns two objects, first is numpy array of image data, second is dict of metadata.
@@ -929,7 +929,7 @@ class NibabelReader(ImageReader):
             img_.append(img)
         return img_ if len(filenames) > 1 else img_[0]
 
-    def get_data(self, img):
+    def get_data(self, img) -> Tuple[np.ndarray, Dict]:
         """
         Extract data array and metadata from loaded image and return them.
         This function returns two objects, first is numpy array of image data, second is dict of metadata.
@@ -1095,7 +1095,7 @@ class NumpyReader(ImageReader):
 
         return img_ if len(img_) > 1 else img_[0]
 
-    def get_data(self, img):
+    def get_data(self, img) -> Tuple[np.ndarray, Dict]:
         """
         Extract data array and metadata from loaded image and return them.
         This function returns two objects, first is numpy array of image data, second is dict of metadata.
@@ -1113,7 +1113,7 @@ class NumpyReader(ImageReader):
             img = (img,)
 
         for i in ensure_tuple(img):
-            header = {}
+            header: Dict[MetaKeys, Any] = {}
             if isinstance(i, np.ndarray):
                 # if `channel_dim` is None, can not detect the channel dim, use all the dims as spatial_shape
                 spatial_shape = np.asarray(i.shape)
@@ -1184,7 +1184,7 @@ class PILReader(ImageReader):
 
         return img_ if len(filenames) > 1 else img_[0]
 
-    def get_data(self, img):
+    def get_data(self, img) -> Tuple[np.ndarray, Dict]:
         """
         Extract data array and metadata from loaded image and return them.
         This function returns two objects, first is numpy array of image data, second is dict of metadata.

--- a/monai/data/meta_obj.py
+++ b/monai/data/meta_obj.py
@@ -79,7 +79,7 @@ class MetaObj:
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._meta: dict = MetaObj.get_default_meta()
         self._applied_operations: list = MetaObj.get_default_applied_operations()
         self._pending_operations: list = MetaObj.get_default_applied_operations()  # the same default as applied_ops

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -354,7 +354,7 @@ class MetaTensor(MetaObj, torch.Tensor):
         """
         return convert_data_type(self, output_type=output_type, dtype=dtype, device=device, wrap_sequence=True)[0]
 
-    def set_array(self, src, non_blocking=False, *_args, **_kwargs):
+    def set_array(self, src, non_blocking: bool = False, *_args, **_kwargs):
         """
         Copies the elements from src into self tensor and returns self.
         The src tensor must be broadcastable with the self tensor.
@@ -369,11 +369,11 @@ class MetaTensor(MetaObj, torch.Tensor):
             _args: currently unused parameters.
             _kwargs:  currently unused parameters.
         """
-        src: torch.Tensor = convert_to_tensor(src, track_meta=False, wrap_sequence=True)
+        converted: torch.Tensor = convert_to_tensor(src, track_meta=False, wrap_sequence=True)
         try:
-            return self.copy_(src, non_blocking=non_blocking)
+            return self.copy_(converted, non_blocking=non_blocking)
         except RuntimeError:  # skip the shape checking
-            self.data = src
+            self.data = converted
             return self
 
     @property

--- a/monai/metrics/metric.py
+++ b/monai/metrics/metric.py
@@ -166,7 +166,7 @@ class Cumulative:
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize the internal buffers.
         `self._buffers` are local buffers, they are not usually used directly.

--- a/monai/networks/blocks/warp.py
+++ b/monai/networks/blocks/warp.py
@@ -151,7 +151,7 @@ class DVF2DDF(nn.Module):
         self.num_steps = num_steps
         self.warp_layer = Warp(mode=mode, padding_mode=padding_mode)
 
-    def forward(self, dvf):
+    def forward(self, dvf: torch.Tensor) -> torch.Tensor:
         """
         Args:
             dvf: dvf to be transformed, in shape (batch, ``spatial_dims``, H, W[,D])

--- a/monai/networks/nets/ahnet.py
+++ b/monai/networks/nets/ahnet.py
@@ -270,7 +270,7 @@ class PSP(nn.Module):
                 pad_size = (2 ** (i + 3), 2 ** (i + 3), 0)[-spatial_dims:]
                 self.up_modules.append(conv_trans_type(1, 1, kernel_size=size, stride=size, padding=pad_size))
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         outputs = []
         if self.upsample_mode == "transpose":
             for (project_module, pool_module, up_module) in zip(

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -1577,7 +1577,7 @@ class RandCoarseDropoutd(RandomizableTransform, MapTransform):
         self.dropper.set_random_state(seed, state)
         return self
 
-    def __call__(self, data):
+    def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
         d = dict(data)
         self.randomize(None)
         if not self._do_transform:
@@ -1650,7 +1650,7 @@ class RandCoarseShuffled(RandomizableTransform, MapTransform):
         self.shuffle.set_random_state(seed, state)
         return self
 
-    def __call__(self, data):
+    def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
         d = dict(data)
         self.randomize(None)
         if not self._do_transform:

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -71,7 +71,7 @@ class LoadImaged(MapTransform):
     def __init__(
         self,
         keys: KeysCollection,
-        reader: Optional[Union[ImageReader, str]] = None,
+        reader: Union[Type[ImageReader], str, None] = None,
         dtype: DtypeLike = np.float32,
         meta_keys: Optional[KeysCollection] = None,
         meta_key_postfix: str = DEFAULT_POST_FIX,

--- a/setup.cfg
+++ b/setup.cfg
@@ -157,8 +157,8 @@ ignore_missing_imports = True
 no_implicit_optional = True
 # Warns about casting an expression to its inferred type.
 warn_redundant_casts = True
-# No error on unneeded # type: ignore comments.
-warn_unused_ignores = False
+# Warns about unneeded # type: ignore comments.
+warn_unused_ignores = True
 # Shows a warning when returning a value with type Any from a function declared with a non-Any return type.
 warn_return_any = True
 # Prohibit equality checks, identity checks, and container checks between non-overlapping types.
@@ -169,6 +169,12 @@ show_column_numbers = True
 show_error_codes = True
 # Use visually nicer output in error messages: use soft word wrap, show source code snippets, and show error location markers.
 pretty = False
+# Warns about per-module sections in the config file that do not match any files processed when invoking mypy.
+warn_unused_configs = True
+# Make arguments prepended via Concatenate be truly positional-only.
+strict_concatenate = True
+
+exclude = venv/
 
 [mypy-versioneer]
 # Ignores all non-fatal errors.

--- a/tests/test_flexible_unet.py
+++ b/tests/test_flexible_unet.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import unittest
-from typing import Union
+from typing import Dict, List, Type, Union
 
 import torch
 from parameterized import parameterized
@@ -88,14 +88,14 @@ class ResNetEncoder(ResNet, BaseEncoder):
         return [64, 128, 256, 512]
 
     @classmethod
-    def get_encoder_parameters(cls):
+    def get_encoder_parameters(cls) -> List[Dict]:
         """
         Get parameter list to initialize encoder networks.
         Each parameter dict must have `spatial_dims`, `in_channels`
         and `pretrained` parameters.
         """
         parameter_list = []
-        res_type: Union[ResNetBlock, ResNetBottleneck]
+        res_type: Union[Type[ResNetBlock], Type[ResNetBottleneck]]
         for backbone in range(len(cls.backbone_names)):
             if backbone < 3:
                 res_type = ResNetBlock

--- a/tests/test_inverse_array.py
+++ b/tests/test_inverse_array.py
@@ -38,7 +38,7 @@ class TestInverseArray(unittest.TestCase):
         return MetaTensor(img, affine=affine)
 
     @parameterized.expand(TESTS)
-    def test_inverse_array(self, use_compose, dtype, device):
+    def test_inverse_array(self, use_compose: bool, dtype: torch.dtype, device: torch.device):
         img: MetaTensor
         tr = Compose([AddChannel(), Orientation("RAS"), Flip(1), Spacing([1.0, 1.2, 0.9], align_corners=False)])
         num_invertible = len([i for i in tr.transforms if isinstance(i, InvertibleTransform)])

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import unittest
+from typing import Dict, List
 
 import numpy as np
 import torch
@@ -22,7 +23,7 @@ from monai.transforms import Spacing
 from monai.utils import fall_back_tuple
 from tests.utils import TEST_DEVICES, TEST_NDARRAYS_ALL, assert_allclose, skip_if_quick
 
-TESTS = []
+TESTS: List[List] = []
 for device in TEST_DEVICES:
     TESTS.append(
         [
@@ -264,7 +265,15 @@ for d in TEST_DEVICES:
 @skip_if_quick
 class TestSpacingCase(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_spacing(self, init_param, img, affine, data_param, expected_output, device):
+    def test_spacing(
+        self,
+        init_param: Dict,
+        img: torch.Tensor,
+        affine: torch.Tensor,
+        data_param: Dict,
+        expected_output: torch.Tensor,
+        device: torch.device,
+    ):
         img = MetaTensor(img, affine=affine).to(device)
         res: MetaTensor = Spacing(**init_param)(img, **data_param)
         self.assertEqual(img.device, res.device)
@@ -275,7 +284,7 @@ class TestSpacingCase(unittest.TestCase):
             init_param["pixdim"] = [init_param["pixdim"]] * sr
         init_pixdim = init_param["pixdim"][:sr]
         norm = affine_to_spacing(res.affine, sr).cpu().numpy()
-        assert_allclose(fall_back_tuple(init_pixdim, norm), norm, type_test=False)
+        assert_allclose(fall_back_tuple(init_pixdim, norm), norm, type_test=False)  # type: ignore
 
     @parameterized.expand(TESTS_TORCH)
     def test_spacing_torch(self, pixdim, img, track_meta: bool):

--- a/tests/test_splitdimd.py
+++ b/tests/test_splitdimd.py
@@ -30,14 +30,16 @@ for p in TEST_NDARRAYS:
 
 
 class TestSplitDimd(unittest.TestCase):
+    data: MetaTensor
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         arr = np.random.rand(2, 10, 8, 7)
         affine = make_rand_affine()
         data = {"i": make_nifti_image(arr, affine)}
 
         loader = LoadImaged("i")
-        cls.data: MetaTensor = loader(data)
+        cls.data = loader(data)
 
     @parameterized.expand(TESTS)
     def test_correct(self, keepdim, im_type, update_meta, list_output):

--- a/tests/test_wsireader.py
+++ b/tests/test_wsireader.py
@@ -11,12 +11,14 @@
 
 import os
 import unittest
+from typing import Any, Tuple
 from unittest import skipUnless
 
 import numpy as np
 from numpy.testing import assert_array_equal
 from parameterized import parameterized
 
+from monai.config import PathLike
 from monai.data import DataLoader, Dataset
 from monai.data.image_reader import WSIReader as WSIReaderDeprecated
 from monai.data.wsi_reader import WSIReader
@@ -252,7 +254,9 @@ class WSIReaderDeprecatedTests:
                     reader.get_data(img_obj)
 
         @parameterized.expand([TEST_CASE_TRANSFORM_0])
-        def test_with_dataloader(self, file_path, level, expected_spatial_shape, expected_shape):
+        def test_with_dataloader(
+            self, file_path: PathLike, level: int, expected_spatial_shape: Any, expected_shape: Tuple[int, ...]
+        ):
             train_transform = Compose(
                 [
                     LoadImaged(keys=["image"], reader=WSIReaderDeprecated, backend=self.backend, level=level),
@@ -357,7 +361,9 @@ class WSIReaderTests:
                     reader.get_data(img_obj)
 
         @parameterized.expand([TEST_CASE_TRANSFORM_0])
-        def test_with_dataloader(self, file_path, level, expected_spatial_shape, expected_shape):
+        def test_with_dataloader(
+            self, file_path: PathLike, level: int, expected_spatial_shape: Any, expected_shape: Tuple[int, ...]
+        ):
             train_transform = Compose(
                 [
                     LoadImaged(keys=["image"], reader=WSIReader, backend=self.backend, level=level),
@@ -372,7 +378,9 @@ class WSIReaderTests:
             self.assertTupleEqual(data["image"].shape, expected_shape)
 
         @parameterized.expand([TEST_CASE_TRANSFORM_0])
-        def test_with_dataloader_batch(self, file_path, level, expected_spatial_shape, expected_shape):
+        def test_with_dataloader_batch(
+            self, file_path: PathLike, level: int, expected_spatial_shape: Any, expected_shape: Tuple[int, ...]
+        ):
             train_transform = Compose(
                 [
                     LoadImaged(keys=["image"], reader=WSIReader, backend=self.backend, level=level),


### PR DESCRIPTION
Fixes #5605.

### Description

Fix missing type annotations so `./runtests.sh --mypy` now finds 0 warnings.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
