### PR TITLE
6602 Update bundle properties

### DIFF
--- a/monai/bundle/properties.py
+++ b/monai/bundle/properties.py
@@ -58,15 +58,16 @@ TrainProperties = {
         BundleProperty.REQUIRED: True,
         BundlePropertyConfig.ID: f"train{ID_SEP_KEY}dataset",
     },
-    "train_dataset_data": {
-        BundleProperty.DESC: "data source for the training dataset.",
-        BundleProperty.REQUIRED: True,
-        BundlePropertyConfig.ID: f"train{ID_SEP_KEY}dataset{ID_SEP_KEY}data",
-    },
     "train_inferer": {
         BundleProperty.DESC: "MONAI Inferer object to execute the model computation in training.",
         BundleProperty.REQUIRED: True,
         BundlePropertyConfig.ID: f"train{ID_SEP_KEY}inferer",
+    },
+    "train_dataset_data": {
+        BundleProperty.DESC: "data source for the training dataset.",
+        BundleProperty.REQUIRED: False,
+        BundlePropertyConfig.ID: f"train{ID_SEP_KEY}dataset{ID_SEP_KEY}data",
+        BundlePropertyConfig.REF_ID: None,  # no reference to this ID
     },
     "train_handlers": {
         BundleProperty.DESC: "event-handlers for the training logic.",
@@ -169,11 +170,6 @@ InferProperties = {
         BundleProperty.REQUIRED: True,
         BundlePropertyConfig.ID: "dataset",
     },
-    "dataset_data": {
-        BundleProperty.DESC: "data source for the inference / evaluation dataset.",
-        BundleProperty.REQUIRED: True,
-        BundlePropertyConfig.ID: f"dataset{ID_SEP_KEY}data",
-    },
     "evaluator": {
         BundleProperty.DESC: "inference / evaluation workflow engine.",
         BundleProperty.REQUIRED: True,
@@ -188,6 +184,12 @@ InferProperties = {
         BundleProperty.DESC: "MONAI Inferer object to execute the model computation in inference.",
         BundleProperty.REQUIRED: True,
         BundlePropertyConfig.ID: "inferer",
+    },
+    "dataset_data": {
+        BundleProperty.DESC: "data source for the inference / evaluation dataset.",
+        BundleProperty.REQUIRED: False,
+        BundlePropertyConfig.ID: f"dataset{ID_SEP_KEY}data",
+        BundlePropertyConfig.REF_ID: None,  # no reference to this ID
     },
     "handlers": {
         BundleProperty.DESC: "event-handlers for the inference / evaluation logic.",

--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -371,6 +371,7 @@ class ConfigWorkflow(BundleWorkflow):
             # no ID of reference config item, skipping check for this optional property
             return True
         # check validation `validator` and `interval` properties as the handler index of ValidationHandler is unknown
+        ref: str | None = None
         if name in ("evaluator", "val_interval"):
             if f"train{ID_SEP_KEY}handlers" in self.parser:
                 for h in self.parser[f"train{ID_SEP_KEY}handlers"]:


### PR DESCRIPTION
Fixes #6602  .

### Description

This PR is used to change the required properties of bundle workflow. It also modifies the `_check_optional_id` function to ensure `ref` is existing.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
