### PR TITLE
6559 update check properties

### DIFF
--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -379,7 +379,8 @@ class ConfigWorkflow(BundleWorkflow):
         else:
             ref = self.parser.get(ref_id, None)
         if ref is not None and ref != ID_REF_KEY + id:
-            return False
+            if ref[0] != EXPR_KEY:
+                return False
         return True
 
     @staticmethod

--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -380,7 +380,7 @@ class ConfigWorkflow(BundleWorkflow):
             ref = self.parser.get(ref_id, None)
         # for reference IDs that not refer to a property directly but using expressions, skip the check
         if ref is not None and not ref.startswith(EXPR_KEY) and ref != ID_REF_KEY + id:
-                return False
+            return False
         return True
 
     @staticmethod

--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -378,8 +378,8 @@ class ConfigWorkflow(BundleWorkflow):
                         ref = h.get(ref_id, None)
         else:
             ref = self.parser.get(ref_id, None)
-        if ref is not None and ref != ID_REF_KEY + id:
-            if ref[0] != EXPR_KEY:
+        # for reference IDs that not refer to a property directly but using expressions, skip the check
+        if ref is not None and not ref.startswith(EXPR_KEY) and ref != ID_REF_KEY + id:
                 return False
         return True
 

--- a/tests/test_bundle_workflow.py
+++ b/tests/test_bundle_workflow.py
@@ -117,6 +117,12 @@ class TestBundleWorkflow(unittest.TestCase):
         trainer.initialize()
         # test required and optional properties
         self.assertListEqual(trainer.check_properties(), [])
+        # test override optional properties
+        trainer.parser.update(
+            pairs={"validate#evaluator#postprocessing": "$@validate#postprocessing if @val_interval > 0 else None"}
+        )
+        trainer.initialize()
+        self.assertListEqual(trainer.check_properties(), [])
         # test read / write the properties
         dataset = trainer.train_dataset
         self.assertTrue(isinstance(dataset, Dataset))


### PR DESCRIPTION
Fixes #6559 .

### Description

This PR is used to skip optional property checks on expression based content in a bundle config.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
