### PR TITLE
Add warning in `RandHistogramShift`

### DIFF
--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1471,8 +1471,8 @@ class RandHistogramShift(RandomizableTransform):
         img_min, img_max = img_t.min(), img_t.max()
         if img_min == img_max:
             warn(
-                f"The intensity of the image has only one value {img_min}. "
-                "No histogram shift is done, just return the original image."
+                f"The image's intensity is a single value {img_min}. "
+                "The original image is simply returned, no histogram shift is done."
             )
             return img
         xp, *_ = convert_to_dst_type(self.reference_control_points, dst=img_t)

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1468,9 +1468,15 @@ class RandHistogramShift(RandomizableTransform):
         if self.reference_control_points is None or self.floating_control_points is None:
             raise RuntimeError("please call the `randomize()` function first.")
         img_t = convert_to_tensor(img, track_meta=False)
+        img_min, img_max = img_t.min(), img_t.max()
+        if img_min == img_max:
+            warn(
+                f"The intensity of the image has only one value {img_min}. "
+                "No histogram shift is done, just return the original image."
+            )
+            return img
         xp, *_ = convert_to_dst_type(self.reference_control_points, dst=img_t)
         yp, *_ = convert_to_dst_type(self.floating_control_points, dst=img_t)
-        img_min, img_max = img_t.min(), img_t.max()
         reference_control_points_scaled = xp * (img_max - img_min) + img_min
         floating_control_points_scaled = yp * (img_max - img_min) + img_min
         img_t = self.interp(img_t, reference_control_points_scaled, floating_control_points_scaled)

--- a/tests/test_rand_histogram_shift.py
+++ b/tests/test_rand_histogram_shift.py
@@ -44,6 +44,16 @@ for p in TEST_NDARRAYS:
         ]
     )
 
+WARN_TESTS = []
+for p in TEST_NDARRAYS:
+    WARN_TESTS.append(
+        [
+            {"num_control_points": 5, "prob": 1.0},
+            {"img": p(np.zeros(8).reshape((1, 2, 2, 2)))},
+            np.zeros(8).reshape((1, 2, 2, 2)),
+        ]
+    )
+
 
 class TestRandHistogramShift(unittest.TestCase):
     @parameterized.expand(TESTS)
@@ -70,6 +80,12 @@ class TestRandHistogramShift(unittest.TestCase):
             yi = tr.interp(array_type([[-2, 11], [1, 3], [8, 10]]), x, y)
             self.assertEqual(yi.shape, (3, 2))
             assert_allclose(yi, array_type([[1.0, 5.0], [0.5, -0.5], [4.0, 5.0]]))
+
+    @parameterized.expand(WARN_TESTS)
+    def test_warn(self, input_param, input_data, expected_val):
+        with self.assertWarns(Warning):
+            result = RandHistogramShift(**input_param)(**input_data)
+            assert_allclose(result, expected_val, type_test="tensor")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: KumoLiu <yunl@nvidia.com>

Fixes #5875 .

### Description

Add warning in `RandHistogramShift` when the image's intensity is a single value.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
