### PR TITLE
6894 update rank filter

### DIFF
--- a/monai/utils/dist.py
+++ b/monai/utils/dist.py
@@ -197,11 +197,13 @@ class RankFilter(Filter):
         if dist.is_available() and dist.is_initialized():
             self.rank: int = rank if rank is not None else dist.get_rank()
         else:
-            warnings.warn(
-                "The torch.distributed is either unavailable and uninitiated when RankFilter is instantiated. "
-                "If torch.distributed is used, please ensure that the RankFilter() is called "
-                "after torch.distributed.init_process_group() in the script."
-            )
+            if torch.cuda.is_available() and torch.cuda.device_count() > 1:
+                warnings.warn(
+                    "The torch.distributed is either unavailable and uninitiated when RankFilter is instantiated.\n"
+                    "If torch.distributed is used, please ensure that the RankFilter() is called\n"
+                    "after torch.distributed.init_process_group() in the script.\n",
+                )
+            self.rank = 0
 
     def filter(self, *_args):
         return self.filter_fn(self.rank)

--- a/monai/utils/dist.py
+++ b/monai/utils/dist.py
@@ -201,7 +201,7 @@ class RankFilter(Filter):
                 warnings.warn(
                     "The torch.distributed is either unavailable and uninitiated when RankFilter is instantiated.\n"
                     "If torch.distributed is used, please ensure that the RankFilter() is called\n"
-                    "after torch.distributed.init_process_group() in the script.\n",
+                    "after torch.distributed.init_process_group() in the script.\n"
                 )
             self.rank = 0
 

--- a/tests/test_rankfilter_dist.py
+++ b/tests/test_rankfilter_dist.py
@@ -45,9 +45,20 @@ class DistributedRankFilterTest(DistTestCase):
             log_message = " ".join(lines)
             self.assertEqual(log_message.count("test_warnings"), 1)
 
+    def tearDown(self) -> None:
+        self.log_dir.cleanup()
+
+
+class SingleRankFilterTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        self.log_dir.cleanup()
+
+    def setUp(self):
+        self.log_dir = tempfile.TemporaryDirectory()
+
     def test_rankfilter_single_proc(self):
         logger = logging.getLogger(__name__)
-        log_filename = os.path.join(self.log_dir.name, "records.log")
+        log_filename = os.path.join(self.log_dir.name, "records_sp.log")
         h1 = logging.FileHandler(filename=log_filename)
         h1.setLevel(logging.WARNING)
         logger.addHandler(h1)
@@ -56,11 +67,10 @@ class DistributedRankFilterTest(DistTestCase):
 
         with open(log_filename) as file:
             lines = [line.rstrip() for line in file]
+        logger.removeHandler(h1)
+        h1.close()
         log_message = " ".join(lines)
         self.assertEqual(log_message.count("test_warnings"), 1)
-
-    def tearDown(self) -> None:
-        self.log_dir.cleanup()
 
 
 if __name__ == "__main__":

--- a/tests/test_rankfilter_dist.py
+++ b/tests/test_rankfilter_dist.py
@@ -43,7 +43,21 @@ class DistributedRankFilterTest(DistTestCase):
             with open(log_filename) as file:
                 lines = [line.rstrip() for line in file]
             log_message = " ".join(lines)
-            assert log_message.count("test_warnings") == 1
+            self.assertEqual(log_message.count("test_warnings"), 1)
+
+    def test_rankfilter_single_proc(self):
+        logger = logging.getLogger(__name__)
+        log_filename = os.path.join(self.log_dir.name, "records.log")
+        h1 = logging.FileHandler(filename=log_filename)
+        h1.setLevel(logging.WARNING)
+        logger.addHandler(h1)
+        logger.addFilter(RankFilter())
+        logger.warning("test_warnings")
+
+        with open(log_filename) as file:
+            lines = [line.rstrip() for line in file]
+        log_message = " ".join(lines)
+        self.assertEqual(log_message.count("test_warnings"), 1)
 
     def tearDown(self) -> None:
         self.log_dir.cleanup()


### PR DESCRIPTION
Fixes #6894

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
