### PR TITLE
add ruff in `runtests.sh`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ We encourage you to create pull requests early. It helps us track the contributi
 Please note that, as per PyTorch, MONAI uses American English spelling. This means classes and variables should be: normali**z**e, visuali**z**e, colo~~u~~r, etc.
 
 ### Preparing pull requests
-To ensure the code quality, MONAI relies on several linting tools ([flake8 and its plugins](https://gitlab.com/pycqa/flake8), [black](https://github.com/psf/black), [isort](https://github.com/timothycrosley/isort)),
+To ensure the code quality, MONAI relies on several linting tools ([flake8 and its plugins](https://gitlab.com/pycqa/flake8), [black](https://github.com/psf/black), [isort](https://github.com/timothycrosley/isort), [ruff](https://github.com/astral-sh/ruff)),
 static type analysis tools ([mypy](https://github.com/python/mypy), [pytype](https://github.com/google/pytype)), as well as a set of unit/integration tests.
 
 This section highlights all the necessary preparation steps required before sending a pull request.
@@ -50,7 +50,7 @@ To collaborate efficiently, please read through this section and follow them.
 * [Signing your work](#signing-your-work)
 
 #### Checking the coding style
-Coding style is checked and enforced by flake8, black, and isort, using [a flake8 configuration](./setup.cfg) similar to [PyTorch's](https://github.com/pytorch/pytorch/blob/master/.flake8).
+Coding style is checked and enforced by flake8, black, isort, and ruff, using [a flake8 configuration](./setup.cfg) similar to [PyTorch's](https://github.com/pytorch/pytorch/blob/master/.flake8).
 Before submitting a pull request, we recommend that all linting should pass, by running the following command locally:
 
 ```bash
@@ -63,6 +63,12 @@ python -m pip install -U -r requirements-dev.txt
 
 # try to fix the coding style errors automatically
 ./runtests.sh --autofix
+```
+
+Full linting and type checking may take some time. If you need a quick check, run
+```bash
+# run ruff only
+./runtests.sh --ruff
 ```
 
 #### Licensing information

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ pycodestyle
 pyflakes
 black>=22.12
 isort>=5.1
+ruff
 pytype>=2020.6.1; platform_system != "Windows"
 types-pkg_resources
 mypy>=0.790

--- a/runtests.sh
+++ b/runtests.sh
@@ -45,6 +45,8 @@ doIsortFormat=false
 doIsortFix=false
 doFlake8Format=false
 doPylintFormat=false
+doRuffFormat=false
+doRuffFix=false
 doClangFormat=false
 doCopyRight=false
 doPytypeFormat=false
@@ -58,9 +60,10 @@ NUM_PARALLEL=1
 PY_EXE=${MONAI_PY_EXE:-$(which python)}
 
 function print_usage {
-    echo "runtests.sh [--codeformat] [--autofix] [--black] [--isort] [--flake8] [--pylint] [--clangformat] [--pytype] [--mypy]"
-    echo "            [--unittests] [--disttests] [--coverage] [--quick] [--min] [--net] [--dryrun] [-j number] [--list_tests]"
-    echo "            [--copyright] [--build] [--clean] [--precommit] [--help] [--version]"
+    echo "runtests.sh [--codeformat] [--autofix] [--black] [--isort] [--flake8] [--pylint] [--ruff]"
+    echo "            [--clangformat] [--precommit] [--pytype] [-j number] [--mypy]"
+    echo "            [--unittests] [--disttests] [--coverage] [--quick] [--min] [--net] [--build] [--list_tests]"
+    echo "            [--dryrun] [--copyright] [--clean] [--help] [--version]"
     echo ""
     echo "MONAI unit testing utilities."
     echo ""
@@ -73,18 +76,19 @@ function print_usage {
     echo "./runtests.sh --clean                 # clean up temporary files and run \"${PY_EXE} setup.py develop --uninstall\"."
     echo ""
     echo "Code style check options:"
-    echo "    --black           : perform \"black\" code format checks"
     echo "    --autofix         : format code using \"isort\" and \"black\""
+    echo "    --black           : perform \"black\" code format checks"
     echo "    --isort           : perform \"isort\" import sort checks"
     echo "    --flake8          : perform \"flake8\" code format checks"
     echo "    --pylint          : perform \"pylint\" code format checks"
+    echo "    --ruff            : perform \"ruff\" code format checks"
     echo "    --clangformat     : format csrc code using \"clang-format\""
     echo "    --precommit       : perform source code format check and fix using \"pre-commit\""
     echo ""
     echo "Python type check options:"
     echo "    --pytype          : perform \"pytype\" static type checks"
-    echo "    --mypy            : perform \"mypy\" static type checks"
     echo "    -j, --jobs        : number of parallel jobs to run \"pytype\" (default $NUM_PARALLEL)"
+    echo "    --mypy            : perform \"mypy\" static type checks"
     echo ""
     echo "MONAI unit testing options:"
     echo "    -u, --unittests   : perform unit testing"
@@ -258,6 +262,7 @@ do
             doIsortFormat=true
             doFlake8Format=true
             doPylintFormat=true
+            doRuffFormat=true
             doCopyRight=true
         ;;
         --disttests)
@@ -269,8 +274,10 @@ do
         --autofix)
             doIsortFix=true
             doBlackFix=true
+            doRuffFix=true
             doIsortFormat=true
             doBlackFormat=true
+            doRuffFormat=true
             doCopyRight=true
         ;;
         --clangformat)
@@ -284,6 +291,9 @@ do
         ;;
         --pylint)
             doPylintFormat=true
+        ;;
+        --ruff)
+            doRuffFormat=true
         ;;
         --precommit)
             doPrecommit=true
@@ -546,6 +556,42 @@ then
     then
         print_style_fail_msg
         exit ${pylint_status}
+    else
+        echo "${green}passed!${noColor}"
+    fi
+    set -e # enable exit on failure
+fi
+
+
+if [ $doRuffFormat = true ]
+then
+    set +e  # disable exit on failure so that diagnostics can be given on failure
+    if [ $doRuffFix = true ]
+    then
+        echo "${separator}${blue}ruff-fix${noColor}"
+    else
+        echo "${separator}${blue}ruff${noColor}"
+    fi
+
+    # ensure that the necessary packages for code format testing are installed
+    if ! is_pip_installed ruff
+    then
+        install_deps
+    fi
+    ${cmdPrefix}${PY_EXE} -m ruff --version
+
+    if [ $doRuffFix = true ]
+    then
+        ${cmdPrefix}${PY_EXE} -m ruff check --fix "$(pwd)"
+    else
+        ${cmdPrefix}${PY_EXE} -m ruff check "$(pwd)"
+    fi
+
+    ruff_status=$?
+    if [ ${ruff_status} -ne 0 ]
+    then
+        print_style_fail_msg
+        exit ${ruff_status}
     else
         echo "${green}passed!${noColor}"
     fi

--- a/runtests.sh
+++ b/runtests.sh
@@ -578,13 +578,13 @@ then
     then
         install_deps
     fi
-    ${cmdPrefix}${PY_EXE} -m ruff --version
+    ruff --version
 
     if [ $doRuffFix = true ]
     then
-        ${cmdPrefix}${PY_EXE} -m ruff check --fix "$(pwd)"
+        ruff check --fix "$(pwd)"
     else
-        ${cmdPrefix}${PY_EXE} -m ruff check "$(pwd)"
+        ruff check "$(pwd)"
     fi
 
     ruff_status=$?


### PR DESCRIPTION
### Description

Improve local development experience, ruff is very fast for local checking.
Ruff's auto-fix might have very small potential conflicts with other linters.
Since Ruff has already been used in pre-commit of CI, there should be no breaking changes.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
