### PR TITLE
Add track_meta option for Lambda and derived transforms

### DIFF
--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -1088,6 +1088,8 @@ class Lambdad(MapTransform, InvertibleTransform):
             each element corresponds to a key in ``keys``.
         inv_func: Lambda/function of inverse operation if want to invert transforms, default to `lambda x: x`.
             It also can be a sequence of Callable, each element corresponds to a key in ``keys``.
+        track_meta:  If `False`, then standard data objects will be returned (e.g., torch.Tensor` and `np.ndarray`)
+            as opposed to MONAI's enhanced objects. By default, this is `True`.
         overwrite: whether to overwrite the original data in the input dictionary with lambda function output. it
             can be bool or str, when setting to str, it will create a new key for the output and keep the value of
             key intact. default to True. it also can be a sequence of bool or str, each element corresponds to a key
@@ -1106,6 +1108,7 @@ class Lambdad(MapTransform, InvertibleTransform):
         keys: KeysCollection,
         func: Sequence[Callable] | Callable,
         inv_func: Sequence[Callable] | Callable = no_collation,
+        track_meta: bool = True,
         overwrite: Sequence[bool] | bool | Sequence[str] | str = True,
         allow_missing_keys: bool = False,
     ) -> None:
@@ -1113,7 +1116,7 @@ class Lambdad(MapTransform, InvertibleTransform):
         self.func = ensure_tuple_rep(func, len(self.keys))
         self.inv_func = ensure_tuple_rep(inv_func, len(self.keys))
         self.overwrite = ensure_tuple_rep(overwrite, len(self.keys))
-        self._lambd = Lambda()
+        self._lambd = Lambda(track_meta=track_meta)
 
     def __call__(self, data: Mapping[Hashable, torch.Tensor]) -> dict[Hashable, torch.Tensor]:
         d = dict(data)
@@ -1146,6 +1149,8 @@ class RandLambdad(Lambdad, RandomizableTransform):
             each element corresponds to a key in ``keys``.
         inv_func: Lambda/function of inverse operation if want to invert transforms, default to `lambda x: x`.
             It also can be a sequence of Callable, each element corresponds to a key in ``keys``.
+        track_meta:  If `False`, then standard data objects will be returned (e.g., torch.Tensor` and `np.ndarray`)
+            as opposed to MONAI's enhanced objects. By default, this is `True`.
         overwrite: whether to overwrite the original data in the input dictionary with lambda function output.
             default to True. it also can be a sequence of bool, each element corresponds to a key in ``keys``.
         prob: probability of executing the random function, default to 1.0, with 100% probability to execute.
@@ -1165,6 +1170,7 @@ class RandLambdad(Lambdad, RandomizableTransform):
         keys: KeysCollection,
         func: Sequence[Callable] | Callable,
         inv_func: Sequence[Callable] | Callable = no_collation,
+        track_meta: bool = True,
         overwrite: Sequence[bool] | bool = True,
         prob: float = 1.0,
         allow_missing_keys: bool = False,
@@ -1174,6 +1180,7 @@ class RandLambdad(Lambdad, RandomizableTransform):
             keys=keys,
             func=func,
             inv_func=inv_func,
+            track_meta=track_meta,
             overwrite=overwrite,
             allow_missing_keys=allow_missing_keys,
         )

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -13,8 +13,12 @@ from __future__ import annotations
 
 import unittest
 
+from numpy import ndarray
+from torch import Tensor
+
 from monai.data.meta_tensor import MetaTensor
 from monai.transforms.utility.array import Lambda
+from monai.utils.type_conversion import convert_to_numpy, convert_to_tensor
 from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, assert_allclose
 
 
@@ -43,6 +47,24 @@ class TestLambda(NumpyImageTestCase2D):
             self.assertEqual(len(out.applied_operations), 1)
             out = lambd.inverse(out)
             self.assertEqual(len(out.applied_operations), 0)
+
+    def test_lambda_track_meta_false(self):
+        for p in TEST_NDARRAYS:
+            img = p(self.imt)
+
+            def to_numpy(x):
+                return convert_to_numpy(x)
+
+            lambd = Lambda(func=to_numpy, track_meta=False)
+            out = lambd(img)
+            self.assertIsInstance(out, ndarray)
+
+            def to_tensor(x):
+                return convert_to_tensor(x)
+
+            lambd = Lambda(func=to_tensor, track_meta=False)
+            out = lambd(img)
+            self.assertIsInstance(out, Tensor)
 
 
 if __name__ == "__main__":

--- a/tests/test_lambdad.py
+++ b/tests/test_lambdad.py
@@ -13,8 +13,12 @@ from __future__ import annotations
 
 import unittest
 
+from numpy import ndarray
+from torch import Tensor
+
 from monai.data.meta_tensor import MetaTensor
 from monai.transforms.utility.dictionary import Lambdad
+from monai.utils.type_conversion import convert_to_numpy, convert_to_tensor
 from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, assert_allclose
 
 
@@ -52,6 +56,27 @@ class TestLambdad(NumpyImageTestCase2D):
             inv_img = lambd.inverse(out)["img"]
             self.assertIsInstance(inv_img, MetaTensor)
             self.assertEqual(len(inv_img.applied_operations), 0)
+
+    def test_lambdad_track_meta_false(self):
+        for p in TEST_NDARRAYS:
+            img = p(self.imt)
+            data = {"img": img}
+
+            def to_numpy(x):
+                return convert_to_numpy(x)
+
+            lambd = Lambdad(keys=data.keys(), func=to_numpy, track_meta=False)
+            out = lambd(data)
+            out_img = out["img"]
+            self.assertIsInstance(out_img, ndarray)
+
+            def to_tensor(x):
+                return convert_to_tensor(x)
+
+            lambd = Lambdad(keys=data.keys(), func=to_tensor, track_meta=False)
+            out = lambd(data)
+            out_img = out["img"]
+            self.assertIsInstance(out_img, Tensor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6379 

### Description
`track_meta` flag added to `Lambda` and derived transforms to allow type conversion to `np.ndarray` and `torch.Tensor` based on user-defined function

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
