### PR TITLE
SlidingWindowInfererAdapt

### DIFF
--- a/monai/inferers/__init__.py
+++ b/monai/inferers/__init__.py
@@ -11,7 +11,15 @@
 
 from __future__ import annotations
 
-from .inferer import Inferer, PatchInferer, SaliencyInferer, SimpleInferer, SliceInferer, SlidingWindowInferer
+from .inferer import (
+    Inferer,
+    PatchInferer,
+    SaliencyInferer,
+    SimpleInferer,
+    SliceInferer,
+    SlidingWindowInferer,
+    SlidingWindowInfererAdapt,
+)
 from .merger import AvgMerger, Merger
 from .splitter import SlidingWindowSplitter, Splitter
 from .utils import sliding_window_inference

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -531,7 +531,7 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
 
                     if gpu_stitching:  # if failed on gpu
                         gpu_stitching = False
-                        self.cpu_thresh = inputs.shape[2:].numel()  # update thresh
+                        self.cpu_thresh = inputs.shape[2:].numel() - 1  # update thresh
 
                         if not skip_buffer:
                             buffered_stitching = True

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -506,7 +506,7 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
 
         # if device is provided, use without any adaptations
         if self.device is not None:
-            return super().__call__(inputs=inputs, network=network, *args, **kwargs)
+            return super().__call__(inputs=inputs, network=network, *args, **kwargs)  # type:ignore
 
         skip_buffer = self.buffer_steps is not None and self.buffer_steps <= 0
         cpu_cond = self.cpu_thresh is not None and inputs.shape[2:].numel() > self.cpu_thresh
@@ -523,7 +523,7 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
                     buffer_steps=buffer_steps if buffered_stitching else None,
                     *args,
                     **kwargs,
-                )
+                )  # type:ignore
                 break
             except RuntimeError as e:
                 if (gpu_stitching or buffered_stitching) and "OutOfMemoryError" in str(type(e).__name__):

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -508,7 +508,7 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
         if self.device is not None:
             return super().__call__(inputs=inputs, network=network, *args, **kwargs)
 
-        skip_buffer = self.buffer_steps <= 0
+        skip_buffer = self.buffer_steps is not None and self.buffer_steps <= 0
         cpu_cond = self.cpu_thresh is not None and inputs.shape[2:].numel() > self.cpu_thresh
         gpu_stitching = inputs.is_cuda and not cpu_cond
         buffered_stitching = inputs.is_cuda and cpu_cond and not skip_buffer

--- a/monai/transforms/lazy/utils.py
+++ b/monai/transforms/lazy/utils.py
@@ -216,6 +216,7 @@ def resample(data: torch.Tensor, matrix: NdarrayOrTensor, kwargs: dict | None = 
             and allclose(convert_to_numpy(in_shape, wrap_sequence=True), out_spatial_size)
         ):
             img.affine = call_kwargs["dst_affine"]
+            img = img.to(torch.float32)  # consistent with monai.transforms.spatial.functional.spatial_resample
             return img
         img = monai.transforms.crop_or_pad_nd(img, matrix_np, out_spatial_size, mode=call_kwargs["padding_mode"])
         img = img.to(torch.float32)  # consistent with monai.transforms.spatial.functional.spatial_resample

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -28,7 +28,10 @@ def rotate_90_2d():
     return t
 
 
-RESAMPLE_FUNCTION_CASES = [(get_arange_img((3, 3)), rotate_90_2d(), [[0, 3, 6], [0, 3, 6], [0, 3, 6]])]
+RESAMPLE_FUNCTION_CASES = [
+    (get_arange_img((3, 3)), rotate_90_2d(), [[0, 3, 6], [0, 3, 6], [0, 3, 6]]),
+    (get_arange_img((3, 3)), torch.eye(3), get_arange_img((3, 3))[0]),
+]
 
 
 class TestResampleFunction(unittest.TestCase):

--- a/tests/test_sliding_window_inference.py
+++ b/tests/test_sliding_window_inference.py
@@ -19,7 +19,7 @@ import torch
 from parameterized import parameterized
 
 from monai.data.utils import list_data_collate
-from monai.inferers import SlidingWindowInferer, sliding_window_inference
+from monai.inferers import SlidingWindowInferer, SlidingWindowInfererAdapt, sliding_window_inference
 from monai.utils import optional_import
 from tests.utils import TEST_TORCH_AND_META_TENSORS, skip_if_no_cuda, test_is_quick
 
@@ -301,6 +301,11 @@ class TestSlidingWindowInference(unittest.TestCase):
         np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-4)
 
         result = SlidingWindowInferer(
+            roi_shape, sw_batch_size, overlap=0.5, mode="constant", cval=-1, progress=has_tqdm
+        )(inputs, compute, t1, test2=t2)
+        np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-4)
+
+        result = SlidingWindowInfererAdapt(
             roi_shape, sw_batch_size, overlap=0.5, mode="constant", cval=-1, progress=has_tqdm
         )(inputs, compute, t1, test2=t2)
         np.testing.assert_allclose(result.cpu().numpy(), expected, rtol=1e-4)


### PR DESCRIPTION
SlidingWindowInfererAdapt extends SlidingWindowInferer to automatically switch to buffered and then to CPU stitching, when OOM on GPU. It also records a size of such large images to automatically try CPU stitching for the next large image of a similar size.  If the stitching 'device' input parameter is provided,
    automatic adaptation won't be attempted, please keep the default option device = None for adaptive behavior.
    Note: the output might be on CPU (even if the input was on GPU), if the GPU memory was not sufficient.

---
also fixes #6340 by adding one line to the resampling
