### PR TITLE
Fix instantiate for object instantiation with attribute `path`

### DIFF
--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -214,7 +214,7 @@ def load_submodules(basemod, load_all: bool = True, exclude_pattern: str = "(.*[
     return submodules, err_mod
 
 
-def instantiate(path: str, **kwargs):
+def instantiate(__path: str, **kwargs):
     """
     Create an object instance or partial function from a class or function represented by string.
     `kwargs` will be part of the input arguments to the class constructor or function.
@@ -226,9 +226,9 @@ def instantiate(path: str, **kwargs):
             for `partial` function.
 
     """
-    component = locate(path) if isinstance(path, str) else path
+    component = locate(__path) if isinstance(__path, str) else __path
     if component is None:
-        raise ModuleNotFoundError(f"Cannot locate class or function path: '{path}'.")
+        raise ModuleNotFoundError(f"Cannot locate class or function path: '{__path}'.")
     try:
         if kwargs.pop("_debug_", False) or run_debug:
             warnings.warn(
@@ -243,9 +243,9 @@ def instantiate(path: str, **kwargs):
         if callable(component):  # support regular function, static method and class method
             return partial(component, **kwargs)
     except Exception as e:
-        raise RuntimeError(f"Failed to instantiate '{path}' with kwargs: {kwargs}") from e
+        raise RuntimeError(f"Failed to instantiate '{__path}' with kwargs: {kwargs}") from e
 
-    warnings.warn(f"Component to instantiate must represent a valid class or function, but got {path}.")
+    warnings.warn(f"Component to instantiate must represent a valid class or function, but got {__path}.")
     return component
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -144,6 +144,7 @@ max_line_length = 120
 # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
 # B023 https://github.com/Project-MONAI/MONAI/issues/4627
 # B028 https://github.com/Project-MONAI/MONAI/issues/5855
+# B907 https://github.com/Project-MONAI/MONAI/issues/5868
 ignore =
     E203
     E501
@@ -155,6 +156,7 @@ ignore =
     B023
     B905
     B028
+    B907
 per_file_ignores = __init__.py: F401, __main__.py: F401
 exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,.venv,_version.py
 


### PR DESCRIPTION
Fixes #5865 

-- also fixes https://github.com/Project-MONAI/MONAI/issues/5868 to unblock premerge

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
