### PR TITLE
Fix typos: argments and theashold

### DIFF
--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -142,7 +142,7 @@ class AsDiscrete(Transform):
             Defaults to ``False``.
         to_onehot: if not None, convert input data into the one-hot format with specified number of classes.
             Defaults to ``None``.
-        threshold: if not None, threshold the float values to int number 0 or 1 with specified theashold.
+        threshold: if not None, threshold the float values to int number 0 or 1 with specified threshold.
             Defaults to ``None``.
         rounding: if not None, round the data according to the specified option,
             available options: ["torchrounding"].

--- a/tests/test_crop_foreground.py
+++ b/tests/test_crop_foreground.py
@@ -88,8 +88,8 @@ for p in TEST_NDARRAYS_ALL:
 
 class TestCropForeground(unittest.TestCase):
     @parameterized.expand(TEST_COORDS + TESTS)
-    def test_value(self, argments, image, expected_data):
-        cropper = CropForeground(**argments)
+    def test_value(self, arguments, image, expected_data):
+        cropper = CropForeground(**arguments)
         result = cropper(image)
         assert_allclose(result, expected_data, type_test=False)
         self.assertIsInstance(result, MetaTensor)
@@ -100,10 +100,10 @@ class TestCropForeground(unittest.TestCase):
         self.assertTupleEqual(inv.shape, image.shape)
 
     @parameterized.expand(TEST_COORDS)
-    def test_return_coords(self, argments, image, _):
-        argments["return_coords"] = True
-        _, start_coord, end_coord = CropForeground(**argments)(image)
-        argments["return_coords"] = False
+    def test_return_coords(self, arguments, image, _):
+        arguments["return_coords"] = True
+        _, start_coord, end_coord = CropForeground(**arguments)(image)
+        arguments["return_coords"] = False
         np.testing.assert_allclose(start_coord, np.asarray([1, 1]))
         np.testing.assert_allclose(end_coord, np.asarray([4, 4]))
 

--- a/tests/test_crop_foregroundd.py
+++ b/tests/test_crop_foregroundd.py
@@ -149,8 +149,8 @@ for p in TEST_NDARRAYS_ALL:
 
 class TestCropForegroundd(unittest.TestCase):
     @parameterized.expand(TEST_POSITION + TESTS)
-    def test_value(self, argments, input_data, expected_data):
-        cropper = CropForegroundd(**argments)
+    def test_value(self, arguments, input_data, expected_data):
+        cropper = CropForegroundd(**arguments)
         result = cropper(input_data)
         assert_allclose(result["img"], expected_data, type_test="tensor")
         if "label" in input_data and "img" in input_data:
@@ -161,14 +161,14 @@ class TestCropForegroundd(unittest.TestCase):
             self.assertTupleEqual(inv["label"].shape, input_data["label"].shape)
 
     @parameterized.expand(TEST_POSITION)
-    def test_foreground_position(self, argments, input_data, _):
-        result = CropForegroundd(**argments)(input_data)
+    def test_foreground_position(self, arguments, input_data, _):
+        result = CropForegroundd(**arguments)(input_data)
         np.testing.assert_allclose(result["foreground_start_coord"], np.array([1, 1]))
         np.testing.assert_allclose(result["foreground_end_coord"], np.array([4, 4]))
 
-        argments["start_coord_key"] = "test_start_coord"
-        argments["end_coord_key"] = "test_end_coord"
-        result = CropForegroundd(**argments)(input_data)
+        arguments["start_coord_key"] = "test_start_coord"
+        arguments["end_coord_key"] = "test_end_coord"
+        result = CropForegroundd(**arguments)(input_data)
         np.testing.assert_allclose(result["test_start_coord"], np.array([1, 1]))
         np.testing.assert_allclose(result["test_end_coord"], np.array([4, 4]))
 

--- a/tests/test_gaussian_sharpen.py
+++ b/tests/test_gaussian_sharpen.py
@@ -81,8 +81,8 @@ for p in TEST_NDARRAYS:
 
 class TestGaussianSharpen(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        result = GaussianSharpen(**argments)(image)
+    def test_value(self, arguments, image, expected_data):
+        result = GaussianSharpen(**arguments)(image)
         assert_allclose(result, expected_data, atol=0, rtol=1e-4, type_test="tensor")
 
 

--- a/tests/test_gaussian_sharpend.py
+++ b/tests/test_gaussian_sharpend.py
@@ -81,8 +81,8 @@ for p in TEST_NDARRAYS:
 
 class TestGaussianSharpend(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        result = GaussianSharpend(**argments)(image)
+    def test_value(self, arguments, image, expected_data):
+        result = GaussianSharpend(**arguments)(image)
         assert_allclose(result["img"], expected_data, rtol=1e-4, type_test="tensor")
 
 

--- a/tests/test_gaussian_smooth.py
+++ b/tests/test_gaussian_smooth.py
@@ -85,8 +85,8 @@ for p in TEST_NDARRAYS:
 
 class TestGaussianSmooth(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        result = GaussianSmooth(**argments)(image)
+    def test_value(self, arguments, image, expected_data):
+        result = GaussianSmooth(**arguments)(image)
         assert_allclose(result, expected_data, atol=1e-4, rtol=1e-4, type_test="tensor")
 
 

--- a/tests/test_gaussian_smoothd.py
+++ b/tests/test_gaussian_smoothd.py
@@ -85,8 +85,8 @@ for p in TEST_NDARRAYS:
 
 class TestGaussianSmoothd(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        result = GaussianSmoothd(**argments)(image)
+    def test_value(self, arguments, image, expected_data):
+        result = GaussianSmoothd(**arguments)(image)
         assert_allclose(result["img"], expected_data, rtol=1e-4, type_test="tensor")
 
 

--- a/tests/test_generate_distance_map.py
+++ b/tests/test_generate_distance_map.py
@@ -35,13 +35,13 @@ for p in TEST_NDARRAYS:
 
 class TestGenerateDistanceMap(unittest.TestCase):
     @parameterized.expand(EXCEPTION_TESTS)
-    def test_value(self, argments, mask, probmap, exception_type):
+    def test_value(self, arguments, mask, probmap, exception_type):
         with self.assertRaises(exception_type):
-            GenerateDistanceMap(**argments)(mask, probmap)
+            GenerateDistanceMap(**arguments)(mask, probmap)
 
     @parameterized.expand(TESTS)
-    def test_value2(self, argments, mask, probmap, expected_shape):
-        result = GenerateDistanceMap(**argments)(mask, probmap)
+    def test_value2(self, arguments, mask, probmap, expected_shape):
+        result = GenerateDistanceMap(**arguments)(mask, probmap)
         self.assertEqual(result.shape, expected_shape)
 
 

--- a/tests/test_generate_distance_mapd.py
+++ b/tests/test_generate_distance_mapd.py
@@ -54,13 +54,13 @@ for p in TEST_NDARRAYS:
 
 class TestGenerateDistanceMapd(unittest.TestCase):
     @parameterized.expand(EXCEPTION_TESTS)
-    def test_value(self, argments, mask, border_map, exception_type):
+    def test_value(self, arguments, mask, border_map, exception_type):
         with self.assertRaises(exception_type):
-            GenerateDistanceMapd(**argments)({"mask": mask, "border": border_map})
+            GenerateDistanceMapd(**arguments)({"mask": mask, "border": border_map})
 
     @parameterized.expand(TESTS)
-    def test_value2(self, argments, mask, border_map, expected_shape):
-        result = GenerateDistanceMapd(**argments)({"mask": mask, "border": border_map})
+    def test_value2(self, arguments, mask, border_map, expected_shape):
+        result = GenerateDistanceMapd(**arguments)({"mask": mask, "border": border_map})
         self.assertEqual(result["dist_map"].shape, expected_shape)
 
 

--- a/tests/test_generate_instance_borderd.py
+++ b/tests/test_generate_instance_borderd.py
@@ -43,13 +43,13 @@ for p in TEST_NDARRAYS:
 
 class TestGenerateInstanceBorderd(unittest.TestCase):
     @parameterized.expand(EXCEPTION_TESTS)
-    def test_value(self, argments, mask, hover_map, exception_type):
+    def test_value(self, arguments, mask, hover_map, exception_type):
         with self.assertRaises(exception_type):
-            GenerateInstanceBorderd(**argments)({"mask": mask, "hover_map": hover_map})
+            GenerateInstanceBorderd(**arguments)({"mask": mask, "hover_map": hover_map})
 
     @parameterized.expand(TESTS)
-    def test_value2(self, argments, mask, hover_map, expected_shape):
-        result = GenerateInstanceBorderd(**argments)({"mask": mask, "hover_map": hover_map})
+    def test_value2(self, arguments, mask, hover_map, expected_shape):
+        result = GenerateInstanceBorderd(**arguments)({"mask": mask, "hover_map": hover_map})
         self.assertEqual(result["border"].shape, expected_shape)
 
 

--- a/tests/test_generate_watershed_maskd.py
+++ b/tests/test_generate_watershed_maskd.py
@@ -57,13 +57,13 @@ for p in TEST_NDARRAYS:
 @unittest.skipUnless(has_scipy, "Requires scipy library.")
 class TestGenerateWatershedMaskd(unittest.TestCase):
     @parameterized.expand(EXCEPTION_TESTS)
-    def test_value(self, argments, exception_type):
+    def test_value(self, arguments, exception_type):
         with self.assertRaises(exception_type):
-            GenerateWatershedMaskd(**argments)
+            GenerateWatershedMaskd(**arguments)
 
     @parameterized.expand(TESTS)
-    def test_value2(self, argments, image, expected_shape, expected_value):
-        result = GenerateWatershedMaskd(**argments)({"img": image})
+    def test_value2(self, arguments, image, expected_shape, expected_value):
+        result = GenerateWatershedMaskd(**arguments)({"img": image})
         self.assertEqual(result["mask"].shape, expected_shape)
 
         if isinstance(result["mask"], torch.Tensor):

--- a/tests/test_histogram_normalize.py
+++ b/tests/test_histogram_normalize.py
@@ -47,10 +47,10 @@ for p in TEST_NDARRAYS:
 
 class TestHistogramNormalize(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        result = HistogramNormalize(**argments)(image)
+    def test_value(self, arguments, image, expected_data):
+        result = HistogramNormalize(**arguments)(image)
         assert_allclose(result, expected_data, type_test="tensor")
-        self.assertEqual(get_equivalent_dtype(result.dtype, data_type=np.ndarray), argments.get("dtype", np.float32))
+        self.assertEqual(get_equivalent_dtype(result.dtype, data_type=np.ndarray), arguments.get("dtype", np.float32))
 
 
 if __name__ == "__main__":

--- a/tests/test_histogram_normalized.py
+++ b/tests/test_histogram_normalized.py
@@ -47,10 +47,10 @@ for p in TEST_NDARRAYS:
 
 class TestHistogramNormalized(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        result = HistogramNormalized(**argments)(image)["img"]
+    def test_value(self, arguments, image, expected_data):
+        result = HistogramNormalized(**arguments)(image)["img"]
         assert_allclose(result, expected_data, type_test="tensor")
-        self.assertEqual(get_equivalent_dtype(result.dtype, data_type=np.ndarray), argments.get("dtype", np.float32))
+        self.assertEqual(get_equivalent_dtype(result.dtype, data_type=np.ndarray), arguments.get("dtype", np.float32))
 
 
 if __name__ == "__main__":

--- a/tests/test_label_to_mask.py
+++ b/tests/test_label_to_mask.py
@@ -58,8 +58,8 @@ for p in TEST_NDARRAYS:
 
 class TestLabelToMask(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        result = LabelToMask(**argments)(image)
+    def test_value(self, arguments, image, expected_data):
+        result = LabelToMask(**arguments)(image)
         assert_allclose(result, expected_data, type_test="tensor")
 
 

--- a/tests/test_label_to_maskd.py
+++ b/tests/test_label_to_maskd.py
@@ -58,8 +58,8 @@ for p in TEST_NDARRAYS:
 
 class TestLabelToMaskd(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, input_data, expected_data):
-        result = LabelToMaskd(**argments)(input_data)
+    def test_value(self, arguments, input_data, expected_data):
+        result = LabelToMaskd(**arguments)(input_data)
         r = result["img"]
         assert_allclose(r, expected_data, type_test="tensor")
 

--- a/tests/test_mask_intensity.py
+++ b/tests/test_mask_intensity.py
@@ -54,9 +54,9 @@ TEST_CASE_5 = [
 
 class TestMaskIntensity(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5])
-    def test_value(self, argments, image, expected_data):
+    def test_value(self, arguments, image, expected_data):
         for p in TEST_NDARRAYS:
-            result = MaskIntensity(**argments)(p(image))
+            result = MaskIntensity(**arguments)(p(image))
             assert_allclose(result, p(expected_data), type_test="tensor")
 
     def test_runtime_mask(self):

--- a/tests/test_mask_intensityd.py
+++ b/tests/test_mask_intensityd.py
@@ -56,8 +56,8 @@ TEST_CASE_5 = [
 
 class TestMaskIntensityd(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5])
-    def test_value(self, argments, image, expected_data):
-        result = MaskIntensityd(**argments)(image)
+    def test_value(self, arguments, image, expected_data):
+        result = MaskIntensityd(**arguments)(image)
         np.testing.assert_allclose(result["img"], expected_data)
 
 

--- a/tests/test_median_smooth.py
+++ b/tests/test_median_smooth.py
@@ -30,8 +30,8 @@ for p in TEST_NDARRAYS:
 
 class TestMedianSmooth(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        result = MedianSmooth(**argments)(image)
+    def test_value(self, arguments, image, expected_data):
+        result = MedianSmooth(**arguments)(image)
         assert_allclose(result, expected_data, atol=1e-4, rtol=1e-4, type_test="tensor")
 
 

--- a/tests/test_pathology_he_stain.py
+++ b/tests/test_pathology_he_stain.py
@@ -169,7 +169,7 @@ class TestNormalizeHEStains(unittest.TestCase):
             NORMALIZE_STAINS_TEST_CASE_4,
         ]
     )
-    def test_result_value(self, argments, image, expected_data):
+    def test_result_value(self, arguments, image, expected_data):
         """
         Test that an input image returns an expected normalized image.
 
@@ -218,7 +218,7 @@ class TestNormalizeHEStains(unittest.TestCase):
             with self.assertRaises(TypeError):
                 NormalizeHEStains()(image)
         else:
-            result = NormalizeHEStains(**argments)(image)
+            result = NormalizeHEStains(**arguments)(image)
             np.testing.assert_allclose(result, expected_data)
 
 

--- a/tests/test_pathology_he_stain_dict.py
+++ b/tests/test_pathology_he_stain_dict.py
@@ -163,7 +163,7 @@ class TestNormalizeHEStainsD(unittest.TestCase):
             NORMALIZE_STAINS_TEST_CASE_4,
         ]
     )
-    def test_result_value(self, argments, image, expected_data):
+    def test_result_value(self, arguments, image, expected_data):
         """
         Test that an input image returns an expected normalized image.
 
@@ -213,7 +213,7 @@ class TestNormalizeHEStainsD(unittest.TestCase):
             with self.assertRaises(TypeError):
                 NormalizeHEStainsD([key])({key: image})
         else:
-            result = NormalizeHEStainsD([key], **argments)({key: image})
+            result = NormalizeHEStainsD([key], **arguments)({key: image})
             np.testing.assert_allclose(result[key], expected_data)
 
 

--- a/tests/test_rand_gaussian_sharpen.py
+++ b/tests/test_rand_gaussian_sharpen.py
@@ -127,8 +127,8 @@ for p in TEST_NDARRAYS:
 
 class TestRandGaussianSharpen(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        converter = RandGaussianSharpen(**argments)
+    def test_value(self, arguments, image, expected_data):
+        converter = RandGaussianSharpen(**arguments)
         converter.set_random_state(seed=0)
         result = converter(image)
         assert_allclose(result, expected_data, atol=0, rtol=1e-4, type_test="tensor")

--- a/tests/test_rand_gaussian_sharpend.py
+++ b/tests/test_rand_gaussian_sharpend.py
@@ -130,8 +130,8 @@ for p in TEST_NDARRAYS:
 
 class TestRandGaussianSharpend(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        converter = RandGaussianSharpend(**argments)
+    def test_value(self, arguments, image, expected_data):
+        converter = RandGaussianSharpend(**arguments)
         converter.set_random_state(seed=0)
         result = converter(image)
         assert_allclose(result["img"], expected_data, rtol=1e-4, type_test=False)

--- a/tests/test_rand_gaussian_smooth.py
+++ b/tests/test_rand_gaussian_smooth.py
@@ -85,8 +85,8 @@ for p in TEST_NDARRAYS:
 
 class TestRandGaussianSmooth(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        converter = RandGaussianSmooth(**argments)
+    def test_value(self, arguments, image, expected_data):
+        converter = RandGaussianSmooth(**arguments)
         converter.set_random_state(seed=0)
         result = converter(image)
         assert_allclose(result, expected_data, rtol=1e-4, type_test="tensor")

--- a/tests/test_rand_gaussian_smoothd.py
+++ b/tests/test_rand_gaussian_smoothd.py
@@ -85,8 +85,8 @@ for p in TEST_NDARRAYS:
 
 class TestRandGaussianSmoothd(unittest.TestCase):
     @parameterized.expand(TESTS)
-    def test_value(self, argments, image, expected_data):
-        converter = RandGaussianSmoothd(**argments)
+    def test_value(self, arguments, image, expected_data):
+        converter = RandGaussianSmoothd(**arguments)
         converter.set_random_state(seed=0)
         result = converter(image)
         assert_allclose(result["img"], expected_data, rtol=1e-4, type_test=False)


### PR DESCRIPTION
### Description

Fix typos: 
- argments -> arguments
- theashold -> threshold

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
