### PR TITLE
3D bug in EfficientNet Squeeze and Excitation layer

### DIFF
--- a/monai/networks/nets/efficientnet.py
+++ b/monai/networks/nets/efficientnet.py
@@ -161,9 +161,9 @@ class MBConvBlock(nn.Module):
             self._se_adaptpool = adaptivepool_type(1)
             num_squeezed_channels = max(1, int(in_channels * self.se_ratio))
             self._se_reduce = conv_type(in_channels=oup, out_channels=num_squeezed_channels, kernel_size=1)
-            self._se_reduce_padding = _make_same_padder(self._se_reduce, [1, 1])
+            self._se_reduce_padding = _make_same_padder(self._se_reduce, [1, 1, 1])
             self._se_expand = conv_type(in_channels=num_squeezed_channels, out_channels=oup, kernel_size=1)
-            self._se_expand_padding = _make_same_padder(self._se_expand, [1, 1])
+            self._se_expand_padding = _make_same_padder(self._se_expand, [1, 1, 1])
 
         # Pointwise convolution phase
         final_oup = out_channels


### PR DESCRIPTION
Fixes #5574.

### Description

I believe the image_size = [1, 1] in _make_same_padder() should actually be [1, 1, 1] for the EfficientNet to support 3D. This is just by inspection, but I suspect this oversight came from extending 2D code.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
