### PR TITLE
6668 fix hard-coded `up_kernel_size` in `ViTAutoEnc`

### DIFF
--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -94,6 +94,7 @@ from .misc import (
     str2list,
     to_tuple_of_dictionaries,
     zip_with,
+    is_sqrt,
 )
 from .module import (
     InvalidPyTorchVersionError,

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -80,6 +80,7 @@ from .misc import (
     is_module_ver_at_least,
     is_scalar,
     is_scalar_tensor,
+    is_sqrt,
     issequenceiterable,
     list_to_dict,
     path_to_uri,
@@ -94,7 +95,6 @@ from .misc import (
     str2list,
     to_tuple_of_dictionaries,
     zip_with,
-    is_sqrt,
 )
 from .module import (
     InvalidPyTorchVersionError,

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import inspect
 import itertools
 import os
+import math
 import pprint
 import random
 import shutil
@@ -853,3 +854,10 @@ def run_cmd(cmd_list: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
         output = str(e.stdout.decode(errors="replace"))
         errors = str(e.stderr.decode(errors="replace"))
         raise RuntimeError(f"subprocess call error {e.returncode}: {errors}, {output}.") from e
+
+
+def is_sqrt(size):
+    size = ensure_tuple(size)
+    sqrt_size = [int(math.sqrt(_size)) for _size in size]
+    ret = [_i * _j for _i, _j in zip(sqrt_size, sqrt_size)]
+    return ensure_tuple(ret) == size

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -856,8 +856,11 @@ def run_cmd(cmd_list: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
         raise RuntimeError(f"subprocess call error {e.returncode}: {errors}, {output}.") from e
 
 
-def is_sqrt(size):
-    size = ensure_tuple(size)
-    sqrt_size = [int(math.sqrt(_size)) for _size in size]
-    ret = [_i * _j for _i, _j in zip(sqrt_size, sqrt_size)]
-    return ensure_tuple(ret) == size
+def is_sqrt(num: Sequence[int] | int) -> bool:
+    """
+    Determine if the input is a square number or a squence of square numbers.
+    """
+    num = ensure_tuple(num)
+    sqrt_num = [int(math.sqrt(_num)) for _num in num]
+    ret = [_i * _j for _i, _j in zip(sqrt_num, sqrt_num)]
+    return ensure_tuple(ret) == num

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 import inspect
 import itertools
-import os
 import math
+import os
 import pprint
 import random
 import shutil

--- a/tests/test_vitautoenc.py
+++ b/tests/test_vitautoenc.py
@@ -49,7 +49,7 @@ TEST_CASE_Vitautoenc.append(
         {
             "in_channels": 1,
             "img_size": (512, 512, 32),
-            "patch_size": (16, 16, 16),
+            "patch_size": (64, 64, 16),
             "hidden_size": 768,
             "mlp_dim": 3072,
             "num_layers": 4,
@@ -139,6 +139,19 @@ class TestVitAutoenc(unittest.TestCase):
                 in_channels=4,
                 img_size=(96, 96, 96),
                 patch_size=(16, 16, 16),
+                hidden_size=768,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=12,
+                pos_embed="perc",
+                dropout_rate=0.3,
+            )
+
+        with self.assertRaises(ValueError):
+            ViTAutoEnc(
+                in_channels=4,
+                img_size=(96, 96, 96),
+                patch_size=(9, 9, 9),
                 hidden_size=768,
                 mlp_dim=3072,
                 num_layers=12,


### PR DESCRIPTION
Fixes #6668 .

Fix hard-coded `up_kernel_size` in `ViTAutoEnc` without changing the network architecture.
### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
