### PR TITLE
Update docstring and typehint for `epoch_log` and `iteration_log` in `TensorBoardStatsHandler`

### DIFF
--- a/monai/handlers/tensorboard_handlers.py
+++ b/monai/handlers/tensorboard_handlers.py
@@ -116,7 +116,7 @@ class TensorBoardStatsHandler(TensorBoardHandler):
                 Event filter function accepts as input engine and event value (iteration) and should return True/False.
             epoch_log: whether to write data to TensorBoard when epoch completed, default to `True`.
                 ``epoch_log`` can be also a function or int. If it is an int, it will be interpreted as the epoch interval
-                at which the iteration_event_writer is called. If it is a function, it will be interpreted as an event filter
+                at which the epoch_event_writer is called. If it is a function, it will be interpreted as an event filter.
                 See ``iteration_log`` argument for more details.
             epoch_event_writer: customized callable TensorBoard writer for epoch level.
                 Must accept parameter "engine" and "summary_writer", use default event writer if None.

--- a/monai/handlers/tensorboard_handlers.py
+++ b/monai/handlers/tensorboard_handlers.py
@@ -93,8 +93,8 @@ class TensorBoardStatsHandler(TensorBoardHandler):
         self,
         summary_writer: SummaryWriter | SummaryWriterX | None = None,
         log_dir: str = "./runs",
-        iteration_log: bool | Callable[[Engine, int], bool] = True,
-        epoch_log: bool | Callable[[Engine, int], bool] = True,
+        iteration_log: bool | Callable[[Engine, int], bool] | int = True,
+        epoch_log: bool | Callable[[Engine, int], bool] | int = True,
         epoch_event_writer: Callable[[Engine, Any], Any] | None = None,
         epoch_interval: int = 1,
         iteration_event_writer: Callable[[Engine, Any], Any] | None = None,
@@ -110,11 +110,13 @@ class TensorBoardStatsHandler(TensorBoardHandler):
                 default to create a new TensorBoard writer.
             log_dir: if using default SummaryWriter, write logs to this directory, default is `./runs`.
             iteration_log: whether to write data to TensorBoard when iteration completed, default to `True`.
-                ``iteration_log`` can be also a function and it will be interpreted as an event filter
+                ``iteration_log`` can be also a function or int. If it is an int, it will be interpreted as the iteration interval
+                at which the iteration_event_writer is called. If it is a function, it will be interpreted as an event filter
                 (see https://pytorch.org/ignite/generated/ignite.engine.events.Events.html for details).
                 Event filter function accepts as input engine and event value (iteration) and should return True/False.
             epoch_log: whether to write data to TensorBoard when epoch completed, default to `True`.
-                ``epoch_log`` can be also a function and it will be interpreted as an event filter.
+                ``epoch_log`` can be also a function or int. If it is an int, it will be interpreted as the epoch interval
+                at which the iteration_event_writer is called. If it is a function, it will be interpreted as an event filter
                 See ``iteration_log`` argument for more details.
             epoch_event_writer: customized callable TensorBoard writer for epoch level.
                 Must accept parameter "engine" and "summary_writer", use default event writer if None.


### PR DESCRIPTION
Fixes #7026.

### Description

Update docstring and type-hint for `epoch_log` and `iteration_log` in `TensorBoardStatsHandler`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
