### PR TITLE
6340 update dtype for lazy resampling

### DIFF
--- a/monai/transforms/lazy/utils.py
+++ b/monai/transforms/lazy/utils.py
@@ -158,7 +158,7 @@ def resample(data: torch.Tensor, matrix: NdarrayOrTensor, kwargs: dict | None = 
             - "lazy_padding_mode"
             - "lazy_interpolation_mode" (this option might be ignored when ``mode="auto"``.)
             - "lazy_align_corners"
-            - "lazy_dtype"
+            - "lazy_dtype" (dtype for resampling computation; this might be ignored when ``mode="auto"``.)
             - "atol" for tolerance for matrix floating point comparison.
             - "lazy_resample_mode" for resampling backend, default to `"auto"`. Setting to other values will use the
               `monai.transforms.SpatialResample` for resampling.
@@ -218,6 +218,7 @@ def resample(data: torch.Tensor, matrix: NdarrayOrTensor, kwargs: dict | None = 
             img.affine = call_kwargs["dst_affine"]
             return img
         img = monai.transforms.crop_or_pad_nd(img, matrix_np, out_spatial_size, mode=call_kwargs["padding_mode"])
+        img = img.to(torch.float32)  # consistent with monai.transforms.spatial.functional.spatial_resample
         img.affine = call_kwargs["dst_affine"]
         return img
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,8 +19,8 @@ mccabe
 pep8-naming
 pycodestyle
 pyflakes
-black
-isort
+black>=22.12
+isort>=5.1
 pytype>=2020.6.1; platform_system != "Windows"
 types-pkg_resources
 mypy>=0.790

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -37,6 +37,11 @@ class TestResampleFunction(unittest.TestCase):
         out = resample(convert_to_tensor(img), matrix, {"lazy_shape": img.shape[1:], "lazy_padding_mode": "border"})
         assert_allclose(out[0], expected, type_test=False)
 
+        img = convert_to_tensor(img, dtype=torch.uint8)
+        out = resample(img, matrix, {"lazy_resample_mode": "auto", "lazy_dtype": torch.float})
+        out_1 = resample(img, matrix, {"lazy_resample_mode": "other value", "lazy_dtype": torch.float})
+        self.assertIs(out.dtype, out_1.dtype)  # testing dtype in different lazy_resample_mode
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #6340
Fixes #6253 

### Description


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
