### PR TITLE
Enable algo-specific params for Auto3DSeg ensemble

### DIFF
--- a/monai/apps/auto3dseg/__init__.py
+++ b/monai/apps/auto3dseg/__init__.py
@@ -22,4 +22,4 @@ from .ensemble_builder import (
     EnsembleRunner,
 )
 from .hpo_gen import NNIGen, OptunaGen
-from .utils import export_bundle_algo_history, import_bundle_algo_history, get_name_from_algo_id
+from .utils import export_bundle_algo_history, get_name_from_algo_id, import_bundle_algo_history

--- a/monai/apps/auto3dseg/__init__.py
+++ b/monai/apps/auto3dseg/__init__.py
@@ -22,4 +22,4 @@ from .ensemble_builder import (
     EnsembleRunner,
 )
 from .hpo_gen import NNIGen, OptunaGen
-from .utils import export_bundle_algo_history, import_bundle_algo_history
+from .utils import export_bundle_algo_history, import_bundle_algo_history, get_name_from_algo_id

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -24,7 +24,7 @@ import torch
 import torch.distributed as dist
 
 from monai.apps.auto3dseg.bundle_gen import BundleAlgo
-from monai.apps.auto3dseg.utils import import_bundle_algo_history, get_name_from_algo_id
+from monai.apps.auto3dseg.utils import get_name_from_algo_id, import_bundle_algo_history
 from monai.apps.utils import get_logger
 from monai.auto3dseg import concat_val_to_np
 from monai.auto3dseg.utils import datafold_read
@@ -126,7 +126,7 @@ class AlgoEnsemble(ABC):
                 return VoteEnsemble()(classes)  # do not specify num_classes for one-hot encoding
             else:
                 return VoteEnsemble(num_classes=preds[0].shape[0])(classes)
-    
+
     def _apply_model_specific_param(self, model_specific_param: dict, param: dict, algo_name: str) -> dict:
         """
         Apply the model-specific params to the prediction params based on the name of the Algo.
@@ -135,7 +135,7 @@ class AlgoEnsemble(ABC):
             model_specific_param: a dict that has structure of {"<name of algo>": "<pred_params for that algo>"}.
             param: the prediction params to override.
             algo_name: name of the Algo
-        
+
         Returns:
             param after being updated with the model-specific param
         """

--- a/monai/apps/auto3dseg/utils.py
+++ b/monai/apps/auto3dseg/utils.py
@@ -17,11 +17,8 @@ from monai.apps.auto3dseg.bundle_gen import BundleAlgo
 from monai.auto3dseg import algo_from_pickle, algo_to_pickle
 from monai.utils.enums import AlgoKeys
 
-__all__ = [
-    "import_bundle_algo_history",
-    "export_bundle_algo_history",
-    "get_name_from_algo_id",
-]
+__all__ = ["import_bundle_algo_history", "export_bundle_algo_history", "get_name_from_algo_id"]
+
 
 def import_bundle_algo_history(
     output_folder: str = ".", template_path: str | None = None, only_trained: bool = True
@@ -79,13 +76,14 @@ def export_bundle_algo_history(history: list[dict[str, BundleAlgo]]) -> None:
         algo = algo_dict[AlgoKeys.ALGO]
         algo_to_pickle(algo, template_path=algo.template_path)
 
+
 def get_name_from_algo_id(id: str) -> str:
     """
     Get the name of Algo from the identifier of the Algo.
 
     Args:
         id: identifier which follows a convention of "name_fold_other".
-    
+
     Returns:
         name of the Algo.
     """

--- a/monai/apps/auto3dseg/utils.py
+++ b/monai/apps/auto3dseg/utils.py
@@ -17,6 +17,11 @@ from monai.apps.auto3dseg.bundle_gen import BundleAlgo
 from monai.auto3dseg import algo_from_pickle, algo_to_pickle
 from monai.utils.enums import AlgoKeys
 
+__all__ = [
+    "import_bundle_algo_history",
+    "export_bundle_algo_history",
+    "get_name_from_algo_id",
+]
 
 def import_bundle_algo_history(
     output_folder: str = ".", template_path: str | None = None, only_trained: bool = True
@@ -73,3 +78,15 @@ def export_bundle_algo_history(history: list[dict[str, BundleAlgo]]) -> None:
     for algo_dict in history:
         algo = algo_dict[AlgoKeys.ALGO]
         algo_to_pickle(algo, template_path=algo.template_path)
+
+def get_name_from_algo_id(id: str) -> str:
+    """
+    Get the name of Algo from the identifier of the Algo.
+
+    Args:
+        id: identifier which follows a convention of "name_fold_other".
+    
+    Returns:
+        name of the Algo.
+    """
+    return id.split("_")[0]

--- a/tests/test_auto3dseg_ensemble.py
+++ b/tests/test_auto3dseg_ensemble.py
@@ -72,7 +72,15 @@ train_param = (
     else {}
 )
 
-pred_param = {"files_slices": slice(0, 1), "mode": "mean", "sigmoid": True}
+pred_param = {
+    "files_slices": slice(0, 1),
+    "mode": "mean",
+    "sigmoid": True,
+    "model_specific_params":{
+        "segresnet": {"network#init_filters": 8},
+        "swinunetr": {"network#feature_size": 12},
+    }
+}
 
 
 def create_sim_data(dataroot, sim_datalist, sim_dim, **kwargs):
@@ -171,11 +179,6 @@ class TestEnsembleBuilder(unittest.TestCase):
         builder = AlgoEnsembleBuilder(history, data_src_cfg_name=self.data_src_cfg_name)
         builder.set_ensemble_method(AlgoEnsembleBestN(n_best=1))
         ensemble = builder.get_ensemble()
-        name = ensemble.get_algo_ensemble()[0][AlgoKeys.ID]
-        if name.startswith("segresnet"):
-            pred_param["network#init_filters"] = 8
-        elif name.startswith("swinunetr"):
-            pred_param["network#feature_size"] = 12
         preds = ensemble(pred_param)
         self.assertTupleEqual(preds[0].shape, (2, 24, 24, 24))
 

--- a/tests/test_auto3dseg_ensemble.py
+++ b/tests/test_auto3dseg_ensemble.py
@@ -76,7 +76,7 @@ pred_param = {
     "files_slices": slice(0, 1),
     "mode": "mean",
     "sigmoid": True,
-    "model_specific_params": {"segresnet": {"network#init_filters": 8}, "swinunetr": {"network#feature_size": 12}},
+    "algo_spec_params": {"segresnet": {"network#init_filters": 8}, "swinunetr": {"network#feature_size": 12}},
 }
 
 

--- a/tests/test_auto3dseg_ensemble.py
+++ b/tests/test_auto3dseg_ensemble.py
@@ -76,10 +76,7 @@ pred_param = {
     "files_slices": slice(0, 1),
     "mode": "mean",
     "sigmoid": True,
-    "model_specific_params":{
-        "segresnet": {"network#init_filters": 8},
-        "swinunetr": {"network#feature_size": 12},
-    }
+    "model_specific_params": {"segresnet": {"network#init_filters": 8}, "swinunetr": {"network#feature_size": 12}},
 }
 
 


### PR DESCRIPTION
Fixes #5817 .

### Description

Add an optional "algo_spec_params" in the prediction parameters which allows user to put model-specific param in it.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
