### PR TITLE
Change type of qto_xyz to ndarray

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -319,12 +319,14 @@ class ITKReader(ImageReader):
 
         """
         img_meta_dict = img.GetMetaDataDictionary()
-        meta_dict = {}
-        for key in img_meta_dict.GetKeys():
-            if key.startswith("ITK_"):
-                continue
-            val = img_meta_dict[key]
-            meta_dict[key] = np.asarray(val) if type(val).__name__.startswith("itk") else val
+        meta_dict = {
+            key: img_meta_dict[key]
+            for key in img_meta_dict.GetKeys()
+            if not key.startswith("ITK_")
+        }
+
+        if "qto_xyz" in meta_dict and not isinstance(meta_dict["qto_xyz"], np.ndarray):
+            meta_dict["qto_xyz"] = np.array(meta_dict["qto_xyz"])
 
         meta_dict["spacing"] = np.asarray(img.GetSpacing())
         return meta_dict

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -319,11 +319,7 @@ class ITKReader(ImageReader):
 
         """
         img_meta_dict = img.GetMetaDataDictionary()
-        meta_dict = {
-            key: img_meta_dict[key]
-            for key in img_meta_dict.GetKeys()
-            if not key.startswith("ITK_")
-        }
+        meta_dict = {key: img_meta_dict[key] for key in img_meta_dict.GetKeys() if not key.startswith("ITK_")}
 
         if "qto_xyz" in meta_dict and not isinstance(meta_dict["qto_xyz"], np.ndarray):
             meta_dict["qto_xyz"] = np.array(meta_dict["qto_xyz"])


### PR DESCRIPTION
Fix model inference error due to unknown type of parameter qto_xyz with Dicom files

### Description
In the OHIF labeler, when model inference is started, Dicom files raise an error due to the unknown type of qto_xyz. This PR fixes this by converting the type of qto_xyz to numpy ndarray.  

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
