### PR TITLE
EnsureSameShaped, adds warn option

### DIFF
--- a/tests/test_densenet.py
+++ b/tests/test_densenet.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.nets import DenseNet121, Densenet169, DenseNet264, densenet201
 from monai.utils import optional_import
-from tests.utils import skip_if_quick, test_script_save
+from tests.utils import skip_if_downloading_fails, skip_if_quick, test_script_save
 
 if TYPE_CHECKING:
     import torchvision
@@ -82,7 +82,8 @@ class TestPretrainedDENSENET(unittest.TestCase):
     @parameterized.expand([TEST_PRETRAINED_2D_CASE_1, TEST_PRETRAINED_2D_CASE_2])
     @skip_if_quick
     def test_121_2d_shape_pretrain(self, model, input_param, input_shape, expected_shape):
-        net = model(**input_param).to(device)
+        with skip_if_downloading_fails():
+            net = model(**input_param).to(device)
         with eval_mode(net):
             result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
@@ -91,7 +92,8 @@ class TestPretrainedDENSENET(unittest.TestCase):
     @skipUnless(has_torchvision, "Requires `torchvision` package.")
     def test_pretrain_consistency(self, model, input_param, input_shape):
         example = torch.randn(input_shape).to(device)
-        net = model(**input_param).to(device)
+        with skip_if_downloading_fails():
+            net = model(**input_param).to(device)
         with eval_mode(net):
             result = net.features.forward(example)
         torchvision_net = torchvision.models.densenet121(pretrained=True).to(device)

--- a/tests/test_torchvision_fc_model.py
+++ b/tests/test_torchvision_fc_model.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import unittest
+from test.utils import skip_if_downloading_fails
 from unittest import skipUnless
 
 import torch
@@ -176,7 +177,8 @@ class TestTorchVisionFCModel(unittest.TestCase):
     )
     @skipUnless(has_tv, "Requires TorchVision.")
     def test_with_pretrained(self, input_param, input_shape, expected_shape, expected_value):
-        net = TorchVisionFCModel(**input_param).to(device)
+        with skip_if_downloading_fails():
+            net = TorchVisionFCModel(**input_param).to(device)
         with eval_mode(net):
             result = net.forward(torch.randn(input_shape).to(device))
             value = next(net.features.parameters())[0, 0, 0, 0].item()

--- a/tests/test_torchvision_fc_model.py
+++ b/tests/test_torchvision_fc_model.py
@@ -12,7 +12,6 @@
 from __future__ import annotations
 
 import unittest
-from test.utils import skip_if_downloading_fails
 from unittest import skipUnless
 
 import torch
@@ -22,6 +21,7 @@ from monai.networks import eval_mode
 from monai.networks.nets import TorchVisionFCModel, UNet
 from monai.networks.utils import look_up_named_module, set_named_module
 from monai.utils import min_version, optional_import
+from tests.utils import skip_if_downloading_fails
 
 Inception_V3_Weights, has_enum = optional_import("torchvision.models.inception", name="Inception_V3_Weights")
 


### PR DESCRIPTION
Adds an option to hide warning messages of EnsureSameShaped transform.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
