### PR TITLE
Make template_path in BundleAlgo consistently point to the algorithm_templates folder

### DIFF
--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -400,9 +400,7 @@ def _copy_algos_folder(folder, at_path):
     algos_all = {}
     for name in os.listdir(at_path):
         if os.path.exists(os.path.join(folder, name, "scripts", "algo.py")):
-            algos_all[name] = dict(
-                _target_=f"{name}.scripts.algo.{name.capitalize()}Algo", template_path=at_path
-            )
+            algos_all[name] = dict(_target_=f"{name}.scripts.algo.{name.capitalize()}Algo", template_path=at_path)
             logger.info(f"Copying template: {name} -- {algos_all[name]}")
     if not algos_all:
         raise ValueError(f"Unable to find any algos in {folder}")

--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -52,8 +52,8 @@ class BundleAlgo(Algo):
 
         from monai.apps.auto3dseg import BundleAlgo
 
-        data_stats_yaml = "/workspace/datastats.yaml"
-        algo = BundleAlgo(template_path=../algorithms/templates/segresnet2d/configs)
+        data_stats_yaml = "../datastats.yaml"
+        algo = BundleAlgo(template_path="../algorithm_templates")
         algo.set_data_stats(data_stats_yaml)
         # algo.set_data_src("../data_src.json")
         algo.export_to_disk(".", algo_name="segresnet2d_1")
@@ -69,7 +69,8 @@ class BundleAlgo(Algo):
         Create an Algo instance based on the predefined Algo template.
 
         Args:
-            template_path: path to the root of the algo template.
+            template_path: path to a folder that contains the algorithm templates.
+                Please check https://github.com/Project-MONAI/research-contributions/tree/main/auto3dseg/algorithm_templates
 
         """
 
@@ -154,7 +155,8 @@ class BundleAlgo(Algo):
             os.makedirs(self.output_path, exist_ok=True)
             if os.path.isdir(self.output_path):
                 shutil.rmtree(self.output_path)
-            shutil.copytree(str(self.template_path), self.output_path)
+            # copy algorithm_templates/<Algo> to the working directory output_path
+            shutil.copytree(os.path.join(str(self.template_path), self.name), self.output_path)
         else:
             self.output_path = str(self.template_path)
         if kwargs.pop("fill_template", True):
@@ -342,10 +344,10 @@ default_algo_zip = (
 
 # default algorithms
 default_algos = {
-    "segresnet2d": dict(_target_="segresnet2d.scripts.algo.Segresnet2dAlgo", template_path="segresnet2d"),
-    "dints": dict(_target_="dints.scripts.algo.DintsAlgo", template_path="dints"),
-    "swinunetr": dict(_target_="swinunetr.scripts.algo.SwinunetrAlgo", template_path="swinunetr"),
-    "segresnet": dict(_target_="segresnet.scripts.algo.SegresnetAlgo", template_path="segresnet"),
+    "segresnet2d": dict(_target_="segresnet2d.scripts.algo.Segresnet2dAlgo"),
+    "dints": dict(_target_="dints.scripts.algo.DintsAlgo"),
+    "swinunetr": dict(_target_="swinunetr.scripts.algo.SwinunetrAlgo"),
+    "segresnet": dict(_target_="segresnet.scripts.algo.SegresnetAlgo"),
 }
 
 
@@ -377,7 +379,7 @@ def _download_algos_url(url: str, at_path: str) -> dict[str, dict[str, str]]:
 
     algos_all = deepcopy(default_algos)
     for name in algos_all:
-        algos_all[name]["template_path"] = os.path.join(at_path, algos_all[name]["template_path"])
+        algos_all[name]["template_path"] = at_path
 
     return algos_all
 
@@ -399,7 +401,7 @@ def _copy_algos_folder(folder, at_path):
     for name in os.listdir(at_path):
         if os.path.exists(os.path.join(folder, name, "scripts", "algo.py")):
             algos_all[name] = dict(
-                _target_=f"{name}.scripts.algo.{name.capitalize()}Algo", template_path=os.path.join(at_path, name)
+                _target_=f"{name}.scripts.algo.{name.capitalize()}Algo", template_path=at_path
             )
             logger.info(f"Copying template: {name} -- {algos_all[name]}")
     if not algos_all:
@@ -463,7 +465,7 @@ class BundleGen(AlgoGen):
         self.algos: Any = []
         if isinstance(algos, dict):
             for algo_name, algo_params in sorted(algos.items()):
-                template_path = os.path.dirname(algo_params.get("template_path", "."))
+                template_path = algo_params.get("template_path", ".")
                 if len(template_path) > 0 and template_path not in sys.path:
                     sys.path.append(template_path)
 
@@ -486,7 +488,7 @@ class BundleGen(AlgoGen):
             raise ValueError("Unexpected error algos is not a dict")
 
         self.data_stats_filename = data_stats_filename
-        self.data_src_cfg_filename = data_src_cfg_name
+        self.data_src_cfg_name = data_src_cfg_name
         self.history: list[dict] = []
 
     def set_data_stats(self, data_stats_filename: str) -> None:
@@ -502,18 +504,18 @@ class BundleGen(AlgoGen):
         """Get the filename of the data stats"""
         return self.data_stats_filename
 
-    def set_data_src(self, data_src_cfg_filename):
+    def set_data_src(self, data_src_cfg_name):
         """
         Set the data source filename
 
         Args:
-            data_src_cfg_filename: filename of data_source file
+            data_src_cfg_name: filename of data_source file
         """
-        self.data_src_cfg_filename = data_src_cfg_filename
+        self.data_src_cfg_name = data_src_cfg_name
 
     def get_data_src(self):
         """Get the data source filename"""
-        return self.data_src_cfg_filename
+        return self.data_src_cfg_name
 
     def get_history(self) -> list:
         """Get the history of the bundleAlgo object with their names/identifiers"""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -51,3 +51,4 @@ git+https://github.com/Project-MONAI/MetricsReloaded@monai-support#egg=MetricsRe
 onnx>=1.13.0
 onnxruntime; python_version <= '3.10'
 typeguard<3  # https://github.com/microsoft/nni/issues/5457
+filelock!=3.12.0  # https://github.com/microsoft/nni/issues/5523

--- a/tests/test_auto3dseg_bundlegen.py
+++ b/tests/test_auto3dseg_bundlegen.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
 import nibabel as nib
 import numpy as np
-import sys
 import torch
 
 from monai.apps.auto3dseg import BundleGen, DataAnalyzer

--- a/tests/test_auto3dseg_bundlegen.py
+++ b/tests/test_auto3dseg_bundlegen.py
@@ -18,6 +18,7 @@ import unittest
 
 import nibabel as nib
 import numpy as np
+import sys
 import torch
 
 from monai.apps.auto3dseg import BundleGen, DataAnalyzer
@@ -126,6 +127,7 @@ class TestBundleGen(unittest.TestCase):
         data_src_cfg = os.path.join(work_dir, "data_src_cfg.yaml")
         ConfigParser.export_config_file(data_src, data_src_cfg)
 
+        sys_path = sys.path.copy()
         with skip_if_downloading_fails():
             bundle_generator = BundleGen(
                 algo_path=work_dir,
@@ -138,6 +140,7 @@ class TestBundleGen(unittest.TestCase):
         history_before = bundle_generator.get_history()
         export_bundle_algo_history(history_before)
 
+        sys.path = sys_path  # prevent the import_bundle_algo_history from using the path "work_dir/algorithm_templates"
         tempfile.TemporaryDirectory()
         work_dir_new = os.path.join(test_path, "workdir_2")
         shutil.move(work_dir, work_dir_new)


### PR DESCRIPTION
Fixes #6502 
Fixes #6501

### Background
- BundleAlgo `template_path` points to `algorithm_templates/<Algo>` <= MONAI 1.1. Recent PR #6436 changed that to `algorithm_templates` and make it easier to instantiate the BundleAlgo from "algorithm_templates" folder when the folders are moved. 
- But `BundleGen` did not update accordingly and still save `algorithm_templates/<Algo>` as the `template_path` , which breaks NNI HPO feature which relies heavily on these paths.

### Description
- Make `template_path` points to `algorithm_templates`
- Avoid using the latest `filelock` (3.12.0) which breaks nni
- Fix comments in https://github.com/Project-MONAI/MONAI/pull/6485#issuecomment-1538994050 in #6485

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
