### PR TITLE
added yandex.disk support and test file

### DIFF
--- a/tests/test_download_url_yandex.py
+++ b/tests/test_download_url_yandex.py
@@ -18,8 +18,14 @@ from urllib.error import HTTPError
 
 from monai.apps.utils import download_url
 
-YANDEX_MODEL_URL = "https://cloud-api.yandex.net/v1/disk/public/resources/download?public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2FJL_UJBWVYkexyg"  # noqa: B950
-YANDEX_MODEL_FLAWED_URL = "https://cloud-api.yandex.net/v1/disk/public/resources/download?public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2FJL_UJBWVYkexyg-url-with-error"  # noqa: B950
+YANDEX_MODEL_URL = (
+    "https://cloud-api.yandex.net/v1/disk/public/resources/download?"
+    "public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2FJL_UJBWVYkexyg"
+)
+YANDEX_MODEL_FLAWED_URL = (
+    "https://cloud-api.yandex.net/v1/disk/public/resources/download?"
+    "public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2FJL_UJBWVYkexyg-url-with-error"
+)
 
 
 class TestDownloadUrlYandex(unittest.TestCase):

--- a/tests/test_download_url_yandex.py
+++ b/tests/test_download_url_yandex.py
@@ -20,11 +20,11 @@ from monai.apps.utils import download_url
 
 YANDEX_MODEL_URL = (
     "https://cloud-api.yandex.net/v1/disk/public/resources/download?"
-    "public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2FJL_UJBWVYkexyg"
+    "public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2Fxs0gzlj2_irgWA"
 )
 YANDEX_MODEL_FLAWED_URL = (
     "https://cloud-api.yandex.net/v1/disk/public/resources/download?"
-    "public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2FJL_UJBWVYkexyg-url-with-error"
+    "public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2Fxs0gzlj2_irgWA-url-with-error"
 )
 
 

--- a/tests/test_download_url_yandex.py
+++ b/tests/test_download_url_yandex.py
@@ -1,0 +1,37 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from urllib.error import HTTPError
+
+from monai.apps.utils import download_url
+
+YANDEX_MODEL_URL = "https://cloud-api.yandex.net/v1/disk/public/resources/download?public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2FJL_UJBWVYkexyg"  # noqa: B950
+YANDEX_MODEL_FLAWED_URL = "https://cloud-api.yandex.net/v1/disk/public/resources/download?public_key=https%3A%2F%2Fdisk.yandex.ru%2Fd%2FJL_UJBWVYkexyg-url-with-error"  # noqa: B950
+
+
+class TestDownloadUrlYandex(unittest.TestCase):
+    def test_verify(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            download_url(url=YANDEX_MODEL_URL, filepath=os.path.join(tempdir, "model.pt"))
+
+    def test_verify_error(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            with self.assertRaises(HTTPError):
+                download_url(url=YANDEX_MODEL_FLAWED_URL, filepath=os.path.join(tempdir, "model.pt"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #6666 
/black

### Description
Updated download_url to support internally yandex.disk hosting

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
