### PR TITLE
Fix unused `kernel_size` in `ResBlock`

### DIFF
--- a/monai/networks/blocks/segresnet_block.py
+++ b/monai/networks/blocks/segresnet_block.py
@@ -73,8 +73,8 @@ class ResBlock(nn.Module):
         self.norm1 = get_norm_layer(name=norm, spatial_dims=spatial_dims, channels=in_channels)
         self.norm2 = get_norm_layer(name=norm, spatial_dims=spatial_dims, channels=in_channels)
         self.act = get_act_layer(act)
-        self.conv1 = get_conv_layer(spatial_dims, in_channels=in_channels, out_channels=in_channels)
-        self.conv2 = get_conv_layer(spatial_dims, in_channels=in_channels, out_channels=in_channels)
+        self.conv1 = get_conv_layer(spatial_dims, in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)
+        self.conv2 = get_conv_layer(spatial_dims, in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)
 
     def forward(self, x):
         identity = x

--- a/monai/networks/blocks/segresnet_block.py
+++ b/monai/networks/blocks/segresnet_block.py
@@ -73,8 +73,12 @@ class ResBlock(nn.Module):
         self.norm1 = get_norm_layer(name=norm, spatial_dims=spatial_dims, channels=in_channels)
         self.norm2 = get_norm_layer(name=norm, spatial_dims=spatial_dims, channels=in_channels)
         self.act = get_act_layer(act)
-        self.conv1 = get_conv_layer(spatial_dims, in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)
-        self.conv2 = get_conv_layer(spatial_dims, in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)
+        self.conv1 = get_conv_layer(
+            spatial_dims, in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size
+        )
+        self.conv2 = get_conv_layer(
+            spatial_dims, in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size
+        )
 
     def forward(self, x):
         identity = x

--- a/tests/test_segresnet_block.py
+++ b/tests/test_segresnet_block.py
@@ -23,7 +23,7 @@ TEST_CASE_RESBLOCK = []
 for spatial_dims in range(2, 4):
     for in_channels in range(1, 4):
         for kernel_size in [1, 3]:
-            for norm in ["group", "batch", "instance"]:
+            for norm in [("group", {"num_groups": 1}), "batch", "instance"]:
                 test_case = [
                     {
                         "spatial_dims": spatial_dims,
@@ -34,7 +34,7 @@ for spatial_dims in range(2, 4):
                     (2, in_channels, *([16] * spatial_dims)),
                     (2, in_channels, *([16] * spatial_dims)),
                 ]
-            TEST_CASE_RESBLOCK.append(test_case)
+                TEST_CASE_RESBLOCK.append(test_case)
 
 
 class TestResBlock(unittest.TestCase):


### PR DESCRIPTION
Fixes #6998

### Description
Fixed unused `kernel_size` in `ResBlock`.
Fixed untested `norm` in unit tests.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
