### PR TITLE
5883 review requirements-dev.txt, docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ numpy>=1.17
 itk>=5.2
 nibabel
 parameterized
-scikit-image>=0.14.2
+scikit-image>=0.19.0
 tensorboard
 commonmark==0.9.1
 recommonmark==0.6.0
@@ -23,8 +23,8 @@ einops
 transformers<4.22  # https://github.com/Project-MONAI/MONAI/issues/5157
 mlflow
 tensorboardX
-imagecodecs; platform_system == "Linux"
-tifffile; platform_system == "Linux"
+imagecodecs; platform_system == "Linux" or platform_system == "Darwin"
+tifffile; platform_system == "Linux" or platform_system == "Darwin"
 pyyaml
 fire
 jsonschema

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,10 +27,6 @@ mypy>=0.790
 ninja
 torchvision
 psutil
-Sphinx==3.5.3
-recommonmark==0.6.0
-sphinx-autodoc-typehints==1.11.1
-sphinx-rtd-theme==0.5.2
 cucim==22.8.1; platform_system == "Linux"
 openslide-python==1.1.2
 imagecodecs; platform_system == "Linux" or platform_system == "Darwin"


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5883 

- to run unit/integration tests, the developers should use `runtests.sh`
which implements
https://github.com/Project-MONAI/MONAI/blob/2d0e0214ac80d97e6585edf59ffc6eed96bcfcdb/runtests.sh#L130-L133

- for read-the-docs builds, it automatically runs `cd docs; make html`:
which installs `docs/requirements.txt`
https://github.com/Project-MONAI/MONAI/blob/2d0e0214ac80d97e6585edf59ffc6eed96bcfcdb/docs/Makefile#L22-L23

the `docs/requirements.txt` is only for building the docs, and should work with a tiny workstation instance

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
