### PR TITLE
6020 avoid creating cufile.log when `import monai`

### DIFF
--- a/monai/auto3dseg/utils.py
+++ b/monai/auto3dseg/utils.py
@@ -43,7 +43,6 @@ __all__ = [
 
 measure_np, has_measure = optional_import("skimage.measure", "0.14.2", min_version)
 cp, has_cp = optional_import("cupy")
-cucim, has_cucim = optional_import("cucim")
 
 
 def get_foreground_image(image: MetaTensor) -> np.ndarray:
@@ -93,7 +92,7 @@ def get_label_ccp(mask_index: MetaTensor, use_gpu: bool = True) -> tuple[list[An
             regardless of this setting.
 
     """
-
+    cucim, has_cucim = optional_import("cucim")
     shape_list = []
     if mask_index.device.type == "cuda" and has_cp and has_cucim and use_gpu:
         mask_cupy = ToCupy()(mask_index.short())

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -1274,8 +1274,7 @@ class WSIReader(ImageReader):
         if backend == "openslide":
             return OpenSlide
         if backend == "cucim":
-            CuImage, _ = optional_import("cucim", name="CuImage")
-            return CuImage
+            return optional_import("cucim", name="CuImage")[0]
         if backend == "tifffile":
             return TiffFile
         raise ValueError("`backend` should be 'cuCIM', 'OpenSlide' or 'TiffFile'.")

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -62,7 +62,6 @@ else:
     nrrd, has_nrrd = optional_import("nrrd", allow_namespace_pkg=True)
 
 OpenSlide, _ = optional_import("openslide", name="OpenSlide")
-
 TiffFile, _ = optional_import("tifffile", name="TiffFile")
 
 __all__ = [

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -62,7 +62,7 @@ else:
     nrrd, has_nrrd = optional_import("nrrd", allow_namespace_pkg=True)
 
 OpenSlide, _ = optional_import("openslide", name="OpenSlide")
-CuImage, _ = optional_import("cucim", name="CuImage")
+
 TiffFile, _ = optional_import("tifffile", name="TiffFile")
 
 __all__ = [
@@ -1274,6 +1274,7 @@ class WSIReader(ImageReader):
         if backend == "openslide":
             return OpenSlide
         if backend == "cucim":
+            CuImage, _ = optional_import("cucim", name="CuImage")
             return CuImage
         if backend == "tifffile":
             return TiffFile

--- a/monai/data/wsi_reader.py
+++ b/monai/data/wsi_reader.py
@@ -23,7 +23,6 @@ from monai.data.image_reader import ImageReader, _stack_images
 from monai.data.utils import is_supported_format
 from monai.utils import WSIPatchKeys, ensure_tuple, optional_import, require_pkg
 
-CuImage, _ = optional_import("cucim", name="CuImage")
 OpenSlide, _ = optional_import("openslide", name="OpenSlide")
 TiffFile, _ = optional_import("tifffile", name="TiffFile")
 
@@ -491,13 +490,15 @@ class CuCIMWSIReader(BaseWSIReader):
             whole slide image object or list of such objects
 
         """
+        cuimage_cls, _ = optional_import("cucim", name="CuImage")
+
         wsi_list: list = []
 
         filenames: Sequence[PathLike] = ensure_tuple(data)
         kwargs_ = self.kwargs.copy()
         kwargs_.update(kwargs)
         for filename in filenames:
-            wsi = CuImage(filename, **kwargs_)
+            wsi = cuimage_cls(filename, **kwargs_)
             wsi_list.append(wsi)
 
         return wsi_list if len(filenames) > 1 else wsi_list[0]

--- a/monai/data/wsi_reader.py
+++ b/monai/data/wsi_reader.py
@@ -491,7 +491,6 @@ class CuCIMWSIReader(BaseWSIReader):
 
         """
         cuimage_cls, _ = optional_import("cucim", name="CuImage")
-
         wsi_list: list = []
 
         filenames: Sequence[PathLike] = ensure_tuple(data)

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -67,7 +67,6 @@ morphology, has_morphology = optional_import("skimage.morphology")
 ndimage, _ = optional_import("scipy.ndimage")
 cp, has_cp = optional_import("cupy")
 cp_ndarray, _ = optional_import("cupy", name="ndarray")
-
 exposure, has_skimage = optional_import("skimage.exposure")
 
 __all__ = [

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -67,7 +67,7 @@ morphology, has_morphology = optional_import("skimage.morphology")
 ndimage, _ = optional_import("scipy.ndimage")
 cp, has_cp = optional_import("cupy")
 cp_ndarray, _ = optional_import("cupy", name="ndarray")
-cucim, has_cucim = optional_import("cucim")
+
 exposure, has_skimage = optional_import("skimage.exposure")
 
 __all__ = [
@@ -974,6 +974,7 @@ def get_largest_connected_component_mask(
     """
     # use skimage/cucim.skimage and np/cp depending on whether packages are
     # available and input is non-cpu torch.tensor
+    cucim, has_cucim = optional_import("cucim")
     use_cp = has_cp and has_cucim and isinstance(img, torch.Tensor) and img.device != torch.device("cpu")
     if use_cp:
         img_ = convert_to_cupy(img.short())  # type: ignore

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -477,10 +477,10 @@ def require_pkg(
     def _decorator(obj):
         is_func = isinstance(obj, FunctionType)
         call_obj = obj if is_func else obj.__init__
-        _, has = optional_import(module=pkg_name, version=version, version_checker=version_checker)
 
         @wraps(call_obj)
         def _wrapper(*args, **kwargs):
+            _, has = optional_import(module=pkg_name, version=version, version_checker=version_checker)
             if not has:
                 err_msg = f"required package `{pkg_name}` is not installed or the version doesn't match requirement."
                 if raise_error:


### PR DESCRIPTION
Fixes #6020

### Description

```
pip install cucim
python -c "import cucim"
```
may create a `cufile.log` file in the current working directory (please see https://github.com/rapidsai/cucim/issues/514)

this PR delays the cucim imports to when the modules are really needed. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
