### PR TITLE
6415-fix-mlflow-handler-run-bug

### DIFF
--- a/monai/handlers/mlflow_handler.py
+++ b/monai/handlers/mlflow_handler.py
@@ -99,7 +99,7 @@ class MLFlowHandler:
 
     # parameters that are logged at the start of training
     default_tracking_params = ["max_epochs", "epoch_length"]
-    finish_status = mlflow.entities.RunStatus.to_string(mlflow.entities.RunStatus.FINISHED)
+    run_finish_status = mlflow.entities.RunStatus.to_string(mlflow.entities.RunStatus.FINISHED)
 
     def __init__(
         self,
@@ -193,7 +193,7 @@ class MLFlowHandler:
             runs = self.client.search_runs(self.experiment.experiment_id)
             runs = [r for r in runs if r.info.run_name == run_name or not self.run_name]
             # runs marked as finish should not record info any more
-            runs = [r for r in runs if r.info.status != self.finish_status]
+            runs = [r for r in runs if r.info.status != self.run_finish_status]
             if runs:
                 self.cur_run = self.client.get_run(runs[-1].info.run_id)  # pick latest active run
             else:

--- a/monai/handlers/mlflow_handler.py
+++ b/monai/handlers/mlflow_handler.py
@@ -23,10 +23,10 @@ from monai.config import IgniteInfo
 from monai.utils import ensure_tuple, min_version, optional_import
 
 Events, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Events")
-mlflow, _ = optional_import(
-    "mlflow", descriptor="MLFlow is not installed. Please install it before using MLFlowHandler."
+mlflow, _ = optional_import("mlflow", descriptor="Please install mlflow before using MLFlowHandler.")
+mlflow.entities, _ = optional_import(
+    "mlflow.entities", descriptor="Please install mlflow.entities before using MLFLowHandler."
 )
-mlflow.entities, _ = optional_import("mlflow.entities")
 
 if TYPE_CHECKING:
     from ignite.engine import Engine

--- a/monai/handlers/mlflow_handler.py
+++ b/monai/handlers/mlflow_handler.py
@@ -99,6 +99,7 @@ class MLFlowHandler:
 
     # parameters that are logged at the start of training
     default_tracking_params = ["max_epochs", "epoch_length"]
+    # the finish status of a mlflow run
     run_finish_status = mlflow.entities.RunStatus.to_string(mlflow.entities.RunStatus.FINISHED)
 
     def __init__(
@@ -267,8 +268,7 @@ class MLFlowHandler:
 
         """
         if self.cur_run:
-            status = mlflow.entities.RunStatus.to_string(mlflow.entities.RunStatus.FINISHED)
-            self.client.set_terminated(self.cur_run.info.run_id, status)
+            self.client.set_terminated(self.cur_run.info.run_id, self.run_finish_status)
             self.cur_run = None
 
     def epoch_completed(self, engine: Engine) -> None:

--- a/monai/handlers/mlflow_handler.py
+++ b/monai/handlers/mlflow_handler.py
@@ -25,7 +25,7 @@ from monai.utils import ensure_tuple, min_version, optional_import
 Events, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Events")
 mlflow, _ = optional_import("mlflow", descriptor="Please install mlflow before using MLFlowHandler.")
 mlflow.entities, _ = optional_import(
-    "mlflow.entities", descriptor="Please install mlflow.entities before using MLFLowHandler."
+    "mlflow.entities", descriptor="Please install mlflow.entities before using MLFlowHandler."
 )
 
 if TYPE_CHECKING:

--- a/monai/handlers/mlflow_handler.py
+++ b/monai/handlers/mlflow_handler.py
@@ -86,8 +86,10 @@ class MLFlowHandler:
         state_attributes: expected attributes from `engine.state`, if provided, will extract them
             when epoch completed.
         tag_name: when iteration output is a scalar, `tag_name` is used to track, defaults to `'Loss'`.
-        experiment_name: a name for an experiment, defaults to `monai_experiment`.
-        run_name: a name for a run in an experiment.
+        experiment_name: the experiment name of MLflow, defaults to `monai_experiment`. An experiment can be
+            used to record several runs.
+        run_name: the run name in an experiment. A run can be used to record information about a workflow,
+            like the loss, metrics and so on.
         experiment_param: a dict recording parameters which will not change through the whole workflow,
             like torch version, cuda version and so on.
         artifacts: paths to images that need to be recorded after running the workflow.

--- a/monai/handlers/mlflow_handler.py
+++ b/monai/handlers/mlflow_handler.py
@@ -86,15 +86,15 @@ class MLFlowHandler:
         state_attributes: expected attributes from `engine.state`, if provided, will extract them
             when epoch completed.
         tag_name: when iteration output is a scalar, `tag_name` is used to track, defaults to `'Loss'`.
-        experiment_name: the experiment name of MLflow, defaults to `monai_experiment`. An experiment can be
+        experiment_name: the experiment name of MLflow, default to `'monai_experiment'`. An experiment can be
             used to record several runs.
         run_name: the run name in an experiment. A run can be used to record information about a workflow,
             like the loss, metrics and so on.
         experiment_param: a dict recording parameters which will not change through the whole workflow,
             like torch version, cuda version and so on.
         artifacts: paths to images that need to be recorded after running the workflow.
-        optimizer_param_names: parameter names in the optimizer that need to be recorded during running,
-            default to "lr".
+        optimizer_param_names: parameter names in the optimizer that need to be recorded during running the
+            workflow, default to `'lr'`.
         close_on_complete: whether to close the mlflow run in `complete` phase in workflow, default to False.
 
     For more details of MLFlow usage, please refer to: https://mlflow.org/docs/latest/index.html.

--- a/monai/handlers/mlflow_handler.py
+++ b/monai/handlers/mlflow_handler.py
@@ -23,7 +23,9 @@ from monai.config import IgniteInfo
 from monai.utils import ensure_tuple, min_version, optional_import
 
 Events, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Events")
-mlflow, _ = optional_import("mlflow")
+mlflow, _ = optional_import(
+    "mlflow", descriptor="MLFlow is not installed. Please install it before using MLFlowHandler."
+)
 mlflow.entities, _ = optional_import("mlflow.entities")
 
 if TYPE_CHECKING:
@@ -99,8 +101,6 @@ class MLFlowHandler:
 
     # parameters that are logged at the start of training
     default_tracking_params = ["max_epochs", "epoch_length"]
-    # the finish status of a mlflow run
-    run_finish_status = mlflow.entities.RunStatus.to_string(mlflow.entities.RunStatus.FINISHED)
 
     def __init__(
         self,
@@ -134,6 +134,7 @@ class MLFlowHandler:
         self.artifacts = ensure_tuple(artifacts)
         self.optimizer_param_names = ensure_tuple(optimizer_param_names)
         self.client = mlflow.MlflowClient(tracking_uri=tracking_uri if tracking_uri else None)
+        self.run_finish_status = mlflow.entities.RunStatus.to_string(mlflow.entities.RunStatus.FINISHED)
         self.close_on_complete = close_on_complete
         self.experiment = None
         self.cur_run = None

--- a/monai/handlers/mlflow_handler.py
+++ b/monai/handlers/mlflow_handler.py
@@ -191,6 +191,7 @@ class MLFlowHandler:
             run_name = f"run_{time.strftime('%Y%m%d_%H%M%S')}" if self.run_name is None else self.run_name
             runs = self.client.search_runs(self.experiment.experiment_id)
             runs = [r for r in runs if r.info.run_name == run_name or not self.run_name]
+            runs = [r for r in runs if r.info.status != "FINISHED"]
             if runs:
                 self.cur_run = self.client.get_run(runs[-1].info.run_id)  # pick latest active run
             else:

--- a/tests/test_auto3dseg_bundlegen.py
+++ b/tests/test_auto3dseg_bundlegen.py
@@ -25,7 +25,13 @@ from monai.apps.auto3dseg.utils import export_bundle_algo_history, import_bundle
 from monai.bundle.config_parser import ConfigParser
 from monai.data import create_test_image_3d
 from monai.utils import set_determinism
-from tests.utils import get_testing_algo_template_path, skip_if_downloading_fails, skip_if_no_cuda, skip_if_quick
+from tests.utils import (
+    SkipIfBeforePyTorchVersion,
+    get_testing_algo_template_path,
+    skip_if_downloading_fails,
+    skip_if_no_cuda,
+    skip_if_quick,
+)
 
 num_images_perfold = max(torch.cuda.device_count(), 4)
 num_images_per_batch = 2
@@ -97,6 +103,7 @@ def run_auto3dseg_before_bundlegen(test_path, work_dir):
 
 
 @skip_if_no_cuda
+@SkipIfBeforePyTorchVersion((1, 11, 1))
 @skip_if_quick
 class TestBundleGen(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_handler_mlflow.py
+++ b/tests/test_handler_mlflow.py
@@ -74,8 +74,8 @@ class TestHandlerMLFlow(unittest.TestCase):
             def _train_func(engine, batch):
                 return [batch + 1.0]
 
-            run_id_list = []
-            for _ in range(2):
+            create_engine_times = 3
+            for _ in range(create_engine_times):
                 engine = Engine(_train_func)
 
                 @engine.on(Events.EPOCH_COMPLETED)
@@ -95,11 +95,10 @@ class TestHandlerMLFlow(unittest.TestCase):
                 )
                 handler.attach(engine)
                 engine.run(range(3), max_epochs=2)
-                cur_run = handler.client.search_runs(handler.experiment.experiment_id)[0]
-                run_id_list.append(cur_run.info.run_id)
+                run_cnt = len(handler.client.search_runs(handler.experiment.experiment_id))
                 handler.close()
-            # check the two runs are different
-            self.assertNotEqual(run_id_list[0], run_id_list[1])
+            # the run count should equal to the times of creating engine
+            self.assertEqual(create_engine_times, run_cnt)
 
     def test_metrics_track(self):
         experiment_param = {"backbone": "efficientnet_b0"}

--- a/tests/test_handler_mlflow.py
+++ b/tests/test_handler_mlflow.py
@@ -99,7 +99,7 @@ class TestHandlerMLFlow(unittest.TestCase):
                 run_id_list.append(cur_run.info.run_id)
                 handler.close()
             # check logging output
-            self.assertTrue(run_id_list[0] != run_id_list[1])
+            self.assertNotEqual(run_id_list[0], run_id_list[1])
 
     def test_metrics_track(self):
         experiment_param = {"backbone": "efficientnet_b0"}

--- a/tests/test_handler_mlflow.py
+++ b/tests/test_handler_mlflow.py
@@ -73,14 +73,17 @@ class TestHandlerMLFlow(unittest.TestCase):
             # set up engine
             def _train_func(engine, batch):
                 return [batch + 1.0]
+
             run_id_list = []
             for _ in range(2):
                 engine = Engine(_train_func)
+
                 @engine.on(Events.EPOCH_COMPLETED)
                 def _update_metric(engine):
                     current_metric = engine.state.metrics.get("acc", 0.1)
                     engine.state.metrics["acc"] = current_metric + 0.1
                     engine.state.test = current_metric
+
                 # set up testing handler
                 test_path = os.path.join(tempdir, "mlflow_test")
                 handler = MLFlowHandler(

--- a/tests/test_handler_mlflow.py
+++ b/tests/test_handler_mlflow.py
@@ -70,7 +70,7 @@ class TestHandlerMLFlow(unittest.TestCase):
 
     def test_multi_run(self):
         with tempfile.TemporaryDirectory() as tempdir:
-            # set up engine
+            # set up the train function for engine
             def _train_func(engine, batch):
                 return [batch + 1.0]
 
@@ -98,7 +98,7 @@ class TestHandlerMLFlow(unittest.TestCase):
                 cur_run = handler.client.search_runs(handler.experiment.experiment_id)[0]
                 run_id_list.append(cur_run.info.run_id)
                 handler.close()
-            # check logging output
+            # check the two runs are different
             self.assertNotEqual(run_id_list[0], run_id_list[1])
 
     def test_metrics_track(self):

--- a/tests/test_handler_mlflow.py
+++ b/tests/test_handler_mlflow.py
@@ -74,6 +74,7 @@ class TestHandlerMLFlow(unittest.TestCase):
             def _train_func(engine, batch):
                 return [batch + 1.0]
 
+            # create and run an engine several times to get several runs
             create_engine_times = 3
             for _ in range(create_engine_times):
                 engine = Engine(_train_func)


### PR DESCRIPTION
Fixes #6415  .
(also fixes #6449)

### Description

Fix the mlflow handler bug. When running a bundle with ` MLFLowHandler` back to back without assigning the run name , the later run info will be recorded into the former run, although the former run is finished. This PR checks the status of runs and filters the finished ones.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
