### PR TITLE
6439 adds a compose `mode` for lazy evaluation 

### DIFF
--- a/tests/test_integration_lazy_samples.py
+++ b/tests/test_integration_lazy_samples.py
@@ -74,6 +74,7 @@ def run_training_test(root_dir, device="cuda:0", cachedataset=0, readers=(None, 
         overrides=lazy_kwargs,
         override_keys=("img", "seg"),
         verbose=num_workers > 0,  # testing both flags
+        mode="strict",
     )
 
     # create a training data loader
@@ -149,15 +150,6 @@ def run_training_test(root_dir, device="cuda:0", cachedataset=0, readers=(None, 
                 saver(item)  # just testing the saving
                 saver(in_img)
                 saver(in_seg)
-    if lazy:
-        inverted = 0
-        try:
-            inverted = [inverter(b_data) for b_data in decollate_batch(batch_data)]
-        except RuntimeError as e:
-            if "Lambda" in str(e):
-                inverted = None
-        assert inverted is None, "invert LambdaD + lazy is not supported"
-    else:
         [inverter(b_data) for b_data in decollate_batch(batch_data)]  # expecting no error
     return ops
 

--- a/tests/test_invert.py
+++ b/tests/test_invert.py
@@ -95,11 +95,10 @@ class TestInvert(unittest.TestCase):
         transform = Compose(
             [LoadImage(image_only=True), EnsureChannelFirst(), Orientation("RPS"), Lambda(func=lambda x: x)],
             lazy_evaluation=True,
+            mode="strict",
         )
         output = transform([im_fname for _ in range(2)])
-        with self.assertRaises(RuntimeError):  # transform id mismatch because of lambda
-            with self.assertWarns(Warning):  # warning of wrong ordering lazy + nonlazy_invertible
-                transform.inverse(output)
+        transform.inverse(output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6439

### Description
adds a `mode="strict"` to `Compose` so that only consecutive lazy transforms are combined together for one-step resampling (when `lazy_evaluation=True`).

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
