### PR TITLE
[WIP]6838 support generative and hovernet with TensorRT

### DIFF
--- a/monai/networks/nets/hovernet.py
+++ b/monai/networks/nets/hovernet.py
@@ -604,10 +604,7 @@ class HoVerNet(nn.Module):
             if self.type_prediction is not None:
                 output[HoVerNetBranch.NC.value] = self.type_prediction(x, short_cuts)
         else:
-            output = [
-                self.nucleus_prediction(x, short_cuts),
-                self.horizontal_vertical(x, short_cuts),
-            ]
+            output = [self.nucleus_prediction(x, short_cuts), self.horizontal_vertical(x, short_cuts)]
             if self.type_prediction is not None:
                 output.append(self.type_prediction(x, short_cuts))
 

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -915,7 +915,7 @@ def convert_to_trt(
     if not dynamic_batchsize:
         warnings.warn(f"There is no dynamic batch range. The converted model only takes {input_shape} shape input.")
 
-    #if (dynamic_batchsize is not None) and (len(dynamic_batchsize) != 3):
+    # if (dynamic_batchsize is not None) and (len(dynamic_batchsize) != 3):
     #    warnings.warn(f"The dynamic batch range sequence should have 3 elements, but got {dynamic_batchsize} elements.")
 
     device = device if device else 0
@@ -930,17 +930,23 @@ def convert_to_trt(
     min_input_shape = []
     opt_input_shape = []
     max_input_shape = []
-    if isinstance(input_shape[0], list): 
+    if isinstance(input_shape[0], list):
         inputs = [torch.rand(ensure_tuple(shape)).to(target_device) for shape in input_shape]
         # Use the dynamic batchsize range to generate the min, opt and max model input shape
         if dynamic_batchsize:
-            min_input_shape.extend([scale_batch_size(input_shape[i], dynamic_batchsize[i][0]) for i in range(len(input_shape))])
-            opt_input_shape.extend([scale_batch_size(input_shape[i], dynamic_batchsize[i][1]) for i in range(len(input_shape))])
-            max_input_shape.append([scale_batch_size(input_shape[i], dynamic_batchsize[i][2]) for i in range(len(input_shape))])
+            min_input_shape.extend(
+                [scale_batch_size(input_shape[i], dynamic_batchsize[i][0]) for i in range(len(input_shape))]
+            )
+            opt_input_shape.extend(
+                [scale_batch_size(input_shape[i], dynamic_batchsize[i][1]) for i in range(len(input_shape))]
+            )
+            max_input_shape.append(
+                [scale_batch_size(input_shape[i], dynamic_batchsize[i][2]) for i in range(len(input_shape))]
+            )
         else:
             max_input_shape.extend(input_shape)
             min_input_shape = opt_input_shape = max_input_shape
- 
+
     else:
         inputs = [torch.rand(ensure_tuple(input_shape)).to(target_device)]
         # Use the dynamic batchsize range to generate the min, opt and max model input shape
@@ -984,7 +990,8 @@ def convert_to_trt(
                 input_placeholder = [
                     torch_tensorrt.Input(
                         min_shape=min_input_shape[i], opt_shape=opt_input_shape[i], max_shape=max_input_shape[i]
-                    ) for i in range(len(min_input_shape))
+                    )
+                    for i in range(len(min_input_shape))
                 ]
                 trt_model = torch_tensorrt.compile(
                     ir_model,


### PR DESCRIPTION
Fixes #6838 .

### Description
Add TensorRT support for generative unet and hovernet.
1) For generative unet, the block is that the trt_export API only supports one input shape and corresponding batch range. Therefore this PR aims to extend the API to support multi-input.
2) For the hovernet, the block is mainly the dict type output. To fix this issue, this PR will try to add another list type output for the hovernet, which can be controlled by an input parameter. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
