### PR TITLE
Change deprecated since="1.3" to since="1.2"

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -248,7 +248,7 @@ def _process_bundle_dir(bundle_dir: PathLike | None = None) -> Path:
     return Path(bundle_dir)
 
 
-@deprecated_arg_default("source", "github", "monaihosting", since="1.3", replaced="1.5")
+@deprecated_arg_default("source", "github", "monaihosting", since="1.2", replaced="1.5")
 def download(
     name: str | None = None,
     version: str | None = None,
@@ -376,9 +376,9 @@ def download(
             )
 
 
-@deprecated_arg("net_name", since="1.3", removed="1.5", msg_suffix="please use ``model`` instead.")
-@deprecated_arg("net_kwargs", since="1.3", removed="1.5", msg_suffix="please use ``model`` instead.")
-@deprecated_arg("return_state_dict", since="1.3", removed="1.5")
+@deprecated_arg("net_name", since="1.2", removed="1.5", msg_suffix="please use ``model`` instead.")
+@deprecated_arg("net_kwargs", since="1.2", removed="1.5", msg_suffix="please use ``model`` instead.")
+@deprecated_arg("return_state_dict", since="1.2", removed="1.5")
 def load(
     name: str,
     model: torch.nn.Module | None = None,
@@ -586,7 +586,7 @@ def _get_all_bundles_info(
     return bundles_info
 
 
-@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.3", replaced="1.5")
+@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.2", replaced="1.5")
 def get_all_bundles_list(
     repo: str = "Project-MONAI/model-zoo", tag: str = "hosting_storage_v1", auth_token: str | None = None
 ) -> list[tuple[str, str]]:
@@ -621,7 +621,7 @@ def get_all_bundles_list(
     return bundles_list
 
 
-@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.3", replaced="1.5")
+@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.2", replaced="1.5")
 def get_bundle_versions(
     bundle_name: str,
     repo: str = "Project-MONAI/model-zoo",
@@ -659,7 +659,7 @@ def get_bundle_versions(
     return {"latest_version": all_versions[-1], "all_versions": all_versions}
 
 
-@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.3", replaced="1.5")
+@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.2", replaced="1.5")
 def get_bundle_info(
     bundle_name: str,
     version: str | None = None,

--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -55,7 +55,7 @@ class BundleWorkflow(ABC):
 
     @deprecated_arg(
         "workflow",
-        since="1.3",
+        since="1.2",
         removed="1.5",
         new_name="workflow_type",
         msg_suffix="please use `workflow_type` instead.",
@@ -214,12 +214,12 @@ class ConfigWorkflow(BundleWorkflow):
 
     @deprecated_arg(
         "workflow",
-        since="1.3",
+        since="1.2",
         removed="1.5",
         new_name="workflow_type",
         msg_suffix="please use `workflow_type` instead.",
     )
-    @deprecated_arg_default("workflow_type", None, "train", since="1.3", replaced="1.4")
+    @deprecated_arg_default("workflow_type", None, "train", since="1.2", replaced="1.4")
     def __init__(
         self,
         config_file: str | Sequence[str],

--- a/monai/handlers/ignite_metric.py
+++ b/monai/handlers/ignite_metric.py
@@ -155,7 +155,7 @@ class IgniteMetricHandler(Metric):
             engine.state.metric_details = {}  # type: ignore
 
 
-@deprecated(since="1.3", removed="1.4", msg_suffix="Use IgniteMetricHandler instead of IgniteMetric.")
+@deprecated(since="1.2", removed="1.4", msg_suffix="Use IgniteMetricHandler instead of IgniteMetric.")
 class IgniteMetric(IgniteMetricHandler):
     def __init__(
         self,


### PR DESCRIPTION
Fixes #7015.

### Description
Change deprecated since="1.3" to since="1.2" before 1.3 is released and tagged.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
