### PR TITLE
6799 do not compare types

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,6 +64,9 @@ jobs:
 
     - name: Build
       run: |
+        rm -rf /opt/hostedtoolcache/{node,go,Ruby,Java*}
+        ls -al /opt/hostedtoolcache
+        rm -rf /usr/share/dotnet/
         python -m pip install -U pip wheel
         python -m pip install -r requirements-dev.txt
         BUILD_MONAI=1 ./runtests.sh --build

--- a/tests/test_selfattention.py
+++ b/tests/test_selfattention.py
@@ -62,7 +62,7 @@ class TestResBlock(unittest.TestCase):
         # be  not able to access the matrix
         no_matrix_acess_blk = SABlock(hidden_size=hidden_size, num_heads=num_heads, dropout_rate=dropout_rate)
         no_matrix_acess_blk(torch.randn(input_shape))
-        assert type(no_matrix_acess_blk.att_mat) == torch.Tensor
+        assert isinstance(no_matrix_acess_blk.att_mat, torch.Tensor)
         # no of elements is zero
         assert no_matrix_acess_blk.att_mat.nelement() == 0
 

--- a/tests/test_transformerblock.py
+++ b/tests/test_transformerblock.py
@@ -66,7 +66,7 @@ class TestTransformerBlock(unittest.TestCase):
             hidden_size=hidden_size, mlp_dim=mlp_dim, num_heads=num_heads, dropout_rate=dropout_rate
         )
         no_matrix_acess_blk(torch.randn(input_shape))
-        assert type(no_matrix_acess_blk.attn.att_mat) == torch.Tensor
+        assert isinstance(no_matrix_acess_blk.attn.att_mat, torch.Tensor)
         # no of elements is zero
         assert no_matrix_acess_blk.attn.att_mat.nelement() == 0
 

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -160,7 +160,7 @@ class TestViT(unittest.TestCase):
         # no data in the matrix
         no_matrix_acess_blk = ViT(in_channels=in_channels, img_size=img_size, patch_size=patch_size)
         no_matrix_acess_blk(torch.randn(in_shape))
-        assert type(no_matrix_acess_blk.blocks[0].attn.att_mat) == torch.Tensor
+        assert isinstance(no_matrix_acess_blk.blocks[0].attn.att_mat, torch.Tensor)
         # no of elements is zero
         assert no_matrix_acess_blk.blocks[0].attn.att_mat.nelement() == 0
 


### PR DESCRIPTION
Fixes #6799.

Do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
