### PR TITLE
Add SignalFillEmptyd tranform

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -1717,7 +1717,7 @@ Signal (Dict)
 ^^^^^^^^^^^^^
 
 `SignalFillEmptyd`
-"""""""""""""""""
+""""""""""""""""""
 .. autoclass:: SignalFillEmptyd
     :members:
     :special-members: __call__

--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -1713,6 +1713,15 @@ Post-processing (Dict)
   :members:
   :special-members: __call__
 
+Signal (Dict)
+^^^^^^^^^^^^^
+
+`SignalFillEmptyd`
+"""""""""""""""""
+.. autoclass:: SignalFillEmptyd
+    :members:
+    :special-members: __call__
+
 
 Spatial (Dict)
 ^^^^^^^^^^^^^^

--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -345,6 +345,7 @@ from .signal.array import (
     SignalRandShift,
     SignalRemoveFrequency,
 )
+from .signal.dictionary import SignalFillEmptyd, SignalFillEmptyD, SignalFillEmptyDict
 from .smooth_field.array import (
     RandSmoothDeform,
     RandSmoothFieldAdjustContrast,

--- a/monai/transforms/signal/dictionary.py
+++ b/monai/transforms/signal/dictionary.py
@@ -1,0 +1,54 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+A collection of dictionary-based wrappers around the signal operations defined in :py:class:`monai.transforms.signal.array`.
+
+Class names are ended with 'd' to denote dictionary-based transforms.
+"""
+
+from collections.abc import Hashable, Mapping
+
+import torch
+
+from monai.transforms.transform import MapTransform
+from monai.config.type_definitions import KeysCollection, NdarrayOrTensor
+from monai.transforms.signal.array import SignalFillEmpty
+
+__all__ = [
+    "SignalFillEmptyd",
+    "SignalFillEmptyD",
+    "SignalFillEmptyDict",
+]
+
+class SignalFillEmptyd(MapTransform):
+    """
+    Applies the SignalFillEmptyd transform on the input. All NaN values will be replaced with the
+    replacement value.
+
+    Args:
+        keys: keys of the corresponding items to model output.
+        allow_missing_keys: don't raise exception if key is missing.
+        replacement: The value that the NaN entries shall be mapped to.
+    """
+
+    backend = SignalFillEmpty.backend
+
+    def __init__(self, keys: KeysCollection = None, allow_missing_keys: bool = False, replacement=0.0):
+        super().__init__(keys, allow_missing_keys)
+        self.signal_fill_empty = SignalFillEmpty(replacement=replacement)
+
+    def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Mapping[Hashable, NdarrayOrTensor]:
+        for key in self.key_iterator(data):
+            data[key] = self.signal_fill_empty(data[key])
+        
+        return data
+
+SignalFillEmptyD = SignalFillEmptyDict = SignalFillEmptyd

--- a/monai/transforms/signal/dictionary.py
+++ b/monai/transforms/signal/dictionary.py
@@ -14,19 +14,16 @@ A collection of dictionary-based wrappers around the signal operations defined i
 Class names are ended with 'd' to denote dictionary-based transforms.
 """
 
+from __future__ import annotations
+
 from collections.abc import Hashable, Mapping
 
-import torch
-
-from monai.transforms.transform import MapTransform
 from monai.config.type_definitions import KeysCollection, NdarrayOrTensor
 from monai.transforms.signal.array import SignalFillEmpty
+from monai.transforms.transform import MapTransform
 
-__all__ = [
-    "SignalFillEmptyd",
-    "SignalFillEmptyD",
-    "SignalFillEmptyDict",
-]
+__all__ = ["SignalFillEmptyd", "SignalFillEmptyD", "SignalFillEmptyDict"]
+
 
 class SignalFillEmptyd(MapTransform):
     """
@@ -48,7 +45,8 @@ class SignalFillEmptyd(MapTransform):
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> Mapping[Hashable, NdarrayOrTensor]:
         for key in self.key_iterator(data):
             data[key] = self.signal_fill_empty(data[key])
-        
+
         return data
+
 
 SignalFillEmptyD = SignalFillEmptyDict = SignalFillEmptyd

--- a/tests/test_signal_fillempty.py
+++ b/tests/test_signal_fillempty.py
@@ -32,7 +32,7 @@ class TestSignalFillEmptyNumpy(unittest.TestCase):
         sig[:, 123] = np.NAN
         fillempty = SignalFillEmpty(replacement=0.0)
         fillemptysignal = fillempty(sig)
-        self.assertTrue(not np.isnan(fillemptysignal.any()))
+        self.assertTrue(not np.isnan(fillemptysignal).any())
 
 
 @SkipIfBeforePyTorchVersion((1, 9))
@@ -43,7 +43,7 @@ class TestSignalFillEmptyTorch(unittest.TestCase):
         sig[:, 123] = convert_to_tensor(np.NAN)
         fillempty = SignalFillEmpty(replacement=0.0)
         fillemptysignal = fillempty(sig)
-        self.assertTrue(not torch.isnan(fillemptysignal.any()))
+        self.assertTrue(not torch.isnan(fillemptysignal).any())
 
 
 if __name__ == "__main__":

--- a/tests/test_signal_fillemptyd.py
+++ b/tests/test_signal_fillemptyd.py
@@ -1,0 +1,58 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import numpy as np
+import torch
+
+from monai.transforms import SignalFillEmptyd
+from monai.utils.type_conversion import convert_to_tensor
+from tests.utils import SkipIfBeforePyTorchVersion
+
+TEST_SIGNAL = os.path.join(os.path.dirname(__file__), "testing_data", "signal.npy")
+
+
+@SkipIfBeforePyTorchVersion((1, 9))
+class TestSignalFillEmptyNumpy(unittest.TestCase):
+    def test_correct_parameters_multi_channels(self):
+        self.assertIsInstance(SignalFillEmptyd(replacement=0.0), SignalFillEmptyd)
+        sig = np.load(TEST_SIGNAL)
+        sig[:, 123] = np.NAN
+        data = {}
+        data["signal"] = sig
+        fillempty = SignalFillEmptyd(keys=("signal",), replacement=0.0)
+        data_ = fillempty(data)
+
+        self.assertTrue(np.isnan(sig).any())
+        self.assertTrue(not np.isnan(data_["signal"]).any())
+
+
+@SkipIfBeforePyTorchVersion((1, 9))
+class TestSignalFillEmptyTorch(unittest.TestCase):
+    def test_correct_parameters_multi_channels(self):
+        self.assertIsInstance(SignalFillEmptyd(replacement=0.0), SignalFillEmptyd)
+        sig = convert_to_tensor(np.load(TEST_SIGNAL))
+        sig[:, 123] = convert_to_tensor(np.NAN)
+        data = {}
+        data["signal"] = sig
+        fillempty = SignalFillEmptyd(keys=("signal",), replacement=0.0)
+        data_ = fillempty(data)
+
+        self.assertTrue(np.isnan(sig).any())
+        self.assertTrue(not torch.isnan(data_["signal"]).any())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
As mentioned here https://github.com/Project-MONAI/MONAI/discussions/2637#discussioncomment-7038045 , this transform helps to fix NaN values after the input transforms.
It is basically only a wrapper around `SignalFillEmpty`. 


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
