### PR TITLE
5770 add remove prefix to monai.bundle.load

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -384,9 +384,10 @@ def load(
 
     if model_file is None:
         model_file = os.path.join("models", "model.ts" if load_ts_module is True else "model.pt")
-    name = _add_ngc_prefix(name)
-    if remove_prefix:
-        name = _remove_ngc_prefix(name, prefix=remove_prefix)
+    if source == "ngc":
+        name = _add_ngc_prefix(name)
+        if remove_prefix:
+            name = _remove_ngc_prefix(name, prefix=remove_prefix)
     full_path = os.path.join(bundle_dir_, name, model_file)
     if not os.path.exists(full_path):
         download(

--- a/tests/ngc_bundle_download.py
+++ b/tests/ngc_bundle_download.py
@@ -19,10 +19,10 @@ from parameterized import parameterized
 
 from monai.apps import check_hash
 from monai.apps.mmars import MODEL_DESC, load_from_mmar
-from monai.bundle import download
+from monai.bundle import download, load
 from monai.config import print_debug_info
 from monai.networks.utils import copy_model_state
-from tests.utils import skip_if_downloading_fails, skip_if_quick, skip_if_windows
+from tests.utils import assert_allclose, skip_if_downloading_fails, skip_if_quick, skip_if_windows
 
 TEST_CASE_NGC_1 = [
     "spleen_ct_segmentation",
@@ -41,6 +41,30 @@ TEST_CASE_NGC_2 = [
     "b418a2dc8672ce2fd98dc255036e7a3d",
 ]
 
+TESTCASE_WEIGHTS = {
+    "key": "model.0.conv.unit0.adn.N.bias",
+    "value": torch.tensor(
+        [
+            -0.0705,
+            -0.0937,
+            -0.0422,
+            -0.2068,
+            0.1023,
+            -0.2007,
+            -0.0883,
+            0.0018,
+            -0.1719,
+            0.0116,
+            0.0285,
+            -0.0044,
+            0.1223,
+            -0.1287,
+            -0.1858,
+            0.0460,
+        ]
+    ),
+}
+
 
 @skip_if_windows
 class TestNgcBundleDownload(unittest.TestCase):
@@ -55,6 +79,13 @@ class TestNgcBundleDownload(unittest.TestCase):
                 full_file_path = os.path.join(tempdir, download_name, file_path)
                 self.assertTrue(os.path.exists(full_file_path))
                 self.assertTrue(check_hash(filepath=full_file_path, val=hash_val))
+
+                weights = load(
+                    name=bundle_name, source="ngc", version=version, bundle_dir=tempdir, remove_prefix=remove_prefix
+                )
+                assert_allclose(
+                    weights[TESTCASE_WEIGHTS["key"]], TESTCASE_WEIGHTS["value"], atol=1e-4, rtol=1e-4, type_test=False
+                )
 
 
 @unittest.skip("deprecating mmar tests")


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #5770 .

### Description

This PR enables the `remove_prefix` arg in `monai.bundle.load`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
