### PR TITLE
5935 fixes spacing pixdim inplace change

### DIFF
--- a/monai/metrics/rocauc.py
+++ b/monai/metrics/rocauc.py
@@ -12,10 +12,13 @@
 from __future__ import annotations
 
 import warnings
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
-import numpy.typing as npt
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
 import torch
 
 from monai.utils import Average, look_up_option

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -553,7 +553,7 @@ class Spacing(InvertibleTransform):
             input_affine = np.eye(sr + 1, dtype=np.float64)
         affine_ = to_affine_nd(sr, convert_data_type(input_affine, np.ndarray)[0])
 
-        out_d = self.pixdim[:sr]
+        out_d = self.pixdim[:sr].copy()
         if out_d.size < sr:
             out_d = np.append(out_d, [out_d[-1]] * (sr - out_d.size))
 

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -351,6 +351,16 @@ class TestSpacingCase(unittest.TestCase):
         self.assertEqual(img_out.shape, img_t.shape)
         self.assertLess(((affine - img_out.affine) ** 2).sum() ** 0.5, 5e-2)
 
+    def test_property_no_change(self):
+        affine = torch.tensor(
+            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]], dtype=torch.float32, device="cpu"
+        )
+        affine[:3] *= 1 - 1e-4  # make sure it's not exactly target but close to the target
+        img = MetaTensor(torch.rand((1, 10, 9, 8), dtype=torch.float32), affine=affine, meta={"fname": "somewhere"})
+        tr = Spacing(pixdim=[1.0, 1.0, 1.0])
+        tr(img)
+        assert_allclose(tr.pixdim, [1.0, 1.0, 1.0], type_test=False)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5935

### Description
assigning `out_d[idx]` in the `__call__` shouldn't change `self.pixdim` in Spacing

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
