### PR TITLE
Fix `CheckpointSaver` log error

### DIFF
--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -11,8 +11,8 @@
 
 from __future__ import annotations
 
-import os
 import logging
+import os
 import warnings
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import os
 import logging
 import warnings
 from collections.abc import Mapping
@@ -271,7 +272,11 @@ class CheckpointSaver:
             raise AssertionError
         if not hasattr(self.logger, "info"):
             raise AssertionError("Error, provided logger has not info attribute.")
-        self.logger.info(f"Train completed, saved final checkpoint: {self._final_checkpoint.last_checkpoint}")
+        if self._final_checkpoint.save_handler.filename is not None:
+            _final_checkpoint_path = os.path.join(self.save_dir, self._final_checkpoint.save_handler.filename)
+        else:
+            _final_checkpoint_path = self._final_checkpoint.last_checkpoint
+        self.logger.info(f"Train completed, saved final checkpoint: {_final_checkpoint_path}")
 
     def exception_raised(self, engine: Engine, e: Exception) -> None:
         """Callback for train or validation/evaluation exception raised Event.

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -272,10 +272,10 @@ class CheckpointSaver:
             raise AssertionError
         if not hasattr(self.logger, "info"):
             raise AssertionError("Error, provided logger has not info attribute.")
-        if self._final_checkpoint.save_handler.filename is not None:
-            _final_checkpoint_path = os.path.join(self.save_dir, self._final_checkpoint.save_handler.filename)
+        if self._final_checkpoint.save_handler.filename is not None:  # type: ignore[attr-defined]
+            _final_checkpoint_path = os.path.join(self.save_dir, self._final_checkpoint.save_handler.filename)  # type: ignore[attr-defined]
         else:
-            _final_checkpoint_path = self._final_checkpoint.last_checkpoint
+            _final_checkpoint_path = self._final_checkpoint.last_checkpoint  # type: ignore[assignment]
         self.logger.info(f"Train completed, saved final checkpoint: {_final_checkpoint_path}")
 
     def exception_raised(self, engine: Engine, e: Exception) -> None:

--- a/monai/handlers/checkpoint_saver.py
+++ b/monai/handlers/checkpoint_saver.py
@@ -119,6 +119,7 @@ class CheckpointSaver:
         self._key_metric_checkpoint: Checkpoint | None = None
         self._interval_checkpoint: Checkpoint | None = None
         self._name = name
+        self._final_filename = final_filename
 
         class _DiskSaver(DiskSaver):
             """
@@ -149,7 +150,7 @@ class CheckpointSaver:
 
             self._final_checkpoint = Checkpoint(
                 to_save=self.save_dict,
-                save_handler=_DiskSaver(dirname=self.save_dir, filename=final_filename),
+                save_handler=_DiskSaver(dirname=self.save_dir, filename=self._final_filename),
                 filename_prefix=file_prefix,
                 score_function=_final_func,
                 score_name="final_iteration",
@@ -272,8 +273,8 @@ class CheckpointSaver:
             raise AssertionError
         if not hasattr(self.logger, "info"):
             raise AssertionError("Error, provided logger has not info attribute.")
-        if self._final_checkpoint.save_handler.filename is not None:  # type: ignore[attr-defined]
-            _final_checkpoint_path = os.path.join(self.save_dir, self._final_checkpoint.save_handler.filename)  # type: ignore[attr-defined]
+        if self._final_filename is not None:
+            _final_checkpoint_path = os.path.join(self.save_dir, self._final_filename)
         else:
             _final_checkpoint_path = self._final_checkpoint.last_checkpoint  # type: ignore[assignment]
         self.logger.info(f"Train completed, saved final checkpoint: {_final_checkpoint_path}")
@@ -296,7 +297,11 @@ class CheckpointSaver:
             raise AssertionError
         if not hasattr(self.logger, "info"):
             raise AssertionError("Error, provided logger has not info attribute.")
-        self.logger.info(f"Exception raised, saved the last checkpoint: {self._final_checkpoint.last_checkpoint}")
+        if self._final_filename is not None:
+            _final_checkpoint_path = os.path.join(self.save_dir, self._final_filename)
+        else:
+            _final_checkpoint_path = self._final_checkpoint.last_checkpoint  # type: ignore[assignment]
+        self.logger.info(f"Exception raised, saved the last checkpoint: {_final_checkpoint_path}")
         raise e
 
     def metrics_completed(self, engine: Engine) -> None:


### PR DESCRIPTION
Fixes #6024 .

### Description
Update `CheckpointSaver`  to log right final checkpoint path.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
