### PR TITLE
Remove hard-coded sigmoid for voting ensemble method in Auto3DSeg

### DIFF
--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -197,7 +197,7 @@ class AlgoEnsembleBestN(AlgoEnsemble):
 
         ranks = self.sort_score()
         if len(ranks) < n_best:
-            warn(f"Found {len(ranks)} available algos (pre-defined n_best={n_best}). All {n_available} will be used.")
+            warn(f"Found {len(ranks)} available algos (pre-defined n_best={n_best}). All {len(ranks)} will be used.")
             n_best = len(ranks)
 
         # get the indices that the rank is larger than N

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -37,7 +37,7 @@ class AlgoEnsemble(ABC):
 
     def __init__(self):
         self.algos = []
-        self.mode = "vote"
+        self.mode = "mean"
         self.infer_files = []
         self.algo_ensemble = []
 

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -197,7 +197,8 @@ class AlgoEnsembleBestN(AlgoEnsemble):
 
         ranks = self.sort_score()
         if len(ranks) < n_best:
-            raise ValueError("Number of available algos is less than user-defined N")
+            warn(f"Found {len(ranks)} available algos (pre-defined n_best={n_best}). All {n_available} will be used.")
+            n_best = len(ranks)
 
         # get the indices that the rank is larger than N
         indices = [i for (i, r) in enumerate(ranks) if r >= n_best]

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -37,7 +37,7 @@ class AlgoEnsemble(ABC):
 
     def __init__(self):
         self.algos = []
-        self.mode = "mean"
+        self.mode = "vote"
         self.infer_files = []
         self.algo_ensemble = []
 
@@ -107,8 +107,11 @@ class AlgoEnsemble(ABC):
             prob = MeanEnsemble()(preds)
             return prob2class(prob, dim=0, keepdim=True, sigmoid=sigmoid)
         elif self.mode == "vote":
-            classes = [prob2class(p, dim=0, keepdim=True, sigmoid=False) for p in preds]
-            return VoteEnsemble(num_classes=preds[0].shape[0])(classes)
+            classes = [prob2class(p, dim=0, keepdim=True, sigmoid=sigmoid) for p in preds]
+            if sigmoid:
+                return VoteEnsemble()(classes)  # do not specify num_classes for one-hot encoding
+            else:
+                return VoteEnsemble(num_classes=preds[0].shape[0])(classes)
 
     def __call__(self, pred_param: Optional[Dict[str, Any]] = None):
         """


### PR DESCRIPTION
Signed-off-by: Mingxin Zheng <18563433+mingxin-zheng@users.noreply.github.com>

Fixes item 3 and 5 in #5564.


### Description

The `vote` method in `ensemble_pred` currently does not work for under sigmoid mode, because the function overrides the argument to False before the `VoteEnsemble`.

Also, if the user only trains a small number of algorithm (1 fold for 1 algo) and forgets the update the `n_best` (default is 5) in `AlgoEnsembleBestN` , instead of throwing an error, the fix will automatically use all available algos after posting a warning.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.

