### PR TITLE
Add distance_transform_edt to transforms.__init__

### DIFF
--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -641,6 +641,7 @@ from .utils import (
     create_scale,
     create_shear,
     create_translate,
+    distance_transform_edt,
     equalize_hist,
     extreme_points_to_image,
     generate_label_classes_crop_centers,


### PR DESCRIPTION
Forgot the import of the helper function `distance_transform_edt` in `transforms.__init__`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
