### PR TITLE
5991 add utility enhancements for lazy resampling

### DIFF
--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -490,7 +490,7 @@ class MetaTensor(MetaObj, torch.Tensor):
 
     def peek_pending_rank(self):
         a = self.pending_operations[-1].get(LazyAttr.AFFINE, None) if self.pending_operations else self.affine
-        return int(max(1, len(a) - 1))
+        return 1 if a is None else int(max(1, len(a) - 1))
 
     def new_empty(self, size, dtype=None, device=None, requires_grad=False):
         """

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -486,6 +486,11 @@ class MetaTensor(MetaObj, torch.Tensor):
                 continue
             res = convert_to_dst_type(res, next_matrix)[0]
             res = monai.transforms.lazy.utils.combine_transforms(res, next_matrix)
+        return res
+
+    def peek_pending_rank(self):
+        a = self.pending_operations[-1].get(LazyAttr.AFFINE, None) if self.pending_operations else self.affine
+        return int(max(1, len(a) - 1))
 
     def new_empty(self, size, dtype=None, device=None, requires_grad=False):
         """

--- a/monai/transforms/lazy/utils.py
+++ b/monai/transforms/lazy/utils.py
@@ -38,7 +38,7 @@ class Affine:
             return False
         if not hasattr(data, "shape") or len(data.shape) < 2:
             return False
-        return data.shape[-1] in (3, 4) and data.shape[-2] in (3, 4) and data.shape[-1] == data.shape[-2]
+        return data.shape[-1] in (3, 4) and data.shape[-1] == data.shape[-2]
 
 
 class DisplacementField:
@@ -129,6 +129,6 @@ def resample(data: torch.Tensor, matrix: NdarrayOrTensor, spatial_size, kwargs: 
         "padding_mode": kwargs.pop(LazyAttr.PADDING_MODE, None),
     }
     resampler = monai.transforms.SpatialResample(**init_kwargs)
-    # resampler.lazy_evaluation = False
-    with resampler.trace_transform(False):  # don't track this transform in `data`
+    # resampler.lazy_evaluation = False  # resampler is a lazytransform
+    with resampler.trace_transform(False):  # don't track this transform in `img`
         return resampler(img=img, **call_kwargs)

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -319,7 +319,7 @@ class LazyTransform(Transform, LazyTrait):
     dictionary transforms to simplify implementation of new lazy transforms.
     """
 
-    _lazy_evaluation: bool = False    
+    _lazy_evaluation: bool = False
 
     @property
     def lazy_evaluation(self):

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -319,18 +319,17 @@ class LazyTransform(Transform, LazyTrait):
     dictionary transforms to simplify implementation of new lazy transforms.
     """
 
-    def __init__(self, lazy_evaluation: bool | None = True):
-        self.lazy_evaluation = lazy_evaluation
+    _lazy_evaluation: bool = False    
 
     @property
     def lazy_evaluation(self):
-        return self.lazy_evaluation
+        return self._lazy_evaluation
 
     @lazy_evaluation.setter
     def lazy_evaluation(self, lazy_evaluation: bool):
         if not isinstance(lazy_evaluation, bool):
             raise TypeError(f"lazy_evaluation must be a bool but is of type {type(lazy_evaluation)}")
-        self.lazy_evaluation = lazy_evaluation
+        self._lazy_evaluation = lazy_evaluation
 
 
 class RandomizableTransform(Randomizable, Transform):

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -873,6 +873,7 @@ def create_translate(
         backend: APIs to use, ``numpy`` or ``torch``.
     """
     _backend = look_up_option(backend, TransformBackends)
+    spatial_dims = int(spatial_dims)
     if _backend == TransformBackends.NUMPY:
         return _create_translate(spatial_dims=spatial_dims, shift=shift, eye_func=np.eye, array_func=np.asarray)
     if _backend == TransformBackends.TORCH:

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -515,9 +515,11 @@ class TestMetaTensor(unittest.TestCase):
         self.assertEqual(m.pending_operations, [])
         self.assertEqual(m.peek_pending_shape(), (10, 8))
         self.assertIsInstance(m.peek_pending_affine(), torch.Tensor)
+        self.assertTrue(m.peek_pending_rank() >= 1)
         m.push_pending_operation({})
         self.assertEqual(m.peek_pending_shape(), (10, 8))
         self.assertIsInstance(m.peek_pending_affine(), torch.Tensor)
+        self.assertTrue(m.peek_pending_rank() >= 1)
 
     @parameterized.expand(TESTS)
     def test_multiprocessing(self, device=None, dtype=None):


### PR DESCRIPTION
Part of #5991 .

### Description

This PR adds the minor utility enhancements from #5860 relate to lazy resampling, and it belongs to the first part mentioned in https://github.com/Project-MONAI/MONAI/issues/5991

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
