### PR TITLE
Exclude cuCIM wrappers from get_transform_backends

### DIFF
--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1544,6 +1544,8 @@ def get_transform_backends():
             not in [
                 "BatchInverseTransform",
                 "Compose",
+                "CuCIM",
+                "CuCIMD",
                 "Decollated",
                 "InvertD",
                 "InvertibleTransform",
@@ -1551,6 +1553,8 @@ def get_transform_backends():
                 "LambdaD",
                 "MapTransform",
                 "OneOf",
+                "RandCuCIM",
+                "RandCuCIMD",
                 "RandomOrder",
                 "PadListDataCollate",
                 "RandLambda",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,35 @@ exclude = '''
 [tool.pycln]
 all = true
 exclude = "monai/bundle/__main__.py"
+
+[tool.pytype]
+# Space-separated list of files or directories to exclude.
+exclude = ["versioneer.py", "_version.py"]
+# Space-separated list of files or directories to process.
+inputs = ["monai"]
+# Keep going past errors to analyze as many files as possible.
+keep_going = true
+# Run N jobs in parallel.
+jobs = 8
+# All pytype output goes here.
+output = ".pytype"
+# Paths to source code directories, separated by ':'.
+pythonpath = "."
+# Check attribute values against their annotations.
+check_attribute_types = true
+# Check container mutations against their annotations.
+check_container_types = true
+# Check parameter defaults and assignments against their annotations.
+check_parameter_types = true
+# Check variable values against their annotations.
+check_variable_types = true
+# Comma or space separated list of error names to ignore.
+disable = ["pyi-error"]
+# Report errors.
+report_errors = true
+# Experimental: Infer precise return types even for invalid function calls.
+precise_return = true
+# Experimental: solve unknown types to label with structural types.
+protocols = true
+# Experimental: Only load submodules that are explicitly imported.
+strict_import = false

--- a/runtests.sh
+++ b/runtests.sh
@@ -570,7 +570,7 @@ then
     else
         ${cmdPrefix}${PY_EXE} -m pytype --version
 
-        ${cmdPrefix}${PY_EXE} -m pytype -j ${NUM_PARALLEL} --python-version="$(${PY_EXE} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
+        ${cmdPrefix}${PY_EXE} -m pytype -j ${NUM_PARALLEL} --python-version="$(${PY_EXE} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")" "$(pwd)"
 
         pytype_status=$?
         if [ ${pytype_status} -ne 0 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -215,38 +215,6 @@ check_untyped_defs = True
 # Warns about usage of untyped decorators.
 disallow_untyped_decorators = True
 
-[pytype]
-# Space-separated list of files or directories to exclude.
-exclude = versioneer.py _version.py
-# Space-separated list of files or directories to process.
-inputs = monai
-# Keep going past errors to analyze as many files as possible.
-keep_going = True
-# Run N jobs in parallel.
-jobs = 8
-# All pytype output goes here.
-output = .pytype
-# Paths to source code directories, separated by ':'.
-pythonpath = .
-# Check attribute values against their annotations.
-check_attribute_types = True
-# Check container mutations against their annotations.
-check_container_types = True
-# Check parameter defaults and assignments against their annotations.
-check_parameter_types = True
-# Check variable values against their annotations.
-check_variable_types = True
-# Comma or space separated list of error names to ignore.
-disable = pyi-error
-# Report errors.
-report_errors = True
-# Experimental: Infer precise return types even for invalid function calls.
-precise_return = True
-# Experimental: solve unknown types to label with structural types.
-protocols = True
-# Experimental: Only load submodules that are explicitly imported.
-strict_import = False
-
 [coverage:run]
 concurrency = multiprocessing
 source = .


### PR DESCRIPTION
### Description

This PR exclude `CuCIM`, `CuCIMD`, `RandCuCIM`, and `RandCuCIMD` wrapper transfrom from `get_transform_backends` as they are not supposed to support torch or numpy necessarily.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).

(also resolves #5840)