### PR TITLE
Add stats_sender to MonaiAlgo for FL stats

### DIFF
--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import Mapping, MutableMapping
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import torch
 import torch.distributed as dist

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -359,7 +359,6 @@ class MonaiAlgo(ClientAlgo, MonaiAlgoStats):
         eval_workflow_name: str = "train",
         train_workflow: BundleWorkflow | None = None,
         eval_workflow: BundleWorkflow | None = None,
-        stats_sender: Callable | None = None,
     ):
         self.logger = logger
         self.bundle_root = bundle_root
@@ -391,7 +390,7 @@ class MonaiAlgo(ClientAlgo, MonaiAlgoStats):
             if not isinstance(eval_workflow, BundleWorkflow) or eval_workflow.get_workflow_type() is None:
                 raise ValueError("train workflow must be BundleWorkflow and set type.")
             self.eval_workflow = eval_workflow
-        self.stats_sender = stats_sender
+        self.stats_sender = None
 
         self.app_root = ""
         self.filter_parser: ConfigParser | None = None

--- a/monai/fl/utils/constants.py
+++ b/monai/fl/utils/constants.py
@@ -29,6 +29,7 @@ class ExtraItems(StrEnum):
     MODEL_TYPE = "fl_model_type"
     CLIENT_NAME = "fl_client_name"
     APP_ROOT = "fl_app_root"
+    STATS_SENDER = "fl_stats_sender"
 
 
 class FlPhase(StrEnum):


### PR DESCRIPTION
PR #6220 was closed and NVFlareStatsHandler has now been implemented in NVFlare in https://github.com/NVIDIA/NVFlare/pull/1925. However, there is still the piece in MonaiAlgo to attach the stats_sender in initialize, so this PR adds that missing piece.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
