### PR TITLE
add shape check for arbitrary types for DataStats

### DIFF
--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -681,7 +681,7 @@ class DataStats(Transform):
         if self.data_type if data_type is None else data_type:
             lines.append(f"Type: {type(img)} {img.dtype if hasattr(img, 'dtype') else None}")
         if self.data_shape if data_shape is None else data_shape:
-            lines.append(f"Shape: {img.shape}")
+            lines.append(f"Shape: {img.shape if hasattr(img, 'shape') else None}")
         if self.value_range if value_range is None else value_range:
             if isinstance(img, np.ndarray):
                 lines.append(f"Value range: ({np.min(img)}, {np.max(img)})")

--- a/runtests.sh
+++ b/runtests.sh
@@ -544,7 +544,7 @@ then
     if ! is_pip_installed pylint
     then
         echo "Pip installing pylint ..."
-        ${cmdPrefix}${PY_EXE} -m pip install pylint>2.16
+        ${cmdPrefix}${PY_EXE} -m pip install "pylint>2.16,!=3.0.0"
     fi
     ${cmdPrefix}${PY_EXE} -m pylint --version
 


### PR DESCRIPTION
Fixes #6844.

### Description

DataStats was breaking for arbitrary types (other than tensor or array) because of shape attribute. Changes are made in order to be consistent with other DataStats attributes management like `data_type`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
