### PR TITLE
7036 utility transform channel first

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -996,9 +996,21 @@ Utility
     :members:
     :special-members: __call__
 
+`AsChannelFirst`
+""""""""""""""""
+.. autoclass:: AsChannelFirst
+    :members:
+    :special-members: __call__
+
 `AsChannelLast`
 """""""""""""""
 .. autoclass:: AsChannelLast
+    :members:
+    :special-members: __call__
+
+`AddChannel`
+""""""""""""
+.. autoclass:: AddChannel
     :members:
     :special-members: __call__
 
@@ -1965,9 +1977,21 @@ Utility (Dict)
     :members:
     :special-members: __call__
 
+`AsChannelFirstd`
+"""""""""""""""""
+.. autoclass:: AsChannelFirstd
+    :members:
+    :special-members: __call__
+
 `AsChannelLastd`
 """"""""""""""""
 .. autoclass:: AsChannelLastd
+    :members:
+    :special-members: __call__
+
+`AddChanneld`
+"""""""""""""
+.. autoclass:: AddChanneld
     :members:
     :special-members: __call__
 

--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -471,8 +471,10 @@ from .spatial.functional import spatial_resample
 from .traits import LazyTrait, MultiSampleTrait, RandomizableTrait, ThreadUnsafe
 from .transform import LazyTransform, MapTransform, Randomizable, RandomizableTransform, Transform, apply_transform
 from .utility.array import (
+    AddChannel,
     AddCoordinateChannels,
     AddExtremePointsChannel,
+    AsChannelFirst,
     AsChannelLast,
     CastToType,
     ClassesToIndices,
@@ -506,12 +508,18 @@ from .utility.array import (
     Transpose,
 )
 from .utility.dictionary import (
+    AddChanneld,
+    AddChannelD,
+    AddChannelDict,
     AddCoordinateChannelsd,
     AddCoordinateChannelsD,
     AddCoordinateChannelsDict,
     AddExtremePointsChanneld,
     AddExtremePointsChannelD,
     AddExtremePointsChannelDict,
+    AsChannelFirstd,
+    AsChannelFirstD,
+    AsChannelFirstDict,
     AsChannelLastd,
     AsChannelLastD,
     AsChannelLastDict,

--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -75,7 +75,9 @@ cp, has_cp = optional_import("cupy")
 __all__ = [
     "Identity",
     "RandIdentity",
+    "AsChannelFirst",
     "AsChannelLast",
+    "AddChannel",
     "AddCoordinateChannels",
     "EnsureChannelFirst",
     "EnsureType",
@@ -227,6 +229,40 @@ class EnsureChannelFirst(Transform):
             result = moveaxis(img, int(channel_dim), 0)  # type: ignore
 
         return convert_to_tensor(result, track_meta=get_track_meta())  # type: ignore
+
+
+class AsChannelFirst(EnsureChannelFirst):
+    """
+    Change the channel dimension of the image to the first dimension.
+    Most of the image transformations in ``monai.transforms``
+    assume the input image is in the channel-first format, which has the shape
+    (num_channels, spatial_dim_1[, spatial_dim_2, ...]).
+    This transform could be used to convert, for example, a channel-last image array in shape
+    (spatial_dim_1[, spatial_dim_2, ...], num_channels) into the channel-first format,
+    so that the multidimensional image array can be correctly interpreted by the other transforms.
+
+    Args:
+        channel_dim: which dimension of input image is the channel, default is the last dimension.
+    """
+
+    def __init__(self, channel_dim: int = -1) -> None:
+        super().__init__(channel_dim=channel_dim)
+
+
+class AddChannel(EnsureChannelFirst):
+    """
+    Adds a 1-length channel dimension to the input image.
+    Most of the image transformations in ``monai.transforms``
+    assumes the input image is in the channel-first format, which has the shape
+    (num_channels, spatial_dim_1[, spatial_dim_2, ...]).
+    This transform could be used, for example, to convert a (spatial_dim_1[, spatial_dim_2, ...])
+    spatial image into the channel-first format so that the
+    multidimensional image array can be correctly interpreted by the other
+    transforms.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(channel_dim="no_channel")
 
 
 class RepeatChannel(Transform):

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -70,12 +70,18 @@ from monai.utils.enums import PostFix, TraceKeys, TransformBackends
 from monai.utils.type_conversion import convert_to_dst_type
 
 __all__ = [
+    "AddChannelD",
+    "AddChannelDict",
+    "AddChanneld",
     "AddCoordinateChannelsD",
     "AddCoordinateChannelsDict",
     "AddCoordinateChannelsd",
     "AddExtremePointsChannelD",
     "AddExtremePointsChannelDict",
     "AddExtremePointsChanneld",
+    "AsChannelFirstD",
+    "AsChannelFirstDict",
+    "AsChannelFirstd",
     "AsChannelLastD",
     "AsChannelLastDict",
     "AsChannelLastd",
@@ -265,6 +271,37 @@ class EnsureChannelFirstd(MapTransform):
             meta_dict = d[key].meta if isinstance(d[key], MetaTensor) else None  # type: ignore[attr-defined]
             d[key] = self.adjuster(d[key], meta_dict)  # type: ignore
         return d
+
+
+class AsChannelFirstd(EnsureChannelFirstd):
+    """
+    Dictionary-based wrapper of :py:class:`monai.transforms.AsChannelFirst`.
+    """
+
+    def __init__(self, keys: KeysCollection, channel_dim: int = -1, allow_missing_keys: bool = False) -> None:
+        """
+        Args:
+            keys: keys of the corresponding items to be transformed.
+                See also: :py:class:`monai.transforms.compose.MapTransform`
+            channel_dim: which dimension of input image is the channel, default is the last dimension.
+            allow_missing_keys: don't raise exception if key is missing.
+        """
+        super().__init__(keys=keys, channel_dim=channel_dim, allow_missing_keys=allow_missing_keys)
+
+
+class AddChanneld(EnsureChannelFirstd):
+    """
+    Dictionary-based wrapper of :py:class:`monai.transforms.AddChannel`.
+    """
+
+    def __init__(self, keys: KeysCollection, allow_missing_keys: bool = False) -> None:
+        """
+        Args:
+            keys: keys of the corresponding items to be transformed.
+                See also: :py:class:`monai.transforms.compose.MapTransform`
+            allow_missing_keys: don't raise exception if key is missing.
+        """
+        super().__init__(keys, allow_missing_keys, channel_dim="no_channel")
 
 
 class RepeatChanneld(MapTransform):
@@ -1740,7 +1777,9 @@ class RandImageFilterd(MapTransform, RandomizableTransform):
 RandImageFilterD = RandImageFilterDict = RandImageFilterd
 ImageFilterD = ImageFilterDict = ImageFilterd
 IdentityD = IdentityDict = Identityd
+AsChannelFirstD = AsChannelFirstDict = AsChannelFirstd
 AsChannelLastD = AsChannelLastDict = AsChannelLastd
+AddChannelD = AddChannelDict = AddChanneld
 EnsureChannelFirstD = EnsureChannelFirstDict = EnsureChannelFirstd
 RemoveRepeatedChannelD = RemoveRepeatedChannelDict = RemoveRepeatedChanneld
 RepeatChannelD = RepeatChannelDict = RepeatChanneld

--- a/tests/test_add_channeld.py
+++ b/tests/test_add_channeld.py
@@ -1,0 +1,42 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+from monai.transforms import AddChanneld
+from tests.utils import TEST_NDARRAYS
+
+TESTS = []
+for p in TEST_NDARRAYS:
+    TESTS.append(
+        [
+            {"keys": ["img", "seg"]},
+            {"img": p(np.array([[0, 1], [1, 2]])), "seg": p(np.array([[0, 1], [1, 2]]))},
+            (1, 2, 2),
+        ]
+    )
+
+
+class TestAddChanneld(unittest.TestCase):
+    @parameterized.expand(TESTS)
+    def test_shape(self, input_param, input_data, expected_shape):
+        result = AddChanneld(**input_param)(input_data)
+        self.assertEqual(result["img"].shape, expected_shape)
+        self.assertEqual(result["seg"].shape, expected_shape)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_as_channel_first.py
+++ b/tests/test_as_channel_first.py
@@ -1,0 +1,41 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+from monai.transforms import AsChannelFirst
+from monai.transforms.utils_pytorch_numpy_unification import moveaxis
+from tests.utils import TEST_NDARRAYS, assert_allclose
+
+TESTS = []
+for p in TEST_NDARRAYS:
+    TESTS.append([p, {"channel_dim": -1}, (4, 1, 2, 3)])
+    TESTS.append([p, {"channel_dim": 3}, (4, 1, 2, 3)])
+    TESTS.append([p, {"channel_dim": 2}, (3, 1, 2, 4)])
+
+
+class TestAsChannelFirst(unittest.TestCase):
+    @parameterized.expand(TESTS)
+    def test_value(self, in_type, input_param, expected_shape):
+        test_data = in_type(np.random.randint(0, 2, size=[1, 2, 3, 4]))
+        result = AsChannelFirst(**input_param)(test_data)
+        self.assertTupleEqual(result.shape, expected_shape)
+        expected = moveaxis(test_data, input_param["channel_dim"], 0)
+        assert_allclose(result, expected, type_test="tensor")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_as_channel_firstd.py
+++ b/tests/test_as_channel_firstd.py
@@ -1,0 +1,44 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from parameterized import parameterized
+
+from monai.transforms import AsChannelFirstd
+from tests.utils import TEST_NDARRAYS
+
+TESTS = []
+for p in TEST_NDARRAYS:
+    TESTS.append([p, {"keys": ["image", "label", "extra"], "channel_dim": -1}, (4, 1, 2, 3)])
+    TESTS.append([p, {"keys": ["image", "label", "extra"], "channel_dim": 3}, (4, 1, 2, 3)])
+    TESTS.append([p, {"keys": ["image", "label", "extra"], "channel_dim": 2}, (3, 1, 2, 4)])
+
+
+class TestAsChannelFirstd(unittest.TestCase):
+    @parameterized.expand(TESTS)
+    def test_shape(self, in_type, input_param, expected_shape):
+        test_data = {
+            "image": in_type(np.random.randint(0, 2, size=[1, 2, 3, 4])),
+            "label": in_type(np.random.randint(0, 2, size=[1, 2, 3, 4])),
+            "extra": in_type(np.random.randint(0, 2, size=[1, 2, 3, 4])),
+        }
+        result = AsChannelFirstd(**input_param)(test_data)
+        self.assertTupleEqual(result["image"].shape, expected_shape)
+        self.assertTupleEqual(result["label"].shape, expected_shape)
+        self.assertTupleEqual(result["extra"].shape, expected_shape)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #7036

### Description
the channel related utilities are marked deprecated,
but they are still used in various places:
https://github.com/search?q=org%3AProject-MONAI+AsChannelFirstd&type=code&p=2
https://github.com/search?q=org%3AProject-MONAI+AddChanneld&type=code

This PR keeps them as thin wrappers of `EnsureChannelFirst[d]`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
