### PR TITLE
6426 warn when inverting lazy + non-lazy-invertible transforms

### DIFF
--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -226,12 +226,18 @@ class TraceableTransform(Transform):
         else:
             if out_obj.pending_operations:
                 transform_name = info.get(TraceKeys.CLASS_NAME, "") if isinstance(info, dict) else ""
-                warnings.warn(
+                msg = (
                     f"Applying transform {transform_name} to a MetaTensor with pending operations "
                     "is not supported (as this eventually changes the ordering of applied_operations when the pending "
                     f"operations are executed). Please clear the pending operations before transform {transform_name}."
                     f"\nPending operations: {[x.get(TraceKeys.CLASS_NAME) for x in out_obj.pending_operations]}."
                 )
+                pend = out_obj.pending_operations[-1]
+                if not isinstance(pend.get(TraceKeys.EXTRA_INFO), dict):
+                    pend[TraceKeys.EXTRA_INFO] = dict(pend.get(TraceKeys.EXTRA_INFO, {}))
+                if not isinstance(info.get(TraceKeys.EXTRA_INFO), dict):
+                    info[TraceKeys.EXTRA_INFO] = dict(info.get(TraceKeys.EXTRA_INFO, {}))
+                info[TraceKeys.EXTRA_INFO]["warn"] = pend[TraceKeys.EXTRA_INFO]["warn"] = msg
             out_obj.push_applied_operation(info)
         if isinstance(data, Mapping):
             if not isinstance(data, dict):
@@ -255,6 +261,9 @@ class TraceableTransform(Transform):
         if xform_id == TraceKeys.NONE:
             return
         xform_name = transform.get(TraceKeys.CLASS_NAME, "")
+        warning_msg = transform.get(TraceKeys.EXTRA_INFO, {}).get("warn")
+        if warning_msg:
+            warnings.warn(warning_msg)
         # basic check if multiprocessing uses 'spawn' (objects get recreated so don't have same ID)
         if torch.multiprocessing.get_start_method() in ("spawn", None) and xform_name == self.__class__.__name__:
             return

--- a/tests/test_invert.py
+++ b/tests/test_invert.py
@@ -24,6 +24,7 @@ from monai.transforms import (
     Compose,
     EnsureChannelFirst,
     Invert,
+    Lambda,
     LoadImage,
     Orientation,
     RandAffine,
@@ -87,6 +88,18 @@ class TestInvert(unittest.TestCase):
         print("invert diff", reverted.size - n_good)
         self.assertTrue((reverted.size - n_good) < 300000, f"diff. {reverted.size - n_good}")
         set_determinism(seed=None)
+
+    def test_invert_warn_pending(self):
+        set_determinism(seed=0)
+        im_fname = make_nifti_image(create_test_image_3d(101, 100, 107, noise_max=100)[1])  # label image, discrete
+        transform = Compose(
+            [LoadImage(image_only=True), EnsureChannelFirst(), Orientation("RPS"), Lambda(func=lambda x: x)],
+            lazy_evaluation=True,
+        )
+        output = transform([im_fname for _ in range(2)])
+        with self.assertRaises(RuntimeError):  # transform id mismatch because of lambda
+            with self.assertWarns(Warning):  # warning of wrong ordering lazy + nonlazy_invertible
+                transform.inverse(output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6426

### Description
only warn when checking the most recent applied operations

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
