### PR TITLE
Auto3dseg ensemble path fix

### DIFF
--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -459,6 +459,9 @@ class EnsembleRunner:
             os.makedirs(output_dir, exist_ok=True)
             logger.info(f"Directory {output_dir} is created to save ensemble predictions")
 
+        input_yaml = ConfigParser.load_config_file(self.data_src_cfg_name)
+        data_root_dir = input_yaml.get("dataroot", "")
+
         save_image = {
             "_target_": "SaveImage",
             "output_dir": output_dir,
@@ -467,6 +470,8 @@ class EnsembleRunner:
             "resample": kwargs.pop("resample", False),
             "print_log": False,
             "savepath_in_metadict": True,
+            "data_root_dir": kwargs.pop("data_root_dir", data_root_dir),
+            "separate_folder": kwargs.pop("separate_folder", False),
         }
 
         are_all_args_save_image, extra_args = check_kwargs_exist_in_class_init(SaveImage, kwargs)


### PR DESCRIPTION
Auto3dseg ensembling saves output results to the same filename if input images had the same name (but in different folders). this PR maintains the folder structure, so that the outputs are in different folders.  

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
