### PR TITLE
Add auto-generated data during tests into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,9 @@ tests/testing_data/train_data_stats_by_case.yaml
 tests/testing_data/eval_data_stats_by_case.yaml
 tests/testing_data/CT_2D_head_fixed.mha
 tests/testing_data/CT_2D_head_moving.mha
+tests/testing_data/config_executed.json
+tests/testing_data/eval
+tests/testing_data/nrrd_example.nrrd
 
 # clang format tool
 .clang-format-bin/
@@ -156,3 +159,5 @@ runs
 *.gz
 
 *.pth
+
+*zarr/*


### PR DESCRIPTION
Fixes #7010

### Description
Add auto-generated data during tests into gitignore

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
