### PR TITLE
enhances auto3dseg data analyzer info

### DIFF
--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -438,12 +438,12 @@ class ConfigParser:
 
         """
         _filepath: str = str(Path(filepath))
-        writer = look_up_option(fmt.lower(), {"json", "yaml"})
+        writer = look_up_option(fmt.lower(), {"json", "yaml", "yml"})
         with open(_filepath, "w") as f:
             if writer == "json":
                 json.dump(config, f, **kwargs)
                 return
-            if writer == "yaml":
+            if writer == "yaml" or writer == "yml":
                 return yaml.safe_dump(config, f, **kwargs)
             raise ValueError(f"only support JSON or YAML config file so far, got {writer}.")
 

--- a/tests/test_auto3dseg.py
+++ b/tests/test_auto3dseg.py
@@ -170,7 +170,7 @@ class TestDataAnalyzer(unittest.TestCase):
         work_dir = self.test_dir.name
         self.dataroot_dir = os.path.join(work_dir, "sim_dataroot")
         self.datalist_file = os.path.join(work_dir, "sim_datalist.json")
-        self.datastat_file = os.path.join(work_dir, "datastats.yaml")
+        self.datastat_file = os.path.join(work_dir, "datastats.yml")
         ConfigParser.export_config_file(sim_datalist, self.datalist_file)
 
     @parameterized.expand(SIM_CPU_TEST_CASES)


### PR DESCRIPTION


### Description
- output file name extension to be consistent with `self.fmt`
- improve logging messages when writing files
- export file format may be spelt as 'yml' instead of 'yaml'

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
