### PR TITLE
5902 allow for missing filename_or_obj key

### DIFF
--- a/monai/data/folder_layout.py
+++ b/monai/data/folder_layout.py
@@ -21,7 +21,11 @@ __all__ = ["FolderLayout", "default_name_formatter"]
 def default_name_formatter(metadict, saver):
     """Returns a kwargs dict for :py:meth:`FolderLayout.filename`,
     according to the input metadata and SaveImage transform."""
-    subject = metadict[monai.utils.ImageMetaKey.FILENAME_OR_OBJ] if metadict else getattr(saver, "_data_index", 0)
+    subject = (
+        metadict.get(monai.utils.ImageMetaKey.FILENAME_OR_OBJ, getattr(saver, "_data_index", 0))
+        if metadict
+        else getattr(saver, "_data_index", 0)
+    )
     patch_index = metadict.get(monai.utils.ImageMetaKey.PATCH_INDEX, None) if metadict else None
     return {"subject": f"{subject}", "idx": patch_index}
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -346,7 +346,7 @@ class ResampleToMatch(SpatialResample):
         if dst_affine is not None:
             super().update_meta(img, dst_affine)
         if isinstance(img_dst, MetaTensor) and isinstance(img, MetaTensor):
-            original_fname = img.meta[Key.FILENAME_OR_OBJ]
+            original_fname = img.meta.get(Key.FILENAME_OR_OBJ, "resample_to_match_source")
             img.meta = deepcopy(img_dst.meta)
             img.meta[Key.FILENAME_OR_OBJ] = original_fname  # keep the original name, the others are overwritten
 

--- a/tests/test_resample_to_match.py
+++ b/tests/test_resample_to_match.py
@@ -27,7 +27,7 @@ from parameterized import parameterized
 from monai.data import MetaTensor
 from monai.data.image_reader import ITKReader, NibabelReader
 from monai.data.image_writer import ITKWriter
-from monai.transforms import Compose, EnsureChannelFirstd, LoadImaged, ResampleToMatch, SaveImaged
+from monai.transforms import Compose, EnsureChannelFirstd, LoadImaged, ResampleToMatch, SaveImage, SaveImaged
 from monai.utils import optional_import
 from tests.utils import assert_allclose, download_url_or_skip_test, testing_data_config
 
@@ -97,6 +97,7 @@ class TestResampleToMatch(unittest.TestCase):
         img_2 = MetaTensor(torch.zeros(1, 3, 3, 3))
         im_mod = ResampleToMatch()(img_1, img_2)
         self.assertEqual(im_mod.meta["filename_or_obj"], "resample_to_match_source")
+        SaveImage(output_dir=self.tmpdir, output_postfix="", separate_folder=False, resample=False)(im_mod)
 
 
 if __name__ == "__main__":

--- a/tests/test_resample_to_match.py
+++ b/tests/test_resample_to_match.py
@@ -21,8 +21,10 @@ import unittest
 
 import nibabel as nib
 import numpy as np
+import torch
 from parameterized import parameterized
 
+from monai.data import MetaTensor
 from monai.data.image_reader import ITKReader, NibabelReader
 from monai.data.image_writer import ITKWriter
 from monai.transforms import Compose, EnsureChannelFirstd, LoadImaged, ResampleToMatch, SaveImaged
@@ -89,6 +91,12 @@ class TestResampleToMatch(unittest.TestCase):
         self.assertEqual(im_mod2.shape, data["im2"].shape)
         self.assertLess(((im_mod2.affine - data["im2"].affine) ** 2).sum() ** 0.5, 1e-2)
         self.assertEqual(im_mod2.applied_operations, [])
+
+    def test_no_name(self):
+        img_1 = MetaTensor(torch.zeros(1, 2, 2, 2))
+        img_2 = MetaTensor(torch.zeros(1, 3, 3, 3))
+        im_mod = ResampleToMatch()(img_1, img_2)
+        self.assertEqual(im_mod.meta["filename_or_obj"], "resample_to_match_source")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

Fixes #5902

### Description
the source image in ResampleToMatch may not have a `filename_or_obj` when the source image is not created from `LoadImage`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
