### PR TITLE
5574 Fix `MBConvBlock` issue in 3d

### DIFF
--- a/monai/networks/nets/efficientnet.py
+++ b/monai/networks/nets/efficientnet.py
@@ -163,9 +163,9 @@ class MBConvBlock(nn.Module):
             self._se_adaptpool = adaptivepool_type(1)
             num_squeezed_channels = max(1, int(in_channels * self.se_ratio))
             self._se_reduce = conv_type(in_channels=oup, out_channels=num_squeezed_channels, kernel_size=1)
-            self._se_reduce_padding = _make_same_padder(self._se_reduce, [1, 1])
+            self._se_reduce_padding = _make_same_padder(self._se_reduce, [1] * spatial_dims)
             self._se_expand = conv_type(in_channels=num_squeezed_channels, out_channels=oup, kernel_size=1)
-            self._se_expand_padding = _make_same_padder(self._se_expand, [1, 1])
+            self._se_expand_padding = _make_same_padder(self._se_expand, [1] * spatial_dims)
 
         # Pointwise convolution phase
         final_oup = out_channels

--- a/tests/test_vitautoenc.py
+++ b/tests/test_vitautoenc.py
@@ -65,6 +65,13 @@ TEST_CASE_Vitautoenc.append(
 
 
 class TestPatchEmbeddingBlock(unittest.TestCase):
+    def setUp(self):
+        self.threads = torch.get_num_threads()
+        torch.set_num_threads(4)
+
+    def tearDown(self):
+        torch.set_num_threads(self.threads)
+
     @parameterized.expand(TEST_CASE_Vitautoenc)
     @skip_if_windows
     def test_shape(self, input_param, input_shape, expected_shape):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -153,6 +153,7 @@ def skip_if_downloading_fails():
                 "md5 check",
                 "limit",  # HTTP Error 503: Egress is over the account limit
                 "authenticate",
+                "timed out",  # urlopen error [Errno 110] Connection timed out
             )
         ):
             raise unittest.SkipTest(f"error while downloading: {rt_e}") from rt_e  # incomplete download


### PR DESCRIPTION
Fixes #5574
Closes #5695 

### Description

This PR is used to fix the `MBConvBlock` issue when `spatial_dims` is not 2.
The PR follows the work in:
https://github.com/Project-MONAI/MONAI/pull/5695
As it was not updated after review.
Thanks @swilson314 for posting the issue!

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
