### PR TITLE
Revert "Add ValueError in `GenerateSuccinctContour` (#5719)"

### DIFF
--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -458,10 +458,6 @@ class GenerateSuccinctContour(Transform):
                     elif coord[1] == self.width - 1:
                         corner = 2
                         pixel = (int(coord[0] - 0.5), int(coord[1]))
-                    else:
-                        raise ValueError(
-                            f"Invalid coutour coord {coord} is generated, areas may contain boundaries or small holes"
-                        )
                     sequence.append(pixel)
                     last_added = pixel
                 elif i == len(group) - 1:


### PR DESCRIPTION
This reverts commit 2b160b3db3ee2942a28ff3a5628879c3fe46d7c8.

Fixes https://github.com/Project-MONAI/MONAI/pull/5719#issuecomment-1349697908


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
