### PR TITLE
6208 fix-endoscopic-tool-segmentation-ckpt-export

### DIFF
--- a/monai/networks/nets/basic_unet.py
+++ b/monai/networks/nets/basic_unet.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Union
 
 import torch
 import torch.nn as nn
@@ -149,7 +150,7 @@ class UpCat(nn.Module):
         self.convs = TwoConv(spatial_dims, cat_chns + up_chns, out_chns, act, norm, bias, dropout)
         self.is_pad = is_pad
 
-    def forward(self, x: torch.Tensor, x_e: torch.Tensor | None):
+    def forward(self, x: torch.Tensor, x_e: Union[torch.Tensor, None]):
         """
 
         Args:

--- a/monai/networks/nets/basic_unet.py
+++ b/monai/networks/nets/basic_unet.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 from monai.networks.blocks import Convolution, UpSample
 from monai.networks.layers.factories import Conv, Pool
 from monai.utils import ensure_tuple_rep
+from typing import Optional
 
 __all__ = ["BasicUnet", "Basicunet", "basicunet", "BasicUNet"]
 
@@ -149,7 +150,7 @@ class UpCat(nn.Module):
         self.convs = TwoConv(spatial_dims, cat_chns + up_chns, out_chns, act, norm, bias, dropout)
         self.is_pad = is_pad
 
-    def forward(self, x: torch.Tensor, x_e: torch.Tensor | None):
+    def forward(self, x: torch.Tensor, x_e: Optional[torch.Tensor]):
         """
 
         Args:

--- a/monai/networks/nets/basic_unet.py
+++ b/monai/networks/nets/basic_unet.py
@@ -12,7 +12,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Union
 
 import torch
 import torch.nn as nn
@@ -150,12 +149,12 @@ class UpCat(nn.Module):
         self.convs = TwoConv(spatial_dims, cat_chns + up_chns, out_chns, act, norm, bias, dropout)
         self.is_pad = is_pad
 
-    def forward(self, x: torch.Tensor, x_e: Union[torch.Tensor, None]):
+    def forward(self, x: torch.Tensor, x_e: torch.Tensor):
         """
 
         Args:
             x: features to be upsampled.
-            x_e: features from the encoder.
+            x_e: optional features from the encoder, if None, this branch is not in use.
         """
         x_0 = self.upsample(x)
 

--- a/monai/networks/nets/basic_unet.py
+++ b/monai/networks/nets/basic_unet.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -19,7 +20,6 @@ import torch.nn as nn
 from monai.networks.blocks import Convolution, UpSample
 from monai.networks.layers.factories import Conv, Pool
 from monai.utils import ensure_tuple_rep
-from typing import Optional
 
 __all__ = ["BasicUnet", "Basicunet", "basicunet", "BasicUNet"]
 

--- a/monai/networks/nets/basic_unet.py
+++ b/monai/networks/nets/basic_unet.py
@@ -12,7 +12,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -150,7 +149,7 @@ class UpCat(nn.Module):
         self.convs = TwoConv(spatial_dims, cat_chns + up_chns, out_chns, act, norm, bias, dropout)
         self.is_pad = is_pad
 
-    def forward(self, x: torch.Tensor, x_e: Optional[torch.Tensor]):
+    def forward(self, x: torch.Tensor, x_e: torch.Tensor | None):
         """
 
         Args:

--- a/monai/networks/nets/flexible_unet.py
+++ b/monai/networks/nets/flexible_unet.py
@@ -232,6 +232,7 @@ class FlexibleUNet(nn.Module):
         dropout: float | tuple = 0.0,
         decoder_bias: bool = False,
         upsample: str = "nontrainable",
+        pre_conv: str = "default",
         interp_mode: str = "nearest",
         is_pad: bool = True,
     ) -> None:
@@ -262,6 +263,8 @@ class FlexibleUNet(nn.Module):
             decoder_bias: whether to have a bias term in decoder's convolution blocks.
             upsample: upsampling mode, available options are``"deconv"``, ``"pixelshuffle"``,
                 ``"nontrainable"``.
+            pre_conv:a conv block applied before upsampling. Only used in the "nontrainable" or
+                "pixelshuffle" mode, default to `default`.
             interp_mode: {``"nearest"``, ``"linear"``, ``"bilinear"``, ``"bicubic"``, ``"trilinear"``}
                 Only used in the "nontrainable" mode.
             is_pad: whether to pad upsampling features to fit features from encoder. Default to True.
@@ -309,7 +312,7 @@ class FlexibleUNet(nn.Module):
             bias=decoder_bias,
             upsample=upsample,
             interp_mode=interp_mode,
-            pre_conv="default",
+            pre_conv=pre_conv,
             align_corners=None,
             is_pad=is_pad,
         )


### PR DESCRIPTION
Fixes #6208 .

### Description
1. Add `pre_conv` as a parameter to `FlexibleUNet` to make the model forward compatible.
2. Update the `torch.Tensor` type hint in the `UpCat` function to fit the torchscript requirement.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
