### PR TITLE
update validation epoch

### DIFF
--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -203,6 +203,8 @@ def download_url(
             if urlparse(url).netloc == "drive.google.com":
                 if not has_gdown:
                     raise RuntimeError("To download files from Google Drive, please install the gdown dependency.")
+                if "fuzzy" not in gdown_kwargs:
+                    gdown_kwargs["fuzzy"] = True  # default to true for flexible url
                 gdown.download(url, f"{tmp_name}", quiet=not progress, **gdown_kwargs)
             elif urlparse(url).netloc == "cloud-api.yandex.net":
                 with urlopen(url) as response:

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -142,7 +142,7 @@ class Evaluator(Workflow):
 
         """
         # init env value for current validation process
-        self.state.max_epochs = global_epoch
+        self.state.max_epochs = max(global_epoch, 1)  # at least one epoch of validation
         self.state.epoch = global_epoch - 1
         self.state.iteration = 0
         super().run()

--- a/monai/handlers/validation_handler.py
+++ b/monai/handlers/validation_handler.py
@@ -83,4 +83,4 @@ class ValidationHandler:
         """
         if self.validator is None:
             raise RuntimeError("please set validator in __init__() or call `set_validator()` before training.")
-        self.validator.run(max(engine.state.epoch, 1))
+        self.validator.run(engine.state.epoch)

--- a/monai/handlers/validation_handler.py
+++ b/monai/handlers/validation_handler.py
@@ -83,4 +83,4 @@ class ValidationHandler:
         """
         if self.validator is None:
             raise RuntimeError("please set validator in __init__() or call `set_validator()` before training.")
-        self.validator.run(engine.state.epoch)
+        self.validator.run(max(engine.state.epoch, 1))

--- a/tests/test_handler_validation.py
+++ b/tests/test_handler_validation.py
@@ -23,7 +23,8 @@ from monai.handlers import ValidationHandler
 
 class TestEvaluator(Evaluator):
     def _iteration(self, engine, batchdata):
-        pass
+        engine.state.output = "called"
+        return engine.state.output
 
 
 class TestHandlerValidation(unittest.TestCase):
@@ -44,6 +45,7 @@ class TestHandlerValidation(unittest.TestCase):
         engine.run(data, max_epochs=1)
         self.assertEqual(evaluator.state.max_epochs, 1)
         self.assertEqual(evaluator.state.epoch_length, 8)
+        self.assertEqual(evaluator.state.output, "called")
 
         engine.run(data, max_epochs=5)
         self.assertEqual(evaluator.state.max_epochs, 4)

--- a/tests/test_handler_validation.py
+++ b/tests/test_handler_validation.py
@@ -42,7 +42,7 @@ class TestHandlerValidation(unittest.TestCase):
         ValidationHandler(interval=2, validator=evaluator, exec_at_start=True).attach(engine)
         # test execution at start
         engine.run(data, max_epochs=1)
-        self.assertEqual(evaluator.state.max_epochs, 0)
+        self.assertEqual(evaluator.state.max_epochs, 1)
         self.assertEqual(evaluator.state.epoch_length, 8)
 
         engine.run(data, max_epochs=5)


### PR DESCRIPTION
- this allows for validation epoch at the very beginning of training
- fixes #7122


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
