### PR TITLE
more efficient Dice metrics for large num_class

### DIFF
--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -53,9 +53,10 @@ Metrics
 
 `Mean Dice`
 -----------
-.. autofunction:: compute_meandice
-
 .. autoclass:: DiceMetric
+    :members:
+
+.. autoclass:: DiceHelper
     :members:
 
 `Mean IoU`

--- a/monai/handlers/mean_dice.py
+++ b/monai/handlers/mean_dice.py
@@ -48,7 +48,7 @@ class MeanDice(IgniteMetric):
                 default to True, will save to `engine.state.metric_details` dict with the metric name as key.
 
         See also:
-            :py:meth:`monai.metrics.meandice.compute_meandice`
+            :py:meth:`monai.metrics.meandice.compute_dice`
         """
         metric_fn = DiceMetric(include_background=include_background, reduction=reduction)
         super().__init__(metric_fn=metric_fn, output_transform=output_transform, save_details=save_details)

--- a/monai/metrics/__init__.py
+++ b/monai/metrics/__init__.py
@@ -19,7 +19,7 @@ from .froc import compute_fp_tp_probs, compute_froc_curve_data, compute_froc_sco
 from .generalized_dice import GeneralizedDiceScore, compute_generalized_dice
 from .hausdorff_distance import HausdorffDistanceMetric, compute_hausdorff_distance, compute_percent_hausdorff_distance
 from .loss_metric import LossMetric
-from .meandice import DiceMetric, compute_dice, compute_meandice
+from .meandice import DiceHelper, DiceMetric, compute_dice
 from .meaniou import MeanIoU, compute_iou, compute_meaniou
 from .metric import Cumulative, CumulativeIterationMetric, IterationMetric, Metric
 from .panoptic_quality import PanopticQualityMetric, compute_panoptic_quality

--- a/monai/metrics/confusion_matrix.py
+++ b/monai/metrics/confusion_matrix.py
@@ -85,7 +85,6 @@ class ConfusionMatrixMetric(CumulativeIterationMetric):
             y: ground truth to compute the metric. It must be one-hot format and first dim is batch.
                 The values should be binarized.
         Raises:
-            ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than two dimensions.
         """
         # check dimension

--- a/monai/metrics/confusion_matrix.py
+++ b/monai/metrics/confusion_matrix.py
@@ -16,7 +16,7 @@ from collections.abc import Sequence
 
 import torch
 
-from monai.metrics.utils import do_metric_reduction, ignore_background, is_binary_tensor
+from monai.metrics.utils import do_metric_reduction, ignore_background
 from monai.utils import MetricReduction, ensure_tuple
 
 from .metric import CumulativeIterationMetric
@@ -88,9 +88,6 @@ class ConfusionMatrixMetric(CumulativeIterationMetric):
             ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than two dimensions.
         """
-        is_binary_tensor(y_pred, "y_pred")
-        is_binary_tensor(y, "y")
-
         # check dimension
         dims = y_pred.ndimension()
         if dims < 2:

--- a/monai/metrics/f_beta_score.py
+++ b/monai/metrics/f_beta_score.py
@@ -15,7 +15,7 @@ from collections.abc import Sequence
 
 import torch
 
-from monai.metrics.utils import do_metric_reduction, ignore_background, is_binary_tensor
+from monai.metrics.utils import do_metric_reduction, ignore_background
 from monai.utils import MetricReduction
 
 from .metric import CumulativeIterationMetric
@@ -36,9 +36,6 @@ class FBetaScore(CumulativeIterationMetric):
         self.get_not_nans = get_not_nans
 
     def _compute_tensor(self, y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        is_binary_tensor(y_pred, "y_pred")
-        is_binary_tensor(y, "y")
-
         if y_pred.ndimension() < 2:
             raise ValueError("y_pred should have at least two dimensions.")
 

--- a/monai/metrics/generalized_dice.py
+++ b/monai/metrics/generalized_dice.py
@@ -72,8 +72,7 @@ class GeneralizedDiceScore(CumulativeIterationMetric):
             y (torch.Tensor): binarized ground-truth. It must be in one-hot format and have the same shape as `y_pred`.
 
         Raises:
-            ValueError: if `y_pred` or `y` is not a binarized PyTorch tensor, if `y_pred` and `y` have less than
-            three dimensions, or `y_pred` and `y` don't have the same shape.
+            ValueError: if `y_pred` and `y` have less than 3 dimensions, or `y_pred` and `y` don't have the same shape.
         """
         return compute_generalized_dice(
             y_pred=y_pred, y=y, include_background=self.include_background, weight_type=self.weight_type

--- a/monai/metrics/generalized_dice.py
+++ b/monai/metrics/generalized_dice.py
@@ -17,7 +17,6 @@ from monai.metrics.utils import do_metric_reduction, ignore_background
 from monai.utils import MetricReduction, Weight, look_up_option
 
 from .metric import CumulativeIterationMetric
-from .utils import is_binary_tensor
 
 
 class GeneralizedDiceScore(CumulativeIterationMetric):
@@ -127,10 +126,6 @@ def compute_generalized_dice(
         ValueError: if `y_pred` or `y` are not PyTorch tensors, if `y_pred` and `y` have less than three dimensions,
             or `y_pred` and `y` don't have the same shape.
     """
-    # Ensure tensors are binarized
-    is_binary_tensor(y_pred, "y_pred")
-    is_binary_tensor(y, "y")
-
     # Ensure tensors have at least 3 dimensions and have the same shape
     dims = y_pred.dim()
     if dims < 3:

--- a/monai/metrics/hausdorff_distance.py
+++ b/monai/metrics/hausdorff_distance.py
@@ -80,7 +80,6 @@ class HausdorffDistanceMetric(CumulativeIterationMetric):
                 The values should be binarized.
 
         Raises:
-            ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
         """
         dims = y_pred.ndimension()

--- a/monai/metrics/hausdorff_distance.py
+++ b/monai/metrics/hausdorff_distance.py
@@ -16,13 +16,7 @@ import warnings
 import numpy as np
 import torch
 
-from monai.metrics.utils import (
-    do_metric_reduction,
-    get_mask_edges,
-    get_surface_distance,
-    ignore_background,
-    is_binary_tensor,
-)
+from monai.metrics.utils import do_metric_reduction, get_mask_edges, get_surface_distance, ignore_background
 from monai.utils import MetricReduction, convert_data_type
 
 from .metric import CumulativeIterationMetric
@@ -89,9 +83,6 @@ class HausdorffDistanceMetric(CumulativeIterationMetric):
             ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
         """
-        is_binary_tensor(y_pred, "y_pred")
-        is_binary_tensor(y, "y")
-
         dims = y_pred.ndimension()
         if dims < 3:
             raise ValueError("y_pred should have at least three dimensions.")

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -73,7 +73,6 @@ class DiceMetric(CumulativeIterationMetric):
                 The values should be binarized.
 
         Raises:
-            ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
         """
         dims = y_pred.ndimension()

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -28,13 +28,11 @@ class DiceMetric(CumulativeIterationMetric):
     It supports both multi-classes and multi-labels tasks.
     Input `y_pred` is compared with ground truth `y`.
     `y_pred` is expected to have binarized predictions and `y` can be single-channel class indices or in the
-    one-hot format.
-    The `include_background` parameter can be set to ``False`` to exclude
+    one-hot format. The `include_background` parameter can be set to ``False`` to exclude
     the first category (channel index 0) which is by convention assumed to be background. If the non-background
     segmentations are small compared to the total image size they can get overwhelmed by the signal from the
-    background.
-    `y_preds` and `y` can be a list of channel-first Tensor (CHW[D]) or a batch-first Tensor (BCHW[D]), `y` can
-    also be in the format of `B1HW[D]`.
+    background. `y_preds` and `y` can be a list of channel-first Tensor (CHW[D]) or a batch-first Tensor (BCHW[D]),
+    `y` can also be in the format of `B1HW[D]`.
 
     Example of the typical execution steps of this metric class follows :py:class:`monai.metrics.metric.Cumulative`.
 
@@ -197,6 +195,7 @@ class DiceHelper:
         self.ignore_empty = ignore_empty
 
     def compute_channel(self, y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """"""
         y_o = torch.sum(y)
         if y_o > 0:
             return (2.0 * torch.sum(torch.masked_select(y, y_pred))) / (y_o + torch.sum(y_pred))
@@ -208,6 +207,13 @@ class DiceHelper:
         return (2.0 * torch.sum(torch.masked_select(y, y_pred))) / denorm
 
     def __call__(self, y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        """
+
+        Args:
+            y_pred: input predictions with shape (batch_size, num_classes, spatial_dims...).
+                the number of channels is inferred from ``y_pred.shape[1]``.
+            y: ground truth with shape (batch_size, num_classes or 1, spatial_dims...).
+        """
         n_pred_ch = y_pred.shape[1]
 
         if self.softmax:

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -13,18 +13,21 @@ from __future__ import annotations
 
 import torch
 
-from monai.metrics.utils import do_metric_reduction, ignore_background, is_binary_tensor
-from monai.utils import MetricReduction, deprecated
+from monai.metrics.utils import do_metric_reduction
+from monai.utils import MetricReduction
 
 from .metric import CumulativeIterationMetric
+
+__all__ = ["DiceMetric", "compute_dice", "DiceHelper"]
 
 
 class DiceMetric(CumulativeIterationMetric):
     """
-    Compute average Dice score between two tensors. It can support both multi-classes and multi-labels tasks.
+    Compute average Dice score for a set of pairs of prediction-groundtruth segmentations.
+    It supports both multi-classes and multi-labels tasks.
     Input `y_pred` is compared with ground truth `y`.
-    `y_preds` is expected to have binarized predictions and `y` should be in one-hot format. You can use suitable transforms
-    in ``monai.transforms.post`` first to achieve binarized values.
+    `y_preds` is expected to have binarized predictions and `y` should be in one-hot format. You can use suitable
+    transforms in ``monai.transforms.post`` first to achieve binarized values.
     The `include_background` parameter can be set to ``False`` to exclude
     the first category (channel index 0) which is by convention assumed to be background. If the non-background
     segmentations are small compared to the total image size they can get overwhelmed by the signal from the
@@ -73,16 +76,17 @@ class DiceMetric(CumulativeIterationMetric):
             ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
         """
-        is_binary_tensor(y_pred, "y_pred")
-        is_binary_tensor(y, "y")
-
         dims = y_pred.ndimension()
         if dims < 3:
             raise ValueError(f"y_pred should have at least 3 dimensions (batch, channel, spatial), got {dims}.")
         # compute dice (BxC) for each channel for each batch
-        return compute_dice(
-            y_pred=y_pred, y=y, include_background=self.include_background, ignore_empty=self.ignore_empty
-        )
+        return DiceHelper(  # type: ignore
+            include_background=self.include_background,
+            reduction=MetricReduction.NONE,
+            get_not_nans=False,
+            softmax=False,
+            ignore_empty=self.ignore_empty,
+        )(y_pred=y_pred, y=y)
 
     def aggregate(
         self, reduction: MetricReduction | str | None = None
@@ -98,7 +102,7 @@ class DiceMetric(CumulativeIterationMetric):
         """
         data = self.get_buffer()
         if not isinstance(data, torch.Tensor):
-            raise ValueError("the data to aggregate must be PyTorch Tensor.")
+            raise ValueError(f"the data to aggregate must be PyTorch Tensor, got {type(data)}.")
 
         # do metric reduction
         f, not_nans = do_metric_reduction(data, reduction or self.reduction)
@@ -125,34 +129,103 @@ def compute_dice(
     Returns:
         Dice scores per batch and per class, (shape [batch_size, num_classes]).
 
-    Raises:
-        ValueError: when `y_pred` and `y` have different shapes.
+    """
+    return DiceHelper(  # type: ignore
+        include_background=include_background,
+        reduction=MetricReduction.NONE,
+        get_not_nans=False,
+        softmax=False,
+        ignore_empty=ignore_empty,
+    )(y_pred=y_pred, y=y)
+
+
+class DiceHelper:
+    """
+    Compute Dice score between two tensors `y_pred` and `y`.
+    Different from `monai.metrics.DiceMetric`, this class compues.
+
+    Example:
+
+    .. code-block:: python
+
+        import torch
+        from monai.metrics import DiceHelper
+
+        n_classes, batch_size = 5, 16
+        spatial_shape = (128, 128, 128)
+
+        y_pred = torch.rand(batch_size, n_classes, *spatial_shape).float()  # predictions
+        y = torch.randint(0, n_classes, size=(batch_size, 1, *spatial_shape)).long()  # ground truth
+        score, not_nans = DiceHelper(include_background=False, sigmoid=True, softmax=True)(y_pred, y)
+        print(score, not_nans)
 
     """
 
-    if not include_background:
-        y_pred, y = ignore_background(y_pred=y_pred, y=y)
+    def __init__(
+        self,
+        include_background: bool | None = None,
+        sigmoid: bool = False,
+        softmax: bool | None = None,
+        activate: bool = False,
+        get_not_nans: bool = True,
+        reduction: MetricReduction | str = MetricReduction.MEAN_BATCH,
+        ignore_empty: bool = True,
+    ) -> None:
+        """
 
-    y = y.float()
-    y_pred = y_pred.float()
+        Args:
+            include_background: whether to skip the score on the first channel (default to `sigmoid`).
+            sigmoid: whether ``y_pred`` are/will be sigmoid activated outputs. If True, thesholding at 0.5
+                will be performed to get the discrete prediction.
+            softmax: whether ``y_pred`` are softmax activated outputs. If True, `argmax` will be performed to
+                get the discrete prediction.
+            activate: whether to apply sigmoid to ``y_pred`` if ``sigmoid`` is True.
+            get_not_nans: whether to return the number of not-nan values.
+            reduction: define mode of reduction to the metrics
+            ignore_empty: if `True`, NaN value will be set for empty ground truth cases.
+                If `False`, 1 will be set if the Union of ``y_pred`` and ``y`` is empty.
+        """
+        self.sigmoid = sigmoid
+        self.reduction = reduction
+        self.get_not_nans = get_not_nans
+        self.include_background = sigmoid if include_background is None else include_background
+        self.softmax = not sigmoid if softmax is None else softmax
+        self.activate = activate
+        self.ignore_empty = ignore_empty
 
-    if y.shape != y_pred.shape:
-        raise ValueError(f"y_pred and y should have same shapes, got {y_pred.shape} and {y.shape}.")
+    def compute_channel(self, y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        y_o = torch.sum(y)
+        if y_o > 0:
+            return (2.0 * torch.sum(torch.masked_select(y, y_pred))) / (y_o + torch.sum(y_pred))
+        if self.ignore_empty:
+            return torch.tensor(float("nan"), device=y_o.device)
+        denorm = y_o + torch.sum(y_pred)
+        if denorm <= 0:
+            return torch.tensor(1.0, device=y_o.device)
+        return (2.0 * torch.sum(torch.masked_select(y, y_pred))) / denorm
 
-    # reducing only spatial dimensions (not batch nor channels)
-    n_len = len(y_pred.shape)
-    reduce_axis = list(range(2, n_len))
-    intersection = torch.sum(y * y_pred, dim=reduce_axis)
+    def __call__(self, y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        n_pred_ch = y_pred.shape[1]
 
-    y_o = torch.sum(y, reduce_axis)
-    y_pred_o = torch.sum(y_pred, dim=reduce_axis)
-    denominator = y_o + y_pred_o
+        if self.softmax:
+            if n_pred_ch > 1:
+                y_pred = torch.argmax(y_pred, dim=1, keepdim=True)
 
-    if ignore_empty:
-        return torch.where(y_o > 0, (2.0 * intersection) / denominator, torch.tensor(float("nan"), device=y_o.device))
-    return torch.where(denominator > 0, (2.0 * intersection) / denominator, torch.tensor(1.0, device=y_o.device))
+        elif self.sigmoid:
+            if self.activate:
+                y_pred = torch.sigmoid(y_pred)
+            y_pred = y_pred > 0.5
 
+        first_ch = 0 if self.include_background else 1
+        data = []
+        for b in range(y_pred.shape[0]):
+            c_list = []
+            for c in range(first_ch, n_pred_ch) if n_pred_ch > 1 else [1]:
+                x_pred = (y_pred[b, 0] == c) if (y_pred.shape[1] == 1) else y_pred[b, c].bool()
+                x = (y[b, 0] == c) if (y.shape[1] == 1) else y[b, c]
+                c_list.append(self.compute_channel(x_pred, x))
+            data.append(torch.stack(c_list))
+        data = torch.stack(data, dim=0).contiguous()  # type: ignore
 
-@deprecated(since="1.0.0", msg_suffix="use `compute_dice` instead.")
-def compute_meandice(*args, **kwargs):
-    return compute_dice(*args, **kwargs)
+        f, not_nans = do_metric_reduction(data, self.reduction)  # type: ignore
+        return (f, not_nans) if self.get_not_nans else f

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -174,12 +174,14 @@ class DiceHelper:
         """
 
         Args:
-            include_background: whether to skip the score on the first channel (default to `sigmoid`).
+            include_background: whether to skip the score on the first channel
+                (default to the value of `sigmoid`, False).
             sigmoid: whether ``y_pred`` are/will be sigmoid activated outputs. If True, thesholding at 0.5
-                will be performed to get the discrete prediction.
+                will be performed to get the discrete prediction. Defaults to False.
             softmax: whether ``y_pred`` are softmax activated outputs. If True, `argmax` will be performed to
-                get the discrete prediction.
-            activate: whether to apply sigmoid to ``y_pred`` if ``sigmoid`` is True.
+                get the discrete prediction. Defaults to the value of ``not sigmoid``.
+            activate: whether to apply sigmoid to ``y_pred`` if ``sigmoid`` is True. Defaults to False.
+                This option is only valid when ``sigmoid`` is True.
             get_not_nans: whether to return the number of not-nan values.
             reduction: define mode of reduction to the metrics
             ignore_empty: if `True`, NaN value will be set for empty ground truth cases.

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -62,6 +62,13 @@ class DiceMetric(CumulativeIterationMetric):
         self.reduction = reduction
         self.get_not_nans = get_not_nans
         self.ignore_empty = ignore_empty
+        self.dice_helper = DiceHelper(
+            include_background=self.include_background,
+            reduction=MetricReduction.NONE,
+            get_not_nans=False,
+            softmax=False,
+            ignore_empty=self.ignore_empty,
+        )
 
     def _compute_tensor(self, y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
         """
@@ -79,13 +86,7 @@ class DiceMetric(CumulativeIterationMetric):
         if dims < 3:
             raise ValueError(f"y_pred should have at least 3 dimensions (batch, channel, spatial), got {dims}.")
         # compute dice (BxC) for each channel for each batch
-        return DiceHelper(  # type: ignore
-            include_background=self.include_background,
-            reduction=MetricReduction.NONE,
-            get_not_nans=False,
-            softmax=False,
-            ignore_empty=self.ignore_empty,
-        )(y_pred=y_pred, y=y)
+        return self.dice_helper(y_pred=y_pred, y=y)  # type: ignore
 
     def aggregate(
         self, reduction: MetricReduction | str | None = None

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -24,6 +24,7 @@ __all__ = ["DiceMetric", "compute_dice", "DiceHelper"]
 class DiceMetric(CumulativeIterationMetric):
     """
     Compute average Dice score for a set of pairs of prediction-groundtruth segmentations.
+
     It supports both multi-classes and multi-labels tasks.
     Input `y_pred` is compared with ground truth `y`.
     `y_preds` is expected to have binarized predictions and `y` should be in one-hot format. You can use suitable
@@ -141,7 +142,7 @@ def compute_dice(
 class DiceHelper:
     """
     Compute Dice score between two tensors `y_pred` and `y`.
-    Different from `monai.metrics.DiceMetric`, this class compues.
+    `y_pred` must have N channels, `y` can be single channel class indices or one-hot.
 
     Example:
 
@@ -155,6 +156,7 @@ class DiceHelper:
 
         y_pred = torch.rand(batch_size, n_classes, *spatial_shape).float()  # predictions
         y = torch.randint(0, n_classes, size=(batch_size, 1, *spatial_shape)).long()  # ground truth
+
         score, not_nans = DiceHelper(include_background=False, sigmoid=True, softmax=True)(y_pred, y)
         print(score, not_nans)
 

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -92,7 +92,7 @@ class DiceMetric(CumulativeIterationMetric):
         self, reduction: MetricReduction | str | None = None
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """
-        Execute reduction logic for the output of `compute_meandice`.
+        Execute reduction and aggregation logic for the output of `compute_dice`.
 
         Args:
             reduction: define mode of reduction to the metrics, will only apply reduction on `not-nan` values,

--- a/monai/metrics/meaniou.py
+++ b/monai/metrics/meaniou.py
@@ -71,7 +71,6 @@ class MeanIoU(CumulativeIterationMetric):
                 The values should be binarized.
 
         Raises:
-            ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
         """
         dims = y_pred.ndimension()

--- a/monai/metrics/meaniou.py
+++ b/monai/metrics/meaniou.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import torch
 
-from monai.metrics.utils import do_metric_reduction, ignore_background, is_binary_tensor
+from monai.metrics.utils import do_metric_reduction, ignore_background
 from monai.utils import MetricReduction, deprecated
 
 from .metric import CumulativeIterationMetric
@@ -74,9 +74,6 @@ class MeanIoU(CumulativeIterationMetric):
             ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
         """
-        is_binary_tensor(y_pred, "y_pred")
-        is_binary_tensor(y, "y")
-
         dims = y_pred.ndimension()
         if dims < 3:
             raise ValueError(f"y_pred should have at least 3 dimensions (batch, channel, spatial), got {dims}.")

--- a/monai/metrics/surface_distance.py
+++ b/monai/metrics/surface_distance.py
@@ -73,7 +73,6 @@ class SurfaceDistanceMetric(CumulativeIterationMetric):
                 The values should be binarized.
 
         Raises:
-            ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
         """
         if y_pred.dim() < 3:

--- a/monai/metrics/surface_distance.py
+++ b/monai/metrics/surface_distance.py
@@ -16,13 +16,7 @@ import warnings
 import numpy as np
 import torch
 
-from monai.metrics.utils import (
-    do_metric_reduction,
-    get_mask_edges,
-    get_surface_distance,
-    ignore_background,
-    is_binary_tensor,
-)
+from monai.metrics.utils import do_metric_reduction, get_mask_edges, get_surface_distance, ignore_background
 from monai.utils import MetricReduction, convert_data_type
 
 from .metric import CumulativeIterationMetric
@@ -82,8 +76,6 @@ class SurfaceDistanceMetric(CumulativeIterationMetric):
             ValueError: when `y` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
         """
-        is_binary_tensor(y_pred, "y_pred")
-        is_binary_tensor(y, "y")
         if y_pred.dim() < 3:
             raise ValueError("y_pred should have at least three dimensions.")
         # compute (BxC) for each channel for each batch

--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -222,7 +222,7 @@ def is_binary_tensor(input: torch.Tensor, name: str) -> None:
     """
     if not isinstance(input, torch.Tensor):
         raise ValueError(f"{name} must be of type PyTorch Tensor.")
-    if not torch.all(input.byte() == input):
+    if not torch.all(input.byte() == input) or input.max() > 1 or input.min() < 0:
         warnings.warn(f"{name} should be a binarized tensor.")
 
 

--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -222,7 +222,7 @@ def is_binary_tensor(input: torch.Tensor, name: str) -> None:
     """
     if not isinstance(input, torch.Tensor):
         raise ValueError(f"{name} must be of type PyTorch Tensor.")
-    if not torch.all(input.byte() == input) or input.max() > 1 or input.min() < 0:
+    if not torch.all(input.byte() == input):
         warnings.warn(f"{name} should be a binarized tensor.")
 
 

--- a/monai/metrics/wrapper.py
+++ b/monai/metrics/wrapper.py
@@ -147,7 +147,6 @@ class MetricsReloadedBinary(MetricsReloadedWrapper):
                 The values should be binarized.
 
         Raises:
-            ValueError: when `y` or `y_pred` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
             ValueError: when second dimension ~= 1
 
@@ -255,7 +254,6 @@ class MetricsReloadedCategorical(MetricsReloadedWrapper):
                 one-hot encoded and binarized.
 
         Raises:
-            ValueError: when `y` or `y_pred` is not a binarized tensor.
             ValueError: when `y_pred` has less than three dimensions.
 
         """

--- a/monai/metrics/wrapper.py
+++ b/monai/metrics/wrapper.py
@@ -15,7 +15,7 @@ from typing import cast
 
 import torch
 
-from monai.metrics.utils import do_metric_reduction, ignore_background, is_binary_tensor
+from monai.metrics.utils import do_metric_reduction, ignore_background
 from monai.utils import MetricReduction, convert_to_numpy, convert_to_tensor, optional_import
 
 from .metric import CumulativeIterationMetric
@@ -69,8 +69,6 @@ class MetricsReloadedWrapper(CumulativeIterationMetric):
 
     def prepare_onehot(self, y_pred, y):
         """Prepares onehot encoded input for metric call."""
-        is_binary_tensor(y_pred, "y_pred")
-        is_binary_tensor(y, "y")
         y = y.float()
         y_pred = y_pred.float()
         if not self.include_background:

--- a/tests/test_compute_meandice.py
+++ b/tests/test_compute_meandice.py
@@ -17,7 +17,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.metrics import DiceMetric, compute_dice, compute_meandice
+from monai.metrics import DiceMetric, compute_dice
 
 _device = "cuda:0" if torch.cuda.is_available() else "cpu"
 # keep background
@@ -195,13 +195,13 @@ class TestComputeMeanDice(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_3])
     def test_nans(self, input_data, expected_value):
-        result = compute_meandice(**input_data)
+        result = compute_dice(**input_data)
         self.assertTrue(np.allclose(np.isnan(result.cpu().numpy()), expected_value))
 
     # DiceMetric class tests
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_10])
     def test_value_class(self, input_data, expected_value):
-        # same test as for compute_meandice
+        # same test as for compute_dice
         vals = {}
         vals["y_pred"] = input_data.pop("y_pred")
         vals["y"] = input_data.pop("y")

--- a/tests/test_compute_meandice.py
+++ b/tests/test_compute_meandice.py
@@ -17,7 +17,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.metrics import DiceMetric, compute_dice
+from monai.metrics import DiceHelper, DiceMetric, compute_dice
 
 _device = "cuda:0" if torch.cuda.is_available() else "cpu"
 # keep background
@@ -197,6 +197,15 @@ class TestComputeMeanDice(unittest.TestCase):
     def test_nans(self, input_data, expected_value):
         result = compute_dice(**input_data)
         self.assertTrue(np.allclose(np.isnan(result.cpu().numpy()), expected_value))
+
+    @parameterized.expand([TEST_CASE_3])
+    def test_helper(self, input_data, _unused):
+        vals = {"y_pred": dict(input_data).pop("y_pred"), "y": dict(input_data).pop("y")}
+        result = DiceHelper(sigmoid=True)(**vals)
+        np.testing.assert_allclose(result[0].cpu().numpy(), [0.0, 0.0, 0.0], atol=1e-4)
+        np.testing.assert_allclose(sorted(result[1].cpu().numpy()), [0.0, 1.0, 2.0], atol=1e-4)
+        result = DiceHelper(softmax=True, get_not_nans=False)(**vals)
+        np.testing.assert_allclose(result[0].cpu().numpy(), [0.0, 0.0], atol=1e-4)
 
     # DiceMetric class tests
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_10])


### PR DESCRIPTION
- mostly from @myron's implementation
- remove `is_binary_tensor` checks, they are too expensive.
- remove the deprecated `compute_meandice` (use `compute_dice` instead)

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
