### PR TITLE
Add CallableEventWithFilter support to GarbageCollector

### DIFF
--- a/monai/handlers/garbage_collector.py
+++ b/monai/handlers/garbage_collector.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import gc
 from typing import TYPE_CHECKING
+from ignite.engine.events import CallableEventWithFilter
 
 from monai.config import IgniteInfo
 from monai.utils import min_version, optional_import
@@ -45,7 +46,7 @@ class GarbageCollector:
 
     def __init__(self, trigger_event: str = "epoch", log_level: int = 10):
         self.trigger_event: Events
-        if isinstance(trigger_event, Events):
+        if isinstance(trigger_event, Events) or isinstance(trigger_events, CallableEventWithFilter):
             self.trigger_event = trigger_event
         elif trigger_event.lower() == "epoch":
             self.trigger_event = Events.EPOCH_COMPLETED

--- a/monai/handlers/garbage_collector.py
+++ b/monai/handlers/garbage_collector.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 import gc
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from monai.config import IgniteInfo
 from monai.utils import min_version, optional_import
@@ -47,8 +47,8 @@ class GarbageCollector:
             - 0 (NOTSET)
     """
 
-    def __init__(self, trigger_event: Union[str, Events, CallableEventWithFilter] = "epoch", log_level: int = 10):
-        self.trigger_event: Union[Events, CallableEventWithFilter]
+    def __init__(self, trigger_event: str | Events | CallableEventWithFilter = "epoch", log_level: int = 10):
+        self.trigger_event: Events | CallableEventWithFilter
         if isinstance(trigger_event, Events) or isinstance(trigger_event, CallableEventWithFilter):
             self.trigger_event = trigger_event
         elif trigger_event.lower() == "epoch":

--- a/monai/handlers/garbage_collector.py
+++ b/monai/handlers/garbage_collector.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
     from ignite.engine import Engine, Events
     from ignite.engine.events import CallableEventWithFilter
 else:
+    CallableEventWithFilter, _ = optional_import("ignite.engine.events", IgniteInfo.OPT_IMPORT_VERSION, min_version, "CallableEventWithFilter")
     Engine, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Engine")
     Events, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Events")
-    Events, _ = optional_import("ignite.engine.events", IgniteInfo.OPT_IMPORT_VERSION, min_version, "CallableEventWithFilter")
 
 
 class GarbageCollector:
@@ -48,7 +48,7 @@ class GarbageCollector:
 
     def __init__(self, trigger_event: str = "epoch", log_level: int = 10):
         self.trigger_event: Events
-        if isinstance(trigger_event, Events) or isinstance(trigger_events, CallableEventWithFilter):
+        if isinstance(trigger_event, Events) or isinstance(trigger_event, CallableEventWithFilter):
             self.trigger_event = trigger_event
         elif trigger_event.lower() == "epoch":
             self.trigger_event = Events.EPOCH_COMPLETED

--- a/monai/handlers/garbage_collector.py
+++ b/monai/handlers/garbage_collector.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import gc
 from typing import TYPE_CHECKING
 
-
 from monai.config import IgniteInfo
 from monai.utils import min_version, optional_import
 
@@ -22,7 +21,9 @@ if TYPE_CHECKING:
     from ignite.engine import Engine, Events
     from ignite.engine.events import CallableEventWithFilter
 else:
-    CallableEventWithFilter, _ = optional_import("ignite.engine.events", IgniteInfo.OPT_IMPORT_VERSION, min_version, "CallableEventWithFilter")
+    CallableEventWithFilter, _ = optional_import(
+        "ignite.engine.events", IgniteInfo.OPT_IMPORT_VERSION, min_version, "CallableEventWithFilter"
+    )
     Engine, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Engine")
     Events, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Events")
 

--- a/monai/handlers/garbage_collector.py
+++ b/monai/handlers/garbage_collector.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 import gc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from monai.config import IgniteInfo
 from monai.utils import min_version, optional_import
@@ -47,8 +47,8 @@ class GarbageCollector:
             - 0 (NOTSET)
     """
 
-    def __init__(self, trigger_event: str = "epoch", log_level: int = 10):
-        self.trigger_event: Events
+    def __init__(self, trigger_event: Union[str, Events, CallableEventWithFilter] = "epoch", log_level: int = 10):
+        self.trigger_event: Union[Events, CallableEventWithFilter]
         if isinstance(trigger_event, Events) or isinstance(trigger_event, CallableEventWithFilter):
             self.trigger_event = trigger_event
         elif trigger_event.lower() == "epoch":

--- a/monai/handlers/garbage_collector.py
+++ b/monai/handlers/garbage_collector.py
@@ -13,16 +13,18 @@ from __future__ import annotations
 
 import gc
 from typing import TYPE_CHECKING
-from ignite.engine.events import CallableEventWithFilter
+
 
 from monai.config import IgniteInfo
 from monai.utils import min_version, optional_import
 
 if TYPE_CHECKING:
     from ignite.engine import Engine, Events
+    from ignite.engine.events import CallableEventWithFilter
 else:
     Engine, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Engine")
     Events, _ = optional_import("ignite.engine", IgniteInfo.OPT_IMPORT_VERSION, min_version, "Events")
+    Events, _ = optional_import("ignite.engine.events", IgniteInfo.OPT_IMPORT_VERSION, min_version, "CallableEventWithFilter")
 
 
 class GarbageCollector:


### PR DESCRIPTION
Fixes # .

### Description

Adds support for CallableEventWithFilter which is useful for not calling the GarbageCollector every iteration but e.g. every 10 iterations.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
