### PR TITLE
6804 enhance compose input check

### DIFF
--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -235,6 +235,13 @@ class Compose(Randomizable, InvertibleTransform):
     ) -> None:
         if transforms is None:
             transforms = []
+
+        if not isinstance(map_items, bool):
+            raise ValueError(
+                f"Argument 'map_items' should be a boolean. Got {type(map_items)}."
+                "Check brackets when passing a sequence of callables."
+            )
+
         self.transforms = ensure_tuple(transforms)
         self.map_items = map_items
         self.unpack_items = unpack_items

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -238,7 +238,7 @@ class Compose(Randomizable, InvertibleTransform):
 
         if not isinstance(map_items, bool):
             raise ValueError(
-                f"Argument 'map_items' should be a boolean. Got {type(map_items)}."
+                f"Argument 'map_items' should be boolean. Got {type(map_items)}."
                 "Check brackets when passing a sequence of callables."
             )
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -14,12 +14,10 @@ from __future__ import annotations
 import logging
 import os
 import sys
-import tempfile
 import unittest
 from copy import deepcopy
 from io import StringIO
 
-import nibabel as nib
 import numpy as np
 import torch
 from parameterized import parameterized
@@ -646,18 +644,14 @@ class TestComposeExecuteWithFlags(unittest.TestCase):
 
 class TestComposeCallableInput(unittest.TestCase):
     def test_value_error_when_not_sequence(self):
-        np_img = np.random.randn(1, 5, 5)
-        test_image = nib.Nifti1Image(np_img, np.eye(4))
-        with tempfile.TemporaryDirectory() as tempdir:
-            test_image_path = os.path.join(tempdir, "test_image.nii.gz")
-            nib.save(test_image, test_image_path)
+        data = torch.tensor(np.random.randn(1, 5, 5))
 
-            xform = mt.Compose([mt.LoadImage(image_only=True), mt.Flip(0), mt.Flip(0)])
-            data = xform(test_image_path)
-            np.testing.assert_allclose(np_img, data, atol=1e-3)
+        xform = mt.Compose([mt.Flip(0), mt.Flip(0)])
+        res = xform(data)
+        np.testing.assert_allclose(data, res, atol=1e-3)
 
-            with self.assertRaises(ValueError):
-                mt.Compose(mt.LoadImage(image_only=True), mt.Flip(0), mt.Flip(0))(test_image_path)
+        with self.assertRaises(ValueError):
+            mt.Compose(mt.Flip(0), mt.Flip(0))(data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes case mentioned in #6804 by checking type of second argument

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
