### PR TITLE
Remove deprecated arg in torchvision models

### DIFF
--- a/monai/networks/nets/torchvision_fc.py
+++ b/monai/networks/nets/torchvision_fc.py
@@ -114,8 +114,10 @@ class TorchVisionFCModel(NetAdapter):
     ):
         if weights is not None:
             model = getattr(models, model_name)(weights=weights, **kwargs)
+        elif pretrained:
+            model = getattr(models, model_name)(weights="DEFAULT", **kwargs)
         else:
-            model = getattr(models, model_name)(pretrained=pretrained, **kwargs)  # 'pretrained' deprecated 0.13
+            model = getattr(models, model_name)(weights=None, **kwargs)
 
         super().__init__(
             model=model,


### PR DESCRIPTION
### Description

For torchvisno models, the parameter `pretrained` is deprecated since 0.13 and may be removed in the future. Our `TorchVisionFC` model has been using this parameter. This PR updated `TorchVisionFC` to remove calling pretrained and instead to call `weights` with appropriate defaults without any change in the functionality (backward compatible).

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.

