### PR TITLE
6985 metatensor_to_itk_image compatible space

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -1316,6 +1316,8 @@ class NrrdReader(ImageReader):
 
             if self.affine_lps_to_ras:
                 header = self._switch_lps_ras(header)
+            if header.get(MetaKeys.SPACE, "left-posterior-superior") == "left-posterior-superior":
+                header[MetaKeys.SPACE] = SpaceKeys.LPS  # assuming LPS if not specified
 
             header[MetaKeys.AFFINE] = header[MetaKeys.ORIGINAL_AFFINE].copy()
             header[MetaKeys.SPATIAL_SHAPE] = header["sizes"]

--- a/tests/test_itk_torch_bridge.py
+++ b/tests/test_itk_torch_bridge.py
@@ -39,6 +39,8 @@ TESTS = ["CT_2D_head_fixed.mha", "CT_2D_head_moving.mha"]
 if not test_is_quick():
     TESTS += ["copd1_highres_INSP_STD_COPD_img.nii.gz", "copd1_highres_EXP_STD_COPD_img.nii.gz"]
 
+RW_TESTS = TESTS + ["nrrd_example.nrrd"]
+
 
 @unittest.skipUnless(has_itk, "Requires `itk` package.")
 class TestITKTorchAffineMatrixBridge(unittest.TestCase):
@@ -47,7 +49,7 @@ class TestITKTorchAffineMatrixBridge(unittest.TestCase):
         self.data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "testing_data")
         self.reader = ITKReader(pixel_type=itk.F)
 
-        for file_name in TESTS:
+        for file_name in RW_TESTS:
             path = os.path.join(self.data_dir, file_name)
             if not os.path.exists(path):
                 with skip_if_downloading_fails():
@@ -480,6 +482,19 @@ class TestITKTorchAffineMatrixBridge(unittest.TestCase):
 
         # Compare outputs
         np.testing.assert_allclose(output_array_monai, output_array_itk, rtol=1e-3, atol=1e-3)
+
+
+@unittest.skipUnless(has_itk, "Requires `itk` package.")
+class TestITKTorchRW(unittest.TestCase):
+    def setUp(self):
+        TestITKTorchAffineMatrixBridge().setUp()
+
+    def tearDown(self):
+        TestITKTorchAffineMatrixBridge().setUp()
+
+    @parameterized.expand(RW_TESTS)
+    def test_rw_itk(self, filepath):
+        print(f"called {filepath}")
 
 
 if __name__ == "__main__":

--- a/tests/testing_data/data_config.json
+++ b/tests/testing_data/data_config.json
@@ -84,6 +84,11 @@
             "url": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/CT_DICOM_SINGLE.zip",
             "hash_type": "sha256",
             "hash_val": "a41f6e93d2e3d68956144f9a847273041d36441da12377d6a1d5ae610e0a7023"
+        },
+        "nrrd_example": {
+            "url": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/CT_IMAGE_cropped.nrrd",
+            "hash_type": "sha256",
+            "hash_val": "66971ad17f0bac50e6082ed6a4dc1ae7093c30517137e53327b15a752327a1c0"
         }
     },
     "videos": {


### PR DESCRIPTION
Fixes #6985

### Description

- update `metatensor_to_itk_image` to  accept RAS metatensor 
- nrrdreader default 'space' from empty/"left-posterior-superior" to `SpaceKeys.LPS`
- more tests

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
