### PR TITLE
fixing lazy argument at Compose.__call__

### DIFF
--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -318,7 +318,7 @@ class Compose(Randomizable, InvertibleTransform):
         """Return number of transformations."""
         return len(self.flatten().transforms)
 
-    def __call__(self, input_, start=0, end=None, threading=False, lazy: bool | None = None):
+    def __call__(self, input_, start=0, end=None, threading=False, lazy: bool | None = False):
         result = execute_compose(
             input_,
             transforms=self.transforms,
@@ -326,7 +326,7 @@ class Compose(Randomizable, InvertibleTransform):
             end=end,
             map_items=self.map_items,
             unpack_items=self.unpack_items,
-            lazy=self.lazy,
+            lazy=lazy,
             overrides=self.overrides,
             threading=threading,
             log_stats=self.log_stats,
@@ -447,7 +447,7 @@ class OneOf(Compose):
                 weights.append(w)
         return OneOf(transforms, weights, self.map_items, self.unpack_items)
 
-    def __call__(self, data, start=0, end=None, threading=False, lazy: str | bool | None = None):
+    def __call__(self, data, start=0, end=None, threading=False, lazy: bool | None = None):
         if start != 0:
             raise ValueError(f"OneOf requires 'start' parameter to be 0 (start set to {start})")
         if end is not None:
@@ -466,7 +466,7 @@ class OneOf(Compose):
             end=end,
             map_items=self.map_items,
             unpack_items=self.unpack_items,
-            lazy=self.lazy,
+            lazy=lazy,
             overrides=self.overrides,
             threading=threading,
             log_stats=self.log_stats,

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -447,7 +447,7 @@ class OneOf(Compose):
                 weights.append(w)
         return OneOf(transforms, weights, self.map_items, self.unpack_items)
 
-    def __call__(self, data, start=0, end=None, threading=False, lazy: bool | None = None):
+    def __call__(self, data, start=0, end=None, threading=False, lazy: bool | None = False):
         if start != 0:
             raise ValueError(f"OneOf requires 'start' parameter to be 0 (start set to {start})")
         if end is not None:
@@ -542,7 +542,7 @@ class RandomOrder(Compose):
         super().__init__(transforms, map_items, unpack_items, log_stats, lazy, overrides)
         self.log_stats = log_stats
 
-    def __call__(self, input_, start=0, end=None, threading=False, lazy: bool | None = None):
+    def __call__(self, input_, start=0, end=None, threading=False, lazy: bool | None = False):
         if start != 0:
             raise ValueError(f"RandomOrder requires 'start' parameter to be 0 (start set to {start})")
         if end is not None:
@@ -561,7 +561,7 @@ class RandomOrder(Compose):
             end=end,
             map_items=self.map_items,
             unpack_items=self.unpack_items,
-            lazy=self.lazy,
+            lazy=lazy,
             threading=threading,
             log_stats=self.log_stats,
         )


### PR DESCRIPTION
[Description]
fixing argument at line 321 to 335 and 450 to 473

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
