### PR TITLE
Update ALGO_HASH/skip slow tests 6359

### DIFF
--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -36,7 +36,7 @@ from monai.utils import ensure_tuple
 from monai.utils.enums import AlgoKeys
 
 logger = get_logger(module_name=__name__)
-ALGO_HASH = os.environ.get("MONAI_ALGO_HASH", "b37ed82")
+ALGO_HASH = os.environ.get("MONAI_ALGO_HASH", "80c832e")
 
 __all__ = ["BundleAlgo", "BundleGen"]
 

--- a/tests/test_bilateral_precise.py
+++ b/tests/test_bilateral_precise.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from torch.autograd import gradcheck
 
 from monai.networks.layers.filtering import BilateralFilter
-from tests.utils import skip_if_no_cpp_extension, skip_if_no_cuda
+from tests.utils import skip_if_no_cpp_extension, skip_if_no_cuda, skip_if_quick
 
 TEST_CASES = [
     [
@@ -364,6 +364,7 @@ TEST_CASES = [
 
 
 @skip_if_no_cpp_extension
+@skip_if_quick
 class BilateralFilterTestCaseCpuPrecise(unittest.TestCase):
     @parameterized.expand(TEST_CASES)
     def test_cpu_precise(self, test_case_description, sigmas, input, expected):

--- a/tests/test_convert_to_onnx.py
+++ b/tests/test_convert_to_onnx.py
@@ -20,7 +20,7 @@ from parameterized import parameterized
 from monai.networks import convert_to_onnx
 from monai.networks.nets import SegResNet, UNet
 from monai.utils.module import pytorch_after
-from tests.utils import SkipIfBeforePyTorchVersion, SkipIfNoModule, optional_import
+from tests.utils import SkipIfBeforePyTorchVersion, SkipIfNoModule, optional_import, skip_if_quick
 
 if torch.cuda.is_available():
     TORCH_DEVICE_OPTIONS = ["cpu", "cuda"]
@@ -34,6 +34,7 @@ onnx, _ = optional_import("onnx")
 
 @SkipIfNoModule("onnx")
 @SkipIfBeforePyTorchVersion((1, 9))
+@skip_if_quick
 class TestConvertToOnnx(unittest.TestCase):
     @parameterized.expand(TESTS)
     def test_unet(self, device, use_trace, use_ort):

--- a/tests/test_dints_network.py
+++ b/tests/test_dints_network.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 
 from monai.networks.nets import DiNTS, TopologyInstance, TopologySearch
 from monai.networks.nets.dints import Cell
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick, test_script_save
 
 TEST_CASES_3D = [
     [
@@ -113,6 +113,7 @@ if torch.cuda.is_available():
     ]
 
 
+@skip_if_quick
 class TestDints(unittest.TestCase):
     @parameterized.expand(TEST_CASES_3D + TEST_CASES_2D)
     def test_dints_inference(self, dints_grid_params, dints_params, input_shape, expected_shape):

--- a/tests/test_gmm.py
+++ b/tests/test_gmm.py
@@ -22,7 +22,7 @@ from parameterized import parameterized
 
 from monai._extensions import load_module
 from monai.networks.layers import GaussianMixtureModel
-from tests.utils import skip_if_darwin, skip_if_no_cuda, skip_if_windows
+from tests.utils import skip_if_darwin, skip_if_no_cuda, skip_if_quick, skip_if_windows
 
 TEST_CASES = [
     [
@@ -259,6 +259,7 @@ TEST_CASES = [
 ]
 
 
+@skip_if_quick
 class GMMTestCase(unittest.TestCase):
     def setUp(self):
         self._var = os.environ.get("TORCH_EXTENSIONS_DIR")

--- a/tests/test_retinanet.py
+++ b/tests/test_retinanet.py
@@ -20,7 +20,7 @@ from monai.apps.detection.networks.retinanet_network import RetinaNet, resnet_fp
 from monai.networks import eval_mode
 from monai.networks.nets import resnet10, resnet18, resnet34, resnet50, resnet101, resnet152, resnet200
 from monai.utils import ensure_tuple, optional_import
-from tests.utils import SkipIfBeforePyTorchVersion, test_onnx_save, test_script_save
+from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick, test_onnx_save, test_script_save
 
 _, has_torchvision = optional_import("torchvision")
 
@@ -99,6 +99,7 @@ for case in [TEST_CASE_1]:
 
 @SkipIfBeforePyTorchVersion((1, 12))
 @unittest.skipUnless(has_torchvision, "Requires torchvision")
+@skip_if_quick
 class TestRetinaNet(unittest.TestCase):
     @parameterized.expand(TEST_CASES)
     def test_retina_shape(self, model, input_param, input_shape):

--- a/tests/test_retinanet_detector.py
+++ b/tests/test_retinanet_detector.py
@@ -21,7 +21,7 @@ from monai.apps.detection.networks.retinanet_detector import RetinaNetDetector, 
 from monai.apps.detection.utils.anchor_utils import AnchorGeneratorWithAnchorShape
 from monai.networks import eval_mode, train_mode
 from monai.utils import optional_import
-from tests.utils import SkipIfBeforePyTorchVersion, test_script_save
+from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick, test_script_save
 
 _, has_torchvision = optional_import("torchvision")
 
@@ -112,6 +112,7 @@ class NaiveNetwork(torch.nn.Module):
 
 @SkipIfBeforePyTorchVersion((1, 11))
 @unittest.skipUnless(has_torchvision, "Requires torchvision")
+@skip_if_quick
 class TestRetinaNetDetector(unittest.TestCase):
     @parameterized.expand(TEST_CASES)
     def test_retina_detector_resnet_backbone_shape(self, input_param, input_shape):

--- a/tests/test_spacingd.py
+++ b/tests/test_spacingd.py
@@ -23,7 +23,7 @@ from monai.data.utils import affine_to_spacing
 from monai.transforms import Spacingd
 from monai.utils import ensure_tuple_rep
 from tests.lazy_transforms_utils import test_resampler_lazy
-from tests.utils import TEST_DEVICES, assert_allclose
+from tests.utils import TEST_DEVICES, assert_allclose, skip_if_quick
 
 TESTS: list[tuple] = []
 for device in TEST_DEVICES:
@@ -134,6 +134,7 @@ class TestSpacingDCase(unittest.TestCase):
             self.assertNotIsInstance(res, MetaTensor)
             self.assertNotEqual(img.shape, res.shape)
 
+    @skip_if_quick
     def test_space_same_shape(self):
         affine_1 = np.array(
             [

--- a/tests/test_trainable_joint_bilateral.py
+++ b/tests/test_trainable_joint_bilateral.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from torch.autograd import gradcheck
 
 from monai.networks.layers.filtering import TrainableJointBilateralFilterFunction
-from tests.utils import skip_if_no_cpp_extension, skip_if_no_cuda
+from tests.utils import skip_if_no_cpp_extension, skip_if_no_cuda, skip_if_quick
 
 TEST_CASES = [
     [
@@ -356,6 +356,7 @@ TEST_CASES = [
 
 
 @skip_if_no_cpp_extension
+@skip_if_quick
 class JointBilateralFilterTestCaseCpuPrecise(unittest.TestCase):
     @parameterized.expand(TEST_CASES)
     def test_cpu_precise(self, test_case_description, sigmas, input, guide, expected):


### PR DESCRIPTION
### Description

The new ALGO_HASH has two updates for better performance of Auto3DSeg algo templates:
- https://github.com/Project-MONAI/research-contributions/pull/193
- https://github.com/Project-MONAI/research-contributions/pull/211

closes #6359 


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
