### PR TITLE
Fixing std type issue for RandRicianNoise when the argument relative is True (#5674)

### DIFF
--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -207,7 +207,7 @@ class RandRicianNoise(RandomizableTransform):
                 raise RuntimeError("If channel_wise is False, mean must be a float or int number.")
             if not isinstance(self.std, (int, float)):
                 raise RuntimeError("If channel_wise is False, std must be a float or int number.")
-            std = self.std * img.std() if self.relative else self.std
+            std = self.std * img.std().item() if self.relative else self.std
             if not isinstance(std, (int, float)):
                 raise RuntimeError("std must be a float or int number.")
             img = self._add_noise(img, mean=self.mean, std=std)


### PR DESCRIPTION
Using .item() to get the value in the tensor that is returned by .std(). This should fix the issue where the type of the std calculation is not an int or float.

Signed-off-by: Nishant Panchal <68797723+Nishantppanchal@users.noreply.github.com>

Fixes #5674 .

### Description

When we use .std() on a tensor, a tensor with the standard deviation inside is returned. To get this standard deviation, we also have to use .item(). However, this was not done, so I fixed it.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
