### PR TITLE
'dimensions'  -> 'spatial_dims'

### DIFF
--- a/monai/networks/nets/varautoencoder.py
+++ b/monai/networks/nets/varautoencoder.py
@@ -68,6 +68,7 @@ class VarAutoEncoder(AutoEncoder):
         - Variational autoencoder network with MedNIST Dataset
           https://github.com/Project-MONAI/tutorials/blob/master/modules/varautoencoder_mednist.ipynb
     """
+
     def __init__(
         self,
         spatial_dims: int,

--- a/monai/networks/nets/varautoencoder.py
+++ b/monai/networks/nets/varautoencoder.py
@@ -56,7 +56,7 @@ class VarAutoEncoder(AutoEncoder):
 
         # 3 layer network accepting images with dimensions (1, 32, 32) and using a latent vector with 2 values
         model = VarAutoEncoder(
-            dimensions=2,
+            spatial_dims=2,
             in_shape=(32, 32),  # image spatial shape
             out_channels=1,
             latent_size=2,

--- a/monai/networks/nets/varautoencoder.py
+++ b/monai/networks/nets/varautoencoder.py
@@ -68,7 +68,6 @@ class VarAutoEncoder(AutoEncoder):
         - Variational autoencoder network with MedNIST Dataset
           https://github.com/Project-MONAI/tutorials/blob/master/modules/varautoencoder_mednist.ipynb
     """
-    @deprecated_arg(name="dimensions", since="0.6", msg_suffix="Please use `spatial_dims` instead.")
     def __init__(
         self,
         spatial_dims: int,

--- a/monai/networks/nets/varautoencoder.py
+++ b/monai/networks/nets/varautoencoder.py
@@ -68,7 +68,7 @@ class VarAutoEncoder(AutoEncoder):
         - Variational autoencoder network with MedNIST Dataset
           https://github.com/Project-MONAI/tutorials/blob/master/modules/varautoencoder_mednist.ipynb
     """
-
+    @deprecated_arg(name="dimensions", since="0.6", msg_suffix="Please use `spatial_dims` instead.")
     def __init__(
         self,
         spatial_dims: int,


### PR DESCRIPTION
VarAutoEncoder.__init__() got an unexpected keyword argument 'dimensions' because now it is called spatial_dims.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
