### PR TITLE
6962 Fix bundle download naming issue

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -160,7 +160,7 @@ def _get_ngc_bundle_url(model_name: str, version: str) -> str:
 
 def _get_monaihosting_bundle_url(model_name: str, version: str) -> str:
     monaihosting_root_path = "https://api.ngc.nvidia.com/v2/models/nvidia/monaihosting"
-    return f"{monaihosting_root_path}/{model_name}/versions/{version}/files/{model_name.lower()}_v{version}.zip"
+    return f"{monaihosting_root_path}/{model_name.lower()}/versions/{version}/files/{model_name}_v{version}.zip"
 
 
 def _download_from_github(repo: str, download_path: Path, filename: str, progress: bool = True) -> None:

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -71,11 +71,7 @@ TEST_CASE_7 = [
     {"spatial_dims": 3, "out_channels": 5},
 ]
 
-TEST_CASE_8 = [
-    ["models/model.pt", "configs/train.json"],
-    "renalStructures_CECT_segmentation",
-    "0.1.0",
-]
+TEST_CASE_8 = [["models/model.pt", "configs/train.json"], "renalStructures_CECT_segmentation", "0.1.0"]
 
 TEST_CASE_9 = [
     ["network.json", "test_output.pt", "test_input.pt", "large_files.yaml"],

--- a/tests/test_bundle_download.py
+++ b/tests/test_bundle_download.py
@@ -136,7 +136,7 @@ class TestDownload(unittest.TestCase):
                 parser = ConfigParser()
                 parser.export_config_file(config=def_args, filepath=def_args_file)
                 cmd = ["coverage", "run", "-m", "monai.bundle", "download", "--args_file", def_args_file]
-                cmd += ["--url", url, "--progress", "False", "--source", "monaihosting"]
+                cmd += ["--url", url, "--progress", "False"]
                 command_line_tests(cmd)
                 for file in bundle_files:
                     file_path = os.path.join(tempdir, bundle_name, file)


### PR DESCRIPTION
Fixes #6962 .

### Description

This PR is used to fix the bundle download issue if using monaihosting source. Detailed information is attached in #6962 .

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
