### PR TITLE
6222 adapative resampling mode based on backends

### DIFF
--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -660,6 +660,7 @@ from .utils import (
     rescale_instance_array,
     reset_ops_id,
     resize_center,
+    resolves_modes,
     sync_meta_info,
     weighted_patch_samples,
     zero_margins,

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -15,7 +15,6 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 
 from __future__ import annotations
 
-import functools
 import warnings
 from collections.abc import Callable
 from copy import deepcopy
@@ -54,6 +53,7 @@ from monai.transforms.utils import (
     create_shear,
     create_translate,
     map_spatial_axes,
+    resolves_modes,
     scale_affine,
 )
 from monai.transforms.utils_pytorch_numpy_unification import argsort, argwhere, linalg_inv, moveaxis
@@ -61,9 +61,7 @@ from monai.utils import (
     GridSampleMode,
     GridSamplePadMode,
     InterpolateMode,
-    NdimageMode,
     NumpyPadMode,
-    SplineMode,
     convert_to_cupy,
     convert_to_dst_type,
     convert_to_numpy,
@@ -695,7 +693,7 @@ class Resize(InvertibleTransform, LazyTransform):
     ) -> None:
         self.size_mode = look_up_option(size_mode, ["all", "longest"])
         self.spatial_size = spatial_size
-        self.mode: InterpolateMode = look_up_option(mode, InterpolateMode)
+        self.mode = mode
         self.align_corners = align_corners
         self.anti_aliasing = anti_aliasing
         self.anti_aliasing_sigma = anti_aliasing_sigma
@@ -759,7 +757,7 @@ class Resize(InvertibleTransform, LazyTransform):
             scale = self.spatial_size / max(img_size)
             sp_size = tuple(int(round(s * scale)) for s in img_size)
 
-        _mode = look_up_option(self.mode if mode is None else mode, InterpolateMode)
+        _mode = self.mode if mode is None else mode
         _align_corners = self.align_corners if align_corners is None else align_corners
         _dtype = get_equivalent_dtype(dtype or self.dtype or img.dtype, torch.Tensor)
         return resize(  # type: ignore
@@ -831,8 +829,8 @@ class Rotate(InvertibleTransform, LazyTransform):
     ) -> None:
         self.angle = angle
         self.keep_size = keep_size
-        self.mode: str = look_up_option(mode, GridSampleMode)
-        self.padding_mode: str = look_up_option(padding_mode, GridSamplePadMode)
+        self.mode: str = mode
+        self.padding_mode: str = padding_mode
         self.align_corners = align_corners
         self.dtype = dtype
 
@@ -867,8 +865,8 @@ class Rotate(InvertibleTransform, LazyTransform):
         """
         img = convert_to_tensor(img, track_meta=get_track_meta())
         _dtype = get_equivalent_dtype(dtype or self.dtype or img.dtype, torch.Tensor)
-        _mode = look_up_option(mode or self.mode, GridSampleMode)
-        _padding_mode = look_up_option(padding_mode or self.padding_mode, GridSamplePadMode)
+        _mode = mode or self.mode
+        _padding_mode = padding_mode or self.padding_mode
         _align_corners = self.align_corners if align_corners is None else align_corners
         im_shape = img.peek_pending_shape() if isinstance(img, MetaTensor) else img.shape[1:]
         output_shape = im_shape if self.keep_size else None
@@ -888,10 +886,11 @@ class Rotate(InvertibleTransform, LazyTransform):
         dtype = transform[TraceKeys.EXTRA_INFO]["dtype"]
         inv_rot_mat = linalg_inv(convert_to_numpy(fwd_rot_mat))
 
+        _, _m, _p, _ = resolves_modes(mode, padding_mode)
         xform = AffineTransform(
             normalized=False,
-            mode=mode,
-            padding_mode=padding_mode,
+            mode=_m,
+            padding_mode=_p,
             align_corners=False if align_corners == TraceKeys.NONE else align_corners,
             reverse_indexing=True,
         )
@@ -953,7 +952,7 @@ class Zoom(InvertibleTransform, LazyTransform):
         **kwargs,
     ) -> None:
         self.zoom = zoom
-        self.mode: InterpolateMode = InterpolateMode(mode)
+        self.mode = mode
         self.padding_mode = padding_mode
         self.align_corners = align_corners
         self.dtype = dtype
@@ -991,7 +990,7 @@ class Zoom(InvertibleTransform, LazyTransform):
         """
         img = convert_to_tensor(img, track_meta=get_track_meta())
         _zoom = ensure_tuple_rep(self.zoom, img.ndim - 1)  # match the spatial image dim
-        _mode = look_up_option(self.mode if mode is None else mode, InterpolateMode).value
+        _mode = self.mode if mode is None else mode
         _padding_mode = padding_mode or self.padding_mode
         _align_corners = self.align_corners if align_corners is None else align_corners
         _dtype = get_equivalent_dtype(dtype or self.dtype or img.dtype, torch.Tensor)
@@ -1181,8 +1180,8 @@ class RandRotate(RandomizableTransform, InvertibleTransform, LazyTransform):
             self.range_z = tuple(sorted([-self.range_z[0], self.range_z[0]]))
 
         self.keep_size = keep_size
-        self.mode: str = look_up_option(mode, GridSampleMode)
-        self.padding_mode: str = look_up_option(padding_mode, GridSamplePadMode)
+        self.mode: str = mode
+        self.padding_mode: str = padding_mode
         self.align_corners = align_corners
         self.dtype = dtype
 
@@ -1231,8 +1230,8 @@ class RandRotate(RandomizableTransform, InvertibleTransform, LazyTransform):
             rotator = Rotate(
                 angle=self.x if ndim == 2 else (self.x, self.y, self.z),
                 keep_size=self.keep_size,
-                mode=look_up_option(mode or self.mode, GridSampleMode),
-                padding_mode=look_up_option(padding_mode or self.padding_mode, GridSamplePadMode),
+                mode=mode or self.mode,
+                padding_mode=padding_mode or self.padding_mode,
                 align_corners=self.align_corners if align_corners is None else align_corners,
                 dtype=dtype or self.dtype or img.dtype,
             )
@@ -1406,7 +1405,7 @@ class RandZoom(RandomizableTransform, InvertibleTransform, LazyTransform):
             raise ValueError(
                 f"min_zoom and max_zoom must have same length, got {len(self.min_zoom)} and {len(self.max_zoom)}."
             )
-        self.mode: InterpolateMode = look_up_option(mode, InterpolateMode)
+        self.mode = mode
         self.padding_mode = padding_mode
         self.align_corners = align_corners
         self.dtype = dtype
@@ -1467,7 +1466,7 @@ class RandZoom(RandomizableTransform, InvertibleTransform, LazyTransform):
             xform = Zoom(
                 self._zoom,
                 keep_size=self.keep_size,
-                mode=look_up_option(mode or self.mode, InterpolateMode),
+                mode=mode or self.mode,
                 padding_mode=padding_mode or self.padding_mode,
                 align_corners=self.align_corners if align_corners is None else align_corners,
                 dtype=dtype or self.dtype,
@@ -1815,35 +1814,6 @@ class Resample(Transform):
         self.align_corners = align_corners
         self.dtype = dtype
 
-    @staticmethod
-    @functools.lru_cache(None)
-    def resolve_modes(interp_mode, padding_mode):
-        """compute the backend and the corresponding mode for the given interpolation mode and padding mode."""
-        _interp_mode = None
-        _padding_mode = None
-        if look_up_option(str(interp_mode), SplineMode, default=None) is not None:
-            backend = TransformBackends.NUMPY
-        else:
-            backend = TransformBackends.TORCH
-
-        if (not USE_COMPILED) and (backend == TransformBackends.TORCH):
-            if str(interp_mode).lower().endswith("linear"):
-                _interp_mode = GridSampleMode("bilinear")
-            _interp_mode = GridSampleMode(interp_mode)
-            _padding_mode = GridSamplePadMode(padding_mode)
-        elif USE_COMPILED and backend == TransformBackends.TORCH:  # compiled is using torch backend param name
-            _padding_mode = 1 if padding_mode == "reflection" else padding_mode  # type: ignore
-            if interp_mode == "bicubic":
-                _interp_mode = 3  # type: ignore
-            elif interp_mode == "bilinear":
-                _interp_mode = 1  # type: ignore
-            else:
-                _interp_mode = GridSampleMode(interp_mode)
-        else:  # TransformBackends.NUMPY
-            _interp_mode = int(interp_mode)  # type: ignore
-            _padding_mode = look_up_option(padding_mode, NdimageMode)
-        return backend, _interp_mode, _padding_mode
-
     def __call__(
         self,
         img: torch.Tensor,
@@ -1894,8 +1864,10 @@ class Resample(Transform):
         _align_corners = self.align_corners if align_corners is None else align_corners
         img_t, *_ = convert_data_type(img, torch.Tensor, dtype=_dtype, device=_device)
         sr = min(len(img_t.peek_pending_shape() if isinstance(img_t, MetaTensor) else img_t.shape[1:]), 3)
-        backend, _interp_mode, _padding_mode = Resample.resolve_modes(
-            self.mode if mode is None else mode, self.padding_mode if padding_mode is None else padding_mode
+        backend, _interp_mode, _padding_mode, _ = resolves_modes(
+            self.mode if mode is None else mode,
+            self.padding_mode if padding_mode is None else padding_mode,
+            backend=None,
         )
 
         if USE_COMPILED or backend == TransformBackends.NUMPY:

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1919,6 +1919,8 @@ def resolves_modes(
     """
     Automatically adjust the resampling interpolation mode and padding mode,
     so that they are compatible with the corresponding API of the `backend`.
+    Depending on the availability of the backends, when there's no exact
+    equivalent, a similar mode is returned.
 
     Args:
         interp_mode: interpolation mode.

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -29,6 +29,8 @@ TEST_CASE_1 = [{"spatial_size": 15, "mode": "area"}, (6, 10, 15)]
 
 TEST_CASE_2 = [{"spatial_size": 6, "mode": "trilinear", "align_corners": True}, (2, 4, 6)]
 
+TEST_CASE_2_1 = [{"spatial_size": 6, "mode": 1, "align_corners": True}, (2, 4, 6)]
+
 TEST_CASE_3 = [{"spatial_size": 15, "anti_aliasing": True}, (6, 10, 15)]
 
 TEST_CASE_4 = [{"spatial_size": 6, "anti_aliasing": True, "anti_aliasing_sigma": 2.0}, (2, 4, 6)]
@@ -108,7 +110,7 @@ class TestResize(NumpyImageTestCase2D):
                 np.abs(good - expected.size) / float(expected.size), diff_t, f"at most {diff_t} percent mismatch "
             )
 
-    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4])
+    @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_2_1, TEST_CASE_3, TEST_CASE_4])
     def test_longest_shape(self, input_param, expected_shape):
         input_data = np.random.randint(0, 2, size=[3, 4, 7, 10])
         input_param["size_mode"] = "longest"

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -31,6 +31,7 @@ for p in TEST_NDARRAYS_ALL:
     TEST_CASES_2D.append((p, -np.pi / 4.5, True, "nearest", "border" if USE_COMPILED else "reflection", False))
     TEST_CASES_2D.append((p, np.pi, False, "nearest", "zeros", False))
     TEST_CASES_2D.append((p, -np.pi / 2, False, "bilinear", "zeros", True))
+    TEST_CASES_2D.append((p, -np.pi / 2, False, 1, "constant", True))
 
 TEST_CASES_3D: list[tuple] = []
 for p in TEST_NDARRAYS_ALL:
@@ -39,6 +40,7 @@ for p in TEST_NDARRAYS_ALL:
     TEST_CASES_3D.append((p, -np.pi / 4.5, True, "nearest", "border" if USE_COMPILED else "reflection", False))
     TEST_CASES_3D.append((p, np.pi, False, "nearest", "zeros", False))
     TEST_CASES_3D.append((p, -np.pi / 2, False, "bilinear", "zeros", False))
+    TEST_CASES_3D.append((p, -np.pi / 2, False, 1, "zeros", False))
 
 TEST_CASES_SHAPE_3D: list[tuple] = []
 for p in TEST_NDARRAYS_ALL:

--- a/tests/test_spacing.py
+++ b/tests/test_spacing.py
@@ -238,7 +238,7 @@ for device in TEST_DEVICES:
     )
     TESTS.append(  # 5D input
         [
-            {"pixdim": 0.5, "padding_mode": "zeros", "mode": "nearest", "scale_extent": True},
+            {"pixdim": 0.5, "padding_mode": "consant", "mode": "nearest", "scale_extent": True},
             torch.ones((1, 368, 336, 368)),  # data
             torch.tensor(
                 [

--- a/tests/test_zoom.py
+++ b/tests/test_zoom.py
@@ -33,6 +33,7 @@ VALID_CASES = [
     (1.5, "nearest", True),
     (1.5, "nearest", False),
     (0.8, "bilinear"),
+    (0.8, 1),
     (0.8, "area"),
     (1.5, "nearest", False, True),
     (0.8, "area", False, True),
@@ -70,7 +71,7 @@ class TestZoom(NumpyImageTestCase2D):
             zoomed = zoom_fn(im)
             test_local_inversion(zoom_fn, zoomed, im)
             _order = 0
-            if mode.endswith("linear"):
+            if mode == 1 or mode.endswith("linear"):
                 _order = 1
             expected = []
             for channel in self.imt[0]:


### PR DESCRIPTION
Fixes #6222

### Description
nonbreaking change extending the current mode+padding mode combinations.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
