### PR TITLE
Default downloading bundles from `monaihosting`

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -45,7 +45,6 @@ from monai.networks import (
 from monai.utils import (
     check_parent_dir,
     deprecated_arg,
-    deprecated_arg_default,
     ensure_tuple,
     get_equivalent_dtype,
     min_version,
@@ -62,8 +61,8 @@ onnx, _ = optional_import("onnx")
 logger = get_logger(module_name=__name__)
 
 # set BUNDLE_DOWNLOAD_SRC="ngc" to use NGC source in default for bundle download
-# set BUNDLE_DOWNLOAD_SRC="monaihosting" to use monaihosting source in default for bundle download
-DEFAULT_DOWNLOAD_SOURCE = os.environ.get("BUNDLE_DOWNLOAD_SRC", "github")
+# set BUNDLE_DOWNLOAD_SRC="github" to use github source in default for bundle download
+DEFAULT_DOWNLOAD_SOURCE = os.environ.get("BUNDLE_DOWNLOAD_SRC", "monaihosting")
 PPRINT_CONFIG_N = 5
 
 
@@ -248,7 +247,6 @@ def _process_bundle_dir(bundle_dir: PathLike | None = None) -> Path:
     return Path(bundle_dir)
 
 
-@deprecated_arg_default("source", "github", "monaihosting", since="1.2", replaced="1.5")
 def download(
     name: str | None = None,
     version: str | None = None,
@@ -541,9 +539,8 @@ def load(
     return model
 
 
-@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.2", replaced="1.5")
 def _get_all_bundles_info(
-    repo: str = "Project-MONAI/model-zoo", tag: str = "hosting_storage_v1", auth_token: str | None = None
+    repo: str = "Project-MONAI/model-zoo", tag: str = "dev", auth_token: str | None = None
 ) -> dict[str, dict[str, dict[str, Any]]]:
     if has_requests:
         if tag == "hosting_storage_v1":
@@ -586,9 +583,8 @@ def _get_all_bundles_info(
     return bundles_info
 
 
-@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.2", replaced="1.5")
 def get_all_bundles_list(
-    repo: str = "Project-MONAI/model-zoo", tag: str = "hosting_storage_v1", auth_token: str | None = None
+    repo: str = "Project-MONAI/model-zoo", tag: str = "dev", auth_token: str | None = None
 ) -> list[tuple[str, str]]:
     """
     Get all bundles names (and the latest versions) that are stored in the release of specified repository
@@ -621,11 +617,10 @@ def get_all_bundles_list(
     return bundles_list
 
 
-@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.2", replaced="1.5")
 def get_bundle_versions(
     bundle_name: str,
     repo: str = "Project-MONAI/model-zoo",
-    tag: str = "hosting_storage_v1",
+    tag: str = "dev",
     auth_token: str | None = None,
 ) -> dict[str, list[str] | str]:
     """
@@ -659,20 +654,16 @@ def get_bundle_versions(
     return {"latest_version": all_versions[-1], "all_versions": all_versions}
 
 
-@deprecated_arg_default("tag", "hosting_storage_v1", "dev", since="1.2", replaced="1.5")
 def get_bundle_info(
     bundle_name: str,
     version: str | None = None,
     repo: str = "Project-MONAI/model-zoo",
-    tag: str = "hosting_storage_v1",
+    tag: str = "dev",
     auth_token: str | None = None,
 ) -> dict[str, Any]:
     """
-    Get all information
-    (include "id", "name", "size", "download_count", "browser_download_url", "created_at", "updated_at") of a bundle
+    Get all information (include "name" and "browser_download_url") of a bundle
     with the specified bundle name and version which is stored in the release of specified repository with the provided tag.
-    Since v1.5, "hosting_storage_v1" will be deprecated in favor of 'dev', which contains only "name" and "browser_download_url".
-    information about a bundle.
     In order to increase the rate limits of calling Github APIs, you can input your personal access token.
     Please check the following link for more details about rate limiting:
     https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -618,10 +618,7 @@ def get_all_bundles_list(
 
 
 def get_bundle_versions(
-    bundle_name: str,
-    repo: str = "Project-MONAI/model-zoo",
-    tag: str = "dev",
-    auth_token: str | None = None,
+    bundle_name: str, repo: str = "Project-MONAI/model-zoo", tag: str = "dev", auth_token: str | None = None
 ) -> dict[str, list[str] | str]:
     """
     Get the latest version, as well as all existing versions of a bundle that is stored in the release of specified

--- a/tests/test_bundle_get_data.py
+++ b/tests/test_bundle_get_data.py
@@ -21,9 +21,9 @@ from tests.utils import SkipIfNoModule, skip_if_downloading_fails, skip_if_quick
 
 requests, _ = optional_import("requests")
 
-TEST_CASE_1 = [{"bundle_name": "brats_mri_segmentation"}]
+TEST_CASE_1 = [{"bundle_name": "brats_mri_segmentation", "tag": "hosting_storage_v1"}]
 
-TEST_CASE_2 = [{"bundle_name": "spleen_ct_segmentation", "version": "0.1.0", "auth_token": None}]
+TEST_CASE_2 = [{"bundle_name": "spleen_ct_segmentation", "version": "0.1.0", "auth_token": None, "tag": "hosting_storage_v1"}]
 
 TEST_CASE_3 = [{"tag": "hosting_storage_v1"}]
 

--- a/tests/test_bundle_get_data.py
+++ b/tests/test_bundle_get_data.py
@@ -23,7 +23,9 @@ requests, _ = optional_import("requests")
 
 TEST_CASE_1 = [{"bundle_name": "brats_mri_segmentation", "tag": "hosting_storage_v1"}]
 
-TEST_CASE_2 = [{"bundle_name": "spleen_ct_segmentation", "version": "0.1.0", "auth_token": None, "tag": "hosting_storage_v1"}]
+TEST_CASE_2 = [
+    {"bundle_name": "spleen_ct_segmentation", "version": "0.1.0", "auth_token": None, "tag": "hosting_storage_v1"}
+]
 
 TEST_CASE_3 = [{"tag": "hosting_storage_v1"}]
 


### PR DESCRIPTION
Fixes #7044

### Description
Update to checking versions and downloading bundles from "monaihosting" as "hosting_storage_v1" is no longer being updated.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
