### PR TITLE
Support regular expression  in the mapping arg of `copy_model_state`

### DIFF
--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -531,11 +531,13 @@ def copy_model_state(
             updated_keys.append(dst_key)
     for s in mapping if mapping else {}:
         dst_key = f"{dst_prefix}{mapping[s]}"
-        if dst_key in dst_dict and dst_key not in to_skip:
-            if dst_dict[dst_key].shape != src_dict[s].shape:
-                warnings.warn(f"Param. shape changed from {dst_dict[dst_key].shape} to {src_dict[s].shape}.")
-            dst_dict[dst_key] = src_dict[s]
-            updated_keys.append(dst_key)
+        src_keys = sorted(set(s_key for s_key in src_dict if s_key not in to_skip and re.compile(s).search(s_key)))
+        dst_keys = sorted(set(d_key for d_key in dst_dict if d_key not in to_skip and re.compile(dst_key).search(d_key)))
+        for _src_key, _dst_key in zip(src_keys, dst_keys):
+            if dst_dict[_dst_key].shape != src_dict[_src_key].shape:
+                warnings.warn(f"Param. shape changed from {dst_dict[_dst_key].shape} to {src_dict[_src_key].shape}.")
+            dst_dict[_dst_key] = src_dict[_src_key]
+            updated_keys.append(_dst_key)
 
     updated_keys = sorted(set(updated_keys))
     unchanged_keys = sorted(set(all_keys).difference(updated_keys))

--- a/tests/test_copy_model_state.py
+++ b/tests/test_copy_model_state.py
@@ -134,7 +134,7 @@ class TestModuleState(unittest.TestCase):
         model_two.to(device_1)
         # test weight map
         model_dict, ch, unch = copy_model_state(
-            model_one, model_two, mapping={"layer_1.weight": "layer.weight", "layer_1.bias": "layer_1.weight"}
+            model_one, model_two, mapping={"layer_1.weight": "^layer.weight", "layer_1.bias": "layer_1.weight"}
         )
         model_one.load_state_dict(model_dict)
         x = np.random.randn(4, 10)


### PR DESCRIPTION
Part of #6552.

### Description
After PR #6835, we have added `copy_model_args` in the `load` API which can help us update the state_dict flexibly.
https://github.com/KumoLiu/MONAI/blob/93a149a611b66153cf804b31a7b36a939e2e593a/monai/bundle/scripts.py#L397

Given this [issue](https://github.com/Project-MONAI/MONAI/issues/6552), we need to be able to filter the model's weights flexibly.
In `copy_model_state`, we already have a "mapping" arg, the filter will be more flexible if we can support regular expression in the mapping. This PR mainly added the support for regular expression for "mapping" arg. 

In the [example](https://github.com/Project-MONAI/MONAI/issues/6552#issuecomment-1587582734) in this [issue](https://github.com/Project-MONAI/MONAI/issues/6552), after this PR, we can do something like:
```
exclude_vars = "encoder.mask_token|encoder.norm.weight|encoder.norm.bias|out.conv.conv.weight|out.conv.conv.bias"
mapping={"encoder.layers(.*).0.0.": "swinViT.layers(.*).0."}
dst_dict, updated_keys, unchanged_keys = copy_model_state(
       model, ssl_weights, exclude_vars=exclude_vars, mapping=mapping
)
```

Additionally, based on the comments of Eric [here](https://github.com/Project-MONAI/MONAI/issues/6552#issuecomment-1697404590), I totally agree, we could add a handler to make the pipeline easier to implement, but perhaps this task is no need to set as a "BundleTodo" for MONAIv1.3 but as an enhancement for MONAI near future.
What do you think? @ericspod @wyli @Nic-Ma 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
