### PR TITLE
Avoid breaking change in creating `BundleWorkflow`

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -533,7 +533,11 @@ def load(
 
     model.to(device)  # type: ignore
 
-    copy_model_state(dst=model, src=model_dict if key_in_ckpt is None else model_dict[key_in_ckpt], **copy_model_args)  # type: ignore
+    copy_model_state(  # type: ignore
+        dst=model,
+        src=model_dict if key_in_ckpt is None else model_dict[key_in_ckpt],
+        **copy_model_args
+    )
 
     return model
 

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -533,10 +533,8 @@ def load(
 
     model.to(device)  # type: ignore
 
-    copy_model_state(  # type: ignore
-        dst=model,
-        src=model_dict if key_in_ckpt is None else model_dict[key_in_ckpt],
-        **copy_model_args
+    copy_model_state(
+        dst=model, src=model_dict if key_in_ckpt is None else model_dict[key_in_ckpt], **copy_model_args  # type: ignore
     )
 
     return model

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -378,7 +378,7 @@ def download(
 
 @deprecated_arg("net_name", since="1.3", removed="1.5", msg_suffix="please use ``model`` instead.")
 @deprecated_arg("net_kwargs", since="1.3", removed="1.5", msg_suffix="please use ``model`` instead.")
-@deprecated_arg_default("return_state_dict", "True", "False", since="1.3", replaced="1.5")
+@deprecated_arg("return_state_dict", since="1.3", removed="1.5")
 def load(
     name: str,
     model: torch.nn.Module | None = None,
@@ -528,11 +528,11 @@ def load(
         elif net_name is not None:
             net_kwargs["_target_"] = net_name
             configer = ConfigComponent(config=net_kwargs)
-            model = configer.instantiate()
+            model = configer.instantiate()  # type: ignore
 
-    model.to(device)
+    model.to(device)  # type: ignore
 
-    copy_model_state(dst=model, src=model_dict if key_in_ckpt is None else model_dict[key_in_ckpt], **copy_model_args)
+    copy_model_state(dst=model, src=model_dict if key_in_ckpt is None else model_dict[key_in_ckpt], **copy_model_args)  # type: ignore
 
     return model
 

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -400,7 +400,7 @@ def load(
     return_state_dict: bool = True,
     net_override: dict = {},
     net_name: str | None = None,
-    **net_kwargs: Any
+    **net_kwargs: Any,
 ) -> object | tuple[torch.nn.Module, dict, dict] | Any:
     """
     Load model weights or TorchScript module of a bundle.

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -521,7 +521,7 @@ def load(
             warnings.warn(f"Cannot find the config file: {bundle_config_file}, return state dict instead.")
             return model_dict
         if _workflow is not None:
-            if getattr(_workflow, "network_def") is None:
+            if not hasattr(_workflow, "network_def"):
                 warnings.warn("No available network definition in the bundle, return state dict instead.")
                 return model_dict
             else:

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -398,7 +398,7 @@ def load(
     args_file: str | None = None,
     copy_model_args: dict | None = None,
     return_state_dict: bool = True,
-    net_override: dict = {},
+    net_override: dict | None = None,
     net_name: str | None = None,
     **net_kwargs: Any,
 ) -> object | tuple[torch.nn.Module, dict, dict] | Any:
@@ -447,7 +447,7 @@ def load(
         copy_model_args: other arguments for the `monai.networks.copy_model_state` function.
         return_state_dict: whether to return state dict, if True, return state_dict, else a corresponding network
             from `_workflow.network_def` will be instantiated and load the achieved weights.
-        net_override: id-value pairs to override the parameters in the network of the bundle.
+        net_override: id-value pairs to override the parameters in the network of the bundle, default to `None`.
         net_name: if not `None`, a corresponding network will be instantiated and load the achieved weights.
             This argument only works when loading weights.
         net_kwargs: other arguments that are used to instantiate the network class defined by `net_name`.
@@ -469,6 +469,7 @@ def load(
         warnings.warn("Incompatible values: model and net_name are all specified, return state dict instead.")
 
     bundle_dir_ = _process_bundle_dir(bundle_dir)
+    net_override = {} if net_override is None else net_override
     copy_model_args = {} if copy_model_args is None else copy_model_args
 
     if device is None:

--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -43,6 +43,10 @@ class BundleWorkflow(ABC):
             or "infer", "inference", "eval", "evaluation" for a inference workflow,
             other unsupported string will raise a ValueError.
             default to `None` for common workflow.
+        workflow: specifies the workflow type: "train" or "training" for a training workflow,
+            or "infer", "inference", "eval", "evaluation" for a inference workflow,
+            other unsupported string will raise a ValueError.
+            default to `None` for common workflow.
 
     """
 
@@ -56,7 +60,8 @@ class BundleWorkflow(ABC):
         new_name="workflow_type",
         msg_suffix="please use `workflow_type` instead.",
     )
-    def __init__(self, workflow_type: str | None = None):
+    def __init__(self, workflow_type: str | None = None, workflow: str | None = None):
+        workflow_type = workflow if workflow is not None else workflow_type
         if workflow_type is None:
             self.properties = copy(MetaProperties)
             self.workflow_type = None
@@ -198,6 +203,10 @@ class ConfigWorkflow(BundleWorkflow):
             or "infer", "inference", "eval", "evaluation" for a inference workflow,
             other unsupported string will raise a ValueError.
             default to `None` for common workflow.
+        workflow: specifies the workflow type: "train" or "training" for a training workflow,
+            or "infer", "inference", "eval", "evaluation" for a inference workflow,
+            other unsupported string will raise a ValueError.
+            default to `None` for common workflow.
         override: id-value pairs to override or add the corresponding config content.
             e.g. ``--net#input_chns 42``, ``--net %/data/other.json#net_arg``
 
@@ -221,8 +230,10 @@ class ConfigWorkflow(BundleWorkflow):
         final_id: str = "finalize",
         tracking: str | dict | None = None,
         workflow_type: str | None = None,
+        workflow: str | None = None,
         **override: Any,
     ) -> None:
+        workflow_type = workflow if workflow is not None else workflow_type
         super().__init__(workflow_type=workflow_type)
         if config_file is not None:
             _config_files = ensure_tuple(config_file)

--- a/tests/ngc_bundle_download.py
+++ b/tests/ngc_bundle_download.py
@@ -83,7 +83,12 @@ class TestNgcBundleDownload(unittest.TestCase):
                 self.assertTrue(check_hash(filepath=full_file_path, val=hash_val))
 
                 model = load(
-                    name=bundle_name, source="ngc", version=version, bundle_dir=tempdir, remove_prefix=remove_prefix, return_state_dict=False
+                    name=bundle_name,
+                    source="ngc",
+                    version=version,
+                    bundle_dir=tempdir,
+                    remove_prefix=remove_prefix,
+                    return_state_dict=False,
                 )
                 assert_allclose(
                     model.state_dict()[TESTCASE_WEIGHTS["key"]],

--- a/tests/ngc_bundle_download.py
+++ b/tests/ngc_bundle_download.py
@@ -83,7 +83,7 @@ class TestNgcBundleDownload(unittest.TestCase):
                 self.assertTrue(check_hash(filepath=full_file_path, val=hash_val))
 
                 model = load(
-                    name=bundle_name, source="ngc", version=version, bundle_dir=tempdir, remove_prefix=remove_prefix
+                    name=bundle_name, source="ngc", version=version, bundle_dir=tempdir, remove_prefix=remove_prefix, return_state_dict=False
                 )
                 assert_allclose(
                     model.state_dict()[TESTCASE_WEIGHTS["key"]],

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -146,6 +146,7 @@ class TestLoad(unittest.TestCase):
                     source="github",
                     progress=False,
                     device=device,
+                    return_state_dict=False,
                 )
 
                 # prepare network
@@ -176,10 +177,26 @@ class TestLoad(unittest.TestCase):
                     device=device,
                     net_name=model_name,
                     source="github",
+                    return_state_dict=False,
                 )
                 model_2.eval()
                 output_2 = model_2.forward(input_tensor)
                 assert_allclose(output_2, expected_output, atol=1e-4, rtol=1e-4, type_test=False)
+
+                # test forward compatibility with return_state_dict=True.
+                model_3 = load(
+                    name=bundle_name,
+                    model_file=model_file,
+                    bundle_dir=tempdir,
+                    progress=False,
+                    device=device,
+                    net_name=model_name,
+                    source="github",
+                    **net_args,
+                )
+                model_3.eval()
+                output_3 = model_3.forward(input_tensor)
+                assert_allclose(output_3, expected_output, atol=1e-4, rtol=1e-4, type_test=False)
 
     @parameterized.expand([TEST_CASE_7])
     @skip_if_quick
@@ -188,7 +205,7 @@ class TestLoad(unittest.TestCase):
             # download bundle, and load weights from the downloaded path
             with tempfile.TemporaryDirectory() as tempdir:
                 # load weights
-                model = load(name=bundle_name, bundle_dir=tempdir, source="monaihosting", progress=False, device=device)
+                model = load(name=bundle_name, bundle_dir=tempdir, source="monaihosting", progress=False, device=device, return_state_dict=False)
 
                 # prepare data and test
                 input_tensor = torch.rand(1, 1, 96, 96, 96).to(device)
@@ -209,7 +226,8 @@ class TestLoad(unittest.TestCase):
                     source="monaihosting",
                     progress=False,
                     device=device,
-                    **net_override,
+                    return_state_dict=False,
+                    net_override=net_override,
                 )
 
                 # prepare data and test

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -146,7 +146,7 @@ class TestLoad(unittest.TestCase):
                     source="github",
                     progress=False,
                     device=device,
-                    return_state_dict=False,
+                    return_state_dict=True,
                 )
 
                 # prepare network
@@ -175,7 +175,6 @@ class TestLoad(unittest.TestCase):
                     bundle_dir=tempdir,
                     progress=False,
                     device=device,
-                    net_name=model_name,
                     source="github",
                     return_state_dict=False,
                 )
@@ -183,7 +182,7 @@ class TestLoad(unittest.TestCase):
                 output_2 = model_2.forward(input_tensor)
                 assert_allclose(output_2, expected_output, atol=1e-4, rtol=1e-4, type_test=False)
 
-                # test forward compatibility with return_state_dict=True.
+                # test compatibility with return_state_dict=True.
                 model_3 = load(
                     name=bundle_name,
                     model_file=model_file,
@@ -192,6 +191,7 @@ class TestLoad(unittest.TestCase):
                     device=device,
                     net_name=model_name,
                     source="github",
+                    return_state_dict=False,
                     **net_args,
                 )
                 model_3.eval()

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -205,7 +205,14 @@ class TestLoad(unittest.TestCase):
             # download bundle, and load weights from the downloaded path
             with tempfile.TemporaryDirectory() as tempdir:
                 # load weights
-                model = load(name=bundle_name, bundle_dir=tempdir, source="monaihosting", progress=False, device=device, return_state_dict=False)
+                model = load(
+                    name=bundle_name,
+                    bundle_dir=tempdir,
+                    source="monaihosting",
+                    progress=False,
+                    device=device,
+                    return_state_dict=False,
+                )
 
                 # prepare data and test
                 input_tensor = torch.rand(1, 1, 96, 96, 96).to(device)


### PR DESCRIPTION
Fixes # .

### Description
Avoid breaking changes introduced by https://github.com/Project-MONAI/MONAI/pull/6835
- when creating `BundleWorkflow`
- when using `load` API, add `return_state_dict` when `model` and `net_name` are both `None`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
