### PR TITLE
update docstring and eval with overrides

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -322,10 +322,7 @@ class PersistentDataset(Dataset):
             lambda t: isinstance(t, RandomizableTrait) or not isinstance(t, Transform)
         )
 
-        if first_random is None:
-            item_transformed = self.transform(item_transformed, end=first_random, threading=True)
-        else:
-            item_transformed = self.transform(item_transformed, start=None, threading=True)
+        item_transformed = self.transform(item_transformed, end=first_random, threading=True)
 
         if self.reset_ops_id:
             reset_ops_id(item_transformed)

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -316,13 +316,16 @@ class PersistentDataset(Dataset):
 
         """
         if not isinstance(self.transform, Compose):
-            raise ValueError("transform must be an instance of monai.transforms.Compose.")
+            raise ValueError(f"transform must be an instance of monai.transforms.Compose, got {type(self.transform)}.")
 
         first_random = self.transform.get_index_of_first(
             lambda t: isinstance(t, RandomizableTrait) or not isinstance(t, Transform)
         )
 
-        item_transformed = self.transform(item_transformed, end=first_random, threading=True)
+        if first_random is None:
+            item_transformed = self.transform(item_transformed, end=first_random, threading=True)
+        else:
+            item_transformed = self.transform(item_transformed, start=None, threading=True)
 
         if self.reset_ops_id:
             reset_ops_id(item_transformed)
@@ -345,8 +348,7 @@ class PersistentDataset(Dataset):
         first_random = self.transform.get_index_of_first(
             lambda t: isinstance(t, RandomizableTrait) or not isinstance(t, Transform)
         )
-        if first_random is not None:
-            item_transformed = self.transform(item_transformed, start=first_random)
+        item_transformed = self.transform(item_transformed, start=first_random)
         return item_transformed
 
     def _cachecheck(self, item_transformed):
@@ -489,7 +491,7 @@ class CacheNTransDataset(PersistentDataset):
             the transformed element up to the N transform object
         """
         if not isinstance(self.transform, Compose):
-            raise ValueError("transform must be an instance of monai.transforms.Compose.")
+            raise ValueError(f"transform must be an instance of monai.transforms.Compose, got {type(self.transform)}.")
 
         item_transformed = self.transform(item_transformed, end=self.cache_n_trans, threading=True)
 
@@ -906,14 +908,14 @@ class CacheDataset(Dataset):
 
         # load data from cache and execute from the first random transform
         if not isinstance(self.transform, Compose):
-            raise ValueError("transform must be an instance of monai.transforms.Compose.")
+            raise ValueError(f"transform must be an instance of monai.transforms.Compose, got {type(self.transform)}.")
 
         first_random = self.transform.get_index_of_first(
             lambda t: isinstance(t, RandomizableTrait) or not isinstance(t, Transform)
         )
         if first_random is not None:
             data = deepcopy(data) if self.copy_cache is True else data
-            data = self.transform(data, start=first_random)
+        data = self.transform(data, start=first_random)
 
         return data
 

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -262,8 +262,8 @@ class Compose(Randomizable, InvertibleTransform):
                 )
 
     def get_index_of_first(self, predicate):
-        for i in range(len(self.transforms)):
-            if predicate(self.transforms[i]):
+        for i, xform in enumerate(self.transforms):
+            if predicate(xform):
                 return i
         return None
 


### PR DESCRIPTION
- docstring updates
- Compose execute with start=None

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
