### PR TITLE
Update utils.py

### DIFF
--- a/monai/inferers/utils.py
+++ b/monai/inferers/utils.py
@@ -278,8 +278,8 @@ def sliding_window_inference(
                 else:
                     output_image_list[0][o_slice] += sw_device_buffer[0].to(device=device)
             else:
-                sw_device_buffer[ss] *= w_t
                 sw_device_buffer[ss] = sw_device_buffer[ss].to(device)
+                sw_device_buffer[ss] *= w_t
                 _compute_coords(unravel_slice, z_scale, output_image_list[ss], sw_device_buffer[ss])
         sw_device_buffer = []
         if buffered:


### PR DESCRIPTION
In some edge cases the inferer outputs:
expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!

The following change ensures the buffer and w_t are on the same device.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
