### PR TITLE
Fix bug in `GenerateInstanceBorder`

### DIFF
--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -216,8 +216,8 @@ class GenerateInstanceBorder(Transform):
             raise ValueError("Not a valid hover map, please check your input")
         hover_h = (hover_h - hover_h_min) / (hover_h_max - hover_h_min)
         hover_v = (hover_v - hover_v_min) / (hover_v_max - hover_v_min)
-        sobelh = self.sobel_gradient(hover_h)[0, ...]
-        sobelv = self.sobel_gradient(hover_v)[1, ...]
+        sobelh = self.sobel_gradient(hover_h)[1, ...]
+        sobelv = self.sobel_gradient(hover_v)[0, ...]
         sobelh_min, sobelh_max = min(sobelh), max(sobelh)
         sobelv_min, sobelv_max = min(sobelv), max(sobelv)
         if (sobelh_max - sobelh_min) == 0 or (sobelv_max - sobelv_min) == 0:


### PR DESCRIPTION
Signed-off-by: KumoLiu <yunl@nvidia.com>

Fixes #5750.

### Description
Change dim in Sobel gradient which have been discussed in https://github.com/Project-MONAI/MONAI/pull/5503.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
