### PR TITLE
6442 fix thread safe issue of DynUNet

### DIFF
--- a/monai/networks/nets/dynunet.py
+++ b/monai/networks/nets/dynunet.py
@@ -269,10 +269,11 @@ class DynUNet(nn.Module):
         out = self.skip_layers(x)
         out = self.output_block(out)
         if self.training and self.deep_supervision:
-            out_all = [out]
-            for feature_map in self.heads:
-                out_all.append(interpolate(feature_map, out.shape[2:]))
-            return torch.stack(out_all, dim=1)
+            out_all = torch.zeros(out.shape[0], len(self.heads) + 1, *out.shape[1:], device=out.device)
+            out_all[:, 0] = out
+            for idx, feature_map in enumerate(self.heads):
+                out_all[:, idx + 1] = interpolate(feature_map, out.shape[2:])
+            return out_all
         return out
 
     def get_input_block(self):

--- a/monai/networks/nets/dynunet.py
+++ b/monai/networks/nets/dynunet.py
@@ -269,7 +269,7 @@ class DynUNet(nn.Module):
         out = self.skip_layers(x)
         out = self.output_block(out)
         if self.training and self.deep_supervision:
-            out_all = torch.zeros(out.shape[0], len(self.heads) + 1, *out.shape[1:], device=out.device)
+            out_all = torch.zeros(out.shape[0], len(self.heads) + 1, *out.shape[1:], device=out.device, dtype=out.dtype)
             out_all[:, 0] = out
             for idx, feature_map in enumerate(self.heads):
                 out_all[:, idx + 1] = interpolate(feature_map, out.shape[2:])


### PR DESCRIPTION
Fixes #6442 .

### Description

This PR is used to fix the thread safe issue of DynUNet. Created list in forward function is replaced by a tensor.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
