### PR TITLE
Fix docs code for ScaleIntensityRangePercentiles

### DIFF
--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1132,7 +1132,7 @@ class ScaleIntensityRangePercentiles(Transform):
     .. code-block:: python
         :emphasize-lines: 11, 22
 
-        image = np.array(
+        image = torch.Tensor(
             [[[1, 2, 3, 4, 5],
               [1, 2, 3, 4, 5],
               [1, 2, 3, 4, 5],
@@ -1144,23 +1144,24 @@ class ScaleIntensityRangePercentiles(Transform):
         # to output range [b_min, b_max]
         scaler = ScaleIntensityRangePercentiles(10, 90, 0, 200, False, False)
         print(scaler(image))
-        [[[0., 50., 100., 150., 200.],
-          [0., 50., 100., 150., 200.],
-          [0., 50., 100., 150., 200.],
-          [0., 50., 100., 150., 200.],
-          [0., 50., 100., 150., 200.],
-          [0., 50., 100., 150., 200.]]]
+        metatensor([[[  0.,  50., 100., 150., 200.],
+             [  0.,  50., 100., 150., 200.],
+             [  0.,  50., 100., 150., 200.],
+             [  0.,  50., 100., 150., 200.],
+             [  0.,  50., 100., 150., 200.],
+             [  0.,  50., 100., 150., 200.]]])
+
 
         # Scale from lower and upper image intensity percentiles
         # to lower and upper percentiles of the output range [b_min, b_max]
         rel_scaler = ScaleIntensityRangePercentiles(10, 90, 0, 200, False, True)
         print(rel_scaler(image))
-        [[[20., 60., 100., 140., 180.],
-          [20., 60., 100., 140., 180.],
-          [20., 60., 100., 140., 180.],
-          [20., 60., 100., 140., 180.],
-          [20., 60., 100., 140., 180.],
-          [20., 60., 100., 140., 180.]]]
+        metatensor([[[ 20.,  60., 100., 140., 180.],
+             [ 20.,  60., 100., 140., 180.],
+             [ 20.,  60., 100., 140., 180.],
+             [ 20.,  60., 100., 140., 180.],
+             [ 20.,  60., 100., 140., 180.],
+             [ 20.,  60., 100., 140., 180.]]])
 
     See Also:
 


### PR DESCRIPTION
When running the docs code for `ScaleIntensityRangePercentiles`, it failed with the error (MONAI 1.2.dev2316):
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mhadlich/anaconda3/envs/monai/lib/python3.8/site-packages/monai/transforms/intensity/array.py", line 998, in __call__
    img_t = self._normalize(img=img_t)
  File "/home/mhadlich/anaconda3/envs/monai/lib/python3.8/site-packages/monai/transforms/intensity/array.py", line 971, in _normalize
    a_min: float = percentile(img, self.lower)  # type: ignore
  File "/home/mhadlich/anaconda3/envs/monai/lib/python3.8/site-packages/monai/transforms/utils_pytorch_numpy_unification.py", line 121, in percentile
    result = torch.quantile(x, q, dim=dim, keepdim=keepdim)
RuntimeError: quantile() input tensor must be either float or double dtype
```

This commit updates the docs for the function to use `torch.Tensor` instead.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
