### PR TITLE
make path user expansion optional

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -128,6 +128,7 @@ class LoadImage(Transform):
         simple_keys: bool = False,
         prune_meta_pattern: str | None = None,
         prune_meta_sep: str = ".",
+        expanduser: bool = True,
         *args,
         **kwargs,
     ) -> None:
@@ -150,6 +151,7 @@ class LoadImage(Transform):
             prune_meta_sep: combined with `prune_meta_pattern`, used to match and prune keys
                 in the metadata (nested dictionary). default is ".", see also :py:class:`monai.transforms.DeleteItemsd`.
                 e.g. ``prune_meta_pattern=".*_code$", prune_meta_sep=" "`` removes meta keys that ends with ``"_code"``.
+            expanduser: if True cast filename to Path and call .expanduser on it, otherwise keep filename as is.
             args: additional parameters for reader if providing a reader name.
             kwargs: additional parameters for reader if providing a reader name.
 
@@ -171,6 +173,7 @@ class LoadImage(Transform):
         self.simple_keys = simple_keys
         self.pattern = prune_meta_pattern
         self.sep = prune_meta_sep
+        self.expanduser = expanduser
 
         self.readers: list[ImageReader] = []
         for r in SUPPORTED_READERS:  # set predefined readers as default
@@ -238,7 +241,9 @@ class LoadImage(Transform):
             reader: runtime reader to load image file and metadata.
 
         """
-        filename = tuple(f"{Path(s).expanduser()}" for s in ensure_tuple(filename))  # allow Path objects
+        filename = tuple(
+            f"{Path(s).expanduser()}" if self.expanduser else s for s in ensure_tuple(filename)  # allow Path objects
+        )
         img, err = None, []
         if reader is not None:
             img = reader.read(filename)  # runtime specified reader

--- a/monai/transforms/io/dictionary.py
+++ b/monai/transforms/io/dictionary.py
@@ -83,6 +83,7 @@ class LoadImaged(MapTransform):
         prune_meta_pattern: str | None = None,
         prune_meta_sep: str = ".",
         allow_missing_keys: bool = False,
+        expanduser: bool = True,
         *args,
         **kwargs,
     ) -> None:
@@ -118,6 +119,7 @@ class LoadImaged(MapTransform):
                 in the metadata (nested dictionary). default is ".", see also :py:class:`monai.transforms.DeleteItemsd`.
                 e.g. ``prune_meta_pattern=".*_code$", prune_meta_sep=" "`` removes meta keys that ends with ``"_code"``.
             allow_missing_keys: don't raise exception if key is missing.
+            expanduser: if True cast filename to Path and call .expanduser on it, otherwise keep filename as is.
             args: additional parameters for reader if providing a reader name.
             kwargs: additional parameters for reader if providing a reader name.
         """
@@ -130,6 +132,7 @@ class LoadImaged(MapTransform):
             simple_keys,
             prune_meta_pattern,
             prune_meta_sep,
+            expanduser,
             *args,
             **kwargs,
         )


### PR DESCRIPTION
### Description

When using `LoadImage`, file paths get wrapped with `pathlib.Path` and `.expanduser()` is called. This causes paths with a protocol prefix to get corrupted (e.g. in my case paths starting with `s3://` are getting one of the forward slashes removed)

This PR makes the wrapping with `Path` and call to `.expanduser()` optional (but set to `True` by default, to preserve current behavior)

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
