### PR TITLE
extend SurfaceDiceMetric for 3D images

### DIFF
--- a/monai/metrics/surface_dice.py
+++ b/monai/metrics/surface_dice.py
@@ -34,8 +34,7 @@ class SurfaceDiceMetric(CumulativeIterationMetric):
     """
     Computes the Normalized Surface Distance (NSD) for each batch sample and class of
     predicted segmentations `y_pred` and corresponding reference segmentations `y` according to equation :eq:`nsd`.
-    This implementation supports 2D images. For 3D images, please refer to DeepMind's implementation
-    https://github.com/deepmind/surface-distance.
+    This implementation supports 2D images and 3D images.
 
     The class- and batch sample-wise NSD values can be aggregated with the function `aggregate`.
 
@@ -79,9 +78,9 @@ class SurfaceDiceMetric(CumulativeIterationMetric):
         r"""
         Args:
             y_pred: Predicted segmentation, typically segmentation model output.
-                It must be a one-hot encoded, batch-first tensor [B,C,H,W].
+                It must be a one-hot encoded, batch-first tensor [B,C,H,W] or [B,C,H,W,D].
             y: Reference segmentation.
-                It must be a one-hot encoded, batch-first tensor [B,C,H,W].
+                It must be a one-hot encoded, batch-first tensor [B,C,H,W] or [B,C,H,W,D].
             kwargs: additional parameters, e.g. ``spacing`` should be passed to correctly compute the metric.
                 ``spacing``: spacing of pixel (or voxel). This parameter is relevant only
                 if ``distance_metric`` is set to ``"euclidean"``.
@@ -168,7 +167,7 @@ def compute_surface_dice(
     will be returned for this class. In the case of a class being present in only one of predicted segmentation or
     reference segmentation, the class NSD will be 0.
 
-    This implementation is based on https://arxiv.org/abs/2111.05408 and supports 2D images.
+    This implementation is based on https://arxiv.org/abs/2111.05408 and supports 2D and 3D images.
     Be aware that the computation of boundaries is different from DeepMind's implementation
     https://github.com/deepmind/surface-distance. In this implementation, the length of a segmentation boundary is
     interpreted as the number of its edge pixels. In DeepMind's implementation, the length of a segmentation boundary
@@ -176,9 +175,9 @@ def compute_surface_dice(
 
     Args:
         y_pred: Predicted segmentation, typically segmentation model output.
-            It must be a one-hot encoded, batch-first tensor [B,C,H,W].
+            It must be a one-hot encoded, batch-first tensor [B,C,H,W] or [B,C,H,W,D].
         y: Reference segmentation.
-            It must be a one-hot encoded, batch-first tensor [B,C,H,W].
+            It must be a one-hot encoded, batch-first tensor [B,C,H,W] or [B,C,H,W,D].
         class_thresholds: List of class-specific thresholds.
             The thresholds relate to the acceptable amount of deviation in the segmentation boundary in pixels.
             Each threshold needs to be a finite, non-negative number.
@@ -215,8 +214,8 @@ def compute_surface_dice(
     if not isinstance(y_pred, torch.Tensor) or not isinstance(y, torch.Tensor):
         raise ValueError("y_pred and y must be PyTorch Tensor.")
 
-    if y_pred.ndimension() != 4 or y.ndimension() != 4:
-        raise ValueError("y_pred and y should have four dimensions: [B,C,H,W].")
+    if y_pred.ndimension() not in (4, 5) or y.ndimension() not in (4, 5):
+        raise ValueError("y_pred and y should be one-hot encoded: [B,C,H,W] or [B,C,H,W,D].")
 
     if y_pred.shape != y.shape:
         raise ValueError(


### PR DESCRIPTION
Fixes # .

### Description

This PR extends the `SurfaceDiceMetric` for 3D images. The implementation already uses generic functions to obtain the boundary edges and compute the distance, the extension just 
- removes the assertion that the input is 2D (`[B,C,W,H]`).
- updates the docstrings
- adds a test case in `TestAllSurfaceDiceMetrics.test_tolerance_euclidean_distance_3d`


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
