### PR TITLE
Fix the nnunet test and enhancment arg parse in train

### DIFF
--- a/monai/apps/nnunet/nnunetv2_runner.py
+++ b/monai/apps/nnunet/nnunetv2_runner.py
@@ -497,7 +497,6 @@ class nnUNetV2Runner:  # noqa: N801
         from nnunetv2.run.run_training import run_training
             kwargs: this optional parameter allows you to specify additional arguments in
                 ``nnunetv2.run.run_training.run_training``. Currently supported args are
-                    - trainer_class_name: name of the custom trainer class. Default: "nnUNetTrainer".
                     - plans_identifier: custom plans identifier. Default: "nnUNetPlans".
                     - pretrained_weights: path to nnU-Net checkpoint file to be used as pretrained model. Will only be
                         used when actually training. Beta. Use with caution. Default: False.
@@ -513,6 +512,14 @@ class nnUNetV2Runner:  # noqa: N801
         if "num_gpus" in kwargs:
             kwargs.pop("num_gpus")
             logger.warning("please use gpu_id to set the GPUs to use")
+
+        if "trainer_class_name" in kwargs:
+            kwargs.pop("trainer_class_name")
+            logger.warning("please specify the `trainer_class_name` in the __init__ of `nnUNetV2Runner`.")
+
+        if "export_validation_probabilities" in kwargs:
+            kwargs.pop("export_validation_probabilities")
+            logger.warning("please specify the `export_validation_probabilities` in the __init__ of `nnUNetV2Runner`.")
 
         if isinstance(gpu_id, tuple) or isinstance(gpu_id, list):
             if len(gpu_id) > 1:

--- a/setup.cfg
+++ b/setup.cfg
@@ -155,6 +155,7 @@ max_line_length = 120
 # B023 https://github.com/Project-MONAI/MONAI/issues/4627
 # B028 https://github.com/Project-MONAI/MONAI/issues/5855
 # B907 https://github.com/Project-MONAI/MONAI/issues/5868
+# B908 https://github.com/Project-MONAI/MONAI/issues/6503
 ignore =
     E203
     E501
@@ -167,6 +168,7 @@ ignore =
     B905
     B028
     B907
+    B908
 per_file_ignores = __init__.py: F401, __main__.py: F401
 exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,.venv,_version.py
 

--- a/tests/test_integration_nnunetv2_runner.py
+++ b/tests/test_integration_nnunetv2_runner.py
@@ -81,11 +81,11 @@ class TestnnUNetV2Runner(unittest.TestCase):
 
     @skip_if_no_cuda
     def test_nnunetv2runner(self) -> None:
-        runner = nnUNetV2Runner(input_config=self.data_src_cfg)
+        runner = nnUNetV2Runner(input_config=self.data_src_cfg, trainer_class_name="nnUNetTrainer_1epoch")
         with skip_if_downloading_fails():
             runner.run(run_train=False, run_find_best_configuration=False, run_predict_ensemble_postprocessing=False)
-            runner.train(configs="3d_fullres", trainer_class_name="nnUNetTrainer_1epoch")
-            runner.find_best_configuration(configs="3d_fullres", trainers="nnUNetTrainer_1epoch")
+            runner.train(configs="3d_fullres")
+            runner.find_best_configuration(configs="3d_fullres")
             runner.predict_ensemble_postprocessing()
 
     def tearDown(self) -> None:


### PR DESCRIPTION
Fixes #6496 .
Fixes #6503 

### Description

Fix the test after nnunet API change in #6470 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] In-line docstrings updated.

