### PR TITLE
Fix `Lazy=True` ignored when using `Dataset` call 

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -95,7 +95,7 @@ class Dataset(_TorchDataset):
         Fetch single data item from `self.data`.
         """
         data_i = self.data[index]
-        return apply_transform(self.transform, data_i) if self.transform is not None else data_i
+        return apply_transform(self.transform, data_i, lazy=self.transform.lazy) if self.transform is not None else data_i
 
     def __getitem__(self, index: int | slice | Sequence[int]):
         """

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -95,7 +95,7 @@ class Dataset(_TorchDataset):
         Fetch single data item from `self.data`.
         """
         data_i = self.data[index]
-        return apply_transform(self.transform, data_i, lazy=self.transform.lazy) if self.transform is not None else data_i
+        return apply_transform(self.transform, data_i) if self.transform is not None else data_i
 
     def __getitem__(self, index: int | slice | Sequence[int]):
         """

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -104,7 +104,7 @@ def apply_transform(
     map_items: bool = True,
     unpack_items: bool = False,
     log_stats: bool | str = False,
-    lazy: bool | None = False,
+    lazy: bool | None = None,
     overrides: dict | None = None,
 ) -> list[ReturnType] | ReturnType:
     """

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -104,7 +104,7 @@ def apply_transform(
     map_items: bool = True,
     unpack_items: bool = False,
     log_stats: bool | str = False,
-    lazy: bool | None = None,
+    lazy: bool | None = False,
     overrides: dict | None = None,
 ) -> list[ReturnType] | ReturnType:
     """
@@ -124,7 +124,7 @@ def apply_transform(
             disables the logger for processing pipeline errors. Setting it to None or True will enable logging to the
             default logger name. Setting it to a string specifies the logger to which errors should be logged.
         lazy: whether to execute in lazy mode or not. See the :ref:`Lazy Resampling topic<lazy_resampling> for more
-        information about lazy resampling.
+            information about lazy resampling.
         overrides: optional overrides to apply to transform parameters. This parameter is ignored unless transforms
             are being executed lazily. See the :ref:`Lazy Resampling topic<lazy_resampling> for more details and
             examples of its usage.

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -124,7 +124,7 @@ def apply_transform(
             disables the logger for processing pipeline errors. Setting it to None or True will enable logging to the
             default logger name. Setting it to a string specifies the logger to which errors should be logged.
         lazy: whether to execute in lazy mode or not. See the :ref:`Lazy Resampling topic<lazy_resampling> for more
-        information about lazy resampling.
+            information about lazy resampling. Defaults to None.
         overrides: optional overrides to apply to transform parameters. This parameter is ignored unless transforms
             are being executed lazily. See the :ref:`Lazy Resampling topic<lazy_resampling> for more details and
             examples of its usage.

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -104,7 +104,7 @@ def apply_transform(
     map_items: bool = True,
     unpack_items: bool = False,
     log_stats: bool | str = False,
-    lazy: bool | None = False,
+    lazy: bool | None = None,
     overrides: dict | None = None,
 ) -> list[ReturnType] | ReturnType:
     """
@@ -124,7 +124,7 @@ def apply_transform(
             disables the logger for processing pipeline errors. Setting it to None or True will enable logging to the
             default logger name. Setting it to a string specifies the logger to which errors should be logged.
         lazy: whether to execute in lazy mode or not. See the :ref:`Lazy Resampling topic<lazy_resampling> for more
-            information about lazy resampling.
+        information about lazy resampling.
         overrides: optional overrides to apply to transform parameters. This parameter is ignored unless transforms
             are being executed lazily. See the :ref:`Lazy Resampling topic<lazy_resampling> for more details and
             examples of its usage.

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -607,6 +607,12 @@ TEST_COMPOSE_LAZY_ON_CALL_LOGGING_TEST_CASES = [
             "INFO - Pending transforms applied: applied_operations: 1\n"
         ),
     ],
+    [
+        mt.OneOf,
+        (mt.Flip(0),),
+        False,
+        ("INFO - Apply pending transforms - lazy: False, pending: 0, " "upcoming 'Flip', transform.lazy: False\n"),
+    ],
 ]
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -11,9 +11,12 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 import unittest
+from copy import deepcopy
+from io import StringIO
 
 import nibabel as nib
 import numpy as np
@@ -21,6 +24,7 @@ from parameterized import parameterized
 
 from monai.data import Dataset
 from monai.transforms import Compose, LoadImaged, SimulateDelayd
+from tests.test_compose import TEST_COMPOSE_LAZY_ON_CALL_LOGGING_TEST_CASES, data_from_keys
 
 TEST_CASE_1 = [(128, 128, 128)]
 
@@ -88,6 +92,39 @@ class TestDataset(unittest.TestCase):
             self.assertEqual(len(data4_list), 1)
             for d in data4_list:
                 self.assertTupleEqual(d["image"].shape, expected_shape)
+
+    def test_dataset_lazy_on_call(self):
+        data = np.zeros((1, 5, 5))
+        data[0, 0:2, 0:2] = 1
+
+
+class TestDatsesetWithLazy(unittest.TestCase):
+    LOGGER_NAME = "a_logger_name"
+
+    def init_logger(self, name=LOGGER_NAME):
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        formatter = logging.Formatter("%(levelname)s - %(message)s")
+        handler.setFormatter(formatter)
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.INFO)
+        while len(logger.handlers) > 0:
+            logger.removeHandler(logger.handlers[-1])
+        logger.addHandler(handler)
+        return handler, stream
+
+    @parameterized.expand(TEST_COMPOSE_LAZY_ON_CALL_LOGGING_TEST_CASES)
+    def test_dataset_lazy_with_logging(self, compose_type, pipeline, lazy, expected):
+        handler, stream = self.init_logger(name=self.LOGGER_NAME)
+
+        data = data_from_keys(None, 12, 16)
+        c = compose_type(deepcopy(pipeline), log_stats=self.LOGGER_NAME, lazy=lazy)
+        x = Dataset([data], transform=c)
+        x[0]
+
+        handler.flush()
+        actual = stream.getvalue()
+        self.assertEqual(actual, expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -119,8 +119,8 @@ class TestDatsesetWithLazy(unittest.TestCase):
 
         data = data_from_keys(None, 12, 16)
         c = compose_type(deepcopy(pipeline), log_stats=self.LOGGER_NAME, lazy=lazy)
-        x = Dataset([data], transform=c)
-        x[0]
+        ds = Dataset([data], transform=c)
+        ds[0]
 
         handler.flush()
         actual = stream.getvalue()


### PR DESCRIPTION
Fixes #6974.

### Description
Change default value of `lazy` in `apply_transform` to None.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
