### PR TITLE
SlidingWindowInfererAdapt fixes

### DIFF
--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -461,6 +461,7 @@ class SlidingWindowInferer(Inferer):
 
         device = kwargs.pop("device", self.device)
         buffer_steps = kwargs.pop("buffer_steps", self.buffer_steps)
+        buffer_dim = kwargs.pop("buffer_dim", self.buffer_dim)
 
         if device is None and self.cpu_thresh is not None and inputs.shape[2:].numel() > self.cpu_thresh:
             device = "cpu"  # stitch in cpu memory if image is too large
@@ -481,7 +482,7 @@ class SlidingWindowInferer(Inferer):
             self.roi_weight_map,
             None,
             buffer_steps,
-            self.buffer_dim,
+            buffer_dim,
             *args,
             **kwargs,
         )
@@ -524,6 +525,12 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
         gpu_stitching = inputs.is_cuda and not cpu_cond
         buffered_stitching = inputs.is_cuda and cpu_cond and not skip_buffer
         buffer_steps = max(1, self.buffer_steps) if self.buffer_steps is not None else 1
+        buffer_dim = -1
+
+        sh = list(inputs.shape[2:])
+        max_dim = sh.index(max(sh))
+        if inputs.shape[max_dim + 2] / inputs.shape[-1] >= 2:
+            buffer_dim = max_dim
 
         for _ in range(10):  # at most 10 trials
             try:
@@ -532,6 +539,7 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
                     network,
                     device=inputs.device if gpu_stitching else torch.device("cpu"),
                     buffer_steps=buffer_steps if buffered_stitching else None,
+                    buffer_dim=buffer_dim,
                     *args,
                     **kwargs,
                 )
@@ -553,7 +561,7 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
                         buffered_stitching = True
                         self.buffer_steps = buffer_steps
                         logger.warning(
-                            f"GPU stitching failed, attempting with buffer {buffer_steps}, image dim {inputs.shape}.."
+                            f"GPU stitching failed, attempting with buffer {buffer_steps} dim {buffer_dim}, image dim {inputs.shape}.."
                         )
                 elif buffer_steps > 1:
                     buffer_steps = max(1, buffer_steps // 2)
@@ -563,7 +571,6 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
                     )
                 else:
                     buffered_stitching = False
-                    self.buffer_steps = 0  # disable future buffer attempts
                     logger.warning(f"GPU buffered stitching failed, attempting on CPU, image dim {inputs.shape}")
         raise RuntimeError(  # not possible to finish after the trials
             f"SlidingWindowInfererAdapt {skip_buffer} {cpu_cond} {gpu_stitching} {buffered_stitching} {buffer_steps}"

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -555,23 +555,23 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
 
                     if skip_buffer:
                         buffered_stitching = False
-                        logger.warning(f"GPU stitching failed, attempting on CPU, image dim {inputs.shape}..")
+                        logger.warning(f"GPU stitching failed, attempting on CPU, image dim {inputs.shape}.")
 
                     else:
                         buffered_stitching = True
                         self.buffer_steps = buffer_steps
                         logger.warning(
-                            f"GPU stitching failed, attempting with buffer {buffer_steps} dim {buffer_dim}, image dim {inputs.shape}.."
+                            f"GPU stitching failed, buffer {buffer_steps} dim {buffer_dim}, image dim {inputs.shape}."
                         )
                 elif buffer_steps > 1:
                     buffer_steps = max(1, buffer_steps // 2)
                     self.buffer_steps = buffer_steps
                     logger.warning(
-                        f"GPU buffered stitching failed, image dim {inputs.shape} reducing buffer to {buffer_steps}"
+                        f"GPU buffered stitching failed, image dim {inputs.shape} reducing buffer to {buffer_steps}."
                     )
                 else:
                     buffered_stitching = False
-                    logger.warning(f"GPU buffered stitching failed, attempting on CPU, image dim {inputs.shape}")
+                    logger.warning(f"GPU buffered stitching failed, attempting on CPU, image dim {inputs.shape}.")
         raise RuntimeError(  # not possible to finish after the trials
             f"SlidingWindowInfererAdapt {skip_buffer} {cpu_cond} {gpu_stitching} {buffered_stitching} {buffer_steps}"
         )


### PR DESCRIPTION
- auto adjust buffer_dim for images with small last time, such as 768x768x128 CTs
- fixes a small bug when buffered mode is not attempted



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
