### PR TITLE
Adding padding option to autoencoder

### DIFF
--- a/monai/networks/nets/autoencoder.py
+++ b/monai/networks/nets/autoencoder.py
@@ -58,6 +58,8 @@ class AutoEncoder(nn.Module):
         bias: whether to have a bias term in convolution blocks. Defaults to True.
             According to `Performance Tuning Guide <https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html>`_,
             if a conv layer is directly followed by a batch norm layer, bias should be False.
+        padding: controls the amount of implicit zero-paddings on both sides for padding number of points
+            for each dimension in convolution blocks. Defaults to None.
 
     Examples::
 

--- a/monai/networks/nets/autoencoder.py
+++ b/monai/networks/nets/autoencoder.py
@@ -104,6 +104,7 @@ class AutoEncoder(nn.Module):
         norm: tuple | str = Norm.INSTANCE,
         dropout: tuple | str | float | None = None,
         bias: bool = True,
+        padding: Sequence[int], | int | None = None,
     ) -> None:
         super().__init__()
         self.dimensions = spatial_dims
@@ -118,6 +119,7 @@ class AutoEncoder(nn.Module):
         self.norm = norm
         self.dropout = dropout
         self.bias = bias
+        self.padding = padding
         self.num_inter_units = num_inter_units
         self.inter_channels = inter_channels if inter_channels is not None else []
         self.inter_dilations = list(inter_dilations or [1] * len(self.inter_channels))
@@ -178,6 +180,7 @@ class AutoEncoder(nn.Module):
                         dropout=self.dropout,
                         dilation=di,
                         bias=self.bias,
+                        padding=self.padding,
                     )
                 else:
                     unit = Convolution(
@@ -191,6 +194,7 @@ class AutoEncoder(nn.Module):
                         dropout=self.dropout,
                         dilation=di,
                         bias=self.bias,
+                        padding=self.padding,
                     )
 
                 intermediate.add_module("inter_%i" % i, unit)
@@ -231,6 +235,7 @@ class AutoEncoder(nn.Module):
                 norm=self.norm,
                 dropout=self.dropout,
                 bias=self.bias,
+                padding=self.padding,
                 last_conv_only=is_last,
             )
             return mod
@@ -244,6 +249,7 @@ class AutoEncoder(nn.Module):
             norm=self.norm,
             dropout=self.dropout,
             bias=self.bias,
+            padding=self.padding,
             conv_only=is_last,
         )
         return mod
@@ -264,6 +270,7 @@ class AutoEncoder(nn.Module):
             norm=self.norm,
             dropout=self.dropout,
             bias=self.bias,
+            padding=self.padding,
             conv_only=is_last and self.num_res_units == 0,
             is_transposed=True,
         )
@@ -282,6 +289,7 @@ class AutoEncoder(nn.Module):
                 norm=self.norm,
                 dropout=self.dropout,
                 bias=self.bias,
+                padding=self.padding,
                 last_conv_only=is_last,
             )
 

--- a/monai/networks/nets/autoencoder.py
+++ b/monai/networks/nets/autoencoder.py
@@ -104,7 +104,7 @@ class AutoEncoder(nn.Module):
         norm: tuple | str = Norm.INSTANCE,
         dropout: tuple | str | float | None = None,
         bias: bool = True,
-        padding: Sequence[int], | int | None = None,
+        padding: Sequence[int] | int | None = None,
     ) -> None:
         super().__init__()
         self.dimensions = spatial_dims


### PR DESCRIPTION
Fixes #7045  .

### Description

Added "padding" option to `monai/network/nets/autoencoder.py` such that the conv and residual units will be passed the padding option.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.

### Notes
I haven't been able to run the `./runtests.sh`, even tried running `./runtests.sh -h` and got no output (no error or anything). I guess I don't have permissions to run `.sh` files on this machine. However the changes are very small and default to previous functionality so unless somebody passes a padding argument, this should not break existing usage of the function.