### PR TITLE
Revert #6686

### DIFF
--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -176,7 +176,7 @@ def get_mask_edges(
         else:  # pytorch subvoxel, maybe on gpu, but croppad boolean values on GPU is not supported
             seg_pred, seg_gt, or_vol = convert_to_tensor(channel_first, dtype=torch.float16)
         cropper = CropForegroundD(
-            ["pred", "gt"], source_key="src", margin=1, allow_smaller=True, start_coord_key=None, end_coord_key=None
+            ["pred", "gt"], source_key="src", margin=1, allow_smaller=False, start_coord_key=None, end_coord_key=None
         )
         cropped = cropper({"pred": seg_pred, "gt": seg_gt, "src": or_vol})  # type: ignore
         seg_pred, seg_gt = cropped["pred"][0], cropped["gt"][0]

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -839,7 +839,7 @@ class CropForeground(Crop):
                 of image. if None, select foreground on the whole image.
             margin: add margin value to spatial dims of the bounding box, if only 1 value provided, use it for all dims.
             allow_smaller: when computing box size with `margin`, whether to allow the image edges to be smaller than the
-                final box edges.If `False`, part of a padded output box might be outside of the original image, if `True`,
+                final box edges. If `False`, part of a padded output box might be outside of the original image, if `True`,
                 the image edges will be used as the box edges. Default to `True`.
             return_coords: whether return the coordinates of spatial bounding box for foreground.
             k_divisible: make each spatial dimension to be divisible by k, default to 1.

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -819,12 +819,13 @@ class CropForeground(Crop):
 
     """
 
+    @deprecated_arg_default("allow_smaller", old_default=True, new_default=False, since="1.2", replaced="1.3")
     def __init__(
         self,
         select_fn: Callable = is_positive,
         channel_indices: IndexSelection | None = None,
         margin: Sequence[int] | int = 0,
-        allow_smaller: bool = False,
+        allow_smaller: bool = True,
         return_coords: bool = False,
         k_divisible: Sequence[int] | int = 1,
         mode: str = PytorchPadMode.CONSTANT,
@@ -837,9 +838,9 @@ class CropForeground(Crop):
             channel_indices: if defined, select foreground only on the specified channels
                 of image. if None, select foreground on the whole image.
             margin: add margin value to spatial dims of the bounding box, if only 1 value provided, use it for all dims.
-            allow_smaller: when computing box size with `margin`, whether to allow the final box edges to be outside of
-                the image edges (the image is smaller than the box). If `True`, part of a padded output box might be outside
-                of the original image, if `False`, the image edges will be used as the box edges.
+            allow_smaller: when computing box size with `margin`, whether to allow the image edges to be smaller than the
+                final box edges.If `False`, part of a padded output box might be outside of the original image, if `True`,
+                the image edges will be used as the box edges. Default to `True`.
             return_coords: whether return the coordinates of spatial bounding box for foreground.
             k_divisible: make each spatial dimension to be divisible by k, default to 1.
                 if `k_divisible` is an int, the same `k` be applied to all the input spatial dimensions.

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -749,7 +749,7 @@ class CropForegroundd(Cropd):
                 of image. if None, select foreground on the whole image.
             margin: add margin value to spatial dims of the bounding box, if only 1 value provided, use it for all dims.
             allow_smaller: when computing box size with `margin`, whether to allow the image edges to be smaller than the
-                final box edges.If `False`, part of a padded output box might be outside of the original image, if `True`,
+                final box edges. If `False`, part of a padded output box might be outside of the original image, if `True`,
                 the image edges will be used as the box edges. Default to `True`.
             k_divisible: make each spatial dimension to be divisible by k, default to 1.
                 if `k_divisible` is an int, the same `k` be applied to all the input spatial dimensions.

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -722,6 +722,7 @@ class CropForegroundd(Cropd):
     for more information.
     """
 
+    @deprecated_arg_default("allow_smaller", old_default=True, new_default=False, since="1.2", replaced="1.3")
     def __init__(
         self,
         keys: KeysCollection,
@@ -729,7 +730,7 @@ class CropForegroundd(Cropd):
         select_fn: Callable = is_positive,
         channel_indices: IndexSelection | None = None,
         margin: Sequence[int] | int = 0,
-        allow_smaller: bool = False,
+        allow_smaller: bool = True,
         k_divisible: Sequence[int] | int = 1,
         mode: SequenceStr = PytorchPadMode.CONSTANT,
         start_coord_key: str | None = "foreground_start_coord",
@@ -747,9 +748,9 @@ class CropForegroundd(Cropd):
             channel_indices: if defined, select foreground only on the specified channels
                 of image. if None, select foreground on the whole image.
             margin: add margin value to spatial dims of the bounding box, if only 1 value provided, use it for all dims.
-            allow_smaller: when computing box size with `margin`, whether to allow the final box edges to be outside of
-                the image edges (the image is smaller than the box). If `True`, part of a padded output box might be outside
-                of the original image, if `False`, the image edges will be used as the box edges.
+            allow_smaller: when computing box size with `margin`, whether to allow the image edges to be smaller than the
+                final box edges.If `False`, part of a padded output box might be outside of the original image, if `True`,
+                the image edges will be used as the box edges. Default to `True`.
             k_divisible: make each spatial dimension to be divisible by k, default to 1.
                 if `k_divisible` is an int, the same `k` be applied to all the input spatial dimensions.
             mode: available modes for numpy array:{``"constant"``, ``"edge"``, ``"linear_ramp"``, ``"maximum"``,

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -53,6 +53,7 @@ from monai.utils import (
     SplineMode,
     TraceKeys,
     TraceStatusKeys,
+    deprecated_arg_default,
     ensure_tuple,
     ensure_tuple_rep,
     ensure_tuple_size,
@@ -63,7 +64,6 @@ from monai.utils import (
     min_version,
     optional_import,
     pytorch_after,
-    deprecated_arg_default,
 )
 from monai.utils.enums import TransformBackends
 from monai.utils.type_conversion import convert_data_type, convert_to_cupy, convert_to_dst_type, convert_to_tensor

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -972,7 +972,8 @@ def generate_spatial_bounding_box(
             of image. if None, select foreground on the whole image.
         margin: add margin value to spatial dims of the bounding box, if only 1 value provided, use it for all dims.
         allow_smaller: when computing box size with `margin`, whether to allow the image edges to be smaller than the
-                final box edges. If `True`, the bounding boxes edges are aligned with the input image edges, default to `True`.
+                final box edges. If `True`, the bounding boxes edges are aligned with the input image edges, if `False`,
+                the bounding boxes edges are aligned with the final box edges. Default to `True`.
 
     """
     check_non_lazy_pending_ops(img, name="generate_spatial_bounding_box")

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -63,6 +63,7 @@ from monai.utils import (
     min_version,
     optional_import,
     pytorch_after,
+    deprecated_arg_default,
 )
 from monai.utils.enums import TransformBackends
 from monai.utils.type_conversion import convert_data_type, convert_to_cupy, convert_to_dst_type, convert_to_tensor
@@ -945,12 +946,13 @@ def _create_translate(
     return array_func(affine)  # type: ignore
 
 
+@deprecated_arg_default("allow_smaller", old_default=True, new_default=False, since="1.2", replaced="1.3")
 def generate_spatial_bounding_box(
     img: NdarrayOrTensor,
     select_fn: Callable = is_positive,
     channel_indices: IndexSelection | None = None,
     margin: Sequence[int] | int = 0,
-    allow_smaller: bool = False,
+    allow_smaller: bool = True,
 ) -> tuple[list[int], list[int]]:
     """
     Generate the spatial bounding box of foreground in the image with start-end positions (inclusive).
@@ -969,9 +971,8 @@ def generate_spatial_bounding_box(
         channel_indices: if defined, select foreground only on the specified channels
             of image. if None, select foreground on the whole image.
         margin: add margin value to spatial dims of the bounding box, if only 1 value provided, use it for all dims.
-        allow_smaller: when computing box size with `margin`, whether to allow the final box edges to be outside of
-                the image edges (the image is smaller than the box). If `False`, the bounding boxes edges are aligned
-                with the input image edges, default to `False`.
+        allow_smaller: when computing box size with `margin`, whether to allow the image edges to be smaller than the
+                final box edges. If `True`, the bounding boxes edges are aligned with the input image edges, default to `True`.
 
     """
     check_non_lazy_pending_ops(img, name="generate_spatial_bounding_box")
@@ -999,7 +1000,7 @@ def generate_spatial_bounding_box(
         arg_max = where(dt == dt.max())[0]
         min_d = arg_max[0] - margin[di]
         max_d = arg_max[-1] + margin[di] + 1
-        if not allow_smaller:
+        if allow_smaller:
             min_d = max(min_d, 0)
             max_d = min(max_d, spatial_size[di])
 

--- a/tests/test_crop_foreground.py
+++ b/tests/test_crop_foreground.py
@@ -63,7 +63,7 @@ for p in TEST_NDARRAYS_ALL:
 
     TESTS.append(
         [
-            {"select_fn": lambda x: x > 0, "channel_indices": None, "margin": [2, 1], "allow_smaller": False},
+            {"select_fn": lambda x: x > 0, "channel_indices": None, "margin": [2, 1], "allow_smaller": True},
             p([[[0, 0, 0, 0, 0], [0, 1, 2, 1, 0], [0, 2, 3, 2, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]]),
             p([[[0, 0, 0, 0, 0], [0, 1, 2, 1, 0], [0, 2, 3, 2, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]]),
             True,
@@ -72,7 +72,7 @@ for p in TEST_NDARRAYS_ALL:
 
     TESTS.append(
         [
-            {"select_fn": lambda x: x > 0, "channel_indices": None, "margin": [2, 1], "allow_smaller": True},
+            {"select_fn": lambda x: x > 0, "channel_indices": None, "margin": [2, 1], "allow_smaller": False},
             p([[[0, 0, 0, 0, 0], [0, 1, 2, 1, 0], [0, 2, 3, 2, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]]),
             p([[[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 1, 2, 1, 0], [0, 2, 3, 2, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]]),
             True,

--- a/tests/test_crop_foregroundd.py
+++ b/tests/test_crop_foregroundd.py
@@ -88,7 +88,7 @@ for p in TEST_NDARRAYS_ALL:
                 "select_fn": lambda x: x > 0,
                 "channel_indices": None,
                 "margin": [2, 1],
-                "allow_smaller": False,
+                "allow_smaller": True,
             },
             {
                 "img": p(
@@ -107,7 +107,7 @@ for p in TEST_NDARRAYS_ALL:
                 "select_fn": lambda x: x > 0,
                 "channel_indices": None,
                 "margin": [2, 1],
-                "allow_smaller": True,
+                "allow_smaller": False,
             },
             {
                 "img": p(

--- a/tests/test_generate_spatial_bounding_box.py
+++ b/tests/test_generate_spatial_bounding_box.py
@@ -82,7 +82,7 @@ for p in TEST_NDARRAYS:
                 "select_fn": lambda x: x > 0,
                 "channel_indices": None,
                 "margin": [2, 1],
-                "allow_smaller": True,
+                "allow_smaller": False,
             },
             ([-1, 0], [6, 5]),
         ]
@@ -96,7 +96,7 @@ for p in TEST_NDARRAYS:
                 "select_fn": lambda x: x > 0,
                 "channel_indices": None,
                 "margin": [2, 1],
-                "allow_smaller": False,
+                "allow_smaller": True,
             },
             ([0, 0], [5, 5]),
         ]


### PR DESCRIPTION
Fixes #6685.

- Revert #6686 without changing the meaning of `allow_smaller` in `generate_spatial_bounding_box`.
- Update the docstring of the `allow_smaller` to make it more clear.
- Add `deprecated_arg_default`, then after 1.3, `CropForeground` with pad by default even if the image edges are smaller than the final box edges.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
