### PR TITLE
Add text to vision embedding

### DIFF
--- a/monai/networks/blocks/text_enbedding.py
+++ b/monai/networks/blocks/text_enbedding.py
@@ -1,0 +1,60 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+class TextEncoder(nn.Module):
+    """
+    Text to vision encoding by Contrastive Language-Image Pre-training (CLIP) or random embedding.
+    The text to vision encoder loads the pre-trained or random initialized weights with connection to 2D/3D vision models.
+
+    Contrastive Language-Image Pre-training (CLIP), based on: "Radford et al.,
+    Learning Transferable Visual Models From Natural Language Supervision <https://arxiv.org/abs/2103.00020>"
+
+    Connecting text and medical 3D image, based on: "Liu et al.,
+    CLIP-Driven Universal Model for Organ Segmentation and Tumor Detection <https://arxiv.org/pdf/2301.00785.pdf>"
+    """    
+    def __init__(
+        self,
+        out_channels: int,
+        text_dim: int = 512,
+        hidden_size: int = 256,
+        encoding: str = "clip_embedding",
+    ) -> None:
+        """
+        Args:
+            out_channels: number of output channels, to control text-baesd embedding for classes.
+            text_dim: dimension of text embeddings.
+            hidden_size: dimension of hidden features, compatible to different vision feature dimensions.
+            encoding: the text embedding type, default to use clip text pretrained weights
+        """
+        self.encoding = encoding
+
+        if self.encoding == 'rand_embedding':
+            self.organ_embedding = nn.Embedding(out_channels, hidden_size)
+        elif self.encoding == 'clip_embedding':
+            self.register_buffer('text_embedding', torch.randn(out_channels, text_dim))
+            self.text_to_vision = nn.Linear(text_dim, hidden_size)
+
+    def forward(self):
+        if self.encoding == 'clip_embedding':
+            task_encoding = nn.function.relu(self.text_to_vision(self.organ_embedding))
+            task_encoding = task_encoding.unsqueeze(2).unsqueeze(2).unsqueeze(2)
+        else:
+            # text embedding as random initialized 'rand_embedding'
+            task_encoding = self.text_embedding.weight.unsqueeze(2).unsqueeze(2).unsqueeze(2)
+        return task_encoding
+
+
+


### PR DESCRIPTION

As part of the text to vision encoder for medical image analysis.

Support CLIP pre-trained embedding and random text embedding. 

Linked to the issue: https://github.com/Project-MONAI/MONAI/issues/6177