### PR TITLE
Weights & Biases handler for MonAI

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -184,6 +184,11 @@ Decollate batch
 .. autoclass:: DecollateBatch
     :members:
 
+Weights & Biases handlers
+-------------------------
+.. autoclass:: WandbStatsHandler
+    :members:
+
 MLFlow handler
 --------------
 .. autoclass:: MLFlowHandler

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -254,10 +254,10 @@ Since MONAI v0.2.0, the extras syntax such as `pip install 'monai[nibabel]'` is 
 - The options are
 
 ```
-[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, cucim, openslide, pandas, einops, transformers, mlflow, clearml, matplotlib, tensorboardX, tifffile, imagecodecs, pyyaml, fire, jsonschema, ninja, pynrrd, pydicom, h5py, nni, optuna, onnx, onnxruntime]
+[nibabel, skimage, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, cucim, openslide, pandas, einops, transformers, wandb, mlflow, clearml, matplotlib, tensorboardX, tifffile, imagecodecs, pyyaml, fire, jsonschema, ninja, pynrrd, pydicom, h5py, nni, optuna, onnx, onnxruntime]
 ```
 
 which correspond to `nibabel`, `scikit-image`, `pillow`, `tensorboard`,
-`gdown`, `pytorch-ignite`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas`, `einops`, `transformers`, `mlflow`, `clearml`, `matplotlib`, `tensorboardX`, `tifffile`, `imagecodecs`, `pyyaml`, `fire`, `jsonschema`, `ninja`, `pynrrd`, `pydicom`, `h5py`, `nni`, `optuna`, `onnx`, `onnxruntime`, respectively.
+`gdown`, `pytorch-ignite`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas`, `einops`, `transformers`, `wandb`, `mlflow`, `clearml`, `matplotlib`, `tensorboardX`, `tifffile`, `imagecodecs`, `pyyaml`, `fire`, `jsonschema`, `ninja`, `pynrrd`, `pydicom`, `h5py`, `nni`, `optuna`, `onnx`, `onnxruntime`, respectively.
 
 - `pip install 'monai[all]'` installs all the optional dependencies.

--- a/monai/handlers/__init__.py
+++ b/monai/handlers/__init__.py
@@ -42,3 +42,4 @@ from .surface_distance import SurfaceDistance
 from .tensorboard_handlers import TensorBoardHandler, TensorBoardImageHandler, TensorBoardStatsHandler
 from .utils import from_engine, ignore_data, stopping_fn_from_loss, stopping_fn_from_metric, write_metrics_reports
 from .validation_handler import ValidationHandler
+from .wandb_handlers import WandbStatsHandler

--- a/monai/handlers/__init__.py
+++ b/monai/handlers/__init__.py
@@ -43,3 +43,4 @@ from .tensorboard_handlers import TensorBoardHandler, TensorBoardImageHandler, T
 from .utils import from_engine, ignore_data, stopping_fn_from_loss, stopping_fn_from_metric, write_metrics_reports
 from .validation_handler import ValidationHandler
 from .wandb_handlers import WandbStatsHandler
+7

--- a/monai/handlers/wandb_handlers.py
+++ b/monai/handlers/wandb_handlers.py
@@ -1,0 +1,225 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
+
+import torch
+import wandb
+
+from monai.config import IgniteInfo
+from monai.utils import is_scalar, min_version, optional_import
+
+Events, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Events")
+
+if TYPE_CHECKING:
+    from ignite.engine import Engine
+else:
+    Engine, _ = optional_import(
+        "ignite.engine",
+        IgniteInfo.OPT_IMPORT_VERSION,
+        min_version,
+        "Engine",
+        as_type="decorator",
+    )
+
+DEFAULT_TAG = "Loss"
+
+
+class WandbStatsHandler:
+    """
+    WandbStatsHandler defines a set of Ignite Event-handlers for all the Weights & Biases logging
+    logic. It can be used for any Ignite Engine(trainer, validator and evaluator) and support both
+    epoch level and iteration level. The expected data source is Ignite ``engine.state.output`` and
+    ``engine.state.metrics``.
+
+    Default behaviors:
+        - When EPOCH_COMPLETED, write each dictionary item in
+          ``engine.state.metrics`` to TensorBoard.
+        - When ITERATION_COMPLETED, write each dictionary item in
+          ``self.output_transform(engine.state.output)`` to TensorBoard.
+
+    Usage example:
+    ```python
+    # WandbStatsHandler for logging training metrics and losses at
+    # every iteration to Weights & Biases
+    train_wandb_stats_handler = WandbStatsHandler(output_transform=lambda x: x)
+    train_wandb_stats_handler.attach(trainer)
+
+    # WandbStatsHandler for logging validation metrics and losses at
+    # every iteration to Weights & Biases
+    val_wandb_stats_handler = WandbStatsHandler(
+        output_transform=lambda x: None,
+        global_epoch_transform=lambda x: trainer.state.epoch,
+    )
+    val_wandb_stats_handler.attach(evaluator)
+    ```
+
+    """
+
+    def __init__(
+        self,
+        iteration_log: bool = True,
+        epoch_log: bool = True,
+        epoch_event_writer: Optional[Callable[[Engine, Any], Any]] = None,
+        epoch_interval: int = 1,
+        iteration_event_writer: Optional[Callable[[Engine, Any], Any]] = None,
+        iteration_interval: int = 1,
+        output_transform: Callable = lambda x: x[0],
+        global_epoch_transform: Callable = lambda x: x,
+        state_attributes: Optional[Sequence[str]] = None,
+        tag_name: str = DEFAULT_TAG,
+    ):
+        """
+        Args:
+            iteration_log: Whether to write data to Weights & Biases when iteration completed,
+                default to `True`.
+            epoch_log: Whether to write data to Weights & Biases when epoch completed, default to
+                `True`.
+            epoch_event_writer: Customized callable Weights & Biases writer for epoch level. Must
+                accept parameter "engine" and "summary_writer", use default event writer if None.
+            epoch_interval: The epoch interval at which the epoch_event_writer is called. Defaults
+                to 1.
+            iteration_event_writer: Customized callable Weights & Biases writer for iteration level.
+                Must accept parameter "engine" and "summary_writer", use default event writer if None.
+            iteration_interval: The iteration interval at which the iteration_event_writer is called.
+                Defaults to 1.
+            output_transform: A callable that is used to transform the `ignite.engine.state.output`
+                into a scalar to plot, or a dictionary of `{key: scalar}`. In the latter case, the
+                output string will be formatted as key: value. By default this value plotting happens
+                when every iteration completed. The default behavior is to print loss from output[0] as
+                output is a decollated list and we replicated loss value for every item of the decollated
+                list. `engine.state` and `output_transform` inherit from the
+                ignite concept: https://pytorch.org/ignite/concepts.html#state, explanation and usage
+                example are in the tutorial:
+                https://github.com/Project-MONAI/tutorials/blob/master/modules/batch_output_transform.ipynb.
+            global_epoch_transform: A callable that is used to customize global epoch number. For example,
+                in evaluation, the evaluator engine might want to use trainer engines epoch number when
+                plotting epoch vs metric curves.
+            state_attributes: Expected attributes from `engine.state`, if provided, will extract them when
+                epoch completed.
+            tag_name: When iteration output is a scalar, tag_name is used to plot, defaults to `'Loss'`.
+        """
+        if wandb.run is None:
+            raise wandb.Error("You must call `wandb.init()` before WandbStatsHandler()")
+
+        self.iteration_log = iteration_log
+        self.epoch_log = epoch_log
+        self.epoch_event_writer = epoch_event_writer
+        self.epoch_interval = epoch_interval
+        self.iteration_event_writer = iteration_event_writer
+        self.iteration_interval = iteration_interval
+        self.output_transform = output_transform
+        self.global_epoch_transform = global_epoch_transform
+        self.state_attributes = state_attributes
+        self.tag_name = tag_name
+
+    def attach(self, engine: Engine) -> None:
+        """
+        Register a set of Ignite Event-Handlers to a specified Ignite engine.
+
+        Args:
+            engine: Ignite Engine, it can be a trainer, validator or evaluator.
+        """
+        if self.iteration_log and not engine.has_event_handler(self.iteration_completed, Events.ITERATION_COMPLETED):
+            engine.add_event_handler(
+                Events.ITERATION_COMPLETED(every=self.iteration_interval),
+                self.iteration_completed,
+            )
+        if self.epoch_log and not engine.has_event_handler(self.epoch_completed, Events.EPOCH_COMPLETED):
+            engine.add_event_handler(Events.EPOCH_COMPLETED(every=self.epoch_interval), self.epoch_completed)
+
+    def epoch_completed(self, engine: Engine) -> None:
+        """
+        Handler for train or validation/evaluation epoch completed Event. Write epoch level events
+        to Weights & Biases, default values are from Ignite `engine.state.metrics` dict.
+
+        Args:
+            engine: Ignite Engine, it can be a trainer, validator or evaluator.
+        """
+        if self.epoch_event_writer is not None:
+            self.epoch_event_writer(engine)
+        else:
+            self._default_epoch_writer(engine)
+
+    def iteration_completed(self, engine: Engine) -> None:
+        """
+        Handler for train or validation/evaluation iteration completed Event. Write iteration level
+        events to Weighs & Biases, default values are from Ignite `engine.state.output`.
+
+        Args:
+            engine: Ignite Engine, it can be a trainer, validator or evaluator.
+        """
+        if self.iteration_event_writer is not None:
+            self.iteration_event_writer(engine)
+        else:
+            self._default_iteration_writer(engine)
+
+    def _default_epoch_writer(self, engine: Engine) -> None:
+        """
+        Execute epoch level event write operation. Default to write the values from Ignite
+        ``engine.state.metrics`` dict and write the values of specified attributes of ``engine.state``
+        to [Weights & Biases](https://wandb.ai/site).
+
+        Args:
+            engine: Ignite Engine, it can be a trainer, validator or evaluator.
+        """
+        summary_dict = engine.state.metrics
+
+        for key, value in summary_dict.items():
+            if is_scalar(value):
+                value = value.item() if isinstance(value, torch.Tensor) else value
+                wandb.log({key: value})
+
+        if self.state_attributes is not None:
+            for attr in self.state_attributes:
+                value = getattr(engine.state, attr, None)
+                value = value.item() if isinstance(value, torch.Tensor) else value
+                wandb.log({attr: value})
+
+    def _default_iteration_writer(self, engine: Engine) -> None:
+        """
+        Execute iteration level event write operation based on Ignite ``engine.state.output`` data.
+        Extract the values from ``self.output_transform(engine.state.output)``. Since
+        ``engine.state.output`` is a decollated list and we replicated the loss value for every item
+        of the decollated list, the default behavior is to track the loss from ``output[0]``.
+
+        Args:
+            engine: Ignite Engine, it can be a trainer, validator or evaluator.
+        """
+        loss = self.output_transform(engine.state.output)
+        if loss is None:
+            return  # do nothing if output is empty
+        log_dict = dict()
+        if isinstance(loss, dict):
+            for key, value in loss.items():
+                if not is_scalar(value):
+                    warnings.warn(
+                        "ignoring non-scalar output in WandbStatsHandler,"
+                        " make sure ``output_transform(engine.state.output)`` returns"
+                        " a scalar or dictionary of key and scalar pairs to avoid this warning."
+                        " {}:{}".format(key, type(value))
+                    )
+                    continue  # not plot multi dimensional output
+                log_dict[key] = value.item() if isinstance(value, torch.Tensor) else value
+        elif is_scalar(loss):  # not printing multi dimensional output
+            log_dict[self.tag_name] = loss.item() if isinstance(loss, torch.Tensor) else loss
+        else:
+            warnings.warn(
+                "ignoring non-scalar output in WandbStatsHandler,"
+                " make sure ``output_transform(engine.state.output)`` returns"
+                " a scalar or a dictionary of key and scalar pairs to avoid this warning."
+                " {}".format(type(loss))
+            )
+
+        wandb.log(log_dict)

--- a/monai/handlers/wandb_handlers.py
+++ b/monai/handlers/wandb_handlers.py
@@ -111,7 +111,7 @@ class WandbStatsHandler:
             tag_name: When iteration output is a scalar, tag_name is used to plot, defaults to `'Loss'`.
         """
         if wandb.run is None:
-            raise wandb.Error("You must call `wandb.init()` before WandbStatsHandler()")
+            raise wandb.Error("You must call `wandb.init()` before using `WandbStatsHandler()`")
 
         self.iteration_log = iteration_log
         self.epoch_log = epoch_log

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -52,3 +52,4 @@ onnx>=1.13.0
 onnxruntime; python_version <= '3.10'
 typeguard<3  # https://github.com/microsoft/nni/issues/5457
 filelock!=3.12.0  # https://github.com/microsoft/nni/issues/5523
+wandb>=0.15.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,8 @@ einops =
     einops
 transformers =
     transformers<4.22
+wandb =
+    wandb>=0.15.2
 mlflow =
     mlflow
 matplotlib =

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ all =
     pandas
     einops
     transformers<4.22
+    wandb>=0.15.2
     mlflow>=1.28.0
     clearml>=1.10.0rc0
     matplotlib

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -89,6 +89,7 @@ def run_testsuit():
         "test_handler_mean_iou",
         "test_handler_metrics_saver",
         "test_handler_metrics_saver_dist",
+        "test_handler_wandb_stats",
         "test_handler_mlflow",
         "test_handler_nvtx",
         "test_handler_parameter_scheduler",

--- a/tests/test_handler_wandb_stats.py
+++ b/tests/test_handler_wandb_stats.py
@@ -1,0 +1,54 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import glob
+import os
+import shutil
+import tempfile
+import unittest
+
+from ignite.engine import Engine
+
+from monai.handlers import WandbStatsHandler
+from monai.utils import optional_import
+
+wandb, _ = optional_import("wandb")
+
+
+@unittest.skipUnless(wandb, "Requires wandb installation")
+class TestWandbStatsHandler(unittest.TestCase):
+    def test_metric_tracking(self):
+        tempdir = tempfile.TemporaryDirectory()
+        os.system("wandb offline")
+        os.environ["WANDB_DIR"] = tempdir.name
+
+        wandb.init(dir=tempdir.name)
+
+        # set up engine
+        def _train_func(engine, batch):
+            return [batch + 1.0]
+
+        engine = Engine(_train_func)
+
+        handler = WandbStatsHandler(output_transform=lambda x: x)
+        handler.attach(engine)
+
+        engine.run(range(3), max_epochs=2)
+        handler.close()
+
+        self.assertTrue(os.path.isdir(tempdir.name))
+        self.assertTrue(len(glob.glob(os.path.join(tempdir.name, "*"))) > 0)
+        self.assertTrue(len(glob.glob(os.path.join(tempdir.name, "wandb", "*"))) > 0)
+        self.assertTrue(len(glob.glob(os.path.join(tempdir.name, "wandb", "debug*"))) > 0)
+
+        shutil.rmtree(tempdir.name)


### PR DESCRIPTION
### Features Contributed

- `WandbStatsHandler` defines a set of Ignite Event-handlers for all the Weights & Biases logging logic. It can be used for any Ignite Engine(trainer, validator, and evaluator) and support both epoch level and iteration level. The expected data source is Ignite `engine.state.output` and `engine.state.metrics`. Default behaviors:
  - When `EPOCH_COMPLETED`, write each dictionary item in `engine.state.metrics` to [Weights & Biases](https://wandb.ai/site).
  - When `ITERATION_COMPLETED`, write each dictionary item in `self.output_transform(engine.state.output)` to [Weights & Biases](https://wandb.ai/site).

The following colab notebook and Weights & Biases run demonstrate the usage of these handlers and their results respectively:

[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1jbzl1HlfuLw3lzTWBd2n0m3AKt14eS2-?usp=sharing)
[![](https://raw.githubusercontent.com/wandb/assets/main/wandb-github-badge-28-gray.svg)](https://wandb.ai/geekyrakshit/monai-handlers/runs/lgogrhsm)

Some additional Weights & Biases features:
- When `TensorBoardStatsHandler` and `TensorBoardImageHandler` are used inside a wandb run, Weights & Biases automatically hosts the Tensorboard instance inside the [run](https://wandb.ai/geekyrakshit/monai-integration/runs/bdlb6r13/tensorboard) if during [`wandb.init()`](https://docs.wandb.ai/guides/runs), `sync_tensorboard` is set to `True`.
- When used with `TensorBoardImageHandler`, the images and videos are automatically logged to Weights & Biases media panel if during [`wandb.init()`](https://docs.wandb.ai/guides/runs), `sync_tensorboard` is set to `True`.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
