### PR TITLE
Workflow profiler changes

### DIFF
--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -226,8 +226,6 @@ class WorkflowProfiler:
                     break
 
                 self.add_result(result)
-
-                self.add_result(result)
             except Empty:
                 pass
 

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -222,6 +222,7 @@ class WorkflowProfiler:
                 result = self.queue.get()
                 if result is None:
                     break
+                
                 self.add_result(result)
 
             sleep(self.queue_timeout)

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -21,7 +21,6 @@ from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from functools import wraps
 from inspect import getframeinfo, stack
-from queue import Empty
 from time import perf_counter, perf_counter_ns, sleep
 from typing import TYPE_CHECKING, Any, cast
 
@@ -224,7 +223,7 @@ class WorkflowProfiler:
                 if result is None:
                     break
                 self.add_result(result)
-            
+
             sleep(self.queue_timeout)
 
         if not (not self._is_parent() or self.queue.empty()):

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -222,7 +222,7 @@ class WorkflowProfiler:
                 result = self.queue.get()
                 if result is None:
                     break
-                
+
                 self.add_result(result)
 
             sleep(self.queue_timeout)

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 from functools import wraps
 from inspect import getframeinfo, stack
 from queue import Empty
-from time import perf_counter, perf_counter_ns
+from time import perf_counter, perf_counter_ns, sleep
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -219,15 +219,13 @@ class WorkflowProfiler:
     def _read_thread_func(self):
         """Read results from the queue and add to self.results in a thread stared by `__enter__`."""
         while self._is_parent() and self._is_thread_active():
-            try:
+            while not self.queue.empty():
                 result = self.queue.get()
-
                 if result is None:
                     break
-
                 self.add_result(result)
-            except Empty:
-                pass
+            
+            sleep(self.queue_timeout)
 
         if not (not self._is_parent() or self.queue.empty()):
             raise AssertionError


### PR DESCRIPTION
Fixes # .

### Description

When debugging issues with the WorkflowProfiler I saw that it creates 100% CPU usage on one core since it loops relentlessy. This commit fixes that by querying only every 0.1 seconds using ` self.queue_timeout` which I guess was inteded for that because it is unused so far in the code. If it is used in a parent class or has a different function an other variable should be added for this behaviour.

I tried to run the tests, however I ran into the error I just opened a report for: https://github.com/Project-MONAI/MONAI/issues/6655


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
