### PR TITLE
Remove del patches

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -3140,7 +3140,6 @@ class GridPatch(Transform, MultiSampleTrait):
         patches = list(zip(*patch_iterator))
         patched_image = np.array(patches[0])
         locations = np.array(patches[1])[:, 1:, 0]  # only keep the starting location
-        del patches  # it will free up some memory if padding is used.
 
         # Apply threshold filtering
         if self.threshold is not None:


### PR DESCRIPTION
### Description

As discussed here: https://github.com/Project-MONAI/MONAI/pull/6055#discussion_r1123155567
It removes the delete statement in GridPatch.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).