### PR TITLE
5775 Fix `_get_latest_bundle_version` issue on Windows

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -182,7 +182,7 @@ def _get_latest_bundle_version(source: str, name: str, repo: str):
         return None
     elif source == "github":
         repo_owner, repo_name, tag_name = repo.split("/")
-        return get_bundle_versions(name, repo=os.path.join(repo_owner, repo_name), tag=tag_name)["latest_version"]
+        return get_bundle_versions(name, repo=f"{repo_owner}/{repo_name}", tag=tag_name)["latest_version"]
     else:
         raise ValueError(f"To get the latest bundle version, source should be 'github' or 'ngc', got {source}.")
 

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -58,7 +58,6 @@ TEST_CASE_5 = [
 ]
 
 
-@skip_if_windows
 class TestDownload(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     @skip_if_quick

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -26,7 +26,6 @@ from tests.utils import (
     command_line_tests,
     skip_if_downloading_fails,
     skip_if_quick,
-    skip_if_windows,
 )
 
 TEST_CASE_1 = ["test_bundle", None]


### PR DESCRIPTION
Signed-off-by: Yiheng Wang <vennw@nvidia.com>

Fixes #5775 .

### Description

This PR fixes the issue of `_get_latest_bundle_version` on Windows (`os.path.join` will produce backslash which will create a wrong url) 
Thanks @SachidanandAlle for finding this issue.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
