### PR TITLE
optional import cucim.skimage directly

### DIFF
--- a/monai/auto3dseg/utils.py
+++ b/monai/auto3dseg/utils.py
@@ -94,11 +94,11 @@ def get_label_ccp(mask_index: MetaTensor, use_gpu: bool = True) -> tuple[list[An
             regardless of this setting.
 
     """
-    cucim, has_cucim = optional_import("cucim")
+    skimage, has_cucim = optional_import("cucim.skimage")
     shape_list = []
     if mask_index.device.type == "cuda" and has_cp and has_cucim and use_gpu:
         mask_cupy = ToCupy()(mask_index.short())
-        labeled = cucim.skimage.measure.label(mask_cupy)
+        labeled = skimage.measure.label(mask_cupy)
         vals = cp.unique(labeled[cp.nonzero(labeled)])
 
         for ncomp in vals:

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1027,11 +1027,11 @@ def get_largest_connected_component_mask(
     """
     # use skimage/cucim.skimage and np/cp depending on whether packages are
     # available and input is non-cpu torch.tensor
-    cucim, has_cucim = optional_import("cucim")
+    skimage, has_cucim = optional_import("cucim.skimage")
     use_cp = has_cp and has_cucim and isinstance(img, torch.Tensor) and img.device != torch.device("cpu")
     if use_cp:
         img_ = convert_to_cupy(img.short())  # type: ignore
-        label = cucim.skimage.measure.label
+        label = skimage.measure.label
         lib = cp
     else:
         if not has_measure:


### PR DESCRIPTION
Fixes #6956 .

### Description

Looks like an error which introduced by this [PR](https://github.com/rapidsai/cucim/pull/575).
The submodule in cucim.skimage can import correctly, so change to directly import cucim.skimage.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
