### PR TITLE
WIP: Move to numpy.Generators

### DIFF
--- a/monai/apps/detection/transforms/dictionary.py
+++ b/monai/apps/detection/transforms/dictionary.py
@@ -1371,7 +1371,7 @@ class RandRotateBox90d(RandomizableTransform, MapTransform, InvertibleTransform)
         return d
 
     def randomize(self, data: Any | None = None) -> None:
-        self._rand_k = self.R.randint(self.max_k) + 1
+        self._rand_k = self.R.integers(self.max_k) + 1
         super().randomize(None)
 
     def inverse(self, data: Mapping[Hashable, torch.Tensor]) -> dict[Hashable, torch.Tensor]:

--- a/monai/apps/nuclick/transforms.py
+++ b/monai/apps/nuclick/transforms.py
@@ -345,7 +345,7 @@ class AddPointGuidanceSignald(Randomizable, MapTransform):
                 indices = np.argwhere(convert_to_numpy(label) > 0)
 
             if len(indices) > 0:
-                index = self.R.randint(0, len(indices))
+                index = self.R.integers(0, len(indices))
                 return indices[index, 0], indices[index, 1]
             return None
 
@@ -382,8 +382,8 @@ class AddPointGuidanceSignald(Randomizable, MapTransform):
             x = int(math.floor(x))
             y = int(math.floor(y))
             if jitter_range:
-                x = x + self.R.randint(low=-jitter_range, high=jitter_range)
-                y = y + self.R.randint(low=-jitter_range, high=jitter_range)
+                x = x + self.R.integers(low=-jitter_range, high=jitter_range)
+                y = y + self.R.integers(low=-jitter_range, high=jitter_range)
                 x = min(max(0, x), max_x)
                 y = min(max(0, y), max_y)
             point_mask[x, y] = 1

--- a/monai/apps/reconstruction/transforms/array.py
+++ b/monai/apps/reconstruction/transforms/array.py
@@ -98,7 +98,7 @@ class KspaceMask(RandomizableTransform):
                 lines to exclude from under-sampling
                 (2) acceleration: chosen acceleration factor
         """
-        choice = self.R.randint(0, len(self.accelerations))
+        choice = self.R.integers(0, len(self.accelerations))
         center_fraction = self.center_fractions[choice]
         acceleration = self.accelerations[choice]
         return center_fraction, acceleration
@@ -257,7 +257,7 @@ class EquispacedKspaceMask(KspaceMask):
         # Determine acceleration rate by adjusting for the
         # number of low frequencies
         adjusted_accel = (acceleration * (num_low_freqs - num_cols)) / (num_low_freqs * acceleration - num_cols)
-        offset = self.R.randint(0, round(adjusted_accel))
+        offset = self.R.integers(0, round(adjusted_accel))
 
         accel_samples = np.arange(offset, num_cols - 1, adjusted_accel)
         accel_samples = np.around(accel_samples).astype(np.uint)

--- a/monai/config/type_definitions.py
+++ b/monai/config/type_definitions.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 import os
-from typing import Collection, Hashable, Iterable, Sequence, TypeVar, Union
+from typing import Collection, Hashable, Iterable, Sequence, SupportsIndex, Tuple, TypeVar, Union
 
 import numpy as np
 import torch
@@ -83,3 +83,8 @@ PathLike = Union[str, os.PathLike]
 #: SequenceStr
 # string or a sequence of strings for `mode` types.
 SequenceStr = Union[Sequence[str], str]
+
+Shape = Tuple[int, ...]
+
+# Anything that can be coerced to a shape tuple
+ShapeLike = Union[SupportsIndex, Sequence[SupportsIndex]]

--- a/monai/data/dataloader.py
+++ b/monai/data/dataloader.py
@@ -54,7 +54,7 @@ class DataLoader(_TorchDataLoader):
 
         class RandomDataset(torch.utils.data.Dataset, Randomizable):
             def __getitem__(self, index):
-                return self.R.randint(0, 1000, (1,))
+                return self.R.integers(0, 1000, (1,))
 
             def __len__(self):
                 return 16

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -1364,7 +1364,7 @@ class ArrayDataset(Randomizable, _TorchDataset):
         return len(self.dataset)
 
     def randomize(self, data: Any | None = None) -> None:
-        self._seed = self.R.randint(MAX_SEED, dtype="uint32")
+        self._seed = self.R.integers(MAX_SEED, dtype="uint32")
 
     def __getitem__(self, index: int):
         self.randomize()

--- a/monai/data/image_dataset.py
+++ b/monai/data/image_dataset.py
@@ -97,7 +97,7 @@ class ImageDataset(Dataset, Randomizable):
         return len(self.image_files)
 
     def randomize(self, data: Any | None = None) -> None:
-        self._seed = self.R.randint(MAX_SEED, dtype="uint32")
+        self._seed = self.R.integers(MAX_SEED, dtype="uint32")
 
     def __getitem__(self, index: int):
         self.randomize()

--- a/monai/data/iterable_dataset.py
+++ b/monai/data/iterable_dataset.py
@@ -132,7 +132,7 @@ class ShuffleBuffer(Randomizable, IterableDataset):
             yield from IterableDataset(self.generate_item(), transform=self.transform)
 
     def randomize(self, size: int) -> None:
-        self._idx = self.R.randint(size)
+        self._idx = self.R.integers(size)
 
 
 class CSVIterableDataset(IterableDataset):

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -51,6 +51,8 @@ from monai.utils import (
     look_up_option,
     optional_import,
 )
+from monai.utils.deprecate_utils import deprecated_arg
+from monai.utils.utils_random_generator_adaptor import SupportsRandomGeneration, handle_legacy_random_state
 
 pd, _ = optional_import("pandas")
 DataFrame, _ = optional_import("pandas", name="DataFrame")
@@ -104,8 +106,14 @@ SUPPORTED_PICKLE_MOD = {"pickle": pickle}
 AFFINE_TOL = 1e-3
 
 
+@deprecated_arg(
+    "rand_state", since="1.3.0", removed="1.5.0", new_name="generator", msg_suffix="Please use `generator` instead."
+)
 def get_random_patch(
-    dims: Sequence[int], patch_size: Sequence[int], rand_state: np.random.RandomState | None = None
+    dims: Sequence[int],
+    patch_size: Sequence[int],
+    rand_state: np.random.RandomState | None = None,
+    generator: SupportsRandomGeneration | None = None,
 ) -> tuple[slice, ...]:
     """
     Returns a tuple of slices to define a random patch in an array of shape `dims` with size `patch_size` or the as
@@ -121,9 +129,12 @@ def get_random_patch(
         (tuple of slice): a tuple of slice objects defining the patch
     """
 
+    generator = handle_legacy_random_state(
+        rand_state=rand_state, generator=generator, return_legacy_default_random=True
+    )
+
     # choose the minimal corner of the patch
-    rand_int = np.random.randint if rand_state is None else rand_state.randint
-    min_corner = tuple(rand_int(0, ms - ps + 1) if ms > ps else 0 for ms, ps in zip(dims, patch_size))
+    min_corner = tuple(generator.integers(0, ms - ps + 1) if ms > ps else 0 for ms, ps in zip(dims, patch_size))
 
     # create the slices for each dimension which define the patch in the source array
     return tuple(slice(mc, mc + ps) for mc, ps in zip(min_corner, patch_size))

--- a/monai/data/wsi_datasets.py
+++ b/monai/data/wsi_datasets.py
@@ -281,7 +281,7 @@ class SlidingPatchWSIDataset(Randomizable, PatchWSIDataset):
                 offset_limits = tuple((-s, s) for s in self._get_size(sample))
             else:
                 offset_limits = self.offset_limits
-            return tuple(self.R.randint(low, high) for low, high in offset_limits)
+            return tuple(self.R.integers(low, high) for low, high in offset_limits)
         return self.offset
 
     def _evaluate_patch_locations(self, sample):

--- a/monai/transforms/compose.py
+++ b/monai/transforms/compose.py
@@ -260,7 +260,7 @@ class Compose(Randomizable, InvertibleTransform, LazyTransform):
         for _transform in self.transforms:
             if not isinstance(_transform, Randomizable):
                 continue
-            _transform.set_random_state(seed=self.R.randint(MAX_SEED, dtype="uint32"))
+            _transform.set_random_state(seed=self.R.integers(MAX_SEED, dtype="uint32"))
         return self
 
     def randomize(self, data: Any | None = None) -> None:
@@ -731,7 +731,7 @@ class SomeOf(Compose):
         if len(self.transforms) == 0:
             return data
 
-        sample_size = self.R.randint(self.min_num_transforms, self.max_num_transforms + 1)
+        sample_size = self.R.integers(self.min_num_transforms, self.max_num_transforms + 1)
         applied_order = self.R.choice(len(self.transforms), sample_size, replace=self.replace, p=self.weights).tolist()
         _lazy = self._lazy if lazy is None else lazy
 

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -614,10 +614,10 @@ class RandSpatialCrop(Randomizable, Crop):
             max_size = img_size if self.max_roi_size is None else fall_back_tuple(self.max_roi_size, img_size)
             if any(i > j for i, j in zip(self._size, max_size)):
                 raise ValueError(f"min ROI size: {self._size} is larger than max ROI size: {max_size}.")
-            self._size = tuple(self.R.randint(low=self._size[i], high=max_size[i] + 1) for i in range(len(img_size)))
+            self._size = tuple(self.R.integers(low=self._size[i], high=max_size[i] + 1) for i in range(len(img_size)))
         if self.random_center:
             valid_size = get_valid_patch_size(img_size, self._size)
-            self._slices = get_random_patch(img_size, valid_size, self.R)
+            self._slices = get_random_patch(img_size, valid_size, generator=self.R)
 
     def __call__(self, img: torch.Tensor, randomize: bool = True, lazy: bool | None = None) -> torch.Tensor:  # type: ignore
         """
@@ -1167,8 +1167,8 @@ class RandCropByPosNegLabel(Randomizable, TraceableTransform, LazyTransform, Mul
             _shape,
             fg_indices_,
             bg_indices_,
-            self.R,
             self.allow_smaller,
+            generator=self.R,
         )
 
     @LazyTransform.lazy.setter  # type: ignore
@@ -1350,7 +1350,14 @@ class RandCropByLabelClasses(Randomizable, TraceableTransform, LazyTransform, Mu
         if _shape is None:
             raise ValueError("label or image must be provided to infer the output spatial shape.")
         self.centers = generate_label_classes_crop_centers(
-            self.spatial_size, self.num_samples, _shape, indices_, self.ratios, self.R, self.allow_smaller, self.warn
+            self.spatial_size,
+            self.num_samples,
+            _shape,
+            indices_,
+            self.ratios,
+            self.allow_smaller,
+            self.warn,
+            generator=self.R,
         )
 
     @LazyTransform.lazy.setter  # type: ignore

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -684,7 +684,7 @@ class RandSpatialCropSamplesd(Randomizable, MapTransform, LazyTransform, MultiSa
         self.cropper.lazy = value
 
     def randomize(self, data: Any | None = None) -> None:
-        self.sub_seed = self.R.randint(MAX_SEED, dtype="uint32")
+        self.sub_seed = self.R.integers(MAX_SEED, dtype="uint32")
 
     def __call__(
         self, data: Mapping[Hashable, torch.Tensor], lazy: bool | None = None

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -1685,7 +1685,7 @@ class RandHistogramShift(RandomizableTransform):
         super().randomize(None)
         if not self._do_transform:
             return None
-        num_control_point = self.R.randint(self.num_control_points[0], self.num_control_points[1] + 1)
+        num_control_point = self.R.integers(self.num_control_points[0], self.num_control_points[1] + 1)
         self.reference_control_points = np.linspace(0, 1, num_control_point)
         self.floating_control_points = np.copy(self.reference_control_points)
         for i in range(1, num_control_point - 1):
@@ -2079,11 +2079,11 @@ class RandKSpaceSpikeNoise(RandomizableTransform, Fourier):
         if self.channel_wise:
             # randomizing per channel
             for i, chan in enumerate(img):
-                self.sampled_locs.append((i,) + tuple(self.R.randint(0, k) for k in chan.shape))
+                self.sampled_locs.append((i,) + tuple(self.R.integers(0, k) for k in chan.shape))
                 self.sampled_k_intensity.append(self.R.uniform(intensity_range[i][0], intensity_range[i][1]))
         else:
             # working with all channels together
-            spatial = tuple(self.R.randint(0, k) for k in img.shape[1:])
+            spatial = tuple(self.R.integers(0, k) for k in img.shape[1:])
             self.sampled_locs = [(i,) + spatial for i in range(img.shape[0])]
             if isinstance(intensity_range[0], Sequence):
                 self.sampled_k_intensity = [self.R.uniform(p[0], p[1]) for p in intensity_range]
@@ -2168,13 +2168,13 @@ class RandCoarseTransform(RandomizableTransform):
             return None
         size = fall_back_tuple(self.spatial_size, img_size)
         self.hole_coords = []  # clear previously computed coords
-        num_holes = self.holes if self.max_holes is None else self.R.randint(self.holes, self.max_holes + 1)
+        num_holes = self.holes if self.max_holes is None else self.R.integers(self.holes, self.max_holes + 1)
         for _ in range(num_holes):
             if self.max_spatial_size is not None:
                 max_size = fall_back_tuple(self.max_spatial_size, img_size)
-                size = tuple(self.R.randint(low=size[i], high=max_size[i] + 1) for i in range(len(img_size)))
+                size = tuple(self.R.integers(low=size[i], high=max_size[i] + 1) for i in range(len(img_size)))
             valid_size = get_valid_patch_size(img_size, size)
-            self.hole_coords.append((slice(None),) + get_random_patch(img_size, valid_size, self.R))
+            self.hole_coords.append((slice(None),) + get_random_patch(img_size, valid_size, generator=self.R))
 
     @abstractmethod
     def _transform_holes(self, img: np.ndarray) -> np.ndarray:

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -1228,7 +1228,7 @@ class RandRotate90(RandomizableTransform, InvertibleTransform, LazyTransform):
         super().randomize(None)
         if not self._do_transform:
             return None
-        self._rand_k = self.R.randint(self.max_k) + 1
+        self._rand_k = self.R.integers(self.max_k) + 1
 
     def __call__(self, img: torch.Tensor, randomize: bool = True, lazy: bool | None = None) -> torch.Tensor:
         """
@@ -1481,7 +1481,7 @@ class RandAxisFlip(RandomizableTransform, InvertibleTransform, LazyTransform):
         super().randomize(None)
         if not self._do_transform:
             return None
-        self._axis = self.R.randint(data.ndim - 1)
+        self._axis = self.R.integers(data.ndim - 1)
 
     def __call__(self, img: torch.Tensor, randomize: bool = True, lazy: bool | None = None) -> torch.Tensor:
         """
@@ -3439,7 +3439,7 @@ class RandGridPatch(GridPatch, RandomizableTransform, MultiSampleTrait):
         else:
             max_offset = ensure_tuple_rep(self.max_offset, len(self.patch_size))
 
-        self.offset = tuple(self.R.randint(low=low, high=high + 1) for low, high in zip(min_offset, max_offset))
+        self.offset = tuple(self.R.integers(low=low, high=high + 1) for low, high in zip(min_offset, max_offset))
 
     def filter_count(self, image_np: NdarrayOrTensor, locations: np.ndarray) -> tuple[NdarrayOrTensor, np.ndarray]:
         if self.sort_fn == GridPatchSort.RANDOM:

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -713,7 +713,7 @@ class RandRotate90d(RandomizableTransform, MapTransform, InvertibleTransform, La
         self._rand_k = 0
 
     def randomize(self, data: Any | None = None) -> None:
-        self._rand_k = self.R.randint(self.max_k) + 1
+        self._rand_k = self.R.integers(self.max_k) + 1
         super().randomize(None)
 
     def __call__(

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -1126,7 +1126,7 @@ class AddExtremePointsChannel(Randomizable, Transform):
         self._points: list[tuple[int, ...]] = []
 
     def randomize(self, label: NdarrayOrTensor) -> None:
-        self._points = get_extreme_points(label, rand_state=self.R, background=self._background, pert=self._pert)
+        self._points = get_extreme_points(label, generator=self.R, background=self._background, pert=self._pert)
 
     def __call__(
         self,

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -1405,7 +1405,7 @@ class AddExtremePointsChanneld(Randomizable, MapTransform):
         self.rescale_max = rescale_max
 
     def randomize(self, label: NdarrayOrTensor) -> None:
-        self.points = get_extreme_points(label, rand_state=self.R, background=self.background, pert=self.pert)
+        self.points = get_extreme_points(label, generator=self.R, background=self.background, pert=self.pert)
 
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> dict[Hashable, NdarrayOrTensor]:
         d = dict(data)

--- a/monai/utils/utils_random_generator_adaptor.py
+++ b/monai/utils/utils_random_generator_adaptor.py
@@ -1,0 +1,139 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+from numpy._typing import _ArrayLikeFloat_co, _ArrayLikeInt_co
+
+from monai.config.type_definitions import DtypeLike, NdarrayTensor, ShapeLike
+
+
+# FIXME What should the type be for the array in and out?
+@runtime_checkable
+class SupportsRandomGeneration(Protocol):
+    def integers(
+        self, low: int, high: int | None = None, size: ShapeLike | None = None, dtype=DtypeLike, endpoint: bool = False
+    ) -> NdarrayTensor:
+        ...
+
+    def random(self, size: ShapeLike | None = None, dtype=DtypeLike, out: NdarrayTensor | None = None) -> NdarrayTensor:
+        ...
+
+    def choice(
+        self,
+        a: NdarrayTensor,
+        size: ShapeLike | None,
+        replace: bool = True,
+        p: NdarrayTensor | None = None,
+        axis: int = 0,
+        shuffle: bool = True,
+    ) -> NdarrayTensor:
+        ...
+
+    def bytes(self, length: int) -> str:
+        ...
+
+    def shuffle(self, x: NdarrayTensor, axis: int = 0) -> None:
+        ...
+
+    def permutation(self, x: NdarrayTensor, axis: int = 0) -> NdarrayTensor:
+        ...
+
+    def multinomial(
+        self, n: _ArrayLikeInt_co, pvals: _ArrayLikeFloat_co, size: ShapeLike | None = None
+    ) -> NdarrayTensor:
+        ...
+
+    def normal(self, loc: float = 0.0, scale: float = 1.0, size: ShapeLike | None = None) -> NdarrayTensor:
+        ...
+
+    def uniform(self, low: float = 0.0, high: float = 1.0, size: ShapeLike | None = None) -> NdarrayTensor:
+        ...
+
+
+class LegacyRandomStateAdaptor(SupportsRandomGeneration):
+    random_staters: np.random.RandomState
+
+    def __init__(self, seed: int | None = None, random_state: np.random.RandomState | None = None):
+        if random_state is not None and seed is not None:
+            raise ValueError("Cannot specify both rs and seed.")
+        self.random_state = np.random.RandomState(seed=seed) if random_state is None else random_state
+
+    def integers(
+        self, low: int, high: int | None = None, size: ShapeLike | None = None, dtype=DtypeLike, endpoint: bool = False
+    ) -> NdarrayTensor:
+        return self.random_state.randint(low=low, high=high if endpoint else high + 1, size=size, dtype=dtype)
+
+    def random(self, size: ShapeLike | None = None, dtype=DtypeLike, out: NdarrayTensor | None = None) -> NdarrayTensor:
+        if out is not None:
+            raise NotImplementedError("out is not implemented")
+        if dtype is not None:
+            raise NotImplementedError("dtype is not implemented")
+        return self.random_state.random(size)
+
+    def choice(
+        self,
+        a: NdarrayTensor,
+        size: ShapeLike | None,
+        replace: bool = True,
+        p: NdarrayTensor | None = None,
+        axis: int = 0,
+        shuffle: bool = True,
+    ) -> NdarrayTensor:
+        if axis != 0:
+            raise NotImplementedError("axis is not implemented")
+        if not shuffle:
+            raise NotImplementedError("shuffle is not implemented")
+        return self.random_state.choice(a, size, replace, p)
+
+    def permutation(self, x: NdarrayTensor, axis: int = 0) -> NdarrayTensor:
+        if axis != 0:
+            raise NotImplementedError("axis is not implemented")
+        return self.random_state.permutation(x)
+
+    def shuffle(self, x: NdarrayTensor, axis: int = 0) -> None:
+        if axis != 0:
+            raise NotImplementedError("axis is not implemented")
+        return self.random_state.shuffle(x)
+
+    def multinomial(
+        self, n: _ArrayLikeInt_co, pvals: _ArrayLikeFloat_co, size: ShapeLike | None = None
+    ) -> NdarrayTensor:
+        return self.random_state.multinomial(n, pvals, size)
+
+    def normal(self, loc: float = 0.0, scale: float = 1.0, size: ShapeLike | None = None) -> NdarrayTensor:
+        return self.random_state.normal(loc, scale, size)
+
+    def uniform(self, low: float = 0.0, high: float = 1.0, size: ShapeLike | None = None) -> NdarrayTensor:
+        return self.random_state.uniform(low, high, size)
+
+
+def handle_legacy_random_state(
+    rand_state: np.random.RandomState | None = None,
+    generator: SupportsRandomGeneration | None = None,
+    return_legacy_default_random: bool = False,
+) -> SupportsRandomGeneration | None:
+    if generator is not None and rand_state is not None:
+        raise ValueError("rand_state and generator cannot be set at the same time.")
+
+    if rand_state is not None:
+        generator = rand_state
+        rand_state = None
+    if isinstance(generator, np.random.RandomState):
+        generator = LegacyRandomStateAdaptor(generator)
+
+    if generator is None and return_legacy_default_random:
+        generator = LegacyRandomStateAdaptor(np.random.random.__self__)
+
+    return generator

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -40,7 +40,7 @@ def data_from_keys(keys, h, w):
 
 class _RandXform(Randomizable):
     def randomize(self):
-        self.val = self.R.random_sample()
+        self.val = self.R.random()
 
     def __call__(self, __unused):
         self.randomize()
@@ -167,7 +167,7 @@ class TestCompose(unittest.TestCase):
             self.rand = 0.0
 
             def randomize(self, data=None):
-                self.rand = self.R.rand()
+                self.rand = self.R.random()
 
             def __call__(self, data):
                 self.randomize()

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -60,7 +60,7 @@ class TestDataLoader(unittest.TestCase):
 
 class _RandomDataset(torch.utils.data.Dataset, Randomizable):
     def __getitem__(self, index):
-        return self.R.randint(0, 1000, (1,))
+        return self.R.integers(0, 1000, (1,))
 
     def __len__(self):
         return 8


### PR DESCRIPTION
Fixes 6854 .

## Description

In order to move from the deprecated numpy.random.RandomState to the faster and supported numpy.random.Generator, in a first step the generation of randomness in transform and related functions is migrated (i.e. everything with self.R/ implementing Randomizable). The idea of this PR is to change the API for randomness to that of Generators. In order to preserve reproducibility, the old Random Generator should still be used by default while providing an option to switch over to the new implementation.

### Breaking changes
- The API for generating randomness inside transforms uses the new [numpy.random.Generator API](https://numpy.org/doc/stable/reference/random/new-or-different.html), custom transforms would therefore have to adapt the new functionality as well


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
