### PR TITLE
CI: Add dependabot workflow to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
### Description

This adds a dependabot workflow to update github actions versions as I have noticed deprecations in some of the recent runs here in https://github.com/Project-MONAI/MONAI/actions.

This is like what was integrated at https://github.com/Project-MONAI/MONAILabel/commit/2ee812a3e63fc16ba04b0d4b6a977536ef6a9e3b which resulted in automatically created PRs to update outdated github actions in https://github.com/Project-MONAI/MONAILabel/pull/1310 and https://github.com/Project-MONAI/MONAILabel/pull/1311.

Once this is integrated, auto created PRs by dependabot will be opened.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
