### PR TITLE
workaround 5882 reenable weekly preview release

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -3,6 +3,8 @@ name: weekly-preview
 on:
   schedule:
   - cron: "0 2 * * 0"  # 02:00 of every Sunday
+  push:
+    branches: workaround-5882
 
 jobs:
   packaging:
@@ -11,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: dev
+        ref: workaround-5882
         fetch-depth: 0
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
@@ -39,7 +41,9 @@ jobs:
         python setup.py sdist bdist_wheel
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
+        password: ${{ secrets.TEST_PYPI }}
+        repository_url: https://test.pypi.org/legacy/
+        # user: __token__
+        # password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -3,8 +3,6 @@ name: weekly-preview
 on:
   schedule:
   - cron: "0 2 * * 0"  # 02:00 of every Sunday
-  push:
-    branches: workaround-5882
 
 jobs:
   packaging:
@@ -13,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: workaround-5882
+        ref: dev
         fetch-depth: 0
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
@@ -44,6 +42,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        # password: ${{ secrets.PYPI_TOKEN }}
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.TEST_PYPI }}
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
-        # user: __token__
         # password: ${{ secrets.PYPI_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -133,8 +133,9 @@ pydicom =
     pydicom
 h5py =
     h5py
-MetricsReloaded =
-    MetricsReloaded @ git+https://github.com/Project-MONAI/MetricsReloaded@monai-support#egg=MetricsReloaded
+# # workaround https://github.com/Project-MONAI/MONAI/issues/5882
+# MetricsReloaded =
+#     MetricsReloaded @ git+https://github.com/Project-MONAI/MetricsReloaded@monai-support#egg=MetricsReloaded
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9

--- a/tests/test_metrics_reloaded.py
+++ b/tests/test_metrics_reloaded.py
@@ -18,6 +18,9 @@ import torch
 from parameterized import parameterized
 
 from monai.metrics import MetricsReloadedBinary, MetricsReloadedCategorical
+from monai.utils import optional_import
+
+_, has_metrics = optional_import("MetricsReloaded")
 
 # shape: (1, 1, 2, 2)
 y_pred = torch.tensor([[[[1.0, 0.0], [0.0, 1.0]]]])
@@ -71,6 +74,7 @@ TEST_CASES_CATEGORICAL = [
 ]
 
 
+@unittest.skipIf(not has_metrics, "MetricsReloaded not available.")
 class TestMetricsReloaded(unittest.TestCase):
     @parameterized.expand(TEST_CASES_BINARY)
     def test_binary(self, input_param, input_data, expected_val):


### PR DESCRIPTION
part of #5882 

### Description
a workaround to not installing MetricsReloaded when packaging.
once `pip install MetricsReloaded` is made available we can undo the workaround.

workflow tested https://github.com/Project-MONAI/MONAI/actions/runs/3984778767/jobs/6831377542

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
