### PR TITLE
(WIP) test networks with test_onnx_save

### DIFF
--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -672,7 +672,9 @@ def convert_to_onnx(
         set_determinism(seed=None)
         # compare onnx/ort and PyTorch results
         for r1, r2 in zip(torch_out, onnx_out):
-            torch.testing.assert_allclose(r1.cpu(), r2, rtol=rtol, atol=atol)  # type: ignore
+            if isinstance(r1, torch.Tensor):
+                assert_fn = torch.testing.assert_close if pytorch_after(1, 11) else torch.testing.assert_allclose
+                assert_fn(r1.cpu().numpy(), r2, rtol=rtol, atol=atol)  # type: ignore
 
     return onnx_model
 

--- a/tests/test_anchor_box.py
+++ b/tests/test_anchor_box.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.apps.detection.utils.anchor_utils import AnchorGenerator, AnchorGeneratorWithAnchorShape
 from monai.utils import optional_import
-from tests.utils import SkipIfBeforePyTorchVersion, assert_allclose, test_script_save
+from tests.utils import SkipIfBeforePyTorchVersion, assert_allclose, test_script_save, test_onnx_save
 
 _, has_torchvision = optional_import("torchvision")
 
@@ -82,6 +82,22 @@ class TestAnchorGenerator(unittest.TestCase):
         images = torch.rand(image_shape)
         feature_maps = tuple(torch.rand(fs) for fs in feature_maps_shapes)
         test_script_save(anchor, images, feature_maps)
+
+    @parameterized.expand(TEST_CASES_2D)
+    def test_onnx_2d(self, input_param, image_shape, feature_maps_shapes):
+        # test whether support torchscript
+        anchor = AnchorGenerator(**input_param, indexing="xy")
+        images = torch.rand(image_shape)
+        feature_maps = tuple(torch.rand(fs) for fs in feature_maps_shapes)
+        test_onnx_save(anchor, images, feature_maps)
+
+    @parameterized.expand(TEST_CASES_SHAPE_3D)
+    def test_onnx_3d(self, input_param, image_shape, feature_maps_shapes):
+        # test whether support torchscript
+        anchor = AnchorGeneratorWithAnchorShape(**input_param, indexing="ij")
+        images = torch.rand(image_shape)
+        feature_maps = tuple(torch.rand(fs) for fs in feature_maps_shapes)
+        test_onnx_save(anchor, images, feature_maps)
 
 
 if __name__ == "__main__":

--- a/tests/test_autoencoder.py
+++ b/tests/test_autoencoder.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.layers import Act
 from monai.networks.nets import AutoEncoder
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -85,6 +85,11 @@ class TestAutoEncoder(unittest.TestCase):
         net = AutoEncoder(spatial_dims=2, in_channels=1, out_channels=1, channels=(4, 8), strides=(2, 2))
         test_data = torch.randn(2, 1, 32, 32)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        net = AutoEncoder(spatial_dims=2, in_channels=1, out_channels=1, channels=(4, 8), strides=(2, 2))
+        test_data = torch.randn(2, 1, 32, 32)
+        test_onnx_save(net, test_data, atol=1e-3)
 
     def test_channel_stride_difference(self):
         with self.assertRaises(ValueError):

--- a/tests/test_basic_unet.py
+++ b/tests/test_basic_unet.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import BasicUNet
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 CASES_1D = []
 for mode in ["pixelshuffle", "nontrainable", "deconv", None]:
@@ -96,6 +96,11 @@ class TestBasicUNET(unittest.TestCase):
         net = BasicUNet(spatial_dims=2, in_channels=1, out_channels=3)
         test_data = torch.randn(16, 1, 32, 32)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        net = BasicUNet(spatial_dims=2, in_channels=1, out_channels=3)
+        test_data = torch.randn(16, 1, 32, 32)
+        test_onnx_save(net, test_data, atol=0.0001)
 
 
 if __name__ == "__main__":

--- a/tests/test_basic_unetplusplus.py
+++ b/tests/test_basic_unetplusplus.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import BasicUNetPlusPlus
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 CASES_1D = []
 for mode in ["pixelshuffle", "nontrainable", "deconv", None]:
@@ -103,6 +103,11 @@ class TestBasicUNETPlusPlus(unittest.TestCase):
         net = BasicUNetPlusPlus(spatial_dims=2, deep_supervision=True, in_channels=1, out_channels=3)
         test_data = torch.randn(16, 1, 32, 32)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        net = BasicUNetPlusPlus(spatial_dims=2, deep_supervision=True, in_channels=1, out_channels=3)
+        test_data = torch.randn(16, 1, 32, 32)
+        test_onnx_save(net, test_data, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_dints_mixop.py
+++ b/tests/test_dints_mixop.py
@@ -17,7 +17,7 @@ import torch
 from parameterized import parameterized
 
 from monai.networks.nets.dints import Cell, MixedOp
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 TEST_CASES_3D = [
     [
@@ -78,6 +78,11 @@ class TestMixOP(unittest.TestCase):
     def test_script(self, input_param, ops, weight, input_shape, expected_shape):
         net = MixedOp(ops=Cell.OPS3D, **input_param)
         test_script_save(net, torch.randn(input_shape), weight)
+
+    @parameterized.expand(TEST_CASES_3D)
+    def test_onnx(self, input_param, ops, weight, input_shape, expected_shape):
+        net = MixedOp(ops=Cell.OPS3D, **input_param)
+        test_onnx_save(net, torch.randn(input_shape), weight, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_discriminator.py
+++ b/tests/test_discriminator.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import Discriminator
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 TEST_CASE_0 = [
     {"in_shape": (1, 64, 64), "channels": (2, 4, 8), "strides": (2, 2, 2), "num_res_units": 0},
@@ -53,6 +53,11 @@ class TestDiscriminator(unittest.TestCase):
         net = Discriminator(in_shape=(1, 64, 64), channels=(2, 4), strides=(2, 2), num_res_units=0)
         test_data = torch.rand(16, 1, 64, 64)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        net = Discriminator(in_shape=(1, 64, 64), channels=(2, 4), strides=(2, 2), num_res_units=0)
+        test_data = torch.rand(16, 1, 64, 64)
+        test_onnx_save(net, test_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -20,7 +20,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.nets import DynUNet
 from monai.utils import optional_import
-from tests.utils import assert_allclose, skip_if_no_cuda, skip_if_windows, test_script_save
+from tests.utils import assert_allclose, skip_if_no_cuda, skip_if_windows, test_script_save, test_onnx_save
 
 InstanceNorm3dNVFuser, _ = optional_import("apex.normalization", name="InstanceNorm3dNVFuser")
 
@@ -123,6 +123,12 @@ class TestDynUNet(unittest.TestCase):
         net = DynUNet(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASE_DYNUNET_2D[0]
+        net = DynUNet(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=0.0001)
 
 
 @skip_if_no_cuda

--- a/tests/test_dynunet_block.py
+++ b/tests/test_dynunet_block.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.blocks.dynunet_block import UnetBasicBlock, UnetResBlock, UnetUpBlock, get_padding
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 TEST_CASE_RES_BASIC_BLOCK = []
 for spatial_dims in range(2, 4):
@@ -94,6 +94,14 @@ class TestResBasicBlock(unittest.TestCase):
             test_data = torch.randn(input_shape)
             test_script_save(net, test_data)
 
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASE_RES_BASIC_BLOCK[0]
+
+        for net_type in (UnetResBlock, UnetBasicBlock):
+            net = net_type(**input_param)
+            test_data = torch.randn(input_shape)
+            test_onnx_save(net, test_data, atol=1e-3)
+
 
 class TestUpBlock(unittest.TestCase):
     @parameterized.expand(TEST_UP_BLOCK)
@@ -110,6 +118,14 @@ class TestUpBlock(unittest.TestCase):
         test_data = torch.randn(input_shape)
         skip_data = torch.randn(skip_shape)
         test_script_save(net, test_data, skip_data)
+
+    def test_onnx(self):
+        input_param, input_shape, _, skip_shape = TEST_UP_BLOCK[0]
+
+        net = UnetUpBlock(**input_param)
+        test_data = torch.randn(input_shape)
+        skip_data = torch.randn(skip_shape)
+        test_onnx_save(net, test_data, skip_data, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_efficientnet.py
+++ b/tests/test_efficientnet.py
@@ -28,7 +28,7 @@ from monai.networks.nets import (
     get_efficientnet_image_size,
 )
 from monai.utils import optional_import
-from tests.utils import skip_if_downloading_fails, skip_if_quick, test_pretrained_networks, test_script_save
+from tests.utils import skip_if_downloading_fails, skip_if_quick, test_pretrained_networks, test_script_save, test_onnx_save
 
 if TYPE_CHECKING:
     import torchvision
@@ -373,6 +373,13 @@ class TestEFFICIENTNET(unittest.TestCase):
         net.set_swish(memory_efficient=False)  # at the moment custom memory efficient swish is not exportable with jit
         test_data = torch.randn(1, 3, 224, 224)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        with skip_if_downloading_fails():
+            net = EfficientNetBN(model_name="efficientnet-b0", spatial_dims=2, in_channels=3, num_classes=1000)
+        net.set_swish(memory_efficient=False)  # at the moment custom memory efficient swish is not exportable with jit
+        test_data = torch.randn(1, 3, 224, 224)
+        test_onnx_save(net, test_data, atol=1e-3)
 
 
 class TestExtractFeatures(unittest.TestCase):

--- a/tests/test_flexible_unet.py
+++ b/tests/test_flexible_unet.py
@@ -28,7 +28,7 @@ from monai.networks.nets import (
     ResNetBottleneck,
 )
 from monai.utils import optional_import
-from tests.utils import skip_if_downloading_fails, skip_if_quick
+from tests.utils import skip_if_downloading_fails, skip_if_quick, test_onnx_save
 
 torchvision, has_torchvision = optional_import("torchvision")
 PIL, has_pil = optional_import("PIL")
@@ -377,6 +377,15 @@ class TestFLEXIBLEUNET(unittest.TestCase):
 
         # check output shape
         self.assertEqual(result.shape, expected_shape)
+
+    @parameterized.expand(CASES_2D + CASES_3D + CASES_VARIATIONS)
+    def test_onnx(self, input_param, input_shape, expected_shape):
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        with skip_if_downloading_fails():
+            net = FlexibleUNet(**input_param).to(device)
+            input_data = torch.randn(input_shape)
+            test_onnx_save(net, input_data)
 
     @parameterized.expand(CASES_PRETRAIN)
     def test_pretrain(self, input_param, efficient_input_param, weight_list):

--- a/tests/test_fpn_block.py
+++ b/tests/test_fpn_block.py
@@ -21,7 +21,7 @@ from monai.networks.blocks.backbone_fpn_utils import _resnet_fpn_extractor
 from monai.networks.blocks.feature_pyramid_network import FeaturePyramidNetwork
 from monai.networks.nets.resnet import resnet50
 from monai.utils import optional_import
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import SkipIfBeforePyTorchVersion, test_script_save, test_onnx_save
 
 _, has_torchvision = optional_import("torchvision")
 
@@ -64,6 +64,14 @@ class TestFPNBlock(unittest.TestCase):
         data["feat1"] = torch.rand(input_shape[1])
         test_script_save(net, data)
 
+    @parameterized.expand(TEST_CASES)
+    @unittest.skip("pending: https://github.com/pytorch/pytorch/issues/84257")
+    def test_onnx(self, input_param, input_shape, expected_shape):
+        # test whether support onnx
+        net = FeaturePyramidNetwork(**input_param)
+        data = {"feat0": torch.rand(input_shape[0]), "feat1": torch.rand(input_shape[1])}
+        test_onnx_save(net, data)
+
 
 @unittest.skipUnless(has_torchvision, "Requires torchvision")
 class TestFPN(unittest.TestCase):
@@ -82,6 +90,14 @@ class TestFPN(unittest.TestCase):
         net = _resnet_fpn_extractor(backbone=resnet50(), spatial_dims=input_param["spatial_dims"], returned_layers=[1])
         data = torch.rand(input_shape)
         test_script_save(net, data)
+
+    @parameterized.expand(TEST_CASES2)
+    @unittest.skip("pending: https://github.com/pytorch/pytorch/issues/84257")
+    def test_onnx(self, input_param, input_shape, expected_shape):
+        # test whether support onnx
+        net = _resnet_fpn_extractor(backbone=resnet50(), spatial_dims=input_param["spatial_dims"], returned_layers=[1])
+        data = torch.rand(input_shape)
+        test_onnx_save(net, data)
 
 
 if __name__ == "__main__":

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import Generator
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 TEST_CASE_0 = [
     {"latent_shape": (64,), "start_shape": (8, 8, 8), "channels": (8, 4, 1), "strides": (2, 2, 2), "num_res_units": 0},
@@ -53,6 +53,11 @@ class TestGenerator(unittest.TestCase):
         net = Generator(latent_shape=(64,), start_shape=(8, 8, 8), channels=(8, 1), strides=(2, 2), num_res_units=2)
         test_data = torch.rand(16, 64)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        net = Generator(latent_shape=(64,), start_shape=(8, 8, 8), channels=(8, 1), strides=(2, 2), num_res_units=2)
+        test_data = torch.rand(16, 64)
+        test_onnx_save(net, test_data, atol=0.0001)
 
 
 if __name__ == "__main__":

--- a/tests/test_globalnet.py
+++ b/tests/test_globalnet.py
@@ -21,7 +21,7 @@ from monai.networks import eval_mode
 from monai.networks.blocks import Warp
 from monai.networks.nets import GlobalNet
 from monai.networks.nets.regunet import AffineHead
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 TEST_CASES_AFFINE_TRANSFORM = [
     [
@@ -91,6 +91,12 @@ class TestGlobalNet(unittest.TestCase):
         net = GlobalNet(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASES_GLOBAL_NET[0]
+        net = GlobalNet(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_highresnet.py
+++ b/tests/test_highresnet.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import HighResNet
-from tests.utils import DistTestCase, TimedCall, test_script_save
+from tests.utils import DistTestCase, TimedCall, test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -61,6 +61,13 @@ class TestHighResNet(DistTestCase):
         net = HighResNet(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data, rtol=1e-4, atol=1e-4)
+
+    @TimedCall(seconds=800, force_quit=True)
+    def test_onnx(self):
+        input_param, input_shape, expected_shape = TEST_CASE_1
+        net = HighResNet(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, rtol=1e-4, atol=1e-4)
 
 
 if __name__ == "__main__":

--- a/tests/test_hovernet.py
+++ b/tests/test_hovernet.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode, train_mode
 from monai.networks.nets import HoVerNet
 from monai.networks.nets.hovernet import _DenseLayerDecoder
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -181,8 +181,14 @@ class TestHoverNet(unittest.TestCase):
     def test_script(self):
         for padding_flag in [True, False]:
             net = HoVerNet(mode=HoVerNet.Mode.FAST, decoder_padding=padding_flag)
-        test_data = torch.randn(1, 3, 256, 256)
-        test_script_save(net, test_data)
+            test_data = torch.randn(1, 3, 256, 256)
+            test_script_save(net, test_data)
+
+    def test_onnx(self):
+        for padding_flag in [True, False]:
+            net = HoVerNet(mode=HoVerNet.Mode.FAST, decoder_padding=padding_flag)
+            test_data = torch.randn(1, 3, 256, 256)
+            test_onnx_save(net, test_data)
 
     def test_ill_input_shape(self):
         net = HoVerNet(mode=HoVerNet.Mode.FAST)

--- a/tests/test_localnet.py
+++ b/tests/test_localnet.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets.regunet import LocalNet
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -80,6 +80,12 @@ class TestLocalNet(unittest.TestCase):
         net = LocalNet(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASE_LOCALNET_2D[0]
+        net = LocalNet(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_milmodel.py
+++ b/tests/test_milmodel.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.nets import MILModel
 from monai.utils.module import optional_import
-from tests.utils import skip_if_downloading_fails, test_script_save
+from tests.utils import skip_if_downloading_fails, test_script_save, test_onnx_save
 
 models, _ = optional_import("torchvision.models")
 
@@ -86,6 +86,12 @@ class TestMilModel(unittest.TestCase):
         net = MILModel(**input_param)
         test_data = torch.randn(input_shape, dtype=torch.float)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, expected_shape = TEST_CASE_MILMODEL[0]
+        net = MILModel(**input_param)
+        test_data = torch.randn(input_shape, dtype=torch.float)
+        test_onnx_save(net, test_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_multi_scale.py
+++ b/tests/test_multi_scale.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.losses import DiceLoss
 from monai.losses.multi_scale import MultiScaleLoss
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 dice_loss = DiceLoss(include_background=True, sigmoid=True, smooth_nr=1e-5, smooth_dr=1e-5)
 device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -73,6 +73,11 @@ class TestMultiScale(unittest.TestCase):
         input_param, input_data, expected_val = TEST_CASES[0]
         loss = MultiScaleLoss(**input_param)
         test_script_save(loss, input_data["y_pred"], input_data["y_true"])
+
+    def test_onnx(self):
+        input_param, input_data, expected_val = TEST_CASES[0]
+        loss = MultiScaleLoss(**input_param)
+        test_onnx_save(loss, input_data["y_pred"], input_data["y_true"])
 
 
 if __name__ == "__main__":

--- a/tests/test_net_adapter.py
+++ b/tests/test_net_adapter.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import NetAdapter, resnet18
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -42,26 +42,31 @@ TEST_CASE_4 = [
 
 
 class TestNetAdapter(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
-    def test_shape(self, input_param, input_shape, expected_shape):
+    def get_net(self, input_param, device):
         spatial_dims = input_param["dim"]
         stride = (1, 2, 2)[:spatial_dims]
         model = resnet18(spatial_dims=spatial_dims, conv1_t_stride=stride)
         input_param["model"] = model
-        net = NetAdapter(**input_param).to(device)
+        return NetAdapter(**input_param).to(device)
+
+    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
+    def test_shape(self, input_param, input_shape, expected_shape):
+        net = self.get_net(input_param, device)
         with eval_mode(net):
             result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
     @parameterized.expand([TEST_CASE_0])
     def test_script(self, input_param, input_shape, expected_shape):
-        spatial_dims = input_param["dim"]
-        stride = (1, 2, 2)[:spatial_dims]
-        model = resnet18(spatial_dims=spatial_dims, conv1_t_stride=stride)
-        input_param["model"] = model
-        net = NetAdapter(**input_param).to("cpu")
+        net = self.get_net(input_param, "cpu")
         test_data = torch.randn(input_shape).to("cpu")
         test_script_save(net, test_data)
+
+    @parameterized.expand([TEST_CASE_0])
+    def test_onnx(self, input_param, input_shape, expected_shape):
+        net = self.get_net(input_param, "cpu")
+        test_data = torch.randn(input_shape).to("cpu")
+        test_onnx_save(net, test_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_regunet.py
+++ b/tests/test_regunet.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets.regunet import RegUNet
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -82,6 +82,12 @@ class TestREGUNET(unittest.TestCase):
         net = RegUNet(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASE_REGUNET_2D[0]
+        net = RegUNet(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -21,7 +21,7 @@ from monai.networks import eval_mode
 from monai.networks.nets import ResNet, resnet10, resnet18, resnet34, resnet50, resnet101, resnet152, resnet200
 from monai.networks.nets.resnet import ResNetBlock
 from monai.utils import optional_import
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 if TYPE_CHECKING:
     import torchvision
@@ -186,6 +186,12 @@ class TestResNet(unittest.TestCase):
         net = model(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    @parameterized.expand(TEST_SCRIPT_CASES)
+    def test_onnx(self, model, input_param, input_shape, expected_shape):
+        net = model(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_retinanet_detector.py
+++ b/tests/test_retinanet_detector.py
@@ -21,7 +21,7 @@ from monai.apps.detection.networks.retinanet_detector import RetinaNetDetector, 
 from monai.apps.detection.utils.anchor_utils import AnchorGeneratorWithAnchorShape
 from monai.networks import eval_mode, train_mode
 from monai.utils import optional_import
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import SkipIfBeforePyTorchVersion, test_script_save, test_onnx_save
 
 _, has_torchvision = optional_import("torchvision")
 
@@ -183,9 +183,7 @@ class TestRetinaNetDetector(unittest.TestCase):
             targets = [one_target] * len(input_data)
             result = detector.forward(input_data, targets)
 
-    @parameterized.expand(TEST_CASES_TS)
-    def test_script(self, input_param, input_shape):
-        # test whether support torchscript
+    def get_detector_for_script_onnx_test(self, input_param):
         returned_layers = [1]
         anchor_generator = AnchorGeneratorWithAnchorShape(
             feature_map_scales=(1, 2), base_anchor_shapes=((8,) * input_param["spatial_dims"],)
@@ -193,9 +191,26 @@ class TestRetinaNetDetector(unittest.TestCase):
         detector = retinanet_resnet50_fpn_detector(
             **input_param, anchor_generator=anchor_generator, returned_layers=returned_layers
         )
+        return detector
+
+    @parameterized.expand(TEST_CASES_TS)
+    def test_script(self, input_param, input_shape):
+        # test whether support torchscript
+        detector = self.get_detector_for_script_onnx_test(input_param)
         with eval_mode(detector):
             input_data = torch.randn(input_shape)
             test_script_save(detector.network, input_data)
+            # it is ideal not to use trace to work with loop in RetinaNetDetector.
+            # however torch.jit.script fails with RetinaNetDetector. so we use trace here.
+            test_script_save(detector, input_data, use_trace=True)
+
+    @parameterized.expand(TEST_CASES_TS)
+    def test_onnx(self, input_param, input_shape):
+        # test whether support onnx
+        detector = self.get_detector_for_script_onnx_test(input_param)
+        with eval_mode(detector):
+            input_data = torch.randn(input_shape)
+            test_onnx_save(detector, input_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_se_block.py
+++ b/tests/test_se_block.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.blocks import SEBlock
 from monai.networks.layers.factories import Act, Norm
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -75,6 +75,12 @@ class TestSEBlockLayer(unittest.TestCase):
         net = SEBlock(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASES[0]
+        net = SEBlock(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=1e-3)
 
     def test_ill_arg(self):
         with self.assertRaises(ValueError):

--- a/tests/test_se_blocks.py
+++ b/tests/test_se_blocks.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.blocks import ChannelSELayer, ResidualSELayer
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 TEST_CASES = [  # single channel 3D, batch 16
     [{"spatial_dims": 2, "in_channels": 4, "r": 3}, (7, 4, 64, 48), (7, 4, 64, 48)],  # 4-channel 2D, batch 7
@@ -54,6 +54,12 @@ class TestChannelSELayer(unittest.TestCase):
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
 
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASES[0]
+        net = ChannelSELayer(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data)
+
     def test_ill_arg(self):
         with self.assertRaises(ValueError):
             ChannelSELayer(spatial_dims=1, in_channels=4, r=100)
@@ -72,6 +78,12 @@ class TestResidualSELayer(unittest.TestCase):
         net = ResidualSELayer(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASES[0]
+        net = ResidualSELayer(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_segresnet.py
+++ b/tests/test_segresnet.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.nets import SegResNet, SegResNetVAE
 from monai.utils import UpsampleMode
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -99,6 +99,12 @@ class TestResNet(unittest.TestCase):
         net = SegResNet(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, expected_shape = TEST_CASE_SEGRESNET[0]
+        net = SegResNet(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=0.0001)
 
 
 class TestResNetVAE(unittest.TestCase):

--- a/tests/test_segresnet_ds.py
+++ b/tests/test_segresnet_ds.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import SegResNetDS
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import SkipIfBeforePyTorchVersion, test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 TEST_CASE_SEGRESNET_DS = []
@@ -126,6 +126,13 @@ class TestResNetDS(unittest.TestCase):
         net = SegResNetDS(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    @SkipIfBeforePyTorchVersion((1, 10))
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASE_SEGRESNET_DS[0]
+        net = SegResNetDS(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_senet.py
+++ b/tests/test_senet.py
@@ -23,7 +23,7 @@ import monai.networks.nets.senet as se_mod
 from monai.networks import eval_mode
 from monai.networks.nets import SENet, SENet154, SEResNet50, SEResNet101, SEResNet152, SEResNext50, SEResNext101
 from monai.utils import optional_import
-from tests.utils import test_is_quick, test_pretrained_networks, test_script_save, testing_data_config
+from tests.utils import test_is_quick, test_pretrained_networks, test_script_save, test_onnx_save, testing_data_config
 
 if TYPE_CHECKING:
     import pretrainedmodels
@@ -72,6 +72,13 @@ class TestSENET(unittest.TestCase):
         net = net(**net_args)
         input_data = torch.randn(2, 2, 64, 64, 64)
         test_script_save(net, input_data)
+
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5, TEST_CASE_6])
+    def test_onnx(self, net, net_args):
+        # AssertionError: Tensor-likes are not close!
+        net = net(**net_args)
+        input_data = torch.randn(2, 2, 64, 64, 64)
+        test_onnx_save(net, input_data)
 
 
 class TestPretrainedSENET(unittest.TestCase):

--- a/tests/test_swin_unetr.py
+++ b/tests/test_swin_unetr.py
@@ -20,6 +20,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.nets.swin_unetr import PatchMerging, PatchMergingV2, SwinUNETR
 from monai.utils import optional_import
+from tests.utils import test_onnx_save
 
 einops, has_einops = optional_import("einops")
 
@@ -92,6 +93,14 @@ class TestSWINUNETR(unittest.TestCase):
         dim = 10
         t = PatchMerging(dim)(torch.zeros((1, 21, 20, 20, dim)))
         self.assertEqual(t.shape, torch.Size([1, 11, 10, 10, 20]))
+
+    @parameterized.expand(TEST_CASE_SWIN_UNETR)
+    @skipUnless(has_einops, "Requires einops")
+    def test_onnx(self, input_param, input_shape, expected_shape):
+        net = SwinUNETR(**input_param)
+        with eval_mode(net):
+            test_data = torch.randn(input_shape)
+            test_onnx_save(net, test_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_torchvision_fc_model.py
+++ b/tests/test_torchvision_fc_model.py
@@ -21,6 +21,7 @@ from monai.networks import eval_mode
 from monai.networks.nets import TorchVisionFCModel, UNet
 from monai.networks.utils import look_up_named_module, set_named_module
 from monai.utils import min_version, optional_import
+from tests.utils import test_onnx_save
 
 Inception_V3_Weights, has_enum = optional_import("torchvision.models.inception", name="Inception_V3_Weights")
 
@@ -183,6 +184,16 @@ class TestTorchVisionFCModel(unittest.TestCase):
             self.assertEqual(value, expected_value)
             self.assertEqual(result.shape, expected_shape)
 
+    @parameterized.expand(
+        [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5, TEST_CASE_6, TEST_CASE_7]
+        + ([TEST_CASE_8] if has_enum else [])
+    )
+    @skipUnless(has_tv, "Requires TorchVision.")
+    def test_onnx(self, input_param, input_shape, expected_shape):
+        net = TorchVisionFCModel(**input_param).to(device)
+        data = torch.randn(input_shape)
+        net = TorchVisionFCModel(**input_param).to(device)
+        test_onnx_save(net, data)
 
 class TestLookup(unittest.TestCase):
     def test_get_module(self):

--- a/tests/test_unet.py
+++ b/tests/test_unet.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.layers import Act, Norm
 from monai.networks.nets import UNet
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -191,6 +191,26 @@ class TestUNET(unittest.TestCase):
         )
         test_data = torch.randn(16, 1, 16, 4)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        net = UNet(
+            spatial_dims=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2), num_res_units=0
+        )
+        test_data = torch.randn(16, 1, 32, 32)
+        test_onnx_save(net, test_data, atol=0.0001)
+
+    def test_onnx_without_running_stats(self):
+        net = UNet(
+            spatial_dims=2,
+            in_channels=1,
+            out_channels=3,
+            channels=(16, 32, 64),
+            strides=(2, 2),
+            num_res_units=0,
+            norm=("batch", {"track_running_stats": False}),
+        )
+        test_data = torch.randn(16, 1, 16, 4)
+        test_onnx_save(net, test_data, atol=0.0001)
 
     def test_ill_input_shape(self):
         net = UNet(spatial_dims=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2))

--- a/tests/test_unetr.py
+++ b/tests/test_unetr.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets.unetr import UNETR
-from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick, test_script_save
+from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick, test_script_save, test_onnx_save
 
 TEST_CASE_UNETR = []
 for dropout_rate in [0.4]:
@@ -131,6 +131,17 @@ class TestUNETR(unittest.TestCase):
 
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    @parameterized.expand(TEST_CASE_UNETR)
+    @SkipIfBeforePyTorchVersion((1, 9))
+    def test_onnx(self, input_param, input_shape, _):
+        net = UNETR(**(input_param))
+        net.eval()
+        with torch.no_grad():
+            torch.jit.script(net)
+
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_unetr_block.py
+++ b/tests/test_unetr_block.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.blocks.dynunet_block import get_padding
 from monai.networks.blocks.unetr_block import UnetrBasicBlock, UnetrPrUpBlock, UnetrUpBlock
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 TEST_CASE_UNETR_BASIC_BLOCK = []
 for spatial_dims in range(1, 4):
@@ -122,6 +122,13 @@ class TestResBasicBlock(unittest.TestCase):
             test_data = torch.randn(input_shape)
             test_script_save(net, test_data)
 
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_CASE_UNETR_BASIC_BLOCK[0]
+        net = UnetrBasicBlock(**input_param)
+        with eval_mode(net):
+            test_data = torch.randn(input_shape)
+            test_onnx_save(net, test_data)
+
 
 class TestUpBlock(unittest.TestCase):
     @parameterized.expand(TEST_UP_BLOCK)
@@ -138,6 +145,13 @@ class TestUpBlock(unittest.TestCase):
         skip_data = torch.randn(skip_shape)
         test_script_save(net, test_data, skip_data)
 
+    def test_onnx(self):
+        input_param, input_shape, _, skip_shape = TEST_UP_BLOCK[0]
+        net = UnetrUpBlock(**input_param)
+        test_data = torch.randn(input_shape)
+        skip_data = torch.randn(skip_shape)
+        test_onnx_save(net, test_data, skip_data)
+
 
 class TestPrUpBlock(unittest.TestCase):
     @parameterized.expand(TEST_PRUP_BLOCK)
@@ -152,6 +166,12 @@ class TestPrUpBlock(unittest.TestCase):
         net = UnetrPrUpBlock(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, _ = TEST_PRUP_BLOCK[0]
+        net = UnetrPrUpBlock(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_varautoencoder.py
+++ b/tests/test_varautoencoder.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.layers import Act
 from monai.networks.nets import VarAutoEncoder
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -121,6 +121,13 @@ class TestVarAutoEncoder(unittest.TestCase):
         )
         test_data = torch.randn(2, 1, 32, 32)
         test_script_save(net, test_data, rtol=1e-3, atol=1e-3)
+
+    def test_onnx(self):
+        net = VarAutoEncoder(
+            spatial_dims=2, in_shape=(1, 32, 32), out_channels=1, latent_size=2, channels=(4, 8), strides=(2, 2)
+        )
+        test_data = torch.randn(2, 1, 32, 32)
+        test_onnx_save(net, test_data, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets.vit import ViT
-from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick, test_script_save
+from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick, test_script_save, test_onnx_save
 
 TEST_CASE_Vit = []
 for dropout_rate in [0.6]:
@@ -149,6 +149,17 @@ class TestViT(unittest.TestCase):
 
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    @parameterized.expand(TEST_CASE_Vit)
+    @SkipIfBeforePyTorchVersion((1, 9))
+    def test_onnx(self, input_param, input_shape, _):
+        net = ViT(**(input_param))
+        net.eval()
+        with torch.no_grad():
+            torch.jit.script(net)
+
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.networks import eval_mode
 from monai.networks.nets import VNet
-from tests.utils import test_script_save
+from tests.utils import test_script_save, test_onnx_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -75,6 +75,11 @@ class TestVNet(unittest.TestCase):
         net = VNet(spatial_dims=3, in_channels=1, out_channels=3, dropout_dim=3)
         test_data = torch.randn(1, 1, 32, 32, 32)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        net = VNet(spatial_dims=3, in_channels=1, out_channels=3, dropout_dim=3)
+        test_data = torch.randn(1, 1, 32, 32, 32)
+        test_onnx_save(net, test_data, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -716,7 +716,7 @@ class TorchImageTestCase3D(NumpyImageTestCase3D):
         self.segn = torch.tensor(self.segn)
 
 
-def test_script_save(net, *inputs, device=None, rtol=1e-4, atol=0.0):
+def test_script_save(net, *inputs, **kwargs):
     """
     Test the ability to save `net` as a Torchscript object, reload it, and apply inference. The value `inputs` is
     forward-passed through the original and loaded copy of the network and their results returned.
@@ -733,9 +733,7 @@ def test_script_save(net, *inputs, device=None, rtol=1e-4, atol=0.0):
                 filename_or_obj=os.path.join(tempdir, "model.ts"),
                 verify=True,
                 inputs=inputs,
-                device=device,
-                rtol=rtol,
-                atol=atol,
+                **kwargs,
             )
     except (RuntimeError, AttributeError):
         if sys.version_info.major == 3 and sys.version_info.minor == 11:
@@ -743,7 +741,7 @@ def test_script_save(net, *inputs, device=None, rtol=1e-4, atol=0.0):
             return
 
 
-def test_onnx_save(net, *inputs, device=None, rtol=1e-4, atol=0.0):
+def test_onnx_save(net, *inputs, device=None, **kwargs):
     """
     Test the ability to save `net` in ONNX format, reload it and validate with runtime.
     The value `inputs` is forward-passed through the `net` without gradient accumulation
@@ -761,10 +759,8 @@ def test_onnx_save(net, *inputs, device=None, rtol=1e-4, atol=0.0):
                 filename=os.path.join(tempdir, "model.onnx"),
                 verify=True,
                 inputs=inputs,
-                device=device,
                 use_ort=has_onnxruntime,
-                rtol=rtol,
-                atol=atol,
+                **kwargs
             )
     except (RuntimeError, AttributeError):
         if sys.version_info.major == 3 and sys.version_info.minor == 11:


### PR DESCRIPTION
Fixes # .
NA

### Description
onnx export had been enabled in a previous PR. It is necessary to extend test coverage on networks defined in Monai and used (or will be used) in model-zoo.

This PR adds tests on export of those networks and validate exported onnx models.

I still need to try clean up some unwanted messages from test runs.

I skipped loss networks, thinking they are unlikely to be used for inferencing.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
