### PR TITLE
Cannot import name 'CuImage' from 'cucim'

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ mypy>=0.790
 ninja
 torchvision
 psutil
-cucim==22.8.1; platform_system == "Linux"
+cucim>=23.2.0; platform_system == "Linux"
 openslide-python==1.1.2
 imagecodecs; platform_system == "Linux" or platform_system == "Darwin"
 tifffile; platform_system == "Linux" or platform_system == "Darwin"

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ all =
     tqdm>=4.47.0
     lmdb
     psutil
-    cucim>=22.8.1
+    cucim>=23.2.0
     openslide-python==1.1.2
     tifffile
     imagecodecs
@@ -105,7 +105,7 @@ lmdb =
 psutil =
     psutil
 cucim =
-    cucim>=22.8.1
+    cucim>=23.2.0
 openslide =
     openslide-python==1.1.2
 tifffile =


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/tutorials/issues/1464.

### Description
Seems a known issue in Cucim, https://github.com/rapidsai/cucim/issues/518.
Can be fixed when cucim >= 23.2.0.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
