### PR TITLE
5729 Add whatsnew 1.1 (surgical tool part)

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 .. toctree::
    :maxdepth: 1
 
+   whatsnew_1_1.md
    whatsnew_1_0.md
    whatsnew_0_9.md
    whatsnew_0_8.md

--- a/docs/source/whatsnew_1_1.md
+++ b/docs/source/whatsnew_1_1.md
@@ -4,6 +4,8 @@
 
 
 ## Solution of SurgToolLoc Challenge
+![SurgToolLoc](https://rumc-gcorg-p-public.s3.amazonaws.com/i/2022/05/03/problem.png)
+
 [SurgToolLoc](https://surgtoolloc.grand-challenge.org/Home/) is a part of [EndoVis](https://endovis.grand-challenge.org/) challenge at [MICCAI 2022](https://conferences.miccai.org/2022/en/) in Singapore. This challenge is divided into two categories:
 1. Surgical tool classification
 2. Surgical tool classification and localization

--- a/docs/source/whatsnew_1_1.md
+++ b/docs/source/whatsnew_1_1.md
@@ -1,0 +1,10 @@
+# What's new in 1.1 🎉🎉
+
+- Solution of SurgToolLoc Challenge
+
+
+## Solution of SurgToolLoc Challenge
+[SurgToolLoc](https://surgtoolloc.grand-challenge.org/Home/) is a part of [EndoVis](https://endovis.grand-challenge.org/) challenge at [MICCAI 2022](https://conferences.miccai.org/2022/en/) in Singapore. This challenge is divided into two categories:
+1. Surgical tool classification
+2. Surgical tool classification and localization
+Team NVIDIA won prizes by finishing [third](https://surgtoolloc.grand-challenge.org/results/) in both categories, and recreated interesting core components of the solutions in MONAI tutorials. For more details about how to reproduce the solution, please see [the tutorials](https://github.com/Project-MONAI/tutorials/tree/main/competitions/MICCAI/surgtoolloc).

--- a/docs/source/whatsnew_1_1.md
+++ b/docs/source/whatsnew_1_1.md
@@ -7,4 +7,5 @@
 [SurgToolLoc](https://surgtoolloc.grand-challenge.org/Home/) is a part of [EndoVis](https://endovis.grand-challenge.org/) challenge at [MICCAI 2022](https://conferences.miccai.org/2022/en/) in Singapore. This challenge is divided into two categories:
 1. Surgical tool classification
 2. Surgical tool classification and localization
+
 Team NVIDIA won prizes by finishing [third](https://surgtoolloc.grand-challenge.org/results/) in both categories, and recreated interesting core components of the solutions in MONAI tutorials. For more details about how to reproduce the solution, please see [the tutorials](https://github.com/Project-MONAI/tutorials/tree/main/competitions/MICCAI/surgtoolloc).


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #5729 

### Description

This PR creates `whatsnew_1_1.md` file, and adds the introduction of the tutorial of the SurgToolLoc challenge solution.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
