### PR TITLE
5833 fixes Nifti1Image test cases

### DIFF
--- a/tests/test_cachedataset.py
+++ b/tests/test_cachedataset.py
@@ -39,7 +39,7 @@ for c in (0, 1, 2):
 class TestCacheDataset(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     def test_shape(self, transform, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             test_data = []
             for i in ["1", "2"]:
@@ -190,7 +190,7 @@ class TestCacheThread(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     def test_hash_as_key(self, transform, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             test_data = []
             for i in ["1", "2", "2", "3", "3"]:

--- a/tests/test_cachedataset_parallel.py
+++ b/tests/test_cachedataset_parallel.py
@@ -30,7 +30,7 @@ TEST_CASE_3 = [4, 5, None]
 class TestCacheDatasetParallel(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_shape(self, num_workers, dataset_size, transform):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[8, 8, 8]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[8, 8, 8]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
             nib.save(test_image, os.path.join(tempdir, "test_label1.nii.gz"))

--- a/tests/test_cachentransdataset.py
+++ b/tests/test_cachentransdataset.py
@@ -34,7 +34,7 @@ TEST_CASE_1 = [
 class TestCacheNTransDataset(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1])
     def test_n_trans(self, transform, expected_shape):
-        data_array = np.random.randint(0, 2, size=[128, 128, 128])
+        data_array = np.random.randint(0, 2, size=[128, 128, 128]).astype(float)
         test_image = nib.Nifti1Image(data_array, np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image.nii.gz"))

--- a/tests/test_check_missing_files.py
+++ b/tests/test_check_missing_files.py
@@ -22,7 +22,7 @@ from monai.data import check_missing_files
 
 class TestCheckMissingFiles(unittest.TestCase):
     def test_content(self):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
             nib.save(test_image, os.path.join(tempdir, "test_label1.nii.gz"))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -26,7 +26,7 @@ TEST_CASE_1 = [(128, 128, 128)]
 class TestDataset(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1])
     def test_shape(self, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
             nib.save(test_image, os.path.join(tempdir, "test_label1.nii.gz"))

--- a/tests/test_deepgrow_dataset.py
+++ b/tests/test_deepgrow_dataset.py
@@ -62,7 +62,7 @@ class TestCreateDataset(unittest.TestCase):
             else:
                 image = np.random.randint(0, 2, size=(128, 128, 40, image_channel))
             image_file = os.path.join(self.tempdir, f"image{i}.nii.gz")
-            nib.save(nib.Nifti1Image(image, affine), image_file)
+            nib.save(nib.Nifti1Image(image.astype(float), affine), image_file)
 
             if with_label:
                 # 3 slices has label
@@ -72,7 +72,7 @@ class TestCreateDataset(unittest.TestCase):
                 label[0][0][2] = 1
                 label[0][1][2] = 1
                 label_file = os.path.join(self.tempdir, f"label{i}.nii.gz")
-                nib.save(nib.Nifti1Image(label, affine), label_file)
+                nib.save(nib.Nifti1Image(label.astype(float), affine), label_file)
                 datalist.append({"image": image_file, "label": label_file})
             else:
                 datalist.append({"image": image_file})

--- a/tests/test_iterable_dataset.py
+++ b/tests/test_iterable_dataset.py
@@ -32,7 +32,7 @@ class _Stream:
 class TestIterableDataset(unittest.TestCase):
     def test_shape(self):
         expected_shape = (128, 128, 128)
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
         test_data = []
         with tempfile.TemporaryDirectory() as tempdir:
             for i in range(6):

--- a/tests/test_lmdbdataset.py
+++ b/tests/test_lmdbdataset.py
@@ -124,7 +124,7 @@ class TestLMDBDataset(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5, TEST_CASE_6, TEST_CASE_7])
     def test_shape(self, transform, expected_shape, kwargs=None):
         kwargs = kwargs or {}
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
             nib.save(test_image, os.path.join(tempdir, "test_label1.nii.gz"))

--- a/tests/test_smartcachedataset.py
+++ b/tests/test_smartcachedataset.py
@@ -38,7 +38,7 @@ TEST_CASE_5 = [0.5, 2, Compose([LoadImaged(keys=["image", "label", "extra"])])]
 class TestSmartCacheDataset(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5])
     def test_shape(self, replace_rate, num_replace_workers, transform):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[8, 8, 8]), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[8, 8, 8]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
             nib.save(test_image, os.path.join(tempdir, "test_label1.nii.gz"))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -307,7 +307,9 @@ def has_cupy():
 HAS_CUPY = has_cupy()
 
 
-def make_nifti_image(array: NdarrayOrTensor, affine=None, dir=None, fname=None, suffix=".nii.gz", verbose=False):
+def make_nifti_image(
+    array: NdarrayOrTensor, affine=None, dir=None, fname=None, suffix=".nii.gz", verbose=False, dtype=float
+):
     """
     Create a temporary nifti image on the disk and return the image name.
     User is responsible for deleting the temporary file when done with it.
@@ -318,7 +320,7 @@ def make_nifti_image(array: NdarrayOrTensor, affine=None, dir=None, fname=None, 
         affine, *_ = convert_data_type(affine, np.ndarray)
     if affine is None:
         affine = np.eye(4)
-    test_image = nib.Nifti1Image(array, affine)
+    test_image = nib.Nifti1Image(array.astype(dtype), affine)
 
     # if dir not given, create random. Else, make sure it exists.
     if dir is None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -320,7 +320,7 @@ def make_nifti_image(
         affine, *_ = convert_data_type(affine, np.ndarray)
     if affine is None:
         affine = np.eye(4)
-    test_image = nib.Nifti1Image(array.astype(dtype), affine)
+    test_image = nib.Nifti1Image(array.astype(dtype), affine)  # type: ignore
 
     # if dir not given, create random. Else, make sure it exists.
     if dir is None:


### PR DESCRIPTION
Fixes #5833


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
