### PR TITLE
DiceLoss small optimization

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -168,11 +168,11 @@ class DiceLoss(_Loss):
         intersection = torch.sum(target * input, dim=reduce_axis)
 
         if self.squared_pred:
-            target = torch.pow(target, 2)
-            input = torch.pow(input, 2)
-
-        ground_o = torch.sum(target, dim=reduce_axis)
-        pred_o = torch.sum(input, dim=reduce_axis)
+            ground_o = torch.sum(target**2, dim=reduce_axis)
+            pred_o = torch.sum(input**2, dim=reduce_axis)
+        else:
+            ground_o = torch.sum(target, dim=reduce_axis)
+            pred_o = torch.sum(input, dim=reduce_axis)
 
         denominator = ground_o + pred_o
 


### PR DESCRIPTION
Reduces peak GPU memory pressure of Dice loss (and related losses) with squared_pred=True if used with torch.jit.script, by avoiding intermediate vars

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
