### PR TITLE
make `is_tf32_env()` safer

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -180,7 +180,7 @@ def is_tf32_env():
     global _tf32_enabled
     if _tf32_enabled is None:
         _tf32_enabled = False
-        if detect_default_tf32() or torch.backends.cuda.matmul.allow_tf32:
+        if torch.cuda.is_available() and (detect_default_tf32() or torch.backends.cuda.matmul.allow_tf32):
             try:
                 # with TF32 enabled, the speed is ~8x faster, but the precision has ~2 digits less in the result
                 g_gpu = torch.Generator(device="cuda")


### PR DESCRIPTION
Following #6816 
### Description

make `is_tf32_env()` safer.
check `cuda`  to prevent fallthrough case when `pynvml` is not found

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
