### PR TITLE
Fix constructors for DenseNet derived classes

### DIFF
--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -306,7 +306,15 @@ class DenseNet121(DenseNet):
         progress: bool = True,
         **kwargs,
     ) -> None:
-        super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
+        super().__init__(
+            spatial_dims=spatial_dims,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            init_features=init_features,
+            growth_rate=growth_rate,
+            block_config=block_config,
+            **kwargs,
+        )
         if pretrained:
             if spatial_dims > 2:
                 raise NotImplementedError(
@@ -331,7 +339,15 @@ class DenseNet169(DenseNet):
         progress: bool = True,
         **kwargs,
     ) -> None:
-        super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
+        super().__init__(
+            spatial_dims=spatial_dims,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            init_features=init_features,
+            growth_rate=growth_rate,
+            block_config=block_config,
+            **kwargs,
+        )
         if pretrained:
             if spatial_dims > 2:
                 raise NotImplementedError(
@@ -356,7 +372,15 @@ class DenseNet201(DenseNet):
         progress: bool = True,
         **kwargs,
     ) -> None:
-        super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
+        super().__init__(
+            spatial_dims=spatial_dims,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            init_features=init_features,
+            growth_rate=growth_rate,
+            block_config=block_config,
+            **kwargs,
+        )
         if pretrained:
             if spatial_dims > 2:
                 raise NotImplementedError(
@@ -381,7 +405,15 @@ class DenseNet264(DenseNet):
         progress: bool = True,
         **kwargs,
     ) -> None:
-        super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
+        super().__init__(
+            spatial_dims=spatial_dims,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            init_features=init_features,
+            growth_rate=growth_rate,
+            block_config=block_config,
+            **kwargs,
+        )
         if pretrained:
             raise NotImplementedError("Currently PyTorch Hub does not provide densenet264 pretrained models.")
 

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -308,7 +308,7 @@ class DenseNet121(DenseNet):
     ) -> None:
         super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
         if pretrained:
-            if kwargs["spatial_dims"] > 2:
+            if spatial_dims > 2:
                 raise NotImplementedError(
                     "Parameter `spatial_dims` is > 2 ; currently PyTorch Hub does not"
                     "provide pretrained models for more than two spatial dimensions."
@@ -333,7 +333,7 @@ class DenseNet169(DenseNet):
     ) -> None:
         super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
         if pretrained:
-            if kwargs["spatial_dims"] > 2:
+            if spatial_dims > 2:
                 raise NotImplementedError(
                     "Parameter `spatial_dims` is > 2 ; currently PyTorch Hub does not"
                     "provide pretrained models for more than two spatial dimensions."
@@ -358,7 +358,7 @@ class DenseNet201(DenseNet):
     ) -> None:
         super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
         if pretrained:
-            if kwargs["spatial_dims"] > 2:
+            if spatial_dims > 2:
                 raise NotImplementedError(
                     "Parameter `spatial_dims` is > 2 ; currently PyTorch Hub does not"
                     "provide pretrained models for more than two spatial dimensions."

--- a/monai/networks/nets/densenet.py
+++ b/monai/networks/nets/densenet.py
@@ -296,6 +296,9 @@ class DenseNet121(DenseNet):
 
     def __init__(
         self,
+        spatial_dims: int,
+        in_channels: int,
+        out_channels: int,
         init_features: int = 64,
         growth_rate: int = 32,
         block_config: Sequence[int] = (6, 12, 24, 16),
@@ -303,7 +306,7 @@ class DenseNet121(DenseNet):
         progress: bool = True,
         **kwargs,
     ) -> None:
-        super().__init__(init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
+        super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
         if pretrained:
             if kwargs["spatial_dims"] > 2:
                 raise NotImplementedError(
@@ -318,6 +321,9 @@ class DenseNet169(DenseNet):
 
     def __init__(
         self,
+        spatial_dims: int,
+        in_channels: int,
+        out_channels: int,
         init_features: int = 64,
         growth_rate: int = 32,
         block_config: Sequence[int] = (6, 12, 32, 32),
@@ -325,7 +331,7 @@ class DenseNet169(DenseNet):
         progress: bool = True,
         **kwargs,
     ) -> None:
-        super().__init__(init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
+        super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
         if pretrained:
             if kwargs["spatial_dims"] > 2:
                 raise NotImplementedError(
@@ -340,6 +346,9 @@ class DenseNet201(DenseNet):
 
     def __init__(
         self,
+        spatial_dims: int,
+        in_channels: int,
+        out_channels: int,
         init_features: int = 64,
         growth_rate: int = 32,
         block_config: Sequence[int] = (6, 12, 48, 32),
@@ -347,7 +356,7 @@ class DenseNet201(DenseNet):
         progress: bool = True,
         **kwargs,
     ) -> None:
-        super().__init__(init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
+        super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
         if pretrained:
             if kwargs["spatial_dims"] > 2:
                 raise NotImplementedError(
@@ -362,6 +371,9 @@ class DenseNet264(DenseNet):
 
     def __init__(
         self,
+        spatial_dims: int,
+        in_channels: int,
+        out_channels: int,
         init_features: int = 64,
         growth_rate: int = 32,
         block_config: Sequence[int] = (6, 12, 64, 48),
@@ -369,7 +381,7 @@ class DenseNet264(DenseNet):
         progress: bool = True,
         **kwargs,
     ) -> None:
-        super().__init__(init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
+        super().__init__(spatial_dims=spatial_dims, in_channels=in_channels, out_channels=out_channels, init_features=init_features, growth_rate=growth_rate, block_config=block_config, **kwargs)
         if pretrained:
             raise NotImplementedError("Currently PyTorch Hub does not provide densenet264 pretrained models.")
 


### PR DESCRIPTION
### Description

We noted it was possible to instantiate classes derived from DenseNet only if spatial_dims, in_channels, and out_channels parameters were passed by keywords.
Passing them via positional scheme was not working.
This small bug should be fixed now.

### Example:
Before my fix:
```
import monai
net = monai.networks.nets.DenseNet(3,1,2) # Working
net = monai.networks.nets.DenseNet121(3,1,2) # NOT woking
net = monai.networks.nets.DenseNet121(spatial_dims=3, in_channels=1, out_channels=2) # Woking
```

After my fix:
```
import monai
net = monai.networks.nets.DenseNet121(3,1,2) # Woking
```

Thanks to @robsver for pointing this issue out.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
