### PR TITLE
 Add `SlidingWindowInfererAdapt` in docs

### DIFF
--- a/docs/source/inferers.rst
+++ b/docs/source/inferers.rst
@@ -31,6 +31,12 @@ Inferers
     :members:
     :special-members: __call__
 
+`SlidingWindowInfererAdapt`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: SlidingWindowInfererAdapt
+    :members:
+    :special-members: __call__
+
 `SaliencyInferer`
 ~~~~~~~~~~~~~~~~~
 .. autoclass:: SaliencyInferer


### PR DESCRIPTION
Fixes #7023.

### Description
 Add `SlidingWindowInfererAdapt` in https://docs.monai.io/en/latest/inferers.html.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
