### PR TITLE
6326 clone with keyword args

### DIFF
--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -510,9 +510,9 @@ class MetaTensor(MetaObj, torch.Tensor):
             self.as_tensor().new_empty(size=size, dtype=dtype, device=device, requires_grad=requires_grad)
         )
 
-    def clone(self, *_args, **kwargs):
+    def clone(self, **kwargs):
         """
-        returns a copy of the MetaTensor instance.
+        Returns a copy of the MetaTensor instance.
 
         Args:
             kwargs: additional keyword arguments to `torch.clone`.

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -510,9 +510,16 @@ class MetaTensor(MetaObj, torch.Tensor):
             self.as_tensor().new_empty(size=size, dtype=dtype, device=device, requires_grad=requires_grad)
         )
 
-    def clone(self):
-        """returns a copy of the MetaTensor instance."""
-        new_inst = MetaTensor(self.as_tensor().clone())
+    def clone(self, *_args, **kwargs):
+        """
+        returns a copy of the MetaTensor instance.
+
+        Args:
+            kwargs: additional keyword arguments to `torch.clone`.
+
+        See also: https://pytorch.org/docs/stable/generated/torch.clone.html
+        """
+        new_inst = MetaTensor(self.as_tensor().clone(**kwargs))
         new_inst.__dict__ = deepcopy(self.__dict__)
         return new_inst
 

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -177,6 +177,7 @@ class TestMetaTensor(unittest.TestCase):
         a = deepcopy(m)
         self.check(a, m, ids=False)
         # clone
+        a = m.clone(memory_format=torch.preserve_format)
         a = m.clone()
         self.check(a, m, ids=False)
         a = MetaTensor([[]], device=device, dtype=dtype)


### PR DESCRIPTION
Fixes #6326



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
