### PR TITLE
InstanceNorm3dNVFuser fixes

### DIFF
--- a/monai/networks/layers/factories.py
+++ b/monai/networks/layers/factories.py
@@ -262,22 +262,13 @@ def instance_nvfuser_factory(dim):
     https://github.com/NVIDIA/apex#installation
 
     """
-    types = (nn.InstanceNorm1d, nn.InstanceNorm2d)
+
     if dim != 3:
+        types = (nn.InstanceNorm1d, nn.InstanceNorm2d)
         warnings.warn(f"`InstanceNorm3dNVFuser` only supports 3d cases, use {types[dim - 1]} instead.")
         return types[dim - 1]
-    # test InstanceNorm3dNVFuser installation with a basic example
-    has_nvfuser_flag = has_nvfuser
-    if not torch.cuda.is_available():
-        return nn.InstanceNorm3d
-    try:
-        layer = InstanceNorm3dNVFuser(num_features=1, affine=True).to("cuda:0")
-        inp = torch.randn([1, 1, 1, 1, 1]).to("cuda:0")
-        out = layer(inp)
-        del inp, out, layer
-    except Exception:
-        has_nvfuser_flag = False
-    if not has_nvfuser_flag:
+
+    if not has_nvfuser:
         warnings.warn(
             "`apex.normalization.InstanceNorm3dNVFuser` is not installed properly, use nn.InstanceNorm3d instead."
         )

--- a/monai/networks/layers/factories.py
+++ b/monai/networks/layers/factories.py
@@ -65,7 +65,6 @@ import warnings
 from collections.abc import Callable
 from typing import Any
 
-import torch
 import torch.nn as nn
 
 from monai.utils import look_up_option, optional_import

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import DynUNet
-from tests.utils import assert_allclose, test_script_save
+from tests.utils import assert_allclose, skip_if_no_cuda, skip_if_windows, test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -122,9 +122,8 @@ class TestDynUNet(unittest.TestCase):
         test_script_save(net, test_data)
 
 
-# @skip_if_no_cuda
-# @skip_if_windows
-@unittest.skip("temporary skip for 22.12/23.02")
+@skip_if_no_cuda
+@skip_if_windows
 class TestDynUNetWithInstanceNorm3dNVFuser(unittest.TestCase):
     @parameterized.expand([TEST_CASE_DYNUNET_3D[0]])
     def test_consistency(self, input_param, input_shape, _):

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -130,7 +130,7 @@ class TestDynUNet(unittest.TestCase):
 class TestDynUNetWithInstanceNorm3dNVFuser(unittest.TestCase):
     def setUp(self):
         try:
-            layer = InstanceNorm3dNVFuser(num_features=1, affine=True).to("cuda:0")
+            layer = InstanceNorm3dNVFuser(num_features=1, affine=False).to("cuda:0")
             inp = torch.randn([1, 1, 1, 1, 1]).to("cuda:0")
             out = layer(inp)
             del inp, out, layer

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -19,7 +19,10 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import DynUNet
+from monai.utils import optional_import
 from tests.utils import assert_allclose, skip_if_no_cuda, skip_if_windows, test_script_save
+
+InstanceNorm3dNVFuser, _ = optional_import("apex.normalization", name="InstanceNorm3dNVFuser")
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -125,6 +128,15 @@ class TestDynUNet(unittest.TestCase):
 @skip_if_no_cuda
 @skip_if_windows
 class TestDynUNetWithInstanceNorm3dNVFuser(unittest.TestCase):
+    def setUp(self):
+        try:
+            layer = InstanceNorm3dNVFuser(num_features=1, affine=True).to("cuda:0")
+            inp = torch.randn([1, 1, 1, 1, 1]).to("cuda:0")
+            out = layer(inp)
+            del inp, out, layer
+        except Exception:
+            self.skipTest("NVFuser not available")
+
     @parameterized.expand([TEST_CASE_DYNUNET_3D[0]])
     def test_consistency(self, input_param, input_shape, _):
         for eps in [1e-4, 1e-5]:


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/6265

### Description

removes try/except dummy test for InstanceNorm3dNVFuser to avoid OOM gpu mem allocations

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
