### PR TITLE
Autorunner clear gpu mem allocatoins of dataanalyzer

### DIFF
--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -719,7 +719,7 @@ class AutoRunner:
             )
             da.get_all_case_stats()
 
-            da = None
+            da = None  # type: ignore
             torch.cuda.empty_cache()
 
             self.export_cache(analyze=True, datastats=self.datastats_filename)

--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -718,6 +718,10 @@ class AutoRunner:
                 self.datalist_filename, self.dataroot, output_path=self.datastats_filename, **self.analyze_params
             )
             da.get_all_case_stats()
+
+            da = None
+            torch.cuda.empty_cache()
+
             self.export_cache(analyze=True, datastats=self.datastats_filename)
         else:
             logger.info("Skipping data analysis...")


### PR DESCRIPTION
clears gpu mem allocatoins of dataanalyzer

For some reason, after data analyzer finishes, GPU memory was not fully released, and about 1GB persisted, 
this fix helps.

PS: about 300MB still persists on CUDA:0 device even after this fix, but unclear why yet 