### PR TITLE
6555 fixes integration issues

### DIFF
--- a/tests/test_retinanet.py
+++ b/tests/test_retinanet.py
@@ -183,7 +183,7 @@ class TestRetinaNet(unittest.TestCase):
         data = torch.randn(input_shape)
         backbone = model(**input_param)
         if idx == 0:
-            test_onnx_save(backbone, data, rtol=2e-3)
+            test_onnx_save(backbone, data, rtol=2e-2, atol=1e-5)
             return
         feature_extractor = resnet_fpn_feature_extractor(
             backbone=backbone,
@@ -193,7 +193,7 @@ class TestRetinaNet(unittest.TestCase):
             returned_layers=[1, 2],
         )
         if idx == 1:
-            test_onnx_save(feature_extractor, data, rtol=2e-3)
+            test_onnx_save(feature_extractor, data, rtol=2e-2, atol=1e-5)
             return
         net = RetinaNet(
             spatial_dims=input_param["spatial_dims"],
@@ -203,7 +203,7 @@ class TestRetinaNet(unittest.TestCase):
             size_divisible=32,
         )
         if idx == 2:
-            test_onnx_save(net, data, rtol=2e-3)
+            test_onnx_save(net, data, rtol=2e-2, atol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6555

### Description
Absolute differences such as 4.26173210144043e-06 in `test_onnx_save` looks ok, this increases the tolerances. otherwise we randomly run into integration errors because of the checks.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
