### PR TITLE
6387 update_kwargs for merging multiple configs

### DIFF
--- a/docs/source/bundle.rst
+++ b/docs/source/bundle.rst
@@ -48,3 +48,4 @@ Model Bundle
 .. autofunction:: verify_metadata
 .. autofunction:: verify_net_in_out
 .. autofunction:: init_bundle
+.. autofunction:: update_kwargs

--- a/monai/bundle/__init__.py
+++ b/monai/bundle/__init__.py
@@ -29,6 +29,7 @@ from .scripts import (
     run,
     run_workflow,
     trt_export,
+    update_kwargs,
     verify_metadata,
     verify_net_in_out,
 )

--- a/monai/bundle/config_parser.py
+++ b/monai/bundle/config_parser.py
@@ -412,13 +412,16 @@ class ConfigParser:
 
         Args:
             files: path of target files to load, supported postfixes: `.json`, `.yml`, `.yaml`.
-                if providing a list of files, wil merge the content of them.
+                if providing a list of files, will merge the content of them.
+                if providing a string with comma separated file paths, will merge the content of them.
                 if providing a dictionary, return it directly.
             kwargs: other arguments for ``json.load`` or ```yaml.safe_load``, depends on the file format.
         """
         if isinstance(files, dict):  # already a config dict
             return files
         parser = ConfigParser(config={})
+        if isinstance(files, str) and not Path(files).is_file() and "," in files:
+            files = files.split(",")
         for i in ensure_tuple(files):
             for k, v in (cls.load_config_file(i, **kwargs)).items():
                 parser[k] = v

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -103,7 +103,7 @@ def update_kwargs(args: str | dict | None = None, ignore_none: bool = True, **kw
     return args_
 
 
-_update_kwargs = update_kwargs
+_update_args = update_kwargs  # backward compatibility
 
 
 def _pop_args(src: dict, *args: Any, **kwargs: Any) -> tuple:

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -93,7 +93,6 @@ def update_kwargs(args: str | dict | None = None, ignore_none: bool = True, **kw
     for k, v in kwargs.items():
         if ignore_none and v is None:
             continue
-        print(f"{k}={v}")
         if isinstance(v, dict) and isinstance(args_.get(k), dict):
             args_[k] = update_kwargs(args_[k], ignore_none, **v)
         else:

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -87,6 +87,9 @@ def update_kwargs(args: str | dict | None = None, ignore_none: bool = True, **kw
     if isinstance(args, str):
         # args are defined in a structured file
         args_ = ConfigParser.load_config_file(args)
+    if isinstance(args, (tuple, list)) and all(isinstance(x, str) for x in args):
+        primary, overrides = args
+        args_ = update_kwargs(primary, ignore_none, **update_kwargs(overrides, ignore_none, **kwargs))
     if not isinstance(args_, dict):
         return args_
     # recursively update the default args with new args
@@ -98,6 +101,9 @@ def update_kwargs(args: str | dict | None = None, ignore_none: bool = True, **kw
         else:
             args_[k] = v
     return args_
+
+
+_update_kwargs = update_kwargs
 
 
 def _pop_args(src: dict, *args: Any, **kwargs: Any) -> tuple:

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -66,28 +66,36 @@ DEFAULT_DOWNLOAD_SOURCE = os.environ.get("BUNDLE_DOWNLOAD_SRC", "monaihosting")
 PPRINT_CONFIG_N = 5
 
 
-def _update_args(args: str | dict | None = None, ignore_none: bool = True, **kwargs: Any) -> dict:
+def update_kwargs(args: str | dict | None = None, ignore_none: bool = True, **kwargs: Any) -> dict:
     """
-    Update the `args` with the input `kwargs`.
+    Update the `args` dictionary with the input `kwargs`.
     For dict data, recursively update the content based on the keys.
 
+    Example::
+
+        from monai.bundle import update_kwargs
+        update_kwargs({'exist': 1}, exist=2, new_arg=3)
+        # return {'exist': 2, 'new_arg': 3}
+
     Args:
-        args: source args to update.
+        args: source `args` dictionary (or a json/yaml filename to read as dictionary) to update.
         ignore_none: whether to ignore input args with None value, default to `True`.
-        kwargs: destination args to update.
+        kwargs: key=value pairs to be merged into `args`.
 
     """
     args_: dict = args if isinstance(args, dict) else {}
     if isinstance(args, str):
         # args are defined in a structured file
         args_ = ConfigParser.load_config_file(args)
+    if not isinstance(args_, dict):
+        return args_
     # recursively update the default args with new args
     for k, v in kwargs.items():
-        print(k, v)
         if ignore_none and v is None:
             continue
+        print(f"{k}={v}")
         if isinstance(v, dict) and isinstance(args_.get(k), dict):
-            args_[k] = _update_args(args_[k], ignore_none, **v)
+            args_[k] = update_kwargs(args_[k], ignore_none, **v)
         else:
             args_[k] = v
     return args_
@@ -318,7 +326,7 @@ def download(
             so that the command line inputs can be simplified.
 
     """
-    _args = _update_args(
+    _args = update_kwargs(
         args=args_file,
         name=name,
         version=version,
@@ -834,7 +842,7 @@ def verify_metadata(
 
     """
 
-    _args = _update_args(
+    _args = update_kwargs(
         args=args_file,
         meta_file=meta_file,
         filepath=filepath,
@@ -958,7 +966,7 @@ def verify_net_in_out(
 
     """
 
-    _args = _update_args(
+    _args = update_kwargs(
         args=args_file,
         net_id=net_id,
         meta_file=meta_file,
@@ -1127,7 +1135,7 @@ def onnx_export(
             e.g. ``--_meta#network_data_format#inputs#image#num_channels 3``.
 
     """
-    _args = _update_args(
+    _args = update_kwargs(
         args=args_file,
         net_id=net_id,
         filepath=filepath,
@@ -1242,7 +1250,7 @@ def ckpt_export(
             e.g. ``--_meta#network_data_format#inputs#image#num_channels 3``.
 
     """
-    _args = _update_args(
+    _args = update_kwargs(
         args=args_file,
         net_id=net_id,
         filepath=filepath,
@@ -1401,7 +1409,7 @@ def trt_export(
             e.g. ``--_meta#network_data_format#inputs#image#num_channels 3``.
 
     """
-    _args = _update_args(
+    _args = update_kwargs(
         args=args_file,
         net_id=net_id,
         filepath=filepath,
@@ -1614,7 +1622,7 @@ def create_workflow(
         kwargs: arguments to instantiate the workflow class.
 
     """
-    _args = _update_args(args=args_file, workflow_name=workflow_name, config_file=config_file, **kwargs)
+    _args = update_kwargs(args=args_file, workflow_name=workflow_name, config_file=config_file, **kwargs)
     _log_input_summary(tag="run", args=_args)
     (workflow_name, config_file) = _pop_args(
         _args, workflow_name=ConfigWorkflow, config_file=None

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -462,7 +462,7 @@ class MetaTensor(MetaObj, torch.Tensor):
     @property
     def affine(self) -> torch.Tensor:
         """Get the affine. Defaults to ``torch.eye(4, dtype=torch.float64)``"""
-        return self.meta.get(MetaKeys.AFFINE, self.get_default_affine())
+        return self.meta.get(MetaKeys.AFFINE, self.get_default_affine())  # type: ignore
 
     @affine.setter
     def affine(self, d: NdarrayTensor) -> None:

--- a/runtests.sh
+++ b/runtests.sh
@@ -108,7 +108,7 @@ function print_usage {
     echo "    -c, --clean       : clean temporary files from tests and exit"
     echo "    -h, --help        : show this help message and exit"
     echo "    -v, --version     : show MONAI and system version information and exit"
-    echo "    -p, --path        : specify the path used for formatting"
+    echo "    -p, --path        : specify the path used for formatting, default is the current dir if unspecified"
     echo "    --formatfix       : format code using \"isort\" and \"black\" for user specified directories"
     echo ""
     echo "${separator}For bug reports and feature requests, please file an issue at:"
@@ -359,10 +359,9 @@ if [ -e "$testdir" ]
 then
     homedir=$testdir
 else
-    print_error_msg "Incorrect path: $testdir provided, run under $currentdir"
     homedir=$currentdir
 fi
-echo "run tests under $homedir"
+echo "Run tests under $homedir"
 cd "$homedir"
 
 # python path

--- a/tests/test_bundle_utils.py
+++ b/tests/test_bundle_utils.py
@@ -18,6 +18,7 @@ import unittest
 
 import torch
 
+from monai.bundle import update_kwargs
 from monai.bundle.utils import load_bundle_config
 from monai.networks.nets import UNet
 from monai.utils import pprint_edges
@@ -141,6 +142,7 @@ class TestPPrintEdges(unittest.TestCase):
             "[{'a': 1, 'b': 2},\n\n ... omitted 18 line(s)\n\n {'a': 1, 'b': 2}]",
         )
         self.assertEqual(pprint_edges([{"a": 1, "b": 2}] * 8, 4), pprint_edges([{"a": 1, "b": 2}] * 8, 3))
+        self.assertEqual(update_kwargs({"a": 1}, a=2, b=3), {"a": 2, "b": 3})
 
 
 if __name__ == "__main__":

--- a/tests/test_integration_bundle_run.py
+++ b/tests/test_integration_bundle_run.py
@@ -86,9 +86,8 @@ class TestBundleRun(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             # test wrong run_id="run"
             command_line_tests(cmd + ["run", "run", "--config_file", config_file])
-        with self.assertRaises(RuntimeError):
-            # test missing meta file
-            command_line_tests(cmd + ["run", "training", "--config_file", config_file])
+        # test missing meta file
+        self.assertIn("ERROR", command_line_tests(cmd + ["run", "training", "--config_file", config_file]))
 
     def test_scripts_fold(self):
         # test scripts directory has been added to Python search directories automatically
@@ -150,9 +149,8 @@ class TestBundleRun(unittest.TestCase):
         print(output)
         self.assertTrue(expected_condition in output)
 
-        with self.assertRaises(RuntimeError):
-            # test missing meta file
-            command_line_tests(cmd + ["run", "training", "--config_file", config_file])
+        # test missing meta file
+        self.assertIn("ERROR", command_line_tests(cmd + ["run", "training", "--config_file", config_file]))
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     def test_shape(self, config_file, expected_shape):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -818,6 +818,7 @@ def command_line_tests(cmd, copy_env=True):
     try:
         normal_out = subprocess.run(cmd, env=test_env, check=True, capture_output=True)
         print(repr(normal_out).replace("\\n", "\n").replace("\\t", "\t"))
+        return repr(normal_out)
     except subprocess.CalledProcessError as e:
         output = repr(e.stdout).replace("\\n", "\n").replace("\\t", "\t")
         errors = repr(e.stderr).replace("\\n", "\n").replace("\\t", "\t")


### PR DESCRIPTION
Fixes #6387
Fixes #5899

### Description
- add api for update_kwargs
- add support of merging multiple configs files and dictionaries
- remove warning message of directory in `runtests.sh`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
