### PR TITLE
add rand identity

### DIFF
--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -486,6 +486,7 @@ from .utility.array import (
     Lambda,
     MapLabelValue,
     RandCuCIM,
+    RandIdentity,
     RandImageFilter,
     RandLambda,
     RemoveRepeatedChannel,

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -128,6 +128,7 @@ class Identity(Transform):
         """
         return img
 
+
 class RandIdentity(RandomizableTransform):
     """
     Do nothing to the data. This transform is random, so can be used to stop the caching of any

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -22,7 +22,7 @@ import warnings
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from functools import partial
-from typing import Callable
+from typing import Any, Callable
 
 import numpy as np
 import torch
@@ -75,6 +75,7 @@ cp, has_cp = optional_import("cupy")
 
 __all__ = [
     "Identity",
+    "RandIdentity",
     "AsChannelFirst",
     "AsChannelLast",
     "AddChannel",
@@ -126,6 +127,17 @@ class Identity(Transform):
         Apply the transform to `img`.
         """
         return img
+
+class RandIdentity(RandomizableTransform):
+    """
+    Do nothing to the data. This transform is random, so can be used to stop the caching of any
+    subsequent transforms.
+    """
+
+    backend = [TransformBackends.TORCH, TransformBackends.NUMPY]
+
+    def __call__(self, data: Any) -> Any:
+        return data
 
 
 @deprecated(since="0.8", msg_suffix="please use MetaTensor data type and monai.transforms.EnsureChannelFirst instead.")

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -129,7 +129,7 @@ class Identity(Transform):
         return img
 
 
-class RandIdentity(RandomizableTransform):
+class RandIdentity(RandomizableTrait):
     """
     Do nothing to the data. This transform is random, so can be used to stop the caching of any
     subsequent transforms.

--- a/tests/test_randidentity.py
+++ b/tests/test_randidentity.py
@@ -44,5 +44,6 @@ class TestIdentity(NumpyImageTestCase2D):
         # check that the cached value is correct
         self.assertEqual(ds._cache[0], expect_pre_cache)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_randidentity.py
+++ b/tests/test_randidentity.py
@@ -1,0 +1,48 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import monai.transforms as mt
+from monai.data import CacheDataset
+from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, assert_allclose
+
+
+class T(mt.Transform):
+    def __call__(self, x):
+        return x * 2
+
+
+class TestIdentity(NumpyImageTestCase2D):
+    def test_identity(self):
+        for p in TEST_NDARRAYS:
+            img = p(self.imt)
+            identity = mt.RandIdentity()
+            assert_allclose(img, identity(img))
+
+    def test_caching(self, init=1, expect=4, expect_pre_cache=2):
+        # check that we get the correct result (two lots of T so should get 4)
+        x = init
+        transforms = mt.Compose([T(), mt.RandIdentity(), T()])
+        self.assertEqual(transforms(x), expect)
+
+        # check we get correct result with CacheDataset
+        x = [init]
+        ds = CacheDataset(x, transforms)
+        self.assertEqual(ds[0], expect)
+
+        # check that the cached value is correct
+        self.assertEqual(ds._cache[0], expect_pre_cache)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

Adds `RandIdentity` which can be placed in a sequence of transforms to stop the caching of any results beyond this point.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
