### PR TITLE
Fix md5 hashing with FIPS mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.8
+  python: python3
 
 ci:
   autofix_prs: true

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -1370,7 +1370,11 @@ def json_hashing(item) -> bytes:
 
     """
     # TODO: Find way to hash transforms content as part of the cache
-    cache_key = hashlib.md5(json.dumps(item, sort_keys=True).encode("utf-8"), usedforsecurity=False).hexdigest()
+    cache_key = ""
+    if (sys.version_info.minor < 9):
+        cache_key = hashlib.md5(json.dumps(item, sort_keys=True).encode("utf-8")).hexdigest()
+    else:
+        cache_key = hashlib.md5(json.dumps(item, sort_keys=True).encode("utf-8"), usedforsecurity=False).hexdigest()
     return f"{cache_key}".encode()
 
 
@@ -1385,7 +1389,11 @@ def pickle_hashing(item, protocol=pickle.HIGHEST_PROTOCOL) -> bytes:
     Returns: the corresponding hash key
 
     """
-    cache_key = hashlib.md5(pickle.dumps(sorted_dict(item), protocol=protocol), usedforsecurity=False).hexdigest()
+    cache_key = ""
+    if (sys.version_info.minor < 9):
+        cache_key = hashlib.md5(pickle.dumps(sorted_dict(item), protocol=protocol)).hexdigest()
+    else:
+        cache_key = hashlib.md5(pickle.dumps(sorted_dict(item), protocol=protocol), usedforsecurity=False).hexdigest()
     return f"{cache_key}".encode()
 
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -16,6 +16,7 @@ import json
 import logging
 import math
 import os
+import sys
 import pickle
 from collections import abc, defaultdict
 from collections.abc import Generator, Iterable, Mapping, Sequence, Sized

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -16,8 +16,8 @@ import json
 import logging
 import math
 import os
-import sys
 import pickle
+import sys
 from collections import abc, defaultdict
 from collections.abc import Generator, Iterable, Mapping, Sequence, Sized
 from copy import deepcopy
@@ -1372,10 +1372,12 @@ def json_hashing(item) -> bytes:
     """
     # TODO: Find way to hash transforms content as part of the cache
     cache_key = ""
-    if (sys.version_info.minor < 9):
+    if sys.version_info.minor < 9:
         cache_key = hashlib.md5(json.dumps(item, sort_keys=True).encode("utf-8")).hexdigest()
     else:
-        cache_key = hashlib.md5(json.dumps(item, sort_keys=True).encode("utf-8"), usedforsecurity=False).hexdigest()
+        cache_key = hashlib.md5(
+            json.dumps(item, sort_keys=True).encode("utf-8"), usedforsecurity=False  # type: ignore
+        ).hexdigest()
     return f"{cache_key}".encode()
 
 
@@ -1391,10 +1393,12 @@ def pickle_hashing(item, protocol=pickle.HIGHEST_PROTOCOL) -> bytes:
 
     """
     cache_key = ""
-    if (sys.version_info.minor < 9):
+    if sys.version_info.minor < 9:
         cache_key = hashlib.md5(pickle.dumps(sorted_dict(item), protocol=protocol)).hexdigest()
     else:
-        cache_key = hashlib.md5(pickle.dumps(sorted_dict(item), protocol=protocol), usedforsecurity=False).hexdigest()
+        cache_key = hashlib.md5(
+            pickle.dumps(sorted_dict(item), protocol=protocol), usedforsecurity=False  # type: ignore
+        ).hexdigest()
     return f"{cache_key}".encode()
 
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -1370,7 +1370,7 @@ def json_hashing(item) -> bytes:
 
     """
     # TODO: Find way to hash transforms content as part of the cache
-    cache_key = hashlib.md5(json.dumps(item, sort_keys=True).encode("utf-8")).hexdigest()
+    cache_key = hashlib.md5(json.dumps(item, sort_keys=True).encode("utf-8"), usedforsecurity=False).hexdigest()
     return f"{cache_key}".encode()
 
 
@@ -1385,7 +1385,7 @@ def pickle_hashing(item, protocol=pickle.HIGHEST_PROTOCOL) -> bytes:
     Returns: the corresponding hash key
 
     """
-    cache_key = hashlib.md5(pickle.dumps(sorted_dict(item), protocol=protocol)).hexdigest()
+    cache_key = hashlib.md5(pickle.dumps(sorted_dict(item), protocol=protocol), usedforsecurity=False).hexdigest()
     return f"{cache_key}".encode()
 
 


### PR DESCRIPTION
### Description
MD5 hashing is not allowed in FIPS enabled machines for security. A simple fix is to use the `usedforsecurity=False` flag in the `md5()` calls.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
