### PR TITLE
Fix bcprun commandline format

### DIFF
--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -215,7 +215,7 @@ class BundleAlgo(Algo):
         ps_environ["CUDA_VISIBLE_DEVICES"] = str(self.device_setting["CUDA_VISIBLE_DEVICES"])
         if int(self.device_setting["NUM_NODES"]) > 1:
             if self.device_setting["MN_START_METHOD"] == "bcprun":
-                cmd_list=["bcprun", "-n", self.device_setting['NUM_NODES'], "-p", self.device_setting['n_devices'], "-c", cmd]
+                cmd_list=["bcprun", "-n", str(self.device_setting['NUM_NODES']), "-p", str(self.device_setting['n_devices']), "-c", cmd]
             else:
                 raise NotImplementedError(
                     f"{self.device_setting['MN_START_METHOD']} is not supported yet. "

--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -215,7 +215,15 @@ class BundleAlgo(Algo):
         ps_environ["CUDA_VISIBLE_DEVICES"] = str(self.device_setting["CUDA_VISIBLE_DEVICES"])
         if int(self.device_setting["NUM_NODES"]) > 1:
             if self.device_setting["MN_START_METHOD"] == "bcprun":
-                cmd_list=["bcprun", "-n", str(self.device_setting['NUM_NODES']), "-p", str(self.device_setting['n_devices']), "-c", cmd]
+                cmd_list = [
+                    "bcprun",
+                    "-n",
+                    str(self.device_setting["NUM_NODES"]),
+                    "-p",
+                    str(self.device_setting["n_devices"]),
+                    "-c",
+                    cmd,
+                ]
             else:
                 raise NotImplementedError(
                     f"{self.device_setting['MN_START_METHOD']} is not supported yet. "
@@ -223,7 +231,7 @@ class BundleAlgo(Algo):
                 )
         else:
             cmd_list = cmd.split()
-            
+
         _idx = 0
         for _idx, c in enumerate(cmd_list):
             if "=" not in c:  # remove variable assignments before the command such as "OMP_NUM_THREADS=1"

--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -216,7 +216,7 @@ class BundleAlgo(Algo):
         ps_environ["CUDA_VISIBLE_DEVICES"] = str(self.device_setting["CUDA_VISIBLE_DEVICES"])
         if int(self.device_setting["NUM_NODES"]) > 1:
             if self.device_setting["MN_START_METHOD"] == "bcprun":
-                cmd = f"bcprun -n {self.device_setting['NUM_NODES']} -p {self.device_setting['n_devices']} -c {cmd}"
+                cmd = f"bcprun -n {self.device_setting['NUM_NODES']} -p {self.device_setting['n_devices']} -c '{cmd}'"
             else:
                 raise NotImplementedError(
                     f"{self.device_setting['MN_START_METHOD']} is not supported yet. "

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -563,7 +563,7 @@ class EnsembleRunner:
             logger.info(f"Ensembling on {self.device_setting['NUM_NODES']} nodes!")
             cmd = "python " if cmd is None else cmd
             cmd = f"{cmd} -m {base_cmd}"
-            cmd = f"bcprun -n {self.device_setting['NUM_NODES']} -p {self.device_setting['n_devices']} -c {cmd}"
+            cmd = f"bcprun -n {self.device_setting['NUM_NODES']} -p {self.device_setting['n_devices']} -c '{cmd}'"
         else:
             logger.info(f"Ensembling using {self.device_setting['n_devices']} GPU!")
             if cmd is None:

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -563,11 +563,14 @@ class EnsembleRunner:
             logger.info(f"Ensembling on {self.device_setting['NUM_NODES']} nodes!")
             cmd = "python " if cmd is None else cmd
             cmd = f"{cmd} -m {base_cmd}"
-            cmd = f"bcprun -n {self.device_setting['NUM_NODES']} -p {self.device_setting['n_devices']} -c '{cmd}'"
+            cmd_list=["bcprun", "-n", self.device_setting['NUM_NODES'], "-p", self.device_setting['n_devices'], "-c", cmd]
+
         else:
             logger.info(f"Ensembling using {self.device_setting['n_devices']} GPU!")
             if cmd is None:
                 cmd = f"torchrun --nnodes={1:d} --nproc_per_node={self.device_setting['n_devices']:d} "
             cmd = f"{cmd} -m {base_cmd}"
-        _ = subprocess.run(cmd.split(), env=ps_environ, check=True)
+            cmd_list=cmd.split()
+            
+        _ = subprocess.run(cmd_list, env=ps_environ, check=True)
         return

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -563,7 +563,7 @@ class EnsembleRunner:
             logger.info(f"Ensembling on {self.device_setting['NUM_NODES']} nodes!")
             cmd = "python " if cmd is None else cmd
             cmd = f"{cmd} -m {base_cmd}"
-            cmd_list=["bcprun", "-n", self.device_setting['NUM_NODES'], "-p", self.device_setting['n_devices'], "-c", cmd]
+            cmd_list=["bcprun", "-n", str(self.device_setting['NUM_NODES']), "-p", str(self.device_setting['n_devices']), "-c", cmd]
 
         else:
             logger.info(f"Ensembling using {self.device_setting['n_devices']} GPU!")
@@ -571,6 +571,6 @@ class EnsembleRunner:
                 cmd = f"torchrun --nnodes={1:d} --nproc_per_node={self.device_setting['n_devices']:d} "
             cmd = f"{cmd} -m {base_cmd}"
             cmd_list=cmd.split()
-            
+
         _ = subprocess.run(cmd_list, env=ps_environ, check=True)
         return

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -563,14 +563,22 @@ class EnsembleRunner:
             logger.info(f"Ensembling on {self.device_setting['NUM_NODES']} nodes!")
             cmd = "python " if cmd is None else cmd
             cmd = f"{cmd} -m {base_cmd}"
-            cmd_list=["bcprun", "-n", str(self.device_setting['NUM_NODES']), "-p", str(self.device_setting['n_devices']), "-c", cmd]
+            cmd_list = [
+                "bcprun",
+                "-n",
+                str(self.device_setting["NUM_NODES"]),
+                "-p",
+                str(self.device_setting["n_devices"]),
+                "-c",
+                cmd,
+            ]
 
         else:
             logger.info(f"Ensembling using {self.device_setting['n_devices']} GPU!")
             if cmd is None:
                 cmd = f"torchrun --nnodes={1:d} --nproc_per_node={self.device_setting['n_devices']:d} "
             cmd = f"{cmd} -m {base_cmd}"
-            cmd_list=cmd.split()
+            cmd_list = cmd.split()
 
         _ = subprocess.run(cmd_list, env=ps_environ, check=True)
         return


### PR DESCRIPTION
Bug fix of bcprun commandline format

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
