### PR TITLE
feat: set `data_range` as a property

### DIFF
--- a/monai/losses/ssim_loss.py
+++ b/monai/losses/ssim_loss.py
@@ -61,7 +61,7 @@ class SSIMLoss(_Loss):
         """
         super().__init__(reduction=LossReduction(reduction).value)
         self.spatial_dims = spatial_dims
-        self.data_range = data_range
+        self._data_range = data_range
         self.kernel_type = kernel_type
 
         if not isinstance(win_size, Sequence):
@@ -77,13 +77,22 @@ class SSIMLoss(_Loss):
 
         self.ssim_metric = SSIMMetric(
             spatial_dims=self.spatial_dims,
-            data_range=self.data_range,
+            data_range=self._data_range,
             kernel_type=self.kernel_type,
             win_size=self.kernel_size,
             kernel_sigma=self.kernel_sigma,
             k1=self.k1,
             k2=self.k2,
         )
+
+    @property
+    def data_range(self) -> float:
+        return self._data_range
+
+    @data_range.setter
+    def data_range(self, value: float) -> None:
+        self._data_range = value
+        self.ssim_metric.data_range = value
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """


### PR DESCRIPTION
Fixes #6441 

### Description

Creates a setter method for `data_range` by setting it as a property using the **`@property`** decorator.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
