### PR TITLE
Fix SSIMLoss when batchsize bigger than 2

### DIFF
--- a/monai/losses/ssim_loss.py
+++ b/monai/losses/ssim_loss.py
@@ -95,7 +95,7 @@ class SSIMLoss(_Loss):
                 if i == 0:
                     ssim_value = ssim_val
                 else:
-                    ssim_value = torch.cat((ssim_value.view(1), ssim_val.view(1)), dim=0)
+                    ssim_value = torch.cat((ssim_value.view(i), ssim_val.view(1)), dim=0)
 
         else:
             raise ValueError("Batch size is not nonnegative integer value")

--- a/tests/test_ssim_loss.py
+++ b/tests/test_ssim_loss.py
@@ -18,31 +18,34 @@ from parameterized import parameterized
 
 from monai.losses.ssim_loss import SSIMLoss
 
-x = torch.ones([1, 1, 10, 10]) / 2
-y1 = torch.ones([1, 1, 10, 10]) / 2
-y2 = torch.zeros([1, 1, 10, 10])
-data_range = x.max().unsqueeze(0)
 TESTS2D = []
 for device in [None, "cpu", "cuda"] if torch.cuda.is_available() else [None, "cpu"]:
-    TESTS2D.append((x.to(device), y1.to(device), data_range.to(device), torch.tensor(1.0).unsqueeze(0).to(device)))
-    TESTS2D.append((x.to(device), y2.to(device), data_range.to(device), torch.tensor(0.0).unsqueeze(0).to(device)))
+    for batch_size in [1, 2, 16]:
+        x = torch.ones([batch_size, 1, 10, 10]) / 2
+        y1 = torch.ones([batch_size, 1, 10, 10]) / 2
+        y2 = torch.zeros([batch_size, 1, 10, 10])
+        data_range = x.max().unsqueeze(0)
+        TESTS2D.append((x.to(device), y1.to(device), data_range.to(device), torch.tensor(1.0).unsqueeze(0).to(device)))
+        TESTS2D.append((x.to(device), y2.to(device), data_range.to(device), torch.tensor(0.0).unsqueeze(0).to(device)))
 
-x = torch.ones([1, 1, 10, 10, 10]) / 2
-y1 = torch.ones([1, 1, 10, 10, 10]) / 2
-y2 = torch.zeros([1, 1, 10, 10, 10])
-data_range = x.max().unsqueeze(0)
 TESTS3D = []
 for device in [None, "cpu", "cuda"] if torch.cuda.is_available() else [None, "cpu"]:
-    TESTS3D.append((x.to(device), y1.to(device), data_range.to(device), torch.tensor(1.0).unsqueeze(0).to(device)))
-    TESTS3D.append((x.to(device), y2.to(device), data_range.to(device), torch.tensor(0.0).unsqueeze(0).to(device)))
+    for batch_size in [1, 2, 16]:
+        x = torch.ones([batch_size, 1, 10, 10, 10]) / 2
+        y1 = torch.ones([batch_size, 1, 10, 10, 10]) / 2
+        y2 = torch.zeros([batch_size, 1, 10, 10, 10])
+        data_range = x.max().unsqueeze(0)
+        TESTS3D.append((x.to(device), y1.to(device), data_range.to(device), torch.tensor(1.0).unsqueeze(0).to(device)))
+        TESTS3D.append((x.to(device), y2.to(device), data_range.to(device), torch.tensor(0.0).unsqueeze(0).to(device)))
 
-x = torch.ones([1, 1, 10, 10]) / 2
-y = torch.ones([1, 1, 10, 10]) / 2
-y.requires_grad_(True)
-data_range = x.max().unsqueeze(0)
 TESTS2D_GRAD = []
 for device in [None, "cpu", "cuda"] if torch.cuda.is_available() else [None, "cpu"]:
-    TESTS2D_GRAD.append([x.to(device), y.to(device), data_range.to(device)])
+    for batch_size in [1, 2, 16]:
+        x = torch.ones([batch_size, 1, 10, 10]) / 2
+        y = torch.ones([batch_size, 1, 10, 10]) / 2
+        y.requires_grad_(True)
+        data_range = x.max().unsqueeze(0)
+        TESTS2D_GRAD.append([x.to(device), y.to(device), data_range.to(device)])
 
 
 class TestSSIMLoss(unittest.TestCase):


### PR DESCRIPTION
Signed-off-by: Jakob Weigand <jakob.weigand@tum.de>

Fixes #5886.

### Description

When SSIMLoss is called with a tensor of batchsize > 1, SSIMMetric is called for each batch item individually. The result of each call to SSIMMetric is stored in ssim_val. Subsequently, ssim_val is concatenated to ssim_value, which is a collection of all calls to SSIMMetric. Before the concatenation both ssim_val and ssim_value are given a new view of size 1. As ssim_value collects the results of all earlier calls to SSIMMetric, .view(1) raises an error for the second call (as ssim_value has a different absolute size). This commit changes the behavior of the view call, to always use the current size of ssim_value, avoiding this issue but keeping the behavior to concatenate in a single row vector.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
