### PR TITLE
Add ValueError in `GenerateSuccinctContour`

### DIFF
--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -459,7 +459,7 @@ class GenerateSuccinctContour(Transform):
                         corner = 2
                         pixel = (int(coord[0] - 0.5), int(coord[1]))
                     else:
-                        raise ValueError("Invalid coutour generated, may contain boundaries or small holes")
+                        raise ValueError("Invalid coutour is generated, may contain boundaries or small holes")
                     sequence.append(pixel)
                     last_added = pixel
                 elif i == len(group) - 1:

--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -458,6 +458,8 @@ class GenerateSuccinctContour(Transform):
                     elif coord[1] == self.width - 1:
                         corner = 2
                         pixel = (int(coord[0] - 0.5), int(coord[1]))
+                    else:
+                        raise ValueError("Invalid coutour generated, may contain boundaries or small holes")
                     sequence.append(pixel)
                     last_added = pixel
                 elif i == len(group) - 1:


### PR DESCRIPTION
Signed-off-by: KumoLiu <yunl@nvidia.com>

Fixes #5714.

### Description
Add ValueError when an invalid contour is generated.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
