### PR TITLE
Fix ensemble output using RankFilter and minor rename

### DIFF
--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -563,12 +563,12 @@ class AutoRunner:
 
         """
 
-        are_all_args_present, missing_args = check_kwargs_exist_in_class_init(SaveImage, kwargs)
+        are_all_args_present, extra_args = check_kwargs_exist_in_class_init(SaveImage, kwargs)
         if are_all_args_present:
             self.kwargs.update(kwargs)
         else:
             raise ValueError(
-                f"{missing_args} are not supported in monai.transforms.SaveImage,"
+                f"{extra_args} are not supported in monai.transforms.SaveImage,"
                 "Check https://docs.monai.io/en/stable/transforms.html#saveimage for more information."
             )
 

--- a/monai/apps/auto3dseg/data_analyzer.py
+++ b/monai/apps/auto3dseg/data_analyzer.py
@@ -238,7 +238,6 @@ class DataAnalyzer:
         n_cases = len(result_bycase[DataStatsKeys.BY_CASE])
         result[DataStatsKeys.SUMMARY] = summarizer.summarize(cast(list, result_bycase[DataStatsKeys.BY_CASE]))
         result[DataStatsKeys.SUMMARY]["n_cases"] = n_cases
-        result[DataStatsKeys.BY_CASE] = [None] * n_cases
         result_bycase[DataStatsKeys.SUMMARY] = result[DataStatsKeys.SUMMARY]
         if not self._check_data_uniformity([ImageStatsKeys.SPACING], result):
             logger.info("Data spacing is not completely uniform. MONAI transforms may provide unexpected result")

--- a/tests/test_auto3dseg_ensemble.py
+++ b/tests/test_auto3dseg_ensemble.py
@@ -180,10 +180,10 @@ class TestEnsembleBuilder(unittest.TestCase):
         self.assertTrue(runner.ensemble_method.n_best == 3)
 
         save_output = os.path.join(self.test_dir.name, "workdir")
-        runner.set_image_save_transform(
+        save_image = runner._pop_kwargs_to_get_image_save_transform(
             output_dir=save_output, output_postfix="test_ensemble", output_dtype=float, resample=True
         )
-        self.assertIsInstance(ConfigParser(runner.save_image).get_parsed_content(), SaveImage)
+        self.assertIsInstance(ConfigParser(save_image).get_parsed_content(), SaveImage)
 
     def tearDown(self) -> None:
         set_determinism(None)


### PR DESCRIPTION
Fixes #6433 .

also fixes #6338 

### Description

- Move the SaveImage Transform setters back to `ensemble` method to ensure DDP is initiated
- Use RankFilter to suppress logging for rank >0
- Minor updates such as renaming and tests

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
