### PR TITLE
warn or raise ValueError on duplicated key in json/yaml config

### DIFF
--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -12,9 +12,7 @@
 from __future__ import annotations
 
 import json
-import os
 import re
-import warnings
 from collections.abc import Sequence
 from copy import deepcopy
 from pathlib import Path
@@ -25,7 +23,7 @@ from monai.bundle.reference_resolver import ReferenceResolver
 from monai.bundle.utils import ID_REF_KEY, ID_SEP_KEY, MACRO_KEY
 from monai.config import PathLike
 from monai.utils import ensure_tuple, look_up_option, optional_import
-from monai.utils.misc import check_key_duplicates
+from monai.utils.misc import check_key_duplicates, CheckKeyDuplicatesYamlLoader
 
 if TYPE_CHECKING:
     import yaml
@@ -405,7 +403,7 @@ class ConfigParser:
             if _filepath.lower().endswith(cls.suffixes[0]):
                 return json.load(f, object_pairs_hook=check_key_duplicates, **kwargs)  # type: ignore[no-any-return]
             if _filepath.lower().endswith(cls.suffixes[1:]):
-                return yaml.safe_load(f, **kwargs)  # type: ignore[no-any-return]
+                return yaml.load(f, CheckKeyDuplicatesYamlLoader, **kwargs)  # type: ignore[no-any-return]
             raise ValueError(f"only support JSON or YAML config file so far, got name {_filepath}.")
 
     @classmethod

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -16,7 +16,7 @@ import re
 from collections.abc import Sequence
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any
 
 from monai.bundle.config_item import ComponentLocator, ConfigComponent, ConfigExpression, ConfigItem
 from monai.bundle.reference_resolver import ReferenceResolver
@@ -384,7 +384,7 @@ class ConfigParser:
             self.ref_resolver.add_item(ConfigItem(config=item_conf, id=id))
 
     @staticmethod
-    def raise_error_on_key_duplicates(ordered_pairs: Sequence[Tuple[Any, Any]]):
+    def raise_error_on_key_duplicates(ordered_pairs: Sequence[tuple[Any, Any]]):
         """
         Raises ValueError if there is a duplicated key in the sequence of `ordered_pairs`.
         Otherwise, it returns the dict made from this sequence.

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -23,7 +23,7 @@ from monai.bundle.reference_resolver import ReferenceResolver
 from monai.bundle.utils import ID_REF_KEY, ID_SEP_KEY, MACRO_KEY
 from monai.config import PathLike
 from monai.utils import ensure_tuple, look_up_option, optional_import
-from monai.utils.misc import check_key_duplicates, CheckKeyDuplicatesYamlLoader
+from monai.utils.misc import CheckKeyDuplicatesYamlLoader, check_key_duplicates
 
 if TYPE_CHECKING:
     import yaml

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -16,7 +16,7 @@ import re
 from collections.abc import Sequence
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Tuple
 
 from monai.bundle.config_item import ComponentLocator, ConfigComponent, ConfigExpression, ConfigItem
 from monai.bundle.reference_resolver import ReferenceResolver
@@ -384,7 +384,14 @@ class ConfigParser:
             self.ref_resolver.add_item(ConfigItem(config=item_conf, id=id))
 
     @staticmethod
-    def raise_error_on_key_duplicates(ordered_pairs):
+    def raise_error_on_key_duplicates(ordered_pairs: Sequence[Tuple[Any, Any]]):
+        """
+        Raises ValueError if there is a duplicated key in the sequence of `ordered_pairs`.
+        Otherwise, it returns the dict made from this sequence.
+
+        Args:
+            ordered_pairs: sequence of (key, value)
+        """
         keys = set()
         for k, _ in ordered_pairs:
             if k in keys:

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -383,6 +383,16 @@ class ConfigParser:
         else:
             self.ref_resolver.add_item(ConfigItem(config=item_conf, id=id))
 
+    @staticmethod
+    def raise_error_on_key_duplicates(ordered_pairs):
+        keys = set()
+        for k, _ in ordered_pairs:
+            if k in keys:
+                raise ValueError(f"Duplicate key: `{k}`")
+            else:
+                keys.add(k)
+        return dict(ordered_pairs)
+
     @classmethod
     def load_config_file(cls, filepath: PathLike, **kwargs: Any) -> dict:
         """
@@ -400,7 +410,9 @@ class ConfigParser:
             raise ValueError(f'unknown file input: "{filepath}"')
         with open(_filepath) as f:
             if _filepath.lower().endswith(cls.suffixes[0]):
-                return json.load(f, **kwargs)  # type: ignore[no-any-return]
+                return json.load(
+                    f, object_pairs_hook=cls.raise_error_on_key_duplicates, **kwargs
+                )  # type: ignore[no-any-return]
             if _filepath.lower().endswith(cls.suffixes[1:]):
                 return yaml.safe_load(f, **kwargs)  # type: ignore[no-any-return]
             raise ValueError(f"only support JSON or YAML config file so far, got name {_filepath}.")

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -12,9 +12,9 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
+import warnings
 from collections.abc import Sequence
 from copy import deepcopy
 from pathlib import Path
@@ -34,8 +34,6 @@ else:
 __all__ = ["ConfigParser"]
 
 _default_globals = {"monai": "monai", "torch": "torch", "np": "numpy", "numpy": "numpy"}
-
-logger = logging.getLogger(__name__)
 
 
 class ConfigParser:
@@ -405,7 +403,7 @@ class ConfigParser:
                 if os.environ.get("MONAI_FAIL_ON_DUPLICATE_CONFIG", "0") == "1":
                     raise ValueError(f"Duplicate key: `{k}`")
                 else:
-                    logger.warning(f"Duplicate key: `{k}`")
+                    warnings.warn(f"Duplicate key: `{k}`")
             else:
                 keys.add(k)
         return dict(ordered_pairs)

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -384,7 +384,7 @@ class ConfigParser:
             self.ref_resolver.add_item(ConfigItem(config=item_conf, id=id))
 
     @staticmethod
-    def raise_error_on_key_duplicates(ordered_pairs: Sequence[tuple[Any, Any]]):
+    def raise_error_on_key_duplicates(ordered_pairs: Sequence[tuple[Any, Any]]) -> dict[Any, Any]:
         """
         Raises ValueError if there is a duplicated key in the sequence of `ordered_pairs`.
         Otherwise, it returns the dict made from this sequence.
@@ -417,9 +417,9 @@ class ConfigParser:
             raise ValueError(f'unknown file input: "{filepath}"')
         with open(_filepath) as f:
             if _filepath.lower().endswith(cls.suffixes[0]):
-                return json.load(
+                return json.load(  # type: ignore[no-any-return]
                     f, object_pairs_hook=cls.raise_error_on_key_duplicates, **kwargs
-                )  # type: ignore[no-any-return]
+                )
             if _filepath.lower().endswith(cls.suffixes[1:]):
                 return yaml.safe_load(f, **kwargs)  # type: ignore[no-any-return]
             raise ValueError(f"only support JSON or YAML config file so far, got name {_filepath}.")

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -33,9 +33,9 @@ from monai.config.type_definitions import NdarrayOrTensor, NdarrayTensor, PathLi
 from monai.utils.module import optional_import, version_leq
 
 if TYPE_CHECKING:
-    import yaml
+    from yaml import SafeLoader
 else:
-    yaml, _ = optional_import("yaml")
+    SafeLoader, _ = optional_import("yaml", name="SafeLoader", as_type="base")
 
 __all__ = [
     "zip_with",
@@ -711,7 +711,7 @@ def check_key_duplicates(ordered_pairs: Sequence[tuple[Any, Any]]) -> dict[Any, 
     return dict(ordered_pairs)
 
 
-class CheckKeyDuplicatesYamlLoader(yaml.SafeLoader):
+class CheckKeyDuplicatesYamlLoader(SafeLoader):
     def construct_mapping(self, node, deep=False):
         mapping = set()
         for key_node, value_node in node.value:

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -24,13 +24,13 @@ from ast import literal_eval
 from collections.abc import Callable, Iterable, Sequence
 from distutils.util import strtobool
 from pathlib import Path
-from typing import Any, TypeVar, cast, overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
 import numpy as np
 import torch
 
 from monai.config.type_definitions import NdarrayOrTensor, NdarrayTensor, PathLike
-from monai.utils.module import version_leq, optional_import
+from monai.utils.module import optional_import, version_leq
 
 if TYPE_CHECKING:
     import yaml

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -679,3 +679,28 @@ def pprint_edges(val: Any, n_lines: int = 20) -> str:
         hidden_n = len(val_str) - n_lines * 2
         val_str = val_str[:n_lines] + [f"\n ... omitted {hidden_n} line(s)\n\n"] + val_str[-n_lines:]
     return "".join(val_str)
+
+
+def check_key_duplicates(ordered_pairs: Sequence[tuple[Any, Any]]) -> dict[Any, Any]:
+    """
+    Checks if there is a duplicated key in the sequence of `ordered_pairs`.
+    If there is - it will log a warning or raise ValueError
+    (if configured by environmental var `MONAI_FAIL_ON_DUPLICATE_CONFIG==1`)
+
+    Otherwise, it returns the dict made from this sequence.
+
+    Satisfies a format for an `object_pairs_hook` in `json.load`
+
+    Args:
+        ordered_pairs: sequence of (key, value)
+    """
+    keys = set()
+    for k, _ in ordered_pairs:
+        if k in keys:
+            if os.environ.get("MONAI_FAIL_ON_DUPLICATE_CONFIG", "0") == "1":
+                raise ValueError(f"Duplicate key: `{k}`")
+            else:
+                warnings.warn(f"Duplicate key: `{k}`")
+        else:
+            keys.add(k)
+    return dict(ordered_pairs)

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -714,7 +714,7 @@ def check_key_duplicates(ordered_pairs: Sequence[tuple[Any, Any]]) -> dict[Any, 
 class CheckKeyDuplicatesYamlLoader(SafeLoader):
     def construct_mapping(self, node, deep=False):
         mapping = set()
-        for key_node, value_node in node.value:
+        for key_node, _ in node.value:
             key = self.construct_object(key_node, deep=deep)
             if key in mapping:
                 if os.environ.get("MONAI_FAIL_ON_DUPLICATE_CONFIG", "0") == "1":

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -11,11 +11,12 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest import skipUnless
+from unittest import mock, skipUnless
 
 import numpy as np
 from parameterized import parameterized
@@ -110,7 +111,7 @@ TEST_CASE_4 = [{"A": 1, "B": "@A", "C": "@D", "E": "$'test' + '@F'"}]
 
 TEST_CASE_5 = [{"training": {"A": 1, "A_B": 2}, "total": "$@training#A + @training#A_B + 1"}, 4]
 
-TEST_CASE_DUPLICATED_KEY = ["""{"key": {"unique": 1, "duplicate": 0, "duplicate": 4 } }"""]
+TEST_CASE_DUPLICATED_KEY = ["""{"key": {"unique": 1, "duplicate": 0, "duplicate": 4 } }""", 1, [0, 4]]
 
 
 class TestConfigParser(unittest.TestCase):
@@ -307,7 +308,8 @@ class TestConfigParser(unittest.TestCase):
         self.assertEqual(parser.get_parsed_content("total"), expected)
 
     @parameterized.expand([TEST_CASE_DUPLICATED_KEY])
-    def test_parse_json(self, config_string):
+    @mock.patch.dict(os.environ, {"MONAI_FAIL_ON_DUPLICATE_CONFIG": "1"})
+    def test_parse_json_raise(self, config_string, _, __):
         with tempfile.TemporaryDirectory() as tempdir:
             config_path = Path(tempdir) / "config.json"
             config_path.write_text(config_string)
@@ -317,6 +319,20 @@ class TestConfigParser(unittest.TestCase):
                 parser.read_config(config_path)
 
             self.assertTrue("Duplicate key: `duplicate`" in str(context.exception))
+
+    @parameterized.expand([TEST_CASE_DUPLICATED_KEY])
+    def test_parse_json_warn(self, config_string, expected_unique_val, expected_duplicate_vals):
+        with tempfile.TemporaryDirectory() as tempdir:
+            config_path = Path(tempdir) / "config.json"
+            config_path.write_text(config_string)
+            parser = ConfigParser()
+
+            with self.assertLogs(level=logging.WARNING) as log:
+                parser.read_config(config_path)
+            self.assertTrue("Duplicate key: `duplicate`" in " ".join(log.output))
+
+            self.assertEqual(parser.get_parsed_content("key#unique"), expected_unique_val)
+            self.assertIn(parser.get_parsed_content("key#duplicate"), expected_duplicate_vals)
 
 
 if __name__ == "__main__":

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -11,7 +11,6 @@
 
 from __future__ import annotations
 
-import logging
 import os
 import tempfile
 import unittest
@@ -114,10 +113,15 @@ TEST_CASE_5 = [{"training": {"A": 1, "A_B": 2}, "total": "$@training#A + @traini
 
 TEST_CASE_DUPLICATED_KEY_JSON = ["""{"key": {"unique": 1, "duplicate": 0, "duplicate": 4 } }""", "json", 1, [0, 4]]
 
-TEST_CASE_DUPLICATED_KEY_YAML = ["""key: 
+TEST_CASE_DUPLICATED_KEY_YAML = [
+    """key:
     unique: 1
     duplicate: 0
-    duplicate: 4""", "yaml", 1, [0, 4]]
+    duplicate: 4""",
+    "yaml",
+    1,
+    [0, 4],
+]
 
 
 class TestConfigParser(unittest.TestCase):

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -29,6 +29,7 @@ from monai.utils import min_version, optional_import
 from tests.utils import TimedCall
 
 _, has_tv = optional_import("torchvision", "0.8.0", min_version)
+_, has_yaml = optional_import("yaml")
 
 
 @TimedCall(seconds=100, force_quit=True)
@@ -319,6 +320,7 @@ class TestConfigParser(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_DUPLICATED_KEY_JSON, TEST_CASE_DUPLICATED_KEY_YAML])
     @mock.patch.dict(os.environ, {"MONAI_FAIL_ON_DUPLICATE_CONFIG": "1"})
+    @skipUnless(has_yaml, "Requires pyyaml")
     def test_parse_json_raise(self, config_string, extension, _, __):
         with tempfile.TemporaryDirectory() as tempdir:
             config_path = Path(tempdir) / f"config.{extension}"
@@ -331,6 +333,7 @@ class TestConfigParser(unittest.TestCase):
             self.assertTrue("Duplicate key: `duplicate`" in str(context.exception))
 
     @parameterized.expand([TEST_CASE_DUPLICATED_KEY_JSON, TEST_CASE_DUPLICATED_KEY_YAML])
+    @skipUnless(has_yaml, "Requires pyyaml")
     def test_parse_json_warn(self, config_string, extension, expected_unique_val, expected_duplicate_vals):
         with tempfile.TemporaryDirectory() as tempdir:
             config_path = Path(tempdir) / f"config.{extension}"

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -15,6 +15,7 @@ import logging
 import os
 import tempfile
 import unittest
+import warnings
 from pathlib import Path
 from unittest import mock, skipUnless
 
@@ -327,9 +328,14 @@ class TestConfigParser(unittest.TestCase):
             config_path.write_text(config_string)
             parser = ConfigParser()
 
-            with self.assertLogs(level=logging.WARNING) as log:
+            # with self.assertLogs(level=logging.WARNING) as log:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
                 parser.read_config(config_path)
-            self.assertTrue("Duplicate key: `duplicate`" in " ".join(log.output))
+                print(w)
+                # Verify some things
+                self.assertEqual(len(w), 1)
+                self.assertTrue("Duplicate key: `duplicate`" in str(w[-1].message))
 
             self.assertEqual(parser.get_parsed_content("key#unique"), expected_unique_val)
             self.assertIn(parser.get_parsed_content("key#duplicate"), expected_duplicate_vals)


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/5471 .

### Description

[WIP]
Monai will now raise an error whenever there is a duplicated key in any of the config json files.

TBD:
- support similiar thing when reading from yaml

Things to discuss:
- do we want to raise an Error or do we just want a warning message?
- This will raise with the first duplicate encountered, not with a full list, but I think that's a fair & simple approach.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`. (I couldn't run them locally due to OOM)
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.

~~Documentation updated, tested `make html` command in the `docs/` folder.~~ I think that's a safeguard that doesn't require explicit documentation
