### PR TITLE
fix result combining after yaml output

### DIFF
--- a/monai/apps/auto3dseg/data_analyzer.py
+++ b/monai/apps/auto3dseg/data_analyzer.py
@@ -276,7 +276,10 @@ class DataAnalyzer:
         result[DataStatsKeys.BY_CASE] = [None] * n_cases
 
         if not self._check_data_uniformity([ImageStatsKeys.SPACING], result):
-            print("Data spacing is not completely uniform. MONAI transforms may provide unexpected result")
+            logger.info("Data spacing is not completely uniform. MONAI transforms may provide unexpected result")
+
+        # return combined
+        result[DataStatsKeys.BY_CASE] = result_bycase[DataStatsKeys.BY_CASE]
 
         if self.output_path:
             # saving summary and by_case as 2 files, to minimize loading time when only the summary is necessary
@@ -298,6 +301,4 @@ class DataAnalyzer:
             # limitation: https://github.com/pytorch/pytorch/issues/12873#issuecomment-482916237
             torch.cuda.empty_cache()
 
-        # return combined
-        result[DataStatsKeys.BY_CASE] = result_bycase[DataStatsKeys.BY_CASE]
         return result


### PR DESCRIPTION
Fixes #6205 .

### Description

- Correct the mistake that result combining happens after config output.
- Change print to logging

![image](https://user-images.githubusercontent.com/18563433/226515143-7b852a27-c9e9-483f-82b4-e27fc674e1e8.png)


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
