### PR TITLE
Add ClearML as optional dependency

### DIFF
--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -84,6 +84,7 @@ def get_optional_config_values():
     output["transformers"] = get_package_version("transformers")
     output["mlflow"] = get_package_version("mlflow")
     output["pynrrd"] = get_package_version("nrrd")
+    output["clearml"] = get_package_version("clearml")
 
     return output
 

--- a/monai/handlers/clearml_handlers.py
+++ b/monai/handlers/clearml_handlers.py
@@ -45,7 +45,7 @@ class ClearMLHandler:
             project_name: ClearML project name, default to 'MONAI'.
             task_name: ClearML task name, default to 'monai_experiment'.
             output_uri: The default location for output models and other artifacts, default to 'True'.
-            tags: A list of tags (str) to the created Task, default to 'None'.
+            tags: Add a list of tags (str) to the created Task, default to 'None'.
             reuse_last_task_id: Force a new Task (experiment) with a previously used Task ID, default to 'True'.
             continue_last_task: Continue the execution of a previously executed Task (experiment), default to 'False'.
             auto_connect_frameworks: Automatically connect frameworks, default to 'True'.
@@ -104,7 +104,7 @@ class ClearMLStatsHandler(ClearMLHandler, TensorBoardStatsHandler):
             project_name: ClearML project name, default to 'MONAI'.
             task_name: ClearML task name, default to 'monai_experiment'.
             output_uri: The default location for output models and other artifacts, default to 'True'.
-            tags: A list of tags (str) to the created Task, default to 'None'.
+            tags: Add a list of tags (str) to the created Task, default to 'None'.
             reuse_last_task_id: Force a new Task (experiment) with a previously used Task ID, default to 'True'.
             continue_last_task: Continue the execution of a previously executed Task (experiment), default to 'False'.
             auto_connect_frameworks: Automatically connect frameworks, default to 'True'.
@@ -155,7 +155,7 @@ class ClearMLImageHandler(ClearMLHandler, TensorBoardImageHandler):
             project_name: ClearML project name, default to 'MONAI'.
             task_name: ClearML task name, default to 'monai_experiment'.
             output_uri: The default location for output models and other artifacts, default to 'True'.
-            tags: A list of tags (str) to the created Task, default to 'None'.
+            tags: Add a list of tags (str) to the created Task, default to 'None'.
             reuse_last_task_id: Force a new Task (experiment) with a previously used Task ID, default to 'True'.
             continue_last_task: Continue the execution of a previously executed Task (experiment), default to 'False'.
             auto_connect_frameworks: Automatically connect frameworks, default to 'True'.

--- a/setup.cfg
+++ b/setup.cfg
@@ -126,6 +126,8 @@ mlflow =
     mlflow
 matplotlib =
     matplotlib
+clearml =
+    clearml
 tensorboardX =
     tensorboardX
 pyyaml =

--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.losses import PerceptualLoss
 from monai.utils import optional_import
-from tests.utils import SkipIfBeforePyTorchVersion
+from tests.utils import SkipIfBeforePyTorchVersion, skip_if_downloading_fails
 
 _, has_torchvision = optional_import("torchvision")
 TEST_CASES = [
@@ -59,13 +59,15 @@ class TestPerceptualLoss(unittest.TestCase):
 
     @parameterized.expand(TEST_CASES)
     def test_identical_input(self, input_param, input_shape, target_shape):
-        loss = PerceptualLoss(**input_param)
+        with skip_if_downloading_fails():
+            loss = PerceptualLoss(**input_param)
         tensor = torch.randn(input_shape)
         result = loss(tensor, tensor)
         self.assertEqual(result, torch.Tensor([0.0]))
 
     def test_different_shape(self):
-        loss = PerceptualLoss(spatial_dims=2, network_type="squeeze")
+        with skip_if_downloading_fails():
+            loss = PerceptualLoss(spatial_dims=2, network_type="squeeze")
         tensor = torch.randn(2, 1, 64, 64)
         target = torch.randn(2, 1, 32, 32)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
### Description

Add option to install `clearml` as optional dependency with `pip install monai[clearml]`. All of the docstrings were updated and unit tests added in [PR #6013](https://github.com/Project-MONAI/MONAI/pull/6013).   

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
