### PR TITLE
Redo Auto3dseg ensemble path fix

### DIFF
--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -383,10 +383,9 @@ class EnsembleRunner:
                               Suported methods: ["AlgoEnsembleBestN", "AlgoEnsembleBestByFold"].
         mgpu: if using multi-gpu. Default is True.
         kwargs: additional image writing, ensembling parameters and prediction parameters for the ensemble inference.
-                - for image saving, please check the supported parameters in SaveImage transform.
-                - for prediction parameters, please check the supported parameters
-                    in the ``__call__`` method in ``AlgoEnsemble``.
-                - for ensemble parameters, please check the documentation of the selected AlgoEnsemble class.
+              - for image saving, please check the supported parameters in SaveImage transform.
+              - for prediction parameters, please check the supported parameters in the ``AlgoEnsemble`` callables.
+              - for ensemble parameters, please check the documentation of the selected AlgoEnsemble callable.
 
     Example:
 

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -31,7 +31,7 @@ from monai.auto3dseg.utils import datafold_read
 from monai.bundle import ConfigParser
 from monai.data import partition_dataset
 from monai.transforms import MeanEnsemble, SaveImage, VoteEnsemble
-from monai.utils import RankFilter
+from monai.utils import RankFilter, deprecated_arg
 from monai.utils.enums import AlgoKeys
 from monai.utils.misc import check_kwargs_exist_in_class_init, prob2class
 from monai.utils.module import look_up_option, optional_import
@@ -290,7 +290,7 @@ class AlgoEnsembleBuilder:
 
     Args:
         history: a collection of trained bundleAlgo algorithms.
-        data_src_cfg_filename: filename of the data source.
+        data_src_cfg_name: filename of the data source.
 
     Examples:
 
@@ -302,13 +302,14 @@ class AlgoEnsembleBuilder:
 
     """
 
-    def __init__(self, history: Sequence[dict[str, Any]], data_src_cfg_filename: str | None = None):
+    @deprecated_arg("data_src_cfg_filename", since="1.2", removed="1.3", new_name="data_src_cfg_name", msg_suffix="please use `data_src_cfg_name` instead.")
+    def __init__(self, history: Sequence[dict[str, Any]], data_src_cfg_name: str | None = None):
         self.infer_algos: list[dict[AlgoKeys, Any]] = []
         self.ensemble: AlgoEnsemble
         self.data_src_cfg = ConfigParser(globals=False)
 
-        if data_src_cfg_filename is not None and os.path.exists(str(data_src_cfg_filename)):
-            self.data_src_cfg.read_config(data_src_cfg_filename)
+        if data_src_cfg_name is not None and os.path.exists(str(data_src_cfg_name)):
+            self.data_src_cfg.read_config(data_src_cfg_name)
 
         for algo_dict in history:
             # load inference_config_paths
@@ -366,17 +367,22 @@ class AlgoEnsembleBuilder:
 
 class EnsembleRunner:
     """
-    The Runner for ensembler
+    The Runner for ensembler. It ensembles predictions and saves them to the disk with a support of using multi-GPU.
 
     Args:
-        work_dir: working directory to save the intermediate and final results.
         data_src_cfg_name: filename of the data source.
-        num_fold: number of fold.
-        ensemble_method_name: method to ensemble predictions from different model.
+        work_dir: working directory to save the intermediate and final results. Default is `./work_dir`.
+        num_fold: number of fold. Default is 5.
+        ensemble_method_name: method to ensemble predictions from different model. Default is AlgoEnsembleBestByFold.
                               Suported methods: ["AlgoEnsembleBestN", "AlgoEnsembleBestByFold"].
-        mgpu: if using multi-gpu.
+        mgpu: if using multi-gpu. Default is True.
         kwargs: additional image writing, ensembling parameters and prediction parameters for the ensemble inference.
-    Examples:
+                - for image saving, please check the supported parameters in SaveImage transform.
+                - for prediction parameters, please check the supported parameters
+                    in the ``__call__`` method in ``AlgoEnsemble``.
+                - for ensemble parameters, please check the documentation of the selected AlgoEnsemble class.
+
+    Example:
 
         .. code-block:: python
 
@@ -392,7 +398,7 @@ class EnsembleRunner:
 
     def __init__(
         self,
-        data_src_cfg_name: str = "./work_dir/input.yaml",
+        data_src_cfg_name,
         work_dir: str = "./work_dir",
         num_fold: int = 5,
         ensemble_method_name: str = "AlgoEnsembleBestByFold",
@@ -459,6 +465,9 @@ class EnsembleRunner:
             os.makedirs(output_dir, exist_ok=True)
             logger.info(f"Directory {output_dir} is created to save ensemble predictions")
 
+        input_yaml = ConfigParser.load_config_file(self.data_src_cfg_name)
+        data_root_dir = input_yaml.get("dataroot", "")
+
         save_image = {
             "_target_": "SaveImage",
             "output_dir": output_dir,
@@ -467,6 +476,8 @@ class EnsembleRunner:
             "resample": kwargs.pop("resample", False),
             "print_log": False,
             "savepath_in_metadict": True,
+            "data_root_dir": kwargs.pop("data_root_dir", data_root_dir),
+            "separate_folder": kwargs.pop("separate_folder", False),
         }
 
         are_all_args_save_image, extra_args = check_kwargs_exist_in_class_init(SaveImage, kwargs)

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -302,7 +302,13 @@ class AlgoEnsembleBuilder:
 
     """
 
-    @deprecated_arg("data_src_cfg_filename", since="1.2", removed="1.3", new_name="data_src_cfg_name", msg_suffix="please use `data_src_cfg_name` instead.")
+    @deprecated_arg(
+        "data_src_cfg_filename",
+        since="1.2",
+        removed="1.3",
+        new_name="data_src_cfg_name",
+        msg_suffix="please use `data_src_cfg_name` instead.",
+    )
     def __init__(self, history: Sequence[dict[str, Any]], data_src_cfg_name: str | None = None):
         self.infer_algos: list[dict[AlgoKeys, Any]] = []
         self.ensemble: AlgoEnsemble

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -403,7 +403,7 @@ class EnsembleRunner:
 
     def __init__(
         self,
-        data_src_cfg_name,
+        data_src_cfg_name: str,
         work_dir: str = "./work_dir",
         num_fold: int = 5,
         ensemble_method_name: str = "AlgoEnsembleBestByFold",

--- a/tests/test_auto3dseg_ensemble.py
+++ b/tests/test_auto3dseg_ensemble.py
@@ -30,7 +30,7 @@ from monai.apps.auto3dseg import (
 from monai.bundle.config_parser import ConfigParser
 from monai.data import create_test_image_3d
 from monai.transforms import SaveImage
-from monai.utils import optional_import, set_determinism
+from monai.utils import optional_import, set_determinism, check_parent_dir
 from monai.utils.enums import AlgoKeys
 from tests.utils import (
     SkipIfBeforePyTorchVersion,
@@ -46,12 +46,12 @@ num_images_perfold = max(torch.cuda.device_count(), 4)
 num_images_per_batch = 2
 
 fake_datalist: dict[str, list[dict]] = {
-    "testing": [{"image": f"ts_image_{idx:03d}.nii.gz"} for idx in range(num_images_perfold)],
+    "testing": [{"image": f"imagesTs/ts_image_{idx:03d}.nii.gz"} for idx in range(num_images_perfold)],
     "training": [
         {
             "fold": f,
-            "image": f"tr_image_{(f * num_images_perfold + idx):03d}.nii.gz",
-            "label": f"tr_label_{(f * num_images_perfold + idx):03d}.nii.gz",
+            "image": f"imagesTr/tr_image_{(f * num_images_perfold + idx):03d}.nii.gz",
+            "label": f"labelsTr/tr_label_{(f * num_images_perfold + idx):03d}.nii.gz",
         }
         for f in range(num_images_per_batch + 1)
         for idx in range(num_images_perfold)
@@ -74,17 +74,40 @@ train_param = (
 
 pred_param = {"files_slices": slice(0, 1), "mode": "mean", "sigmoid": True}
 
+def create_sim_data(dataroot, sim_datalist, sim_dim, **kwargs):
+    """
+    Create simulated data using create_test_image_3d.
+
+    Args:
+        dataroot: data directory path that hosts the "nii.gz" image files.
+        sim_datalist: a list of data to create.
+        sim_dim: the image sizes, e.g. a tuple of (64, 64, 64).
+    """
+    if not os.path.isdir(dataroot):
+        os.makedirs(dataroot)
+
+    # Generate a fake dataset
+    for d in sim_datalist["testing"] + sim_datalist["training"]:
+        im, seg = create_test_image_3d(sim_dim[0], sim_dim[1], sim_dim[2], **kwargs)
+        nib_image = nib.Nifti1Image(im, affine=np.eye(4))
+        image_fpath = os.path.join(dataroot, d["image"])
+        check_parent_dir(image_fpath)
+        nib.save(nib_image, image_fpath)
+
+        if "label" in d:
+            nib_image = nib.Nifti1Image(seg, affine=np.eye(4))
+            label_fpath = os.path.join(dataroot, d["label"])
+            check_parent_dir(label_fpath)
+            nib.save(nib_image, label_fpath)
 
 @skip_if_quick
+@skip_if_no_cuda
 @SkipIfBeforePyTorchVersion((1, 11, 1))
 @unittest.skipIf(not has_tb, "no tensorboard summary writer")
 class TestEnsembleBuilder(unittest.TestCase):
     def setUp(self) -> None:
         set_determinism(0)
         self.test_dir = tempfile.TemporaryDirectory()
-
-    @skip_if_no_cuda
-    def test_ensemble(self) -> None:
         test_path = self.test_dir.name
 
         dataroot = os.path.join(test_path, "dataroot")
@@ -93,23 +116,10 @@ class TestEnsembleBuilder(unittest.TestCase):
         da_output_yaml = os.path.join(work_dir, "datastats.yaml")
         data_src_cfg = os.path.join(work_dir, "data_src_cfg.yaml")
 
-        if not os.path.isdir(dataroot):
-            os.makedirs(dataroot)
-
         if not os.path.isdir(work_dir):
             os.makedirs(work_dir)
 
-        # Generate a fake dataset
-        for d in fake_datalist["testing"] + fake_datalist["training"]:
-            im, seg = create_test_image_3d(24, 24, 24, rad_max=10, num_seg_classes=1)
-            nib_image = nib.Nifti1Image(im, affine=np.eye(4))
-            image_fpath = os.path.join(dataroot, d["image"])
-            nib.save(nib_image, image_fpath)
-
-            if "label" in d:
-                nib_image = nib.Nifti1Image(seg, affine=np.eye(4))
-                label_fpath = os.path.join(dataroot, d["label"])
-                nib.save(nib_image, label_fpath)
+        create_sim_data(dataroot, fake_datalist, (24, 24, 24), rad_max=10, rad_min=1, num_seg_classes=1)
 
         # write to a json file
         fake_json_datalist = os.path.join(dataroot, "fake_input.json")
@@ -130,14 +140,19 @@ class TestEnsembleBuilder(unittest.TestCase):
 
         ConfigParser.export_config_file(data_src, data_src_cfg)
 
+        self.da_output_yaml = da_output_yaml
+        self.work_dir = work_dir
+        self.data_src_cfg_name = data_src_cfg
+
+    def test_ensemble(self) -> None:
         with skip_if_downloading_fails():
             bundle_generator = BundleGen(
-                algo_path=work_dir,
-                data_stats_filename=da_output_yaml,
-                data_src_cfg_name=data_src_cfg,
+                algo_path=self.work_dir,
+                data_stats_filename=self.da_output_yaml,
+                data_src_cfg_name=self.data_src_cfg_name,
                 templates_path_or_url=get_testing_algo_template_path(),
             )
-        bundle_generator.generate(work_dir, num_fold=1)
+        bundle_generator.generate(self.work_dir, num_fold=1)
         history = bundle_generator.get_history()
 
         for algo_dict in history:
@@ -151,7 +166,7 @@ class TestEnsembleBuilder(unittest.TestCase):
                 _train_param["network#feature_size"] = 12
             algo.train(_train_param)
 
-        builder = AlgoEnsembleBuilder(history, data_src_cfg)
+        builder = AlgoEnsembleBuilder(history, data_src_cfg_name=self.data_src_cfg_name)
         builder.set_ensemble_method(AlgoEnsembleBestN(n_best=1))
         ensemble = builder.get_ensemble()
         name = ensemble.get_algo_ensemble()[0][AlgoKeys.ID]
@@ -168,7 +183,7 @@ class TestEnsembleBuilder(unittest.TestCase):
             print(algo[AlgoKeys.ID])
 
     def test_ensemble_runner(self) -> None:
-        runner = EnsembleRunner()
+        runner = EnsembleRunner(data_src_cfg_name=self.data_src_cfg_name, mgpu=False)
         runner.set_num_fold(3)
         self.assertTrue(runner.num_fold == 3)
         runner.set_ensemble_method(ensemble_method_name="AlgoEnsembleBestByFold")

--- a/tests/test_auto3dseg_ensemble.py
+++ b/tests/test_auto3dseg_ensemble.py
@@ -30,7 +30,7 @@ from monai.apps.auto3dseg import (
 from monai.bundle.config_parser import ConfigParser
 from monai.data import create_test_image_3d
 from monai.transforms import SaveImage
-from monai.utils import optional_import, set_determinism, check_parent_dir
+from monai.utils import check_parent_dir, optional_import, set_determinism
 from monai.utils.enums import AlgoKeys
 from tests.utils import (
     SkipIfBeforePyTorchVersion,
@@ -74,6 +74,7 @@ train_param = (
 
 pred_param = {"files_slices": slice(0, 1), "mode": "mean", "sigmoid": True}
 
+
 def create_sim_data(dataroot, sim_datalist, sim_dim, **kwargs):
     """
     Create simulated data using create_test_image_3d.
@@ -99,6 +100,7 @@ def create_sim_data(dataroot, sim_datalist, sim_dim, **kwargs):
             label_fpath = os.path.join(dataroot, d["label"])
             check_parent_dir(label_fpath)
             nib.save(nib_image, label_fpath)
+
 
 @skip_if_quick
 @skip_if_no_cuda


### PR DESCRIPTION
redo #6481 .

### Description

- Take the code from #6481 
- Deprecate `data_src_cfg_filename` and replace it with `data_src_cfg_name` so that the same thing can be consistent across AutoRunner, BundleGen, and Ensemble classes
- Make `data_src_cfg_name` a required argument in the ensemble runner because it is prone to error to use a default name.
- Improves test structure, but nothing major is changed.

What is not done:
- Add tests to check the output structure, because EnsembleRunner doesn't support changing the pred_param for individual algo seperately, and then I can't really run the `ensemble` method in EnsembleRunner.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
