### PR TITLE
 Change default dtype value in `Watershed` and `GenerateWatershedMarkers`

### DIFF
--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -732,7 +732,7 @@ class HoVerNetInstanceMapPostProcessing(Transform):
                 :, instance_bbox[0][0] : instance_bbox[0][1], instance_bbox[0][2] : instance_bbox[0][3]
             ]
             offset = [instance_bbox[0][2], instance_bbox[0][0]]
-            instance_contour = self.generate_instance_contour(instance_mask, offset)
+            instance_contour = self.generate_instance_contour(FillHoles()(instance_mask), offset)
             if instance_contour is not None:
                 instance_centroid = self.generate_instance_centroid(instance_mask, offset)
                 instance_info[inst_id] = {

--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -61,13 +61,13 @@ class Watershed(Transform):
         connectivity: an array with the same number of dimensions as image whose non-zero elements indicate
             neighbors for connection. Following the scipy convention, default is a one-connected array of
             the dimension of the image.
-        dtype: target data content type to convert, default is np.uint8.
+        dtype: target data content type to convert, default is np.int64.
 
     """
 
     backend = [TransformBackends.NUMPY]
 
-    def __init__(self, connectivity: Optional[int] = 1, dtype: DtypeLike = np.uint8) -> None:
+    def __init__(self, connectivity: Optional[int] = 1, dtype: DtypeLike = np.int64) -> None:
         self.connectivity = connectivity
         self.dtype = dtype
 
@@ -292,7 +292,7 @@ class GenerateWatershedMarkers(Transform):
         min_object_size: objects smaller than this size (in pixel) are removed. Defaults to 10.
         postprocess_fn: additional post-process function on the markers.
             If not provided, :py:class:`monai.transforms.post.FillHoles()` will be used.
-        dtype: target data type to convert to. Defaults to np.uint8.
+        dtype: target data type to convert to. Defaults to np.int64.
 
     """
 
@@ -304,7 +304,7 @@ class GenerateWatershedMarkers(Transform):
         radius: int = 2,
         min_object_size: int = 10,
         postprocess_fn: Optional[Callable] = None,
-        dtype: DtypeLike = np.uint8,
+        dtype: DtypeLike = np.int64,
     ) -> None:
         self.threshold = threshold
         self.radius = radius


### PR DESCRIPTION
Fixes #.

### Description

- When the image is large, the number of instances may exceed np.uint8, so the default dtype should set to `np.int64`
- a workaround way to add `FillHoles` before `generate_instance_contour`, may prevent the issue when instances contain hole

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
