### PR TITLE
Fix KeyError in `PydicomReader`

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -663,7 +663,7 @@ class PydicomReader(ImageReader):
         # "00200032" is the tag of `ImagePositionPatient`
         sx, sy, sz = metadata["00200032"]["Value"]
         # "00280030" is the tag of `PixelSpacing`
-        spacing = metadata["00280030"]["Value"]
+        spacing = metadata["00280030"]["Value"] if "00280030" in metadata else (1.0, 1.0)
         dr, dc = metadata.get("spacing", spacing)[:2]
         affine[0, 0] = cx * dr
         affine[0, 1] = rx * dc


### PR DESCRIPTION
Fixes #6945 .

### Description
Try get "00280030" (PixelSpacing) first.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
