### PR TITLE
Add str type annotation to device parameter in ToTensorD

### DIFF
--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -514,7 +514,7 @@ class ToTensord(MapTransform, InvertibleTransform):
         self,
         keys: KeysCollection,
         dtype: torch.dtype | None = None,
-        device: torch.device | None = None,
+        device: torch.device | str | None = None,
         wrap_sequence: bool = True,
         track_meta: bool | None = None,
         allow_missing_keys: bool = False,


### PR DESCRIPTION
### Description

A simple fix adding `str` type annotation to the `device` parameter in `ToTensorD`, making it consistent with `ToTensor`. As this fix is very simple, I hope it's okay I don't create an issue in advance.
