### PR TITLE
Remove redundant array copy for TiffFileWSIReader

### DIFF
--- a/monai/data/wsi_reader.py
+++ b/monai/data/wsi_reader.py
@@ -825,7 +825,7 @@ class TiffFileWSIReader(BaseWSIReader):
         # Extract patch
         downsampling_ratio = self.get_downsample_ratio(wsi=wsi, level=level)
         location_ = [round(location[i] / downsampling_ratio) for i in range(len(location))]
-        patch = wsi_image[location_[0] : location_[0] + size[0], location_[1] : location_[1] + size[1], :].copy()
+        patch = wsi_image[location_[0] : location_[0] + size[0], location_[1] : location_[1] + size[1], :]
 
         # Make the channel to desired dimensions
         patch = np.moveaxis(patch, -1, self.channel_dim)


### PR DESCRIPTION
Fixes #5580 

### Description
This PR removes an "unnecessary" array copy in WSITiffFileReader, which was causing an slow down in loading whole slide images.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).