### PR TITLE
Unify env vars access

### DIFF
--- a/monai/apps/auto3dseg/bundle_gen.py
+++ b/monai/apps/auto3dseg/bundle_gen.py
@@ -42,9 +42,11 @@ from monai.bundle.config_parser import ConfigParser
 from monai.config import PathLike
 from monai.utils import ensure_tuple, look_up_option, run_cmd
 from monai.utils.enums import AlgoKeys
+from monai.utils.misc import MONAIEnvVars
 
 logger = get_logger(module_name=__name__)
-ALGO_HASH = os.environ.get("MONAI_ALGO_HASH", "3e11dd0")
+ALGO_HASH = MONAIEnvVars.algo_hash()
+
 
 __all__ = ["BundleAlgo", "BundleGen"]
 

--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -275,10 +275,10 @@ def get_surface_distance(
     """
     lib: ModuleType = torch if isinstance(seg_pred, torch.Tensor) else np
     if not seg_gt.any():
-        dis = lib.inf * lib.ones_like(seg_gt, dtype=lib.float32)
+        dis = np.inf * lib.ones_like(seg_gt, dtype=lib.float32)
     else:
         if not lib.any(seg_pred):
-            dis = lib.inf * lib.ones_like(seg_gt, dtype=lib.float32)
+            dis = np.inf * lib.ones_like(seg_gt, dtype=lib.float32)
             dis = dis[seg_gt]
             return convert_to_dst_type(dis, seg_pred, dtype=dis.dtype)[0]
         if distance_metric == "euclidean":

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -552,7 +552,7 @@ def copy_model_state(
     if inplace and isinstance(dst, torch.nn.Module):
         if isinstance(dst, (nn.DataParallel, nn.parallel.DistributedDataParallel)):
             dst = dst.module
-        dst.load_state_dict(dst_dict)
+        dst.load_state_dict(dst_dict)  # type: ignore
     return dst_dict, updated_keys, unchanged_keys
 
 

--- a/monai/optimizers/novograd.py
+++ b/monai/optimizers/novograd.py
@@ -70,7 +70,7 @@ class Novograd(Optimizer):
         for group in self.param_groups:
             group.setdefault("amsgrad", False)
 
-    def step(self, closure: Callable[[], T] | None = None) -> T | None:
+    def step(self, closure: Callable[[], T] | None = None) -> T | None:  # type: ignore
         """Performs a single optimization step.
 
         Arguments:

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -34,6 +34,7 @@ from monai.utils import (
     convert_to_numpy,
     convert_to_tensor,
 )
+from monai.utils.misc import MONAIEnvVars
 
 __all__ = ["TraceableTransform", "InvertibleTransform"]
 
@@ -70,7 +71,7 @@ class TraceableTransform(Transform):
     `MONAI_TRACE_TRANSFORM` when initializing the class.
     """
 
-    tracing = os.environ.get("MONAI_TRACE_TRANSFORM", "1") != "0"
+    tracing = MONAIEnvVars.trace_transform() != "0"
 
     def set_tracing(self, tracing: bool) -> None:
         """Set whether to trace transforms."""

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -11,7 +11,6 @@
 
 from __future__ import annotations
 
-import os
 import warnings
 from collections.abc import Hashable, Mapping
 from contextlib import contextmanager

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -551,6 +551,7 @@ class MONAIEnvVars:
     def testing_algo_template() -> str | None:
         return os.environ.get("MONAI_TESTING_ALGO_TEMPLATE", None)
 
+
 class ImageMetaKey:
     """
     Common key names in the metadata header of images

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -527,6 +527,29 @@ class MONAIEnvVars:
     def doc_images() -> str | None:
         return os.environ.get("MONAI_DOC_IMAGES")
 
+    @staticmethod
+    def algo_hash() -> str | None:
+        return os.environ.get("MONAI_ALGO_HASH", "e01d67a")
+
+    @staticmethod
+    def trace_transform() -> str | None:
+        return os.environ.get("MONAI_TRACE_TRANSFORM", "1")
+
+    @staticmethod
+    def eval_expr() -> str | None:
+        return os.environ.get("MONAI_EVAL_EXPR", "1")
+
+    @staticmethod
+    def allow_missing_reference() -> str | None:
+        return os.environ.get("MONAI_ALLOW_MISSING_REFERENCE", "1")
+
+    @staticmethod
+    def extra_test_data() -> str | None:
+        return os.environ.get("MONAI_EXTRA_TEST_DATA", "1")
+
+    @staticmethod
+    def testing_algo_template() -> str | None:
+        return os.environ.get("MONAI_TESTING_ALGO_TEMPLATE", None)
 
 class ImageMetaKey:
     """

--- a/tests/test_monai_env_vars.py
+++ b/tests/test_monai_env_vars.py
@@ -35,7 +35,7 @@ class TestMONAIEnvVars(unittest.TestCase):
     def test_monai_env_vars(self):
         for debug in (False, True):
             os.environ["MONAI_DEBUG"] = str(debug)
-            self.assertEqual(MONAIEnvVars.debug(), str(debug))
+            self.assertEqual(os.environ.get("MONAI_DEBUG"), str(debug))
             self.assertEqual(MONAIEnvVars.debug(), debug)
 
 

--- a/tests/test_monai_env_vars.py
+++ b/tests/test_monai_env_vars.py
@@ -21,7 +21,7 @@ class TestMONAIEnvVars(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(__class__, cls).setUpClass()
-        cls.orig_value = MONAIEnvVars.debug()
+        cls.orig_value = str(MONAIEnvVars.debug())
 
     @classmethod
     def tearDownClass(cls):
@@ -29,7 +29,7 @@ class TestMONAIEnvVars(unittest.TestCase):
             os.environ["MONAI_DEBUG"] = cls.orig_value
         else:
             os.environ.pop("MONAI_DEBUG")
-        print("MONAI debug value:", MONAIEnvVars.debug())
+        print("MONAI debug value:", str(MONAIEnvVars.debug()))
         super(__class__, cls).tearDownClass()
 
     def test_monai_env_vars(self):

--- a/tests/test_monai_env_vars.py
+++ b/tests/test_monai_env_vars.py
@@ -21,7 +21,7 @@ class TestMONAIEnvVars(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(__class__, cls).setUpClass()
-        cls.orig_value = os.environ.get("MONAI_DEBUG")
+        cls.orig_value = MONAIEnvVars.debug()
 
     @classmethod
     def tearDownClass(cls):
@@ -29,13 +29,13 @@ class TestMONAIEnvVars(unittest.TestCase):
             os.environ["MONAI_DEBUG"] = cls.orig_value
         else:
             os.environ.pop("MONAI_DEBUG")
-        print("MONAI debug value:", os.environ.get("MONAI_DEBUG"))
+        print("MONAI debug value:", MONAIEnvVars.debug())
         super(__class__, cls).tearDownClass()
 
     def test_monai_env_vars(self):
         for debug in (False, True):
             os.environ["MONAI_DEBUG"] = str(debug)
-            self.assertEqual(os.environ.get("MONAI_DEBUG"), str(debug))
+            self.assertEqual(MONAIEnvVars.debug(), str(debug))
             self.assertEqual(MONAIEnvVars.debug(), debug)
 
 

--- a/tests/test_monai_utils_misc.py
+++ b/tests/test_monai_utils_misc.py
@@ -75,7 +75,7 @@ class TestMiscKwargs(unittest.TestCase):
 
 class TestCommandRunner(unittest.TestCase):
     def setUp(self):
-        self.orig_flag = MONAIEnvVars.debug()
+        self.orig_flag = str(MONAIEnvVars.debug())
 
     def tearDown(self):
         if self.orig_flag is not None:

--- a/tests/test_monai_utils_misc.py
+++ b/tests/test_monai_utils_misc.py
@@ -16,7 +16,7 @@ import unittest
 
 from parameterized import parameterized
 
-from monai.utils.misc import check_kwargs_exist_in_class_init, run_cmd, to_tuple_of_dictionaries
+from monai.utils.misc import check_kwargs_exist_in_class_init, run_cmd, to_tuple_of_dictionaries, MONAIEnvVars
 
 TO_TUPLE_OF_DICTIONARIES_TEST_CASES = [
     ({}, tuple(), tuple()),
@@ -75,7 +75,7 @@ class TestMiscKwargs(unittest.TestCase):
 
 class TestCommandRunner(unittest.TestCase):
     def setUp(self):
-        self.orig_flag = os.environ.get("MONAI_DEBUG")
+        self.orig_flag = MONAIEnvVars.debug()
 
     def tearDown(self):
         if self.orig_flag is not None:

--- a/tests/test_monai_utils_misc.py
+++ b/tests/test_monai_utils_misc.py
@@ -16,7 +16,7 @@ import unittest
 
 from parameterized import parameterized
 
-from monai.utils.misc import check_kwargs_exist_in_class_init, run_cmd, to_tuple_of_dictionaries, MONAIEnvVars
+from monai.utils.misc import MONAIEnvVars, check_kwargs_exist_in_class_init, run_cmd, to_tuple_of_dictionaries
 
 TO_TUPLE_OF_DICTIONARIES_TEST_CASES = [
     ({}, tuple(), tuple()),

--- a/tests/test_network_consistency.py
+++ b/tests/test_network_consistency.py
@@ -23,9 +23,10 @@ from parameterized.parameterized import parameterized
 
 import monai.networks.nets as nets
 from monai.utils import set_determinism
+from monai.utils.misc import MONAIEnvVars
 from tests.utils import assert_allclose
 
-extra_test_data_dir = os.environ.get("MONAI_EXTRA_TEST_DATA")
+extra_test_data_dir = MONAIEnvVars.extra_test_data()
 
 TESTS = []
 if extra_test_data_dir is not None:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -16,6 +16,7 @@ import unittest
 
 import monai.transforms as mt
 from monai.data import Dataset
+from monai.utils.misc import MONAIEnvVars
 
 
 class FaultyTransform(mt.Transform):
@@ -31,7 +32,7 @@ class TestTransform(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(__class__, cls).setUpClass()
-        cls.orig_value = os.environ.get("MONAI_DEBUG")
+        cls.orig_value = MONAIEnvVars.debug()
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -32,7 +32,7 @@ class TestTransform(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(__class__, cls).setUpClass()
-        cls.orig_value = MONAIEnvVars.debug()
+        cls.orig_value = str(MONAIEnvVars.debug())
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,6 +49,7 @@ from monai.utils import optional_import
 from monai.utils.module import pytorch_after
 from monai.utils.tf32 import detect_default_tf32
 from monai.utils.type_conversion import convert_data_type
+from monai.utils.misc import MONAIEnvVars
 
 nib, _ = optional_import("nibabel")
 http_error, has_req = optional_import("requests", name="HTTPError")
@@ -75,7 +76,7 @@ def get_testing_algo_template_path():
 
     https://github.com/Project-MONAI/MONAI/blob/1.1.0/monai/apps/auto3dseg/bundle_gen.py#L380-L381
     """
-    return os.environ.get("MONAI_TESTING_ALGO_TEMPLATE", None)
+    return MONAIEnvVars.testing_algo_template()
 
 
 def clone(data: NdarrayTensor) -> NdarrayTensor:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,10 +46,10 @@ from monai.data import create_test_image_2d, create_test_image_3d
 from monai.data.meta_tensor import MetaTensor, get_track_meta
 from monai.networks import convert_to_onnx, convert_to_torchscript
 from monai.utils import optional_import
+from monai.utils.misc import MONAIEnvVars
 from monai.utils.module import pytorch_after
 from monai.utils.tf32 import detect_default_tf32
 from monai.utils.type_conversion import convert_data_type
-from monai.utils.misc import MONAIEnvVars
 
 nib, _ = optional_import("nibabel")
 http_error, has_req = optional_import("requests", name="HTTPError")


### PR DESCRIPTION
Fixes #6879.

### Description

Some environment variable called using `os.get.environ("MONAI_VAR")` instead of `monai.utils.MONAIEnvVars`.

 Can't use `monai.utils.MONAIEnvVars` in `monai.utils.module.py` due to circular imports.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
