### PR TITLE
Match type hint with `ResidualUnit` and `Convolution`

### DIFF
--- a/monai/networks/blocks/denseblock.py
+++ b/monai/networks/blocks/denseblock.py
@@ -74,7 +74,7 @@ class ConvDenseBlock(DenseBlock):
         adn_ordering: str = "NDA",
         act: tuple | str | None = Act.PRELU,
         norm: tuple | str | None = Norm.INSTANCE,
-        dropout: int | None = None,
+        dropout: tuple | str | float | None = None,
         bias: bool = True,
     ):
         self.spatial_dims = spatial_dims


### PR DESCRIPTION
### Description

I noticed the type hint for `dropout` in `ConvDenseBlock` did not match the ones further down the file, when `dropout` is passed on to `ResidualUnit` or `Convolution`.
This pull request changes this type hint to match the downstream ones.

I don't think this will cause issues with the unit tests, but they're currently running while I prepare this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
