### PR TITLE
6976 improve config expr error msg

### DIFF
--- a/monai/bundle/config_item.py
+++ b/monai/bundle/config_item.py
@@ -18,6 +18,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from importlib import import_module
+from pprint import pformat
 from typing import Any
 
 from monai.bundle.utils import EXPR_KEY
@@ -157,7 +158,7 @@ class ConfigItem:
         return self.config
 
     def __repr__(self) -> str:
-        return str(self.config)
+        return f"{type(self).__name__}: \n{pformat(self.config)}"
 
 
 class ConfigComponent(ConfigItem, Instantiable):
@@ -291,7 +292,7 @@ class ConfigComponent(ConfigItem, Instantiable):
         try:
             return instantiate(modname, mode, **args)
         except Exception as e:
-            raise RuntimeError(f"Failed to instantiate {self}.") from e
+            raise RuntimeError(f"Failed to instantiate {self}") from e
 
 
 class ConfigExpression(ConfigItem):
@@ -372,7 +373,10 @@ class ConfigExpression(ConfigItem):
                     warnings.warn(f"the new global variable `{k}` conflicts with `self.globals`, override it.")
                 globals_[k] = v
         if not run_debug:
-            return eval(value[len(self.prefix) :], globals_, locals)
+            try:
+                return eval(value[len(self.prefix) :], globals_, locals)
+            except Exception as e:
+                raise RuntimeError(f"Failed to evaluate {self}") from e
         warnings.warn(
             f"\n\npdb: value={value}\n"
             f"See also Debugger commands documentation: https://docs.python.org/3/library/pdb.html\n"

--- a/tests/test_config_item.py
+++ b/tests/test_config_item.py
@@ -128,6 +128,10 @@ class TestConfigItem(unittest.TestCase):
         flag = expr.is_import_statement(expr.config)
         self.assertEqual(flag, expected)
 
+    def test_error_expr(self):
+        with self.assertRaisesRegex(RuntimeError, r"1\+\[\]"):
+            ConfigExpression(id="", config="$1+[]").evaluate()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #6976 



### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
