### PR TITLE
MyPy disallow untyped decorators

### DIFF
--- a/monai/apps/deepedit/interaction.py
+++ b/monai/apps/deepedit/interaction.py
@@ -96,4 +96,4 @@ class Interaction:
 
         # first item in batch only
         engine.state.batch = batchdata
-        return engine._iteration(engine, batchdata)
+        return engine._iteration(engine, batchdata)  # type: ignore[arg-type]

--- a/monai/apps/deepgrow/interaction.py
+++ b/monai/apps/deepgrow/interaction.py
@@ -85,4 +85,4 @@ class Interaction:
             # collate list into a batch for next round interaction
             batchdata = list_data_collate(batchdata_list)
 
-        return engine._iteration(engine, batchdata)
+        return engine._iteration(engine, batchdata)  # type: ignore[arg-type]

--- a/monai/apps/reconstruction/networks/nets/complex_unet.py
+++ b/monai/apps/reconstruction/networks/nets/complex_unet.py
@@ -65,6 +65,7 @@ class ComplexUnet(nn.Module):
         conv_net: Optional[nn.Module] = None,
     ):
         super().__init__()
+        self.unet: nn.Module
         if conv_net is None:
             self.unet = BasicUNet(
                 spatial_dims=spatial_dims,

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, Type
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
 
 import torch
 from torch.utils.data import DataLoader
@@ -99,7 +99,7 @@ class Evaluator(Workflow):
         val_handlers: Sequence | None = None,
         amp: bool = False,
         mode: ForwardMode | str = ForwardMode.EVAL,
-        event_names: list[str | EventEnum | Type[EventEnum]] | None = None,
+        event_names: list[str | EventEnum | type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
         decollate: bool = True,
         to_kwargs: dict | None = None,
@@ -237,7 +237,7 @@ class SupervisedEvaluator(Evaluator):
         val_handlers: Sequence | None = None,
         amp: bool = False,
         mode: ForwardMode | str = ForwardMode.EVAL,
-        event_names: list[str | EventEnum  | Type[EventEnum]] | None = None,
+        event_names: list[str | EventEnum  | type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
         decollate: bool = True,
         to_kwargs: dict | None = None,
@@ -380,7 +380,7 @@ class EnsembleEvaluator(Evaluator):
         val_handlers: Sequence | None = None,
         amp: bool = False,
         mode: ForwardMode | str = ForwardMode.EVAL,
-        event_names: list[str | EventEnum | Type[EventEnum]] | None = None,
+        event_names: list[str | EventEnum | type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
         decollate: bool = True,
         to_kwargs: dict | None = None,

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -237,7 +237,7 @@ class SupervisedEvaluator(Evaluator):
         val_handlers: Sequence | None = None,
         amp: bool = False,
         mode: ForwardMode | str = ForwardMode.EVAL,
-        event_names: list[str | EventEnum  | type[EventEnum]] | None = None,
+        event_names: list[str | EventEnum | type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
         decollate: bool = True,
         to_kwargs: dict | None = None,

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, Type
 
 import torch
 from torch.utils.data import DataLoader
@@ -99,7 +99,7 @@ class Evaluator(Workflow):
         val_handlers: Sequence | None = None,
         amp: bool = False,
         mode: ForwardMode | str = ForwardMode.EVAL,
-        event_names: list[str | EventEnum] | None = None,
+        event_names: list[str | EventEnum | Type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
         decollate: bool = True,
         to_kwargs: dict | None = None,
@@ -133,7 +133,7 @@ class Evaluator(Workflow):
         else:
             raise ValueError(f"unsupported mode: {mode}, should be 'eval' or 'train'.")
 
-    def run(self, global_epoch: int = 1) -> None:
+    def run(self, global_epoch: int = 1) -> None:  # type: ignore[override]
         """
         Execute validation/evaluation based on Ignite Engine.
 
@@ -237,7 +237,7 @@ class SupervisedEvaluator(Evaluator):
         val_handlers: Sequence | None = None,
         amp: bool = False,
         mode: ForwardMode | str = ForwardMode.EVAL,
-        event_names: list[str | EventEnum] | None = None,
+        event_names: list[str | EventEnum  | Type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
         decollate: bool = True,
         to_kwargs: dict | None = None,
@@ -380,7 +380,7 @@ class EnsembleEvaluator(Evaluator):
         val_handlers: Sequence | None = None,
         amp: bool = False,
         mode: ForwardMode | str = ForwardMode.EVAL,
-        event_names: list[str | EventEnum] | None = None,
+        event_names: list[str | EventEnum | Type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
         decollate: bool = True,
         to_kwargs: dict | None = None,

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, Type
 
 import torch
 from torch.optim.optimizer import Optimizer
@@ -43,7 +43,7 @@ class Trainer(Workflow):
 
     """
 
-    def run(self) -> None:
+    def run(self) -> None:  # type: ignore[override]
         """
         Execute training based on Ignite Engine.
         If call this function multiple times, it will continuously run from the previous state.
@@ -151,7 +151,7 @@ class SupervisedTrainer(Trainer):
         metric_cmp_fn: Callable = default_metric_cmp_fn,
         train_handlers: Sequence | None = None,
         amp: bool = False,
-        event_names: list[str | EventEnum] | None = None,
+        event_names: list[str | EventEnum | Type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
         decollate: bool = True,
         optim_set_to_none: bool = False,

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, Type
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
 
 import torch
 from torch.optim.optimizer import Optimizer
@@ -151,7 +151,7 @@ class SupervisedTrainer(Trainer):
         metric_cmp_fn: Callable = default_metric_cmp_fn,
         train_handlers: Sequence | None = None,
         amp: bool = False,
-        event_names: list[str | EventEnum | Type[EventEnum]] | None = None,
+        event_names: list[str | EventEnum | type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
         decollate: bool = True,
         optim_set_to_none: bool = False,

--- a/monai/engines/workflow.py
+++ b/monai/engines/workflow.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Sequence, Union, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Sequence, Type, Union
 
 import torch
 import torch.distributed as dist

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -21,7 +21,7 @@ import monai
 from monai.apps.auto3dseg.data_analyzer import DataAnalyzer
 from monai.auto3dseg import SegSummarizer
 from monai.bundle import DEFAULT_EXP_MGMT_SETTINGS, ConfigComponent, ConfigItem, ConfigParser, patch_bundle_tracking
-from monai.engines import Trainer, SupervisedTrainer
+from monai.engines import SupervisedTrainer, Trainer
 from monai.fl.client import ClientAlgo, ClientAlgoStats
 from monai.fl.utils.constants import (
     BundleKeys,

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -21,7 +21,7 @@ import monai
 from monai.apps.auto3dseg.data_analyzer import DataAnalyzer
 from monai.auto3dseg import SegSummarizer
 from monai.bundle import DEFAULT_EXP_MGMT_SETTINGS, ConfigComponent, ConfigItem, ConfigParser, patch_bundle_tracking
-from monai.engines import Trainer
+from monai.engines import Trainer, SupervisedTrainer
 from monai.fl.client import ClientAlgo, ClientAlgoStats
 from monai.fl.utils.constants import (
     BundleKeys,
@@ -429,7 +429,7 @@ class MonaiAlgo(ClientAlgo, MonaiAlgoStats):
         self.train_parser: Optional[ConfigParser] = None
         self.eval_parser: Optional[ConfigParser] = None
         self.filter_parser: Optional[ConfigParser] = None
-        self.trainer: Optional[Trainer] = None
+        self.trainer: Optional[SupervisedTrainer] = None
         self.evaluator: Optional[Any] = None
         self.pre_filters = None
         self.post_weight_filters = None

--- a/monai/handlers/ignite_metric.py
+++ b/monai/handlers/ignite_metric.py
@@ -19,17 +19,21 @@ from monai.metrics import CumulativeIterationMetric
 from monai.utils import min_version, optional_import
 
 idist, _ = optional_import("ignite", IgniteInfo.OPT_IMPORT_VERSION, min_version, "distributed")
-Metric, _ = optional_import("ignite.metrics", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Metric", as_type="base")
-reinit__is_reduced, _ = optional_import(
-    "ignite.metrics.metric", IgniteInfo.OPT_IMPORT_VERSION, min_version, "reinit__is_reduced", as_type="decorator"
-)
+
+
 if TYPE_CHECKING:
     from ignite.engine import Engine
+    from ignite.metrics import Metric
+    from ignite.metrics.metric import reinit__is_reduced
 else:
     Engine, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Engine")
+    Metric, _ = optional_import("ignite.metrics", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Metric", as_type="base")
+    reinit__is_reduced, _ = optional_import(
+        "ignite.metrics.metric", IgniteInfo.OPT_IMPORT_VERSION, min_version, "reinit__is_reduced", as_type="decorator"
+    )
 
 
-class IgniteMetric(Metric):  # type: ignore[valid-type, misc] # due to optional_import
+class IgniteMetric(Metric):
     """
     Base Metric class based on ignite event handler mechanism.
     The input `prediction` or `label` data can be a PyTorch Tensor or numpy array with batch dim and channel dim,
@@ -107,7 +111,7 @@ class IgniteMetric(Metric):  # type: ignore[valid-type, misc] # due to optional_
                 result = result.item()
         return result
 
-    def attach(self, engine: Engine, name: str) -> None:
+    def attach(self, engine: Engine, name: str) -> None:  # type: ignore[override]
         """
         Attaches current metric to provided engine. On the end of engine's run,
         `engine.state.metrics` dictionary will contain computed metric's value under provided name.

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -16,7 +16,7 @@ import warnings
 from copy import deepcopy
 from enum import Enum
 from itertools import zip_longest
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 import torch
@@ -2730,7 +2730,7 @@ class Rand2DElastic(RandomizableTransform):
             grid = CenterSpatialCrop(roi_size=sp_size)(grid[0])
         else:
             _device = img.device if isinstance(img, torch.Tensor) else self.device
-            grid = create_grid(spatial_size=sp_size, device=_device, backend="torch")
+            grid = cast(torch.Tensor, create_grid(spatial_size=sp_size, device=_device, backend="torch"))
         out: torch.Tensor = self.resampler(
             img,
             grid,

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -15,7 +15,7 @@ defined in :py:class:`monai.transforms.spatial.array`.
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
-from typing import Any, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Hashable, List, Mapping, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 import torch
@@ -426,7 +426,7 @@ class Spacingd(MapTransform, InvertibleTransform):
     def inverse(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Dict[Hashable, NdarrayOrTensor]:
         d = dict(data)
         for key in self.key_iterator(d):
-            d[key] = self.spacing_transform.inverse(d[key])
+            d[key] = self.spacing_transform.inverse(cast(torch.Tensor, d[key]))
         return d
 
 
@@ -1045,7 +1045,7 @@ class Rand2DElasticd(RandomizableTransform, MapTransform):
             )
             grid = CenterSpatialCrop(roi_size=sp_size)(grid[0])
         else:
-            grid = create_grid(spatial_size=sp_size, device=device, backend="torch")
+            grid = cast(torch.Tensor, create_grid(spatial_size=sp_size, device=device, backend="torch"))
 
         for key, mode, padding_mode in self.key_iterator(d, self.mode, self.padding_mode):
             d[key] = self.rand_2d_elastic.resampler(d[key], grid, mode=mode, padding_mode=padding_mode)  # type: ignore

--- a/monai/utils/deprecate_utils.py
+++ b/monai/utils/deprecate_utils.py
@@ -14,14 +14,15 @@ import sys
 import warnings
 from functools import wraps
 from types import FunctionType
-from typing import Any, Optional, Callable, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 from monai.utils.module import version_leq
 
 from .. import __version__
 
 __all__ = ["deprecated", "deprecated_arg", "DeprecatedError", "deprecated_arg_default"]
-T = TypeVar('T', type, Callable)
+T = TypeVar("T", type, Callable)
+
 
 class DeprecatedError(Exception):
     pass

--- a/monai/utils/deprecate_utils.py
+++ b/monai/utils/deprecate_utils.py
@@ -138,8 +138,6 @@ def deprecated_arg(
     using the Sphinx directives such as `.. versionchanged:: version` and `.. deprecated:: version`.
     https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded
 
-    In the current implementation type annotations are not preserved.
-
 
     Args:
         name: name of position or keyword argument to mark as deprecated.
@@ -234,7 +232,7 @@ def deprecated_arg_default(
     msg_suffix: str = "",
     version_val: str = __version__,
     warning_category=FutureWarning,
-):
+) -> Callable[[T], T]:
     """
     Marks a particular arguments default of a callable as deprecated. It is changed from `old_default` to `new_default`
     in version `changed`.
@@ -246,8 +244,6 @@ def deprecated_arg_default(
     The relevant docstring of the deprecating function should also be updated accordingly,
     using the Sphinx directives such as `.. versionchanged:: version` and `.. deprecated:: version`.
     https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded
-
-    In the current implementation type annotations are not preserved.
 
 
     Args:

--- a/monai/utils/deprecate_utils.py
+++ b/monai/utils/deprecate_utils.py
@@ -124,7 +124,7 @@ def deprecated_arg(
     version_val: str = __version__,
     new_name: Optional[str] = None,
     warning_category=FutureWarning,
-):
+) -> Callable[[T], T]:
     """
     Marks a particular named argument of a callable as deprecated. The same conditions for `since` and `removed` as
     described in the `deprecated` decorator.

--- a/monai/utils/deprecate_utils.py
+++ b/monai/utils/deprecate_utils.py
@@ -14,14 +14,14 @@ import sys
 import warnings
 from functools import wraps
 from types import FunctionType
-from typing import Any, Optional
+from typing import Any, Optional, Callable, TypeVar
 
 from monai.utils.module import version_leq
 
 from .. import __version__
 
 __all__ = ["deprecated", "deprecated_arg", "DeprecatedError", "deprecated_arg_default"]
-
+T = TypeVar('T', type, Callable)
 
 class DeprecatedError(Exception):
     pass
@@ -40,7 +40,7 @@ def deprecated(
     msg_suffix: str = "",
     version_val: str = __version__,
     warning_category=FutureWarning,
-):
+) -> Callable[[T], T]:
     """
     Marks a function or class as deprecated. If `since` is given this should be a version at or earlier than the
     current version and states at what version of the definition was marked as deprecated. If `removed` is given

--- a/setup.cfg
+++ b/setup.cfg
@@ -208,7 +208,10 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-monai.*]
+# Also check the body of functions with no types in their type signature.
 check_untyped_defs = True
+# Warns about usage of untyped decorators.
+disallow_untyped_decorators = True
 
 [pytype]
 # Space-separated list of files or directories to exclude.

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import unittest
+from typing import cast
 
 import nibabel as nib
 import numpy as np
@@ -186,7 +187,7 @@ class TestOrientationCase(unittest.TestCase):
     ):
         img = MetaTensor(img, affine=affine).to(device)
         ornt = Orientation(**init_param)
-        res: MetaTensor = ornt(img)
+        res = cast(MetaTensor, ornt(img))
         assert_allclose(res, expected_data.to(device))
         new_code = nib.orientations.aff2axcodes(res.affine.cpu(), labels=ornt.labels)
         self.assertEqual("".join(new_code), expected_code)
@@ -204,6 +205,7 @@ class TestOrientationCase(unittest.TestCase):
         assert_allclose(res, expected_data)
         if track_meta:
             self.assertIsInstance(res, MetaTensor)
+            assert isinstance(res, MetaTensor)  # for mypy type narrowing
             new_code = nib.orientations.aff2axcodes(res.affine.cpu(), labels=ornt.labels)
             self.assertEqual("".join(new_code), expected_code)
         else:

--- a/tests/test_orientationd.py
+++ b/tests/test_orientationd.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import unittest
-from typing import Optional
+from typing import Optional, cast
 
 import nibabel as nib
 import numpy as np
@@ -74,7 +74,7 @@ class TestOrientationdCase(unittest.TestCase):
         data = {k: img.clone() for k in ornt.keys}
         res = ornt(data)
         for k in ornt.keys:
-            _im = res[k]
+            _im = cast(MetaTensor, res[k])
             self.assertIsInstance(_im, MetaTensor)
             np.testing.assert_allclose(_im.shape, expected_shape)
             code = nib.aff2axcodes(_im.affine.cpu(), ornt.ornt_transform.labels)
@@ -94,6 +94,7 @@ class TestOrientationdCase(unittest.TestCase):
             np.testing.assert_allclose(_im.shape, expected_shape)
             if track_meta:
                 self.assertIsInstance(_im, MetaTensor)
+                assert isinstance(_im, MetaTensor)  # for mypy type narrowing
                 code = nib.aff2axcodes(_im.affine.cpu(), ornt.ornt_transform.labels)
                 self.assertEqual("".join(code), expected_code)
             else:

--- a/tests/test_spacingd.py
+++ b/tests/test_spacingd.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import unittest
-from typing import List, Tuple, Mapping
+from typing import List, Tuple
 
 import numpy as np
 import torch

--- a/tests/test_spacingd.py
+++ b/tests/test_spacingd.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import unittest
-from typing import List, Tuple
+from typing import List, Tuple, Mapping
 
 import numpy as np
 import torch
@@ -104,11 +104,11 @@ class TestSpacingDCase(unittest.TestCase):
     def test_orntd_torch(self, init_param, img: torch.Tensor, track_meta: bool, device):
         set_track_meta(track_meta)
         tr = Spacingd(**init_param)
-        data = {"seg": img.to(device)}
-        res = tr(data)["seg"]
+        res = tr({"seg": img.to(device)})["seg"]
 
         if track_meta:
             self.assertIsInstance(res, MetaTensor)
+            assert isinstance(res, MetaTensor)  # for mypy type narrowing
             new_spacing = affine_to_spacing(res.affine, 3)
             assert_allclose(new_spacing, init_param["pixdim"], type_test=False)
             self.assertNotEqual(img.shape, res.shape)


### PR DESCRIPTION
Fixes #5823.

### Description
This PR types following decorators:
- `deprecated`
- `deprecated_arg`
- `deprecated_arg_default`

Found [here](https://github.com/Project-MONAI/MONAI/blob/dev/monai/utils/deprecate_utils.py). 
It also fixes any typing issues that occurred because of the additional typing.

Secondly, it fixes untyped decorator usage of the `ignite` library (because of `optional_import`) for [Workflow](https://github.com/Project-MONAI/MONAI/blob/34d713f9887a85f140630a75e9261b89f0005c84/monai/engines/workflow.py#L45) and [IgniteMetric](https://github.com/Project-MONAI/MONAI/blob/f9d472af05ceb56513771ea2faccebb79edc1a7a/monai/handlers/ignite_metric.py#L36). 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
