### PR TITLE
Fix for zoom used in a lazy pipeline

### DIFF
--- a/monai/transforms/lazy/functional.py
+++ b/monai/transforms/lazy/functional.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import torch
 
+from monai.data.utils import to_affine_nd
 from monai.data.meta_tensor import MetaTensor
 from monai.transforms.lazy.utils import (
     affine_from_pending,
@@ -78,6 +79,9 @@ def apply_transforms(
         return data, []
 
     cumulative_xform = affine_from_pending(pending[0])
+    if cumulative_xform.shape[0] == 3:
+        cumulative_xform = to_affine_nd(3, cumulative_xform)
+
     cur_kwargs = kwargs_from_pending(pending[0])
     override_kwargs: dict[str, Any] = {}
     if "mode" in overrides:
@@ -100,6 +104,8 @@ def apply_transforms(
             _cur_kwargs.update(override_kwargs)
             data = resample(data.to(device), cumulative_xform, _cur_kwargs)
         next_matrix = affine_from_pending(p)
+        if next_matrix.shape[0] == 3:
+            next_matrix = to_affine_nd(3, next_matrix)
         cumulative_xform = combine_transforms(cumulative_xform, next_matrix)
         cur_kwargs.update(new_kwargs)
     cur_kwargs.update(override_kwargs)

--- a/monai/transforms/lazy/functional.py
+++ b/monai/transforms/lazy/functional.py
@@ -15,8 +15,8 @@ from typing import Any
 
 import torch
 
-from monai.data.utils import to_affine_nd
 from monai.data.meta_tensor import MetaTensor
+from monai.data.utils import to_affine_nd
 from monai.transforms.lazy.utils import (
     affine_from_pending,
     combine_transforms,

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -338,13 +338,10 @@ class TestComposeExecuteWithFlags(unittest.TestCase):
                 self.assertTrue(expected, actual)
 
 
-TEST_LAZY_COMPOSE_PIPELINE_FIX_CASES = [
-    [(Flip(0), Flip(1), Rotate90(1), Zoom(0.8), NormalizeIntensity())],
-]
+TEST_LAZY_COMPOSE_PIPELINE_FIX_CASES = [[(Flip(0), Flip(1), Rotate90(1), Zoom(0.8), NormalizeIntensity())]]
 
 
 class TestLazyComposePipelineFixes(unittest.TestCase):
-
     @parameterized.expand(TEST_LAZY_COMPOSE_PIPELINE_FIX_CASES)
     def test_lazy_compose_pipeline_fixes(self, pipeline):
         data = torch.unsqueeze(torch.tensor(np.arange(12 * 16).reshape(12, 16)), dim=0)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -338,5 +338,19 @@ class TestComposeExecuteWithFlags(unittest.TestCase):
                 self.assertTrue(expected, actual)
 
 
+TEST_LAZY_COMPOSE_PIPELINE_FIX_CASES = [
+    [(Flip(0), Flip(1), Rotate90(1), Zoom(0.8), NormalizeIntensity())],
+]
+
+
+class TestLazyComposePipelineFixes(unittest.TestCase):
+
+    @parameterized.expand(TEST_LAZY_COMPOSE_PIPELINE_FIX_CASES)
+    def test_lazy_compose_pipeline_fixes(self, pipeline):
+        data = torch.unsqueeze(torch.tensor(np.arange(12 * 16).reshape(12, 16)), dim=0)
+        c = Compose(deepcopy(pipeline), lazy_evaluation=True)
+        _ = c(data)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If you run the following pipeline with lazy resampling it breaks as the pending info contains a 3x3 affine transform and there are 4x4 affine transforms already in the list:

```
[Flip(0), Flip(1), Rotate90(1), Zoom(0.8), NormalizeIntensity()]
```

Although it could be fixed by ensuring that Zoom always puts out a 4x4 affine, the more flexible and pragmatic solution is to promote 2d affine transforms to 3d affine transforms as a matter of course. This way we never have the issue that a given transform (particularly potential 3rd party transforms modified for lazy execution) can subsequently cause this problem.

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
