### PR TITLE
5852 fixes partial callable config parser

### DIFF
--- a/monai/bundle/config_item.py
+++ b/monai/bundle/config_item.py
@@ -236,7 +236,7 @@ class ConfigComponent(ConfigItem, Instantiable):
         config = dict(self.get_config())
         target = config.get("_target_")
         if not isinstance(target, str):
-            raise ValueError("must provide a string for the `_target_` of component to instantiate.")
+            return target
 
         module = self.locator.get_component_module_name(target)
         if module is None:

--- a/monai/bundle/config_item.py
+++ b/monai/bundle/config_item.py
@@ -236,7 +236,7 @@ class ConfigComponent(ConfigItem, Instantiable):
         config = dict(self.get_config())
         target = config.get("_target_")
         if not isinstance(target, str):
-            return target
+            return target  # for feature discussed in project-monai/monai#5852
 
         module = self.locator.get_component_module_name(target)
         if module is None:

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -19,7 +19,7 @@ import warnings
 from collections.abc import Callable, Collection, Hashable, Mapping
 from functools import partial, wraps
 from importlib import import_module
-from inspect import isclass, isfunction, ismethod
+from inspect import isclass
 from pkgutil import walk_packages
 from pydoc import locate
 from re import match
@@ -241,8 +241,7 @@ def instantiate(path: str, **kwargs):
             pdb.set_trace()
         if isclass(component):
             return component(**kwargs)
-        # support regular function, static method and class method
-        if isfunction(component) or (ismethod(component) and isclass(getattr(component, "__self__", None))):
+        if callable(component):  # support regular function, static method and class method
             return partial(component, **kwargs)
     except Exception as e:
         raise RuntimeError(f"Failed to instantiate '{path}' with kwargs: {kwargs}") from e

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -226,8 +226,7 @@ def instantiate(path: str, **kwargs):
             for `partial` function.
 
     """
-
-    component = locate(path)
+    component = locate(path) if isinstance(path, str) else path
     if component is None:
         raise ModuleNotFoundError(f"Cannot locate class or function path: '{path}'.")
     try:

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,5 +1,5 @@
 # Requirements for minimal tests
 -r requirements.txt
-setuptools>=50.3.0,!=60.0.0,!=60.6.0
+setuptools>=50.3.0,!=66.0.0,!=60.6.0
 coverage>=5.5
 parameterized

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -248,6 +248,14 @@ class TestConfigParser(unittest.TestCase):
         result = trans(np.ones(64))
         self.assertTupleEqual(result.shape, (1, 8, 8))
 
+    def test_non_str_target(self):
+        configs = {
+            "fwd": {"_target_": "$@model().forward", "x": "$torch.rand(1, 3, 256, 256)"},
+            "model": {"_target_": "monai.networks.nets.resnet.resnet18", "pretrained": False, "spatial_dims": 2},
+        }
+        self.assertTrue(callable(ConfigParser(config=configs).fwd))
+        self.assertTupleEqual(tuple(ConfigParser(config=configs).fwd().shape), (1, 400))
+
     def test_error_instance(self):
         config = {"transform": {"_target_": "Compose", "transforms_wrong_key": []}}
         parser = ConfigParser(config=config)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -274,6 +274,10 @@ class TestConfigParser(unittest.TestCase):
         result = trans(np.ones(64))
         self.assertTupleEqual(result.shape, (1, 8, 8))
 
+    def test_builtin(self):
+        config = {"import statements": "$import math", "calc": {"_target_": "math.isclose", "a": 0.001, "b": 0.001}}
+        self.assertEqual(ConfigParser(config).calc(), True)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5852

### Description
1. the following partial instantiate doesn't work
```py
config = {"import statements": "$import math", 
          "calc": {"_target_": "math.isclose", "a": 0.001, "b": 0.001}}
print(ConfigParser(config).calc())
```
with an error message:
```
Component to instantiate must represent a valid class or function, but got math.isclose.
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    print(ConfigParser(config).calc())
TypeError: isclose() missing required argument 'a' (pos 1)
```

because `math.isclose` is a builtin type but not a function:

```py
import inspect
inspect.isfunction(math.isclose)  # False
inspect.isbuiltin(math.isclose)  # True
```

the `partial` should support `callable` including builtin functions


2. also this PR supports `_target_` of reference object's methods such as partial init:
```py
"forward": {"_target_": "$@model().forward", "x": "$torch.rand(1, 3, 256, 256)"}
```

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
