### PR TITLE
Add warning in `GenerateSuccinctContour`

### DIFF
--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -461,7 +461,7 @@ class GenerateSuccinctContour(Transform):
                         pixel = (int(coord[0] - 0.5), int(coord[1]))
                     else:
                         warnings.warn(f"Invalid contour coord {coord} is generated, skip this instance.")
-                        return None
+                        return None  # type: ignore
                     sequence.append(pixel)
                     last_added = pixel
                 elif i == len(group) - 1:

--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -460,7 +460,7 @@ class GenerateSuccinctContour(Transform):
                         corner = 2
                         pixel = (int(coord[0] - 0.5), int(coord[1]))
                     else:
-                        warnings.warn(f"Invalid coutour coord {coord} is generated, skip this instance!!")
+                        warnings.warn(f"Invalid coutour coord {coord} is generated, skip this instance.")
                         return None
                     sequence.append(pixel)
                     last_added = pixel

--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -460,7 +460,7 @@ class GenerateSuccinctContour(Transform):
                         corner = 2
                         pixel = (int(coord[0] - 0.5), int(coord[1]))
                     else:
-                        warnings.warn(f"Invalid coutour coord {coord} is generated, skip this instance.")
+                        warnings.warn(f"Invalid contour coord {coord} is generated, skip this instance.")
                         return None
                     sequence.append(pixel)
                     last_added = pixel

--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -9,6 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -458,6 +459,9 @@ class GenerateSuccinctContour(Transform):
                     elif coord[1] == self.width - 1:
                         corner = 2
                         pixel = (int(coord[0] - 0.5), int(coord[1]))
+                    else:
+                        warnings.warn(f"Invalid coutour coord {coord} is generated, skip this instance!!")
+                        return None
                     sequence.append(pixel)
                     last_added = pixel
                 elif i == len(group) - 1:
@@ -555,7 +559,8 @@ class GenerateInstanceContour(Transform):
         inst_contour_cv = find_contours(inst_mask, level=self.contour_level)
         generate_contour = GenerateSuccinctContour(inst_mask.shape[0], inst_mask.shape[1])
         inst_contour = generate_contour(inst_contour_cv)
-
+        if inst_contour is None:
+            return None
         # less than `self.min_num_points` points don't make a contour, so skip.
         # They are likely to be artifacts as the contours obtained via approximation.
         if inst_contour.shape[0] < self.min_num_points:


### PR DESCRIPTION
Signed-off-by: KumoLiu <yunl@nvidia.com>

Fixes #5714.

### Description
Add warning in `GenerateSuccinctContour` and skip invalid instance.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
