### PR TITLE
Update docstring for `include_background`

### DIFF
--- a/monai/handlers/confusion_matrix.py
+++ b/monai/handlers/confusion_matrix.py
@@ -35,7 +35,7 @@ class ConfusionMatrix(IgniteMetric):
         """
 
         Args:
-            include_background: whether to skip metric computation on the first channel of
+            include_background: whether to include metric computation on the first channel of
                 the predicted output. Defaults to True.
             metric_name: [``"sensitivity"``, ``"specificity"``, ``"precision"``, ``"negative predictive value"``,
                 ``"miss rate"``, ``"fall out"``, ``"false discovery rate"``, ``"false omission rate"``,

--- a/monai/handlers/metrics_reloaded_handler.py
+++ b/monai/handlers/metrics_reloaded_handler.py
@@ -36,7 +36,7 @@ class MetricsReloadedBinaryHandler(IgniteMetric):
 
         Args:
             metric_name: Name of a binary metric from the MetricsReloaded package.
-            include_background: whether to skip computation on the first channel of
+            include_background: whether to include computation on the first channel of
                 the predicted output. Defaults to ``True``.
             reduction: define mode of reduction to the metrics, will only apply reduction on `not-nan` values,
                 available reduction modes: {``"none"``, ``"mean"``, ``"sum"``, ``"mean_batch"``, ``"sum_batch"``,
@@ -84,7 +84,7 @@ class MetricsReloadedCategoricalHandler(IgniteMetric):
 
         Args:
             metric_name: Name of a categorical metric from the MetricsReloaded package.
-            include_background: whether to skip computation on the first channel of
+            include_background: whether to include computation on the first channel of
                 the predicted output. Defaults to ``True``.
             reduction: define mode of reduction to the metrics, will only apply reduction on `not-nan` values,
                 available reduction modes: {``"none"``, ``"mean"``, ``"sum"``, ``"mean_batch"``, ``"sum_batch"``,

--- a/monai/metrics/confusion_matrix.py
+++ b/monai/metrics/confusion_matrix.py
@@ -37,7 +37,7 @@ class ConfusionMatrixMetric(CumulativeIterationMetric):
     Example of the typical execution steps of this metric class follows :py:class:`monai.metrics.metric.Cumulative`.
 
     Args:
-        include_background: whether to skip metric computation on the first channel of
+        include_background: whether to include metric computation on the first channel of
             the predicted output. Defaults to True.
         metric_name: [``"sensitivity"``, ``"specificity"``, ``"precision"``, ``"negative predictive value"``,
             ``"miss rate"``, ``"fall out"``, ``"false discovery rate"``, ``"false omission rate"``,
@@ -143,7 +143,7 @@ def get_confusion_matrix(y_pred: torch.Tensor, y: torch.Tensor, include_backgrou
             The values should be binarized.
         y: ground truth to compute the metric. It must be one-hot format and first dim is batch.
             The values should be binarized.
-        include_background: whether to skip metric computation on the first channel of
+        include_background: whether to include metric computation on the first channel of
             the predicted output. Defaults to True.
 
     Raises:

--- a/monai/metrics/generalized_dice.py
+++ b/monai/metrics/generalized_dice.py
@@ -113,7 +113,7 @@ def compute_generalized_dice(
             and in the NCHW[D] format, where N is the batch dimension, C is the channel dimension, and the
             remaining are the spatial dimensions.
         y (torch.Tensor): binarized ground-truth. It should be binarized, in one-hot format and have the same shape as `y_pred`.
-        include_background (bool, optional): whether to skip score computation on the first channel of the
+        include_background (bool, optional): whether to include score computation on the first channel of the
             predicted output. Defaults to True.
         weight_type (Union[Weight, str], optional): {``"square"``, ``"simple"``, ``"uniform"``}. Type of function to
             transform ground truth volume into a weight factor. Defaults to ``"square"``.

--- a/monai/metrics/hausdorff_distance.py
+++ b/monai/metrics/hausdorff_distance.py
@@ -154,7 +154,7 @@ def compute_hausdorff_distance(
             should be binarized.
         y: ground truth to compute mean the distance. It must be one-hot format and first dim is batch.
             The values should be binarized.
-        include_background: whether to skip distance computation on the first channel of
+        include_background: whether to include distance computation on the first channel of
             the predicted output. Defaults to ``False``.
         distance_metric: : [``"euclidean"``, ``"chessboard"``, ``"taxicab"``]
             the metric used to compute surface distance. Defaults to ``"euclidean"``.

--- a/monai/metrics/meandice.py
+++ b/monai/metrics/meandice.py
@@ -37,7 +37,7 @@ class DiceMetric(CumulativeIterationMetric):
     Example of the typical execution steps of this metric class follows :py:class:`monai.metrics.metric.Cumulative`.
 
     Args:
-        include_background: whether to skip Dice computation on the first channel of
+        include_background: whether to include Dice computation on the first channel of
             the predicted output. Defaults to ``True``.
         reduction: define mode of reduction to the metrics, will only apply reduction on `not-nan` values,
             available reduction modes: {``"none"``, ``"mean"``, ``"sum"``, ``"mean_batch"``, ``"sum_batch"``,
@@ -128,7 +128,7 @@ def compute_dice(
         y_pred: input data to compute, typical segmentation model output.
             `y_pred` can be single-channel class indices or in the one-hot format.
         y: ground truth to compute mean dice metric. `y` can be single-channel class indices or in the one-hot format.
-        include_background: whether to skip Dice computation on the first channel of
+        include_background: whether to include Dice computation on the first channel of
             the predicted output. Defaults to True.
         ignore_empty: whether to ignore empty ground truth cases during calculation.
             If `True`, NaN value will be set for empty ground truth cases.
@@ -188,7 +188,7 @@ class DiceHelper:
         """
 
         Args:
-            include_background: whether to skip the score on the first channel
+            include_background: whether to include the score on the first channel
                 (default to the value of `sigmoid`, False).
             sigmoid: whether ``y_pred`` are/will be sigmoid activated outputs. If True, thresholding at 0.5
                 will be performed to get the discrete prediction. Defaults to False.

--- a/monai/metrics/meaniou.py
+++ b/monai/metrics/meaniou.py
@@ -35,7 +35,7 @@ class MeanIoU(CumulativeIterationMetric):
     Example of the typical execution steps of this metric class follows :py:class:`monai.metrics.metric.Cumulative`.
 
     Args:
-        include_background: whether to skip IoU computation on the first channel of
+        include_background: whether to include IoU computation on the first channel of
             the predicted output. Defaults to ``True``.
         reduction: define mode of reduction to the metrics, will only apply reduction on `not-nan` values,
             available reduction modes: {``"none"``, ``"mean"``, ``"sum"``, ``"mean_batch"``, ``"sum_batch"``,
@@ -113,7 +113,7 @@ def compute_iou(
             should be binarized.
         y: ground truth to compute mean IoU metric. It must be one-hot format and first dim is batch.
             The values should be binarized.
-        include_background: whether to skip IoU computation on the first channel of
+        include_background: whether to include IoU computation on the first channel of
             the predicted output. Defaults to True.
         ignore_empty: whether to ignore empty ground truth cases during calculation.
             If `True`, NaN value will be set for empty ground truth cases.

--- a/monai/metrics/surface_dice.py
+++ b/monai/metrics/surface_dice.py
@@ -49,7 +49,7 @@ class SurfaceDiceMetric(CumulativeIterationMetric):
         class_thresholds: List of class-specific thresholds.
             The thresholds relate to the acceptable amount of deviation in the segmentation boundary in pixels.
             Each threshold needs to be a finite, non-negative number.
-        include_background: Whether to skip NSD computation on the first channel of the predicted output.
+        include_background: Whether to include NSD computation on the first channel of the predicted output.
             Defaults to ``False``.
         distance_metric: The metric used to compute surface distances.
             One of [``"euclidean"``, ``"chessboard"``, ``"taxicab"``].
@@ -186,7 +186,7 @@ def compute_surface_dice(
         class_thresholds: List of class-specific thresholds.
             The thresholds relate to the acceptable amount of deviation in the segmentation boundary in pixels.
             Each threshold needs to be a finite, non-negative number.
-        include_background: Whether to skip the surface dice computation on the first channel of
+        include_background: Whether to include the surface dice computation on the first channel of
             the predicted output. Defaults to ``False``.
         distance_metric: The metric used to compute surface distances.
             One of [``"euclidean"``, ``"chessboard"``, ``"taxicab"``].

--- a/monai/metrics/surface_distance.py
+++ b/monai/metrics/surface_distance.py
@@ -42,7 +42,7 @@ class SurfaceDistanceMetric(CumulativeIterationMetric):
     Example of the typical execution steps of this metric class follows :py:class:`monai.metrics.metric.Cumulative`.
 
     Args:
-        include_background: whether to skip distance computation on the first channel of
+        include_background: whether to include distance computation on the first channel of
             the predicted output. Defaults to ``False``.
         symmetric: whether to calculate the symmetric average surface distance between
             `seg_pred` and `seg_gt`. Defaults to ``False``.
@@ -148,7 +148,7 @@ def compute_average_surface_distance(
             should be binarized.
         y: ground truth to compute mean the distance. It must be one-hot format and first dim is batch.
             The values should be binarized.
-        include_background: whether to skip distance computation on the first channel of
+        include_background: whether to include distance computation on the first channel of
             the predicted output. Defaults to ``False``.
         symmetric: whether to calculate the symmetric average surface distance between
             `seg_pred` and `seg_gt`. Defaults to ``False``.

--- a/monai/metrics/wrapper.py
+++ b/monai/metrics/wrapper.py
@@ -33,7 +33,7 @@ class MetricsReloadedWrapper(CumulativeIterationMetric):
 
     Args:
         metric_name: Name of a metric from the MetricsReloaded package.
-        include_background: whether to skip computation on the first channel of
+        include_background: whether to include computation on the first channel of
             the predicted output. Defaults to ``True``.
         reduction: define mode of reduction to the metrics, will only apply reduction on `not-nan` values,
             available reduction modes: {``"none"``, ``"mean"``, ``"sum"``, ``"mean_batch"``, ``"sum_batch"``,
@@ -82,7 +82,7 @@ class MetricsReloadedBinary(MetricsReloadedWrapper):
 
     Args:
         metric_name: Name of a binary metric from the MetricsReloaded package.
-        include_background: whether to skip computation on the first channel of
+        include_background: whether to include computation on the first channel of
             the predicted output. Defaults to ``True``.
         reduction: define mode of reduction to the metrics, will only apply reduction on `not-nan` values,
             available reduction modes: {``"none"``, ``"mean"``, ``"sum"``, ``"mean_batch"``, ``"sum_batch"``,
@@ -186,7 +186,7 @@ class MetricsReloadedCategorical(MetricsReloadedWrapper):
 
     Args:
         metric_name: Name of a categorical metric from the MetricsReloaded package.
-        include_background: whether to skip computation on the first channel of
+        include_background: whether to include computation on the first channel of
             the predicted output. Defaults to ``True``.
         reduction: define mode of reduction to the metrics, will only apply reduction on `not-nan` values,
             available reduction modes: {``"none"``, ``"mean"``, ``"sum"``, ``"mean_batch"``, ``"sum_batch"``,


### PR DESCRIPTION
Fixes # .

### Description
Now the docstring for `include_background` is as below, which may cause confusion, just update **skip** to **include**.
> include_background (bool) – whether to skip Dice computation on the first channel of the predicted output. Defaults to True.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
