### PR TITLE
[WIP] Add RankFilter to skip logging when the rank is not meeting criteria

### DIFF
--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from .aliases import alias, resolve_name
 from .decorators import MethodReplacer, RestartGenerator
 from .deprecate_utils import DeprecatedError, deprecated, deprecated_arg, deprecated_arg_default
-from .dist import evenly_divisible_all_gather, get_dist_device, string_list_all_gather
+from .dist import RankFilter, evenly_divisible_all_gather, get_dist_device, string_list_all_gather
 from .enums import (
     Average,
     BlendMode,

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -156,6 +156,7 @@ def run_testsuit():
         "test_rand_zoom",
         "test_rand_zoomd",
         "test_randtorchvisiond",
+        "test_rankfilter_dist",
         "test_resample_backends",
         "test_resize",
         "test_resized",

--- a/tests/test_rankfilter_dist.py
+++ b/tests/test_rankfilter_dist.py
@@ -1,0 +1,59 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import unittest
+
+import torch
+import torch.distributed as dist
+
+from monai.utils import RankFilter
+from tests.utils import DistCall, DistTestCase
+
+
+class DistributedRankFilterTest(DistTestCase):
+    def setUp(self):
+        self.log_dir = tempfile.TemporaryDirectory()
+
+    @DistCall(nnodes=1, nproc_per_node=2)
+    def test_even(self):
+        logger = logging.getLogger(__name__)
+        log_filename = os.path.join(self.log_dir.name, "records.log")
+        h1 = logging.FileHandler(filename=log_filename)
+        h1.setLevel(logging.WARNING)
+
+        logger.addHandler(h1)
+
+        if torch.cuda.device_count() > 1:
+            dist.init_process_group(backend="nccl", init_method="env://")
+            rank_filer = RankFilter()
+            logger.addFilter(rank_filer)
+
+        logger.warning("test_warnings")
+
+        dist.barrier()
+        if dist.get_rank() == 0:
+            with open(log_filename) as file:
+                lines = [line.rstrip() for line in file]
+            log_message = " ".join(lines)
+
+            assert log_message.count("test_warnings") == 1
+
+    def tearDown(self) -> None:
+        self.log_dir.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #6230 and a part of #6189 

### Description

The RankFilter class is a convenient filter that extends the Filter class in the Python logging module.
The purpose is to control which log records are processed based on the rank in a distributed environment.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
