### PR TITLE
Add single if statement for warn

### DIFF
--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -570,9 +570,9 @@ def generate_label_classes_crop_centers(
 
     for i, array in enumerate(indices):
         if len(array) == 0:
+            ratios_[i] = 0
             if warn:
                 warnings.warn(f"no available indices of class {i} to crop, set the crop ratio of this class to zero.")
-            ratios_[i] = 0
 
     centers = []
     classes = rand_state.choice(len(ratios_), size=num_samples, p=np.asarray(ratios_) / np.sum(ratios_))

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -569,8 +569,9 @@ def generate_label_classes_crop_centers(
         raise ValueError(f"ratios should not contain negative number, got {ratios_}.")
 
     for i, array in enumerate(indices):
-        if len(array) == 0 and warn:
-            warnings.warn(f"no available indices of class {i} to crop, set the crop ratio of this class to zero.")
+        if len(array) == 0:
+            if warn:
+                warnings.warn(f"no available indices of class {i} to crop, set the crop ratio of this class to zero.")
             ratios_[i] = 0
 
     centers = []


### PR DESCRIPTION
Avoids crashing of the function if `ratios_[i] = 0` cannot be updated

Fixes #6121 

### Description

Adds additional if statement to check if warn is true, so that the following code can still be executed. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
