### PR TITLE
5804 Simplify the configparser usage to get parsed attributes easily

### DIFF
--- a/docs/source/bundle.rst
+++ b/docs/source/bundle.rst
@@ -32,6 +32,7 @@ Model Bundle
 ---------------
 .. autoclass:: ConfigParser
     :members:
+    :special-members:
 
 `Scripts`
 ---------

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -118,11 +118,14 @@ class ConfigParser:
 
     def __getattr__(self, id):
         """
-        Get the config by id.
+        Get the parsed result of ``ConfigItem`` with the specified ``id``
+        with default arguments (e.g. ``lazy=True``, ``instantiate=True`` and ``eval_expr=True``).
 
         Args:
-            id: id to specify the expected position. See also :py:meth:`__getitem__`.
-
+            id: id of the ``ConfigItem``.
+        
+        See also:
+             :py:meth:`get_parsed_content`
         """
         return self.get_parsed_content(id)
 

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -116,6 +116,16 @@ class ConfigParser:
     def __repr__(self):
         return f"{self.config}"
 
+    def __getattr__(self, id):
+        """
+        Get the config by id.
+
+        Args:
+            id: id to specify the expected position. See also :py:meth:`__getitem__`.
+
+        """
+        return self[id]
+
     def __getitem__(self, id: Union[str, int]):
         """
         Get the config by id.

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -123,7 +123,7 @@ class ConfigParser:
 
         Args:
             id: id of the ``ConfigItem``.
-        
+
         See also:
              :py:meth:`get_parsed_content`
         """

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -124,7 +124,7 @@ class ConfigParser:
             id: id to specify the expected position. See also :py:meth:`__getitem__`.
 
         """
-        return self[id]
+        return self.get_parsed_content(id)
 
     def __getitem__(self, id: Union[str, int]):
         """

--- a/tests/test_auto3dseg_ensemble.py
+++ b/tests/test_auto3dseg_ensemble.py
@@ -139,7 +139,7 @@ class TestEnsembleBuilder(unittest.TestCase):
         builder = AlgoEnsembleBuilder(history, data_src_cfg)
         builder.set_ensemble_method(AlgoEnsembleBestN(n_best=1))
         ensemble = builder.get_ensemble()
-        pred_param["network#init_filter"] = 8  # segresnet
+        pred_param["network#init_filters"] = 8  # segresnet
         preds = ensemble(pred_param)
         self.assertTupleEqual(preds[0].shape, (2, 24, 24, 24))
 

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -256,6 +256,11 @@ class TestConfigParser(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, ".*bdb.BdbQuit.*"):
             case_pdb()
 
+    def test_get_via_attributes(self):
+        config = {"A": {"B": {"C": 1}}}
+        parser = ConfigParser(config=config)
+        self.assertEqual(parser.A, {"B": {"C": 1}})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -257,9 +257,20 @@ class TestConfigParser(unittest.TestCase):
             case_pdb()
 
     def test_get_via_attributes(self):
-        config = {"A": {"B": {"C": 1}}}
+        config = {
+            "A": {"B": {"C": 1}},
+            "my_dims": 2,
+            "dims_1": "$@my_dims + 1",
+            "patch_size": [8, 8],
+            "transform": {"_target_": "Lambda", "func": "$lambda x: x.reshape((1, *@patch_size))"},
+        }
         parser = ConfigParser(config=config)
         self.assertEqual(parser.A, {"B": {"C": 1}})
+        self.assertEqual(parser.dims_1, 3)
+
+        trans = parser.transform
+        result = trans(np.ones(64))
+        self.assertTupleEqual(result.shape, (1, 8, 8))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
part of #5804.

### Description

This adds a simple attribute access for ConfigParser so

```python
from monai.bundle import ConfigParser
parser = ConfigParser({"a":"b"})
a = parser.get_parsed_content("a")
```
can be rewritten to
```python
from monai.bundle import ConfigParser
parser = ConfigParser({"a":"b"})
a = parser.a
```
This only works for variables/methods that are not included in ConfigParser so e.g. `parser.config` would still get the whole config.
This PR only supports shallow attribute accesses, since the returned value will be a `dict` where you need to use `["key"]` to get the content.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.