### PR TITLE
Add `download_large_files` in `monai/bundle/scripts.py`

### DIFF
--- a/monai/bundle/__init__.py
+++ b/monai/bundle/__init__.py
@@ -19,6 +19,7 @@ from .scripts import (
     ckpt_export,
     create_workflow,
     download,
+    download_large_files,
     get_all_bundles_list,
     get_bundle_info,
     get_bundle_versions,
@@ -30,7 +31,6 @@ from .scripts import (
     trt_export,
     verify_metadata,
     verify_net_in_out,
-    download_large_files,
 )
 from .utils import (
     DEFAULT_EXP_MGMT_SETTINGS,

--- a/monai/bundle/__init__.py
+++ b/monai/bundle/__init__.py
@@ -30,6 +30,7 @@ from .scripts import (
     trt_export,
     verify_metadata,
     verify_net_in_out,
+    download_large_files,
 )
 from .utils import (
     DEFAULT_EXP_MGMT_SETTINGS,

--- a/monai/bundle/__main__.py
+++ b/monai/bundle/__main__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from monai.bundle.scripts import (
     ckpt_export,
     download,
+    download_large_files,
     init_bundle,
     onnx_export,
     run,
@@ -21,7 +22,6 @@ from monai.bundle.scripts import (
     trt_export,
     verify_metadata,
     verify_net_in_out,
-    download_large_files,
 )
 
 if __name__ == "__main__":

--- a/monai/bundle/__main__.py
+++ b/monai/bundle/__main__.py
@@ -21,6 +21,7 @@ from monai.bundle.scripts import (
     trt_export,
     verify_metadata,
     verify_net_in_out,
+    download_large_files,
 )
 
 if __name__ == "__main__":

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -1641,14 +1641,13 @@ def download_large_files(bundle_path: str, large_file_name: str | None = None) -
 
     """
     if large_file_name is None:
-        for large_file_type in [".yml", ".yaml", ".json"]:
-            large_file_name = "large_files" + large_file_type
-            large_file_path = os.path.join(bundle_path, large_file_name)
-            if os.path.exists(large_file_path):
-                break
+        large_file_path = list(Path(bundle_path).glob("large_files*"))
+        large_file_path = list(filter(lambda x: x.suffix in [".yml", ".yaml", ".json"], large_file_path))
+        if len(large_file_path) == 0:
+            raise FileNotFoundError("Cannot find the large files.")
 
     parser = ConfigParser()
-    parser.read_config(os.path.join(bundle_path, large_file_name))
+    parser.read_config(large_file_path)
     large_files_list = parser.get()["large_files"]
     for lf_data in large_files_list:
         lf_data["fuzzy"] = True

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -1586,3 +1586,43 @@ def create_workflow(
     workflow_.initialize()
 
     return workflow_
+
+
+def download_large_files(bundle_path: str, large_file_name: str | None = None) -> None:
+    """
+    This utility allows you to download large files from a bundle. It supports file suffixes like ".yml", ".yaml", and ".json".
+    If you don't specify a `large_file_name`, it will automatically search for large files among the supported suffixes.
+
+    Typical usage examples:
+    .. code-block:: bash
+
+        # Execute this module as a CLI entry to download large files from a bundle path:
+        python -m monai.bundle download_large_files --bundle_path <bundle_path>
+
+        # Execute this module as a CLI entry to download large files from the bundle path with a specified `large_file_name`:
+        python -m monai.bundle download_large_files --bundle_path <bundle_path> --large_file_name large_files.yaml
+
+    Args:
+        bundle_path: The path to the bundle where the files are located.
+        large_file_name: (Optional) The name of the large file to be downloaded.
+
+    """
+    if large_file_name is None:
+        for large_file_type in [".yml", ".yaml", ".json"]:
+            large_file_name = "large_files" + large_file_type
+            large_file_path = os.path.join(bundle_path, large_file_name)
+            if os.path.exists(large_file_path):
+                break
+
+    parser = ConfigParser()
+    parser.read_config(os.path.join(bundle_path, large_file_name))
+    large_files_list = parser.get()["large_files"]
+    for lf_data in large_files_list:
+        lf_data["fuzzy"] = True
+        if "hash_val" in lf_data and lf_data.get("hash_val", "") == "":
+            lf_data.pop("hash_val")
+        if "hash_type" in lf_data and lf_data.get("hash_type", "") == "":
+            lf_data.pop("hash_type")
+        lf_data["filepath"] = os.path.join(bundle_path, lf_data["path"])
+        lf_data.pop("path")
+        download_url(**lf_data)

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -1621,7 +1621,7 @@ def create_workflow(
     return workflow_
 
 
-def download_large_files(bundle_path: str, large_file_name: str | None = None) -> None:
+def download_large_files(bundle_path: str | None = None, large_file_name: str | None = None) -> None:
     """
     This utility allows you to download large files from a bundle. It supports file suffixes like ".yml", ".yaml", and ".json".
     If you don't specify a `large_file_name`, it will automatically search for large files among the supported suffixes.
@@ -1636,15 +1636,16 @@ def download_large_files(bundle_path: str, large_file_name: str | None = None) -
         python -m monai.bundle download_large_files --bundle_path <bundle_path> --large_file_name large_files.yaml
 
     Args:
-        bundle_path: The path to the bundle where the files are located.
+        bundle_path: (Optional) The path to the bundle where the files are located. Default is `os.getcwd()`.
         large_file_name: (Optional) The name of the large file to be downloaded.
 
     """
+    bundle_path = os.getcwd() if bundle_path is None else bundle_path
     if large_file_name is None:
         large_file_path = list(Path(bundle_path).glob("large_files*"))
         large_file_path = list(filter(lambda x: x.suffix in [".yml", ".yaml", ".json"], large_file_path))
         if len(large_file_path) == 0:
-            raise FileNotFoundError("Cannot find the large files.")
+            raise FileNotFoundError(f"Cannot find the large_files.yml/yaml/json under {bundle_path}.")
 
     parser = ConfigParser()
     parser.read_config(large_file_path)

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -71,63 +71,70 @@ TEST_CASE_7 = [
     {"spatial_dims": 3, "out_channels": 5},
 ]
 
+TEST_CASE_8 = [
+    ["network.json", "test_output.pt", "test_input.pt", "large_files.yaml"],
+    "test_bundle_v0.1.2",
+    "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/test_bundle_v0.1.2.zip",
+    {"model.pt": "27952767e2e154e3b0ee65defc5aed38", "model.ts": "97746870fe591f69ac09827175b00675"},
+]
 
-class TestDownload(unittest.TestCase):
-    @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
-    @skip_if_quick
-    def test_github_download_bundle(self, bundle_name, version):
-        bundle_files = ["model.pt", "model.ts", "network.json", "test_output.pt", "test_input.pt"]
-        repo = "Project-MONAI/MONAI-extra-test-data/0.8.1"
-        hash_val = "a131d39a0af717af32d19e565b434928"
-        with skip_if_downloading_fails():
-            # download a whole bundle from github releases
-            with tempfile.TemporaryDirectory() as tempdir:
-                cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--name", bundle_name, "--source", "github"]
-                cmd += ["--bundle_dir", tempdir, "--repo", repo]
-                if version is not None:
-                    cmd += ["--version", version]
-                command_line_tests(cmd)
-                for file in bundle_files:
-                    file_path = os.path.join(tempdir, "test_bundle", file)
-                    self.assertTrue(os.path.exists(file_path))
-                    if file == "network.json":
-                        self.assertTrue(check_hash(filepath=file_path, val=hash_val))
 
-    @parameterized.expand([TEST_CASE_3])
-    @skip_if_quick
-    def test_url_download_bundle(self, bundle_files, bundle_name, url, hash_val):
-        with skip_if_downloading_fails():
-            # download a single file from url, also use `args_file`
-            with tempfile.TemporaryDirectory() as tempdir:
-                def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
-                def_args_file = os.path.join(tempdir, "def_args.json")
-                parser = ConfigParser()
-                parser.export_config_file(config=def_args, filepath=def_args_file)
-                cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
-                cmd += ["--url", url, "--source", "github"]
-                command_line_tests(cmd)
-                for file in bundle_files:
-                    file_path = os.path.join(tempdir, bundle_name, file)
-                    self.assertTrue(os.path.exists(file_path))
-                if file == "network.json":
-                    self.assertTrue(check_hash(filepath=file_path, val=hash_val))
+# class TestDownload(unittest.TestCase):
+#     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
+#     @skip_if_quick
+#     def test_github_download_bundle(self, bundle_name, version):
+#         bundle_files = ["model.pt", "model.ts", "network.json", "test_output.pt", "test_input.pt"]
+#         repo = "Project-MONAI/MONAI-extra-test-data/0.8.1"
+#         hash_val = "a131d39a0af717af32d19e565b434928"
+#         with skip_if_downloading_fails():
+#             # download a whole bundle from github releases
+#             with tempfile.TemporaryDirectory() as tempdir:
+#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--name", bundle_name, "--source", "github"]
+#                 cmd += ["--bundle_dir", tempdir, "--repo", repo]
+#                 if version is not None:
+#                     cmd += ["--version", version]
+#                 command_line_tests(cmd)
+#                 for file in bundle_files:
+#                     file_path = os.path.join(tempdir, "test_bundle", file)
+#                     self.assertTrue(os.path.exists(file_path))
+#                     if file == "network.json":
+#                         self.assertTrue(check_hash(filepath=file_path, val=hash_val))
 
-    @parameterized.expand([TEST_CASE_6])
-    @skip_if_quick
-    def test_monaihosting_download_bundle(self, bundle_files, bundle_name, url):
-        with skip_if_downloading_fails():
-            # download a single file from url, also use `args_file`
-            with tempfile.TemporaryDirectory() as tempdir:
-                def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
-                def_args_file = os.path.join(tempdir, "def_args.json")
-                parser = ConfigParser()
-                parser.export_config_file(config=def_args, filepath=def_args_file)
-                cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
-                cmd += ["--url", url, "--progress", "False", "--source", "monaihosting"]
-                command_line_tests(cmd)
-                for file in bundle_files:
-                    file_path = os.path.join(tempdir, bundle_name, file)
-                    self.assertTrue(os.path.exists(file_path))
+#     @parameterized.expand([TEST_CASE_3])
+#     @skip_if_quick
+#     def test_url_download_bundle(self, bundle_files, bundle_name, url, hash_val):
+#         with skip_if_downloading_fails():
+#             # download a single file from url, also use `args_file`
+#             with tempfile.TemporaryDirectory() as tempdir:
+#                 def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
+#                 def_args_file = os.path.join(tempdir, "def_args.json")
+#                 parser = ConfigParser()
+#                 parser.export_config_file(config=def_args, filepath=def_args_file)
+#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
+#                 cmd += ["--url", url, "--source", "github"]
+#                 command_line_tests(cmd)
+#                 for file in bundle_files:
+#                     file_path = os.path.join(tempdir, bundle_name, file)
+#                     self.assertTrue(os.path.exists(file_path))
+#                 if file == "network.json":
+#                     self.assertTrue(check_hash(filepath=file_path, val=hash_val))
+
+#     @parameterized.expand([TEST_CASE_6])
+#     @skip_if_quick
+#     def test_monaihosting_download_bundle(self, bundle_files, bundle_name, url):
+#         with skip_if_downloading_fails():
+#             # download a single file from url, also use `args_file`
+#             with tempfile.TemporaryDirectory() as tempdir:
+#                 def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
+#                 def_args_file = os.path.join(tempdir, "def_args.json")
+#                 parser = ConfigParser()
+#                 parser.export_config_file(config=def_args, filepath=def_args_file)
+#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
+#                 cmd += ["--url", url, "--progress", "False", "--source", "monaihosting"]
+#                 command_line_tests(cmd)
+#                 for file in bundle_files:
+#                     file_path = os.path.join(tempdir, bundle_name, file)
+#                     self.assertTrue(os.path.exists(file_path))
 
 
 class TestLoad(unittest.TestCase):
@@ -147,7 +154,6 @@ class TestLoad(unittest.TestCase):
                     progress=False,
                     device=device,
                 )
-
                 # prepare network
                 with open(os.path.join(tempdir, bundle_name, bundle_files[2])) as f:
                     net_args = json.load(f)["network_def"]
@@ -248,6 +254,34 @@ class TestLoad(unittest.TestCase):
                 self.assertTrue(metadata["pytorch_version"] == "1.7.1")
                 # test extra_file_dict
                 self.assertTrue("network.json" in extra_file_dict.keys())
+
+
+# class TestDownloadLargefiles(unittest.TestCase):
+#     @parameterized.expand([TEST_CASE_8])
+#     @skip_if_quick
+#     def test_url_download_large_files(self, bundle_files, bundle_name, url, hash_val):
+#         with skip_if_downloading_fails():
+#             # download a single file from url, also use `args_file`
+#             with tempfile.TemporaryDirectory() as tempdir:
+#                 def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
+#                 def_args_file = os.path.join(tempdir, "def_args.json")
+#                 parser = ConfigParser()
+#                 parser.export_config_file(config=def_args, filepath=def_args_file)
+#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
+#                 cmd += ["--url", url, "--source", "github"]
+#                 command_line_tests(cmd)
+#                 for file in bundle_files:
+#                     file_path = os.path.join(tempdir, bundle_name, file)
+#                     print(file_path)
+#                     self.assertTrue(os.path.exists(file_path))
+
+#                 # download large files
+#                 bundle_path = os.path.join(tempdir, bundle_name)
+#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download_large_files", "--bundle_path", bundle_path]
+#                 command_line_tests(cmd)
+#                 for file in ["model.pt", "model.ts"]:
+#                     file_path = os.path.join(tempdir, bundle_name, f"models/{file}")
+#                     self.assertTrue(check_hash(filepath=file_path, val=hash_val[file]))
 
 
 if __name__ == "__main__":

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -79,62 +79,62 @@ TEST_CASE_8 = [
 ]
 
 
-# class TestDownload(unittest.TestCase):
-#     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
-#     @skip_if_quick
-#     def test_github_download_bundle(self, bundle_name, version):
-#         bundle_files = ["model.pt", "model.ts", "network.json", "test_output.pt", "test_input.pt"]
-#         repo = "Project-MONAI/MONAI-extra-test-data/0.8.1"
-#         hash_val = "a131d39a0af717af32d19e565b434928"
-#         with skip_if_downloading_fails():
-#             # download a whole bundle from github releases
-#             with tempfile.TemporaryDirectory() as tempdir:
-#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--name", bundle_name, "--source", "github"]
-#                 cmd += ["--bundle_dir", tempdir, "--repo", repo]
-#                 if version is not None:
-#                     cmd += ["--version", version]
-#                 command_line_tests(cmd)
-#                 for file in bundle_files:
-#                     file_path = os.path.join(tempdir, "test_bundle", file)
-#                     self.assertTrue(os.path.exists(file_path))
-#                     if file == "network.json":
-#                         self.assertTrue(check_hash(filepath=file_path, val=hash_val))
+class TestDownload(unittest.TestCase):
+    @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
+    @skip_if_quick
+    def test_github_download_bundle(self, bundle_name, version):
+        bundle_files = ["model.pt", "model.ts", "network.json", "test_output.pt", "test_input.pt"]
+        repo = "Project-MONAI/MONAI-extra-test-data/0.8.1"
+        hash_val = "a131d39a0af717af32d19e565b434928"
+        with skip_if_downloading_fails():
+            # download a whole bundle from github releases
+            with tempfile.TemporaryDirectory() as tempdir:
+                cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--name", bundle_name, "--source", "github"]
+                cmd += ["--bundle_dir", tempdir, "--repo", repo]
+                if version is not None:
+                    cmd += ["--version", version]
+                command_line_tests(cmd)
+                for file in bundle_files:
+                    file_path = os.path.join(tempdir, "test_bundle", file)
+                    self.assertTrue(os.path.exists(file_path))
+                    if file == "network.json":
+                        self.assertTrue(check_hash(filepath=file_path, val=hash_val))
 
-#     @parameterized.expand([TEST_CASE_3])
-#     @skip_if_quick
-#     def test_url_download_bundle(self, bundle_files, bundle_name, url, hash_val):
-#         with skip_if_downloading_fails():
-#             # download a single file from url, also use `args_file`
-#             with tempfile.TemporaryDirectory() as tempdir:
-#                 def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
-#                 def_args_file = os.path.join(tempdir, "def_args.json")
-#                 parser = ConfigParser()
-#                 parser.export_config_file(config=def_args, filepath=def_args_file)
-#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
-#                 cmd += ["--url", url, "--source", "github"]
-#                 command_line_tests(cmd)
-#                 for file in bundle_files:
-#                     file_path = os.path.join(tempdir, bundle_name, file)
-#                     self.assertTrue(os.path.exists(file_path))
-#                 if file == "network.json":
-#                     self.assertTrue(check_hash(filepath=file_path, val=hash_val))
+    @parameterized.expand([TEST_CASE_3])
+    @skip_if_quick
+    def test_url_download_bundle(self, bundle_files, bundle_name, url, hash_val):
+        with skip_if_downloading_fails():
+            # download a single file from url, also use `args_file`
+            with tempfile.TemporaryDirectory() as tempdir:
+                def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
+                def_args_file = os.path.join(tempdir, "def_args.json")
+                parser = ConfigParser()
+                parser.export_config_file(config=def_args, filepath=def_args_file)
+                cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
+                cmd += ["--url", url, "--source", "github"]
+                command_line_tests(cmd)
+                for file in bundle_files:
+                    file_path = os.path.join(tempdir, bundle_name, file)
+                    self.assertTrue(os.path.exists(file_path))
+                if file == "network.json":
+                    self.assertTrue(check_hash(filepath=file_path, val=hash_val))
 
-#     @parameterized.expand([TEST_CASE_6])
-#     @skip_if_quick
-#     def test_monaihosting_download_bundle(self, bundle_files, bundle_name, url):
-#         with skip_if_downloading_fails():
-#             # download a single file from url, also use `args_file`
-#             with tempfile.TemporaryDirectory() as tempdir:
-#                 def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
-#                 def_args_file = os.path.join(tempdir, "def_args.json")
-#                 parser = ConfigParser()
-#                 parser.export_config_file(config=def_args, filepath=def_args_file)
-#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
-#                 cmd += ["--url", url, "--progress", "False", "--source", "monaihosting"]
-#                 command_line_tests(cmd)
-#                 for file in bundle_files:
-#                     file_path = os.path.join(tempdir, bundle_name, file)
-#                     self.assertTrue(os.path.exists(file_path))
+    @parameterized.expand([TEST_CASE_6])
+    @skip_if_quick
+    def test_monaihosting_download_bundle(self, bundle_files, bundle_name, url):
+        with skip_if_downloading_fails():
+            # download a single file from url, also use `args_file`
+            with tempfile.TemporaryDirectory() as tempdir:
+                def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
+                def_args_file = os.path.join(tempdir, "def_args.json")
+                parser = ConfigParser()
+                parser.export_config_file(config=def_args, filepath=def_args_file)
+                cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
+                cmd += ["--url", url, "--progress", "False", "--source", "monaihosting"]
+                command_line_tests(cmd)
+                for file in bundle_files:
+                    file_path = os.path.join(tempdir, bundle_name, file)
+                    self.assertTrue(os.path.exists(file_path))
 
 
 class TestLoad(unittest.TestCase):
@@ -281,32 +281,32 @@ class TestLoad(unittest.TestCase):
                 self.assertTrue("network.json" in extra_file_dict.keys())
 
 
-# class TestDownloadLargefiles(unittest.TestCase):
-#     @parameterized.expand([TEST_CASE_8])
-#     @skip_if_quick
-#     def test_url_download_large_files(self, bundle_files, bundle_name, url, hash_val):
-#         with skip_if_downloading_fails():
-#             # download a single file from url, also use `args_file`
-#             with tempfile.TemporaryDirectory() as tempdir:
-#                 def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
-#                 def_args_file = os.path.join(tempdir, "def_args.json")
-#                 parser = ConfigParser()
-#                 parser.export_config_file(config=def_args, filepath=def_args_file)
-#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
-#                 cmd += ["--url", url, "--source", "github"]
-#                 command_line_tests(cmd)
-#                 for file in bundle_files:
-#                     file_path = os.path.join(tempdir, bundle_name, file)
-#                     print(file_path)
-#                     self.assertTrue(os.path.exists(file_path))
+class TestDownloadLargefiles(unittest.TestCase):
+    @parameterized.expand([TEST_CASE_8])
+    @skip_if_quick
+    def test_url_download_large_files(self, bundle_files, bundle_name, url, hash_val):
+        with skip_if_downloading_fails():
+            # download a single file from url, also use `args_file`
+            with tempfile.TemporaryDirectory() as tempdir:
+                def_args = {"name": bundle_name, "bundle_dir": tempdir, "url": ""}
+                def_args_file = os.path.join(tempdir, "def_args.json")
+                parser = ConfigParser()
+                parser.export_config_file(config=def_args, filepath=def_args_file)
+                cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
+                cmd += ["--url", url, "--source", "github"]
+                command_line_tests(cmd)
+                for file in bundle_files:
+                    file_path = os.path.join(tempdir, bundle_name, file)
+                    print(file_path)
+                    self.assertTrue(os.path.exists(file_path))
 
-#                 # download large files
-#                 bundle_path = os.path.join(tempdir, bundle_name)
-#                 cmd = ["coverage", "run", "-m", "monai.bundle", "download_large_files", "--bundle_path", bundle_path]
-#                 command_line_tests(cmd)
-#                 for file in ["model.pt", "model.ts"]:
-#                     file_path = os.path.join(tempdir, bundle_name, f"models/{file}")
-#                     self.assertTrue(check_hash(filepath=file_path, val=hash_val[file]))
+                # download large files
+                bundle_path = os.path.join(tempdir, bundle_name)
+                cmd = ["coverage", "run", "-m", "monai.bundle", "download_large_files", "--bundle_path", bundle_path]
+                command_line_tests(cmd)
+                for file in ["model.pt", "model.ts"]:
+                    file_path = os.path.join(tempdir, bundle_name, f"models/{file}")
+                    self.assertTrue(check_hash(filepath=file_path, val=hash_val[file]))
 
 
 if __name__ == "__main__":

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -73,7 +73,7 @@ TEST_CASE_7 = [
 
 TEST_CASE_8 = [
     ["network.json", "test_output.pt", "test_input.pt", "large_files.yaml"],
-    "test_bundle_v0.1.2",
+    "test_bundle",
     "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/test_bundle_v0.1.2.zip",
     {"model.pt": "27952767e2e154e3b0ee65defc5aed38", "model.ts": "97746870fe591f69ac09827175b00675"},
 ]


### PR DESCRIPTION
Fixes #6362 .

### Description

Add `download_large_files` in `monai/bundle/scripts.py`.
Refer to the one in https://github.com/Project-MONAI/model-zoo/blob/131b0da3f540ed13a8a1c02d8395e92a682d47cf/ci/utils.py#L93.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
