### PR TITLE
6717 fixes `current_mode` check in `convert_applied_interp_mode`

### DIFF
--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1398,10 +1398,10 @@ def convert_applied_interp_mode(trans_info, mode: str = "nearest", align_corners
     trans_info = dict(trans_info)
     if "mode" in trans_info:
         current_mode = trans_info["mode"]
-        if current_mode[0] in _interp_modes:
-            trans_info["mode"] = [mode for _ in range(len(mode))]
-        elif current_mode in _interp_modes:
+        if isinstance(current_mode, int) or current_mode in _interp_modes:
             trans_info["mode"] = mode
+        elif isinstance(current_mode[0], int) or current_mode[0] in _interp_modes:
+            trans_info["mode"] = [mode for _ in range(len(mode))]
     if "align_corners" in trans_info:
         _align_corners = TraceKeys.NONE if align_corners is None else align_corners
         current_value = trans_info["align_corners"]

--- a/tests/test_invert.py
+++ b/tests/test_invert.py
@@ -50,7 +50,7 @@ class TestInvert(unittest.TestCase):
                 LoadImage(image_only=True),
                 EnsureChannelFirst(),
                 Orientation("RPS"),
-                Spacing(pixdim=(1.2, 1.01, 0.9), mode="bilinear", dtype=np.float32),
+                Spacing(pixdim=(1.2, 1.01, 0.9), mode=1, dtype=np.float32),
                 RandFlip(prob=0.5, spatial_axis=[1, 2]),
                 RandAxisFlip(prob=0.5),
                 RandRotate90(prob=0, spatial_axes=(1, 2)),

--- a/tests/test_invertd.py
+++ b/tests/test_invertd.py
@@ -58,7 +58,7 @@ class TestInvertd(unittest.TestCase):
                 RandRotate90d(KEYS, prob=0, spatial_axes=(1, 2)),
                 RandZoomd(KEYS, prob=0.5, min_zoom=0.5, max_zoom=1.1, keep_size=True),
                 RandRotated(KEYS, prob=0.5, range_x=np.pi, mode="bilinear", align_corners=True, dtype=np.float64),
-                RandAffined(KEYS, prob=0.5, rotate_range=np.pi, mode="nearest"),
+                RandAffined(KEYS, prob=0.5, rotate_range=np.pi, mode=["nearest", 0]),
                 ResizeWithPadOrCropd(KEYS, 100),
                 CastToTyped(KEYS, dtype=[torch.uint8, np.uint8]),
                 CopyItemsd("label", times=2, names=["label_inverted", "label_inverted1"]),


### PR DESCRIPTION
Fixes #6717.

Add int check for  `current_mode` in `convert_applied_interp_mode`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
