### PR TITLE
Lazy resampling entry for whats_new_1_2

### DIFF
--- a/docs/source/whatsnew_1_2.md
+++ b/docs/source/whatsnew_1_2.md
@@ -6,6 +6,7 @@
 - MetricsReloaded integration
 - Bundle workflow APIs
 - Modular patch inference
+- Lazy resampling for preprocessing
 
 ## Auto3DSeg enhancements and benchmarks
 Auto3DSeg is an innovative solution for 3D medical image segmentation, leveraging the advancements in MONAI and GPUs for algorithm development and deployment.
@@ -57,3 +58,20 @@ to construct the result image corresponding to the input image. Although dependi
 the exact implementations of a patch inference may vary, the overall process of splitting, running inference, and merging the results remains the same.
 In this release, we have created a modular design for patch inference, which defines the overall process while abstracting away the specific
 behavior of how to split the image into patches, how to pre and post process each patch, and how to merge the output patches.
+
+## Lazy resampling for preprocessing
+Lazy Resampling is a new, experimental feature for preprocessing. It works under
+the hood along with MONAI transforms to concatenate together adjacent spatial and
+cropping transforms. This allows MONAI to reduce the number of resamples
+that your pipeline undergoes. Depending on your preprocessing pipeline, it can potentially:
+
+* reduce processing time
+* reduce processing memory
+* reduce incidental artifacts added by resampling
+* preserve data that would otherwise be cropped and replaced with padding
+
+Lazy Resampling pipelines can use a mixture of MONAI and non-MONAI transforms, so
+should work with almost all existing pipelines simply by setting `lazy=True`
+on MONAI `Compose` instances.  Please see the
+[Lazy Resampling topic](https://docs.monai.io/en/stable/lazy_resampling.html)
+in the documentation for more details.

--- a/docs/source/whatsnew_1_2.md
+++ b/docs/source/whatsnew_1_2.md
@@ -59,11 +59,11 @@ the exact implementations of a patch inference may vary, the overall process of 
 In this release, we have created a modular design for patch inference, which defines the overall process while abstracting away the specific
 behavior of how to split the image into patches, how to pre and post process each patch, and how to merge the output patches.
 
-## Lazy resampling for preprocessing
+## Lazy Resampling for preprocessing
 Lazy Resampling is a new, experimental feature for preprocessing. It works under
-the hood along with MONAI transforms to concatenate together adjacent spatial and
-cropping transforms. This allows MONAI to reduce the number of resamples
-that your pipeline undergoes. Depending on your preprocessing pipeline, it can potentially:
+the hood along with MONAI transforms to combine adjacent spatial and
+cropping transforms into a single operation. This allows MONAI to reduce the number of data resamples
+ a pipeline undergoes. Depending on the preprocessing pipeline, it can potentially:
 
 * reduce processing time
 * reduce processing memory
@@ -72,6 +72,6 @@ that your pipeline undergoes. Depending on your preprocessing pipeline, it can p
 
 Lazy Resampling pipelines can use a mixture of MONAI and non-MONAI transforms, so
 should work with almost all existing pipelines simply by setting `lazy=True`
-on MONAI `Compose` instances.  Please see the
+on MONAI `Compose` instances.  See the
 [Lazy Resampling topic](https://docs.monai.io/en/stable/lazy_resampling.html)
 in the documentation for more details.


### PR DESCRIPTION
Fixes #6580.

### Description

Added Lazy resampling entry to the markdown

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
