### PR TITLE
Add `in_mm3` in `remove_small_objects`

### DIFF
--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -261,11 +261,9 @@ def get_surface_distance(
             - ``"euclidean"``, uses Exact Euclidean distance transform.
             - ``"chessboard"``, uses `chessboard` metric in chamfer type of transform.
             - ``"taxicab"``, uses `taxicab` metric in chamfer type of transform.
-        spacing: spacing of pixel (or voxel) along each axis. If a sequence, must be of
-            length equal to the image dimensions; if a single number, this is used for all axes.
-            If ``None``, spacing of unity is used. Defaults to ``None``.
         spacing: spacing of pixel (or voxel). This parameter is relevant only if ``distance_metric`` is set to ``"euclidean"``.
-            Several input options are allowed: (1) If a single number, isotropic spacing with that value is used.
+            Several input options are allowed:
+            (1) If a single number, isotropic spacing with that value is used.
             (2) If a sequence of numbers, the length of the sequence must be equal to the image dimensions.
             (3) If ``None``, spacing of unity is used. Defaults to ``None``.
 

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -361,7 +361,7 @@ class RemoveSmallObjects(Transform):
     Data should be one-hotted.
 
     Args:
-        min_size: objects smaller than this size (in pixel or in physical scale if physical_scale is True) are removed.
+        min_size: objects smaller than this size (in number of voxels; or volume in mm^3 if in_mm3 is True) are removed.
         connectivity: Maximum number of orthogonal hops to consider a pixel/voxel as a neighbor.
             Accepted values are ranging from  1 to input.ndim. If ``None``, a full
             connectivity of ``input.ndim`` is used. For more details refer to linked scikit-image

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -361,7 +361,8 @@ class RemoveSmallObjects(Transform):
     Data should be one-hotted.
 
     Args:
-        min_size: objects smaller than this size (in number of voxels; or volume in mm^3 if in_mm3 is True) are removed.
+        min_size: objects smaller than this size (in number of voxels; or surface area/volume value
+            in whatever units your image is if by_measure is True) are removed.
         connectivity: Maximum number of orthogonal hops to consider a pixel/voxel as a neighbor.
             Accepted values are ranging from  1 to input.ndim. If ``None``, a full
             connectivity of ``input.ndim`` is used. For more details refer to linked scikit-image
@@ -369,9 +370,10 @@ class RemoveSmallObjects(Transform):
         independent_channels: Whether or not to consider channels as independent. If true, then
             conjoining islands from different labels will be removed if they are below the threshold.
             If false, the overall size islands made from all non-background voxels will be used.
-        in_mm3: Whether the specified min_size is in number of voxels or volume in mm^3, default is false.
-            If true, min-size will be divided by pixdim. e.g. if min_size is 3 and in_mm3
-            is true, objects smaller than 3mm^3 are removed.
+        by_measure: Whether the specified min_size is in number of voxels. if this is True then min_size
+            represents a surface area or volume value of whatever units your image is in (mm^3, cm^2, etc.)
+            default is False. e.g. if min_size is 3, by_measure is True and the units of your data is mm,
+            objects smaller than 3mm^3 are removed.
         pixdim: the pixdim of the input image. if a single number, this is used for all axes.
             If a sequence of numbers, the length of the sequence must be equal to the image dimensions.
 
@@ -390,10 +392,10 @@ class RemoveSmallObjects(Transform):
             data2 = MetaTensor(data1, affine=affine)
 
             # remove objects smaller than 3mm^3, input is MetaTensor
-            trans = RemoveSmallObjects(min_size=3, in_mm3=True)
+            trans = RemoveSmallObjects(min_size=3, by_measure=True)
             out = trans(data2)
             # remove objects smaller than 3mm^3, input is not MetaTensor
-            trans = RemoveSmallObjects(min_size=3, in_mm3=True, pixdim=(2, 1, 1))
+            trans = RemoveSmallObjects(min_size=3, by_measure=True, pixdim=(2, 1, 1))
             out = trans(data1)
 
             # remove objects smaller than 3 (in pixel)
@@ -415,13 +417,13 @@ class RemoveSmallObjects(Transform):
         min_size: int = 64,
         connectivity: int = 1,
         independent_channels: bool = True,
-        in_mm3: bool = False,
+        by_measure: bool = False,
         pixdim: Sequence[float] | float | np.ndarray | None = None,
     ) -> None:
         self.min_size = min_size
         self.connectivity = connectivity
         self.independent_channels = independent_channels
-        self.in_mm3 = in_mm3
+        self.by_measure = by_measure
         self.pixdim = pixdim
 
     def __call__(self, img: NdarrayOrTensor) -> NdarrayOrTensor:
@@ -435,7 +437,7 @@ class RemoveSmallObjects(Transform):
         """
 
         return remove_small_objects(
-            img, self.min_size, self.connectivity, self.independent_channels, self.in_mm3, self.pixdim
+            img, self.min_size, self.connectivity, self.independent_channels, self.by_measure, self.pixdim
         )
 
 

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -369,9 +369,9 @@ class RemoveSmallObjects(Transform):
         independent_channels: Whether or not to consider channels as independent. If true, then
             conjoining islands from different labels will be removed if they are below the threshold.
             If false, the overall size islands made from all non-background voxels will be used.
-        physical_scale: Whether or not to consider min_size at physical scale, default is false.
-            If true, pixdim will be used to multiply min_size. e.g. if min_size is 3 and physical_scale
-            is True, objects smaller than 3mm^3 are removed.
+        in_mm3: Whether the specified min_size is in number of voxels or volume in mm^3, default is false.
+            If true, min-size will be divided by pixdim. e.g. if min_size is 3 and in_mm3
+            is true, objects smaller than 3mm^3 are removed.
         pixdim: the pixdim of the input image. if a single number, this is used for all axes.
             If a sequence of numbers, the length of the sequence must be equal to the image dimensions.
 
@@ -390,10 +390,10 @@ class RemoveSmallObjects(Transform):
             data2 = MetaTensor(data1, affine=affine)
 
             # remove objects smaller than 3mm^3, input is MetaTensor
-            trans = RemoveSmallObjects(min_size=3, physical_scale=True)
+            trans = RemoveSmallObjects(min_size=3, in_mm3=True)
             out = trans(data2)
             # remove objects smaller than 3mm^3, input is not MetaTensor
-            trans = RemoveSmallObjects(min_size=3, physical_scale=True, pixdim=(2, 1, 1))
+            trans = RemoveSmallObjects(min_size=3, in_mm3=True, pixdim=(2, 1, 1))
             out = trans(data1)
 
             # remove objects smaller than 3 (in pixel)
@@ -415,13 +415,13 @@ class RemoveSmallObjects(Transform):
         min_size: int = 64,
         connectivity: int = 1,
         independent_channels: bool = True,
-        physical_scale: bool = False,
+        in_mm3: bool = False,
         pixdim: Sequence[float] | float | np.ndarray | None = None,
     ) -> None:
         self.min_size = min_size
         self.connectivity = connectivity
         self.independent_channels = independent_channels
-        self.physical_scale = physical_scale
+        self.in_mm3 = in_mm3
         self.pixdim = pixdim
 
     def __call__(self, img: NdarrayOrTensor) -> NdarrayOrTensor:
@@ -435,7 +435,7 @@ class RemoveSmallObjects(Transform):
         """
 
         return remove_small_objects(
-            img, self.min_size, self.connectivity, self.independent_channels, self.physical_scale, self.pixdim
+            img, self.min_size, self.connectivity, self.independent_channels, self.in_mm3, self.pixdim
         )
 
 

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -369,11 +369,15 @@ class RemoveSmallObjects(Transform):
         independent_channels: Whether or not to consider channels as independent. If true, then
             conjoining islands from different labels will be removed if they are below the threshold.
             If false, the overall size islands made from all non-background voxels will be used.
+        physical_scale: Whether or not to consider min_size at physical scale, default is false. If true,
+            min_size will be multiplied by pixdim.
     """
 
     backend = [TransformBackends.NUMPY]
 
-    def __init__(self, min_size: int = 64, connectivity: int = 1, independent_channels: bool = True) -> None:
+    def __init__(
+        self, min_size: int = 64, connectivity: int = 1, independent_channels: bool = True, physical_scale: bool = False
+    ) -> None:
         self.min_size = min_size
         self.connectivity = connectivity
         self.independent_channels = independent_channels

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -407,14 +407,14 @@ class RemoveSmallObjects(Transform):
 
         if self.resample and isinstance(img, MetaTensor):
             original_pixdim = img.pixdim
-            img = Spacing(pixdim=(1, 1, 1))(img, self.mode)
+            img = Spacing(pixdim=(1.0, 1.0, 1.0))(img, self.mode)
 
         out = remove_small_objects(
             img, self.min_size, self.connectivity, self.independent_channels, self.physical_scale
         )
 
         if self.resample and isinstance(img, MetaTensor):
-            out = Spacing(pixdim=original_pixdim)(out, self.mode)
+            out = Spacing(pixdim=original_pixdim)(out, self.mode)  # type: ignore
 
         return out
 

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -376,7 +376,7 @@ class RemoveSmallObjects(Transform):
         pixdim: the pixdim of the input image. if a single number, this is used for all axes.
             If a sequence of numbers, the length of the sequence must be equal to the image dimensions.
 
-    Example:
+    Example::
 
         .. code-block:: python
 

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -381,6 +381,7 @@ class RemoveSmallObjects(Transform):
         self.min_size = min_size
         self.connectivity = connectivity
         self.independent_channels = independent_channels
+        self.physical_scale = physical_scale
 
     def __call__(self, img: NdarrayOrTensor) -> NdarrayOrTensor:
         """
@@ -391,7 +392,7 @@ class RemoveSmallObjects(Transform):
         Returns:
             An array with shape (C, spatial_dim1[, spatial_dim2, ...]).
         """
-        return remove_small_objects(img, self.min_size, self.connectivity, self.independent_channels)
+        return remove_small_objects(img, self.min_size, self.connectivity, self.independent_channels, self.physical_scale)
 
 
 class LabelFilter(Transform):

--- a/monai/transforms/post/array.py
+++ b/monai/transforms/post/array.py
@@ -27,7 +27,6 @@ from monai.data.meta_tensor import MetaTensor
 from monai.networks import one_hot
 from monai.networks.layers import GaussianFilter, apply_filter, separable_filtering
 from monai.transforms.inverse import InvertibleTransform
-from monai.transforms.spatial.array import Spacing
 from monai.transforms.transform import Transform
 from monai.transforms.utility.array import ToTensor
 from monai.transforms.utils import (

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -270,7 +270,7 @@ class RemoveSmallObjectsd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.RemoveSmallObjectsd`.
 
     Args:
-        min_size: objects smaller than this size are removed.
+        min_size: objects smaller than this size (in number of voxels; or volume in mm^3 if in_mm3 is True) are removed.
         connectivity: Maximum number of orthogonal hops to consider a pixel/voxel as a neighbor.
             Accepted values are ranging from  1 to input.ndim. If ``None``, a full
             connectivity of ``input.ndim`` is used. For more details refer to linked scikit-image
@@ -278,9 +278,9 @@ class RemoveSmallObjectsd(MapTransform):
         independent_channels: Whether or not to consider channels as independent. If true, then
             conjoining islands from different labels will be removed if they are below the threshold.
             If false, the overall size islands made from all non-background voxels will be used.
-        physical_scale: Whether or not to consider min_size at physical scale, default is false.
-            If true, pixdim will be used to multiply min_size. e.g. if min_size is 3 and physical_scale
-            is True, objects smaller than 3mm^3 are removed.
+        in_mm3: Whether the specified min_size is in number of voxels or volume in mm^3, default is false.
+            If true, min-size will be divided by pixdim. e.g. if min_size is 3 and in_mm3
+            is true, objects smaller than 3mm^3 are removed.
         pixdim: the pixdim of the input image. if a single number, this is used for all axes.
             If a sequence of numbers, the length of the sequence must be equal to the image dimensions.
     """
@@ -293,12 +293,12 @@ class RemoveSmallObjectsd(MapTransform):
         min_size: int = 64,
         connectivity: int = 1,
         independent_channels: bool = True,
-        physical_scale: bool = False,
+        in_mm3: bool = False,
         pixdim: Sequence[float] | float | np.ndarray | None = None,
         allow_missing_keys: bool = False,
     ) -> None:
         super().__init__(keys, allow_missing_keys)
-        self.converter = RemoveSmallObjects(min_size, connectivity, independent_channels, physical_scale, pixdim)
+        self.converter = RemoveSmallObjects(min_size, connectivity, independent_channels, in_mm3, pixdim)
 
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> dict[Hashable, NdarrayOrTensor]:
         d = dict(data)

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -270,7 +270,8 @@ class RemoveSmallObjectsd(MapTransform):
     Dictionary-based wrapper of :py:class:`monai.transforms.RemoveSmallObjectsd`.
 
     Args:
-        min_size: objects smaller than this size (in number of voxels; or volume in mm^3 if in_mm3 is True) are removed.
+        min_size: objects smaller than this size (in number of voxels; or surface area/volume value
+            in whatever units your image is if by_measure is True) are removed.
         connectivity: Maximum number of orthogonal hops to consider a pixel/voxel as a neighbor.
             Accepted values are ranging from  1 to input.ndim. If ``None``, a full
             connectivity of ``input.ndim`` is used. For more details refer to linked scikit-image
@@ -278,9 +279,10 @@ class RemoveSmallObjectsd(MapTransform):
         independent_channels: Whether or not to consider channels as independent. If true, then
             conjoining islands from different labels will be removed if they are below the threshold.
             If false, the overall size islands made from all non-background voxels will be used.
-        in_mm3: Whether the specified min_size is in number of voxels or volume in mm^3, default is false.
-            If true, min-size will be divided by pixdim. e.g. if min_size is 3 and in_mm3
-            is true, objects smaller than 3mm^3 are removed.
+        by_measure: Whether the specified min_size is in number of voxels. if this is True then min_size
+            represents a surface area or volume value of whatever units your image is in (mm^3, cm^2, etc.)
+            default is False. e.g. if min_size is 3, by_measure is True and the units of your data is mm,
+            objects smaller than 3mm^3 are removed.
         pixdim: the pixdim of the input image. if a single number, this is used for all axes.
             If a sequence of numbers, the length of the sequence must be equal to the image dimensions.
     """
@@ -293,12 +295,12 @@ class RemoveSmallObjectsd(MapTransform):
         min_size: int = 64,
         connectivity: int = 1,
         independent_channels: bool = True,
-        in_mm3: bool = False,
+        by_measure: bool = False,
         pixdim: Sequence[float] | float | np.ndarray | None = None,
         allow_missing_keys: bool = False,
     ) -> None:
         super().__init__(keys, allow_missing_keys)
-        self.converter = RemoveSmallObjects(min_size, connectivity, independent_channels, in_mm3, pixdim)
+        self.converter = RemoveSmallObjects(min_size, connectivity, independent_channels, by_measure, pixdim)
 
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> dict[Hashable, NdarrayOrTensor]:
         d = dict(data)

--- a/monai/transforms/post/dictionary.py
+++ b/monai/transforms/post/dictionary.py
@@ -278,6 +278,11 @@ class RemoveSmallObjectsd(MapTransform):
         independent_channels: Whether or not to consider channels as independent. If true, then
             conjoining islands from different labels will be removed if they are below the threshold.
             If false, the overall size islands made from all non-background voxels will be used.
+        physical_scale: Whether or not to consider min_size at physical scale, default is false.
+            If true, pixdim will be used to multiply min_size. e.g. if min_size is 3 and physical_scale
+            is True, objects smaller than 3mm^3 are removed.
+        pixdim: the pixdim of the input image. if a single number, this is used for all axes.
+            If a sequence of numbers, the length of the sequence must be equal to the image dimensions.
     """
 
     backend = RemoveSmallObjects.backend
@@ -288,10 +293,12 @@ class RemoveSmallObjectsd(MapTransform):
         min_size: int = 64,
         connectivity: int = 1,
         independent_channels: bool = True,
+        physical_scale: bool = False,
+        pixdim: Sequence[float] | float | np.ndarray | None = None,
         allow_missing_keys: bool = False,
     ) -> None:
         super().__init__(keys, allow_missing_keys)
-        self.converter = RemoveSmallObjects(min_size, connectivity, independent_channels)
+        self.converter = RemoveSmallObjects(min_size, connectivity, independent_channels, physical_scale, pixdim)
 
     def __call__(self, data: Mapping[Hashable, NdarrayOrTensor]) -> dict[Hashable, NdarrayOrTensor]:
         d = dict(data)

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1072,7 +1072,7 @@ def remove_small_objects(
     min_size: int = 64,
     connectivity: int = 1,
     independent_channels: bool = True,
-    in_mm3: bool = False,
+    by_measure: bool = False,
     pixdim: Sequence[float] | float | np.ndarray | None = None,
 ) -> NdarrayTensor:
     """
@@ -1090,8 +1090,9 @@ def remove_small_objects(
             connectivity of ``input.ndim`` is used. For more details refer to linked scikit-image
             documentation.
         independent_channels: Whether to consider each channel independently.
-        in_mm3: Whether the specified min_size is in number of voxels or volume in mm^3, default is false.
-            If true, min-size will be divided by pixdim.
+        by_measure: Whether the specified min_size is in number of voxels. if this is True then min_size
+            represents a surface area or volume value of whatever units your image is in (mm^3, cm^2, etc.)
+            default is False.
         pixdim: the pixdim of the input image. if a single number, this is used for all axes.
             If a sequence of numbers, the length of the sequence must be equal to the image dimensions.
     """
@@ -1102,7 +1103,7 @@ def remove_small_objects(
     if not has_morphology:
         raise RuntimeError("Skimage required.")
 
-    if in_mm3:
+    if by_measure:
         sr = len(img.shape[1:])
         if isinstance(img, monai.data.MetaTensor):
             _pixdim = img.pixdim

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1110,7 +1110,7 @@ def remove_small_objects(
             _pixdim = ensure_tuple_rep(pixdim, sr)
         else:
             warnings.warn("`img` is not of type MetaTensor and `pixdim` is None, assuming affine to be identity.")
-            _pixdim = (1.0, ) * sr
+            _pixdim = (1.0,) * sr
         min_size = int(np.prod(np.array(_pixdim)) * min_size)
 
     img_np: np.ndarray

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1112,6 +1112,8 @@ def remove_small_objects(
             warnings.warn("`img` is not of type MetaTensor and `pixdim` is None, assuming affine to be identity.")
             _pixdim = (1.0,) * sr
         min_size = int(np.prod(np.array(_pixdim)) * min_size)
+    elif pixdim is not None:
+        warnings.warn(`pixdim is specified by not in use when computing the volume.`)
 
     img_np: np.ndarray
     img_np, *_ = convert_data_type(img, np.ndarray)

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1068,7 +1068,11 @@ def get_largest_connected_component_mask(
 
 
 def remove_small_objects(
-    img: NdarrayTensor, min_size: int = 64, connectivity: int = 1, independent_channels: bool = True
+    img: NdarrayTensor,
+    min_size: int = 64,
+    connectivity: int = 1,
+    independent_channels: bool = True,
+    physical_scale: bool = False,
 ) -> NdarrayTensor:
     """
     Use `skimage.morphology.remove_small_objects` to remove small objects from images.
@@ -1085,6 +1089,8 @@ def remove_small_objects(
             connectivity of ``input.ndim`` is used. For more details refer to linked scikit-image
             documentation.
         independent_channels: Whether to consider each channel independently.
+        physical_scale: Whether or not to consider min_size at physical scale, default is false. If true,
+            min_size will be multiplied by pixdim.
     """
     # if all equal to one value, no need to call skimage
     if len(unique(img)) == 1:
@@ -1092,6 +1098,12 @@ def remove_small_objects(
 
     if not has_morphology:
         raise RuntimeError("Skimage required.")
+
+    if physical_scale:
+        if isinstance(img, monai.data.MetaTensor):
+            min_size = int(np.prod(np.array(img.pixdim)) * min_size)
+        else:
+            warnings.warn("`img` is not of type MetaTensor, assuming affine to be identity.")
 
     img_np: np.ndarray
     img_np, *_ = convert_data_type(img, np.ndarray)

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1111,7 +1111,11 @@ def remove_small_objects(
         else:
             warnings.warn("`img` is not of type MetaTensor and `pixdim` is None, assuming affine to be identity.")
             _pixdim = (1.0,) * sr
-        min_size = int(min_size / np.prod(np.array(_pixdim)))
+        voxel_volume = np.prod(np.array(_pixdim))
+        if voxel_volume == 0:
+            warnings.warn("Invalid `pixdim` value detected, set it to 1. Please verify the pixdim settings.")
+            voxel_volume = 1
+        min_size = np.ceil(min_size / voxel_volume)
     elif pixdim is not None:
         warnings.warn("`pixdim` is specified but not in use when computing the volume.")
 

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1072,7 +1072,7 @@ def remove_small_objects(
     min_size: int = 64,
     connectivity: int = 1,
     independent_channels: bool = True,
-    physical_scale: bool = False,
+    in_mm3: bool = False,
     pixdim: Sequence[float] | float | np.ndarray | None = None,
 ) -> NdarrayTensor:
     """
@@ -1090,8 +1090,8 @@ def remove_small_objects(
             connectivity of ``input.ndim`` is used. For more details refer to linked scikit-image
             documentation.
         independent_channels: Whether to consider each channel independently.
-        physical_scale: Whether or not to consider min_size at physical scale, default is false. If true,
-            min_size will be multiplied by pixdim.
+        in_mm3: Whether the specified min_size is in number of voxels or volume in mm^3, default is false.
+            If true, min-size will be divided by pixdim.
         pixdim: the pixdim of the input image. if a single number, this is used for all axes.
             If a sequence of numbers, the length of the sequence must be equal to the image dimensions.
     """
@@ -1102,7 +1102,7 @@ def remove_small_objects(
     if not has_morphology:
         raise RuntimeError("Skimage required.")
 
-    if physical_scale:
+    if in_mm3:
         sr = len(img.shape[1:])
         if isinstance(img, monai.data.MetaTensor):
             _pixdim = img.pixdim
@@ -1111,9 +1111,9 @@ def remove_small_objects(
         else:
             warnings.warn("`img` is not of type MetaTensor and `pixdim` is None, assuming affine to be identity.")
             _pixdim = (1.0,) * sr
-        min_size = int(np.prod(np.array(_pixdim)) * min_size)
+        min_size = int(min_size / np.prod(np.array(_pixdim)))
     elif pixdim is not None:
-        warnings.warn(`pixdim is specified by not in use when computing the volume.`)
+        warnings.warn("`pixdim` is specified but not in use when computing the volume.")
 
     img_np: np.ndarray
     img_np, *_ = convert_data_type(img, np.ndarray)

--- a/tests/test_remove_small_objects.py
+++ b/tests/test_remove_small_objects.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import unittest
 
 import numpy as np
+import torch
 from parameterized import parameterized
 
 from monai.data.meta_tensor import MetaTensor
@@ -32,8 +33,8 @@ TEST_INPUT1 = np.array([[[0, 0, 2, 1, 0], [1, 1, 1, 2, 0], [1, 1, 1, 0, 1]]])
 TEST_OUTPUT1 = np.array([[[0, 0, 2, 1, 0], [1, 1, 1, 2, 0], [1, 1, 1, 0, 0]]])
 
 TEST_INPUT2 = np.array([[[1, 1, 1, 0, 0], [1, 1, 1, 0, 0], [0, 0, 0, 0, 0], [0, 1, 1, 0, 1], [0, 0, 0, 1, 1]]])
-affine = np.eye(4)
-affine[0, 0] = 2
+affine = torch.eye(4, dtype=torch.float64)
+affine[0, 0] = 2.0
 TEST_INPUT3 = MetaTensor(TEST_INPUT2, affine=affine)
 
 

--- a/tests/test_remove_small_objects.py
+++ b/tests/test_remove_small_objects.py
@@ -50,8 +50,8 @@ for dtype in (int, float):
 
 TESTS_PHYSICAL: list[tuple] = []
 for dtype in (int, float):
-    TESTS_PHYSICAL.append((dtype, np.array, TEST_INPUT2, None, {"min_size": 3, "in_mm3": True, "pixdim": (2, 1)}))
-    TESTS_PHYSICAL.append((dtype, MetaTensor, TEST_INPUT3, None, {"min_size": 3, "in_mm3": True}))
+    TESTS_PHYSICAL.append((dtype, np.array, TEST_INPUT2, None, {"min_size": 3, "by_measure": True, "pixdim": (2, 1)}))
+    TESTS_PHYSICAL.append((dtype, MetaTensor, TEST_INPUT3, None, {"min_size": 3, "by_measure": True}))
 
 
 @SkipIfNoModule("skimage.morphology")

--- a/tests/test_remove_small_objects.py
+++ b/tests/test_remove_small_objects.py
@@ -72,7 +72,7 @@ class TestRemoveSmallObjects(unittest.TestCase):
     @parameterized.expand(TESTS_PHYSICAL)
     def test_remove_small_objects_physical(self, dtype, im_type, lbl, expected, params):
         params = params or {}
-        min_size = params["min_size"] / 2
+        min_size = np.ceil(params["min_size"] / 2)
 
         if expected is None:
             dtype = bool if lbl.max() <= 1 else int

--- a/tests/test_remove_small_objects.py
+++ b/tests/test_remove_small_objects.py
@@ -50,10 +50,8 @@ for dtype in (int, float):
 
 TESTS_PHYSICAL: list[tuple] = []
 for dtype in (int, float):
-    TESTS_PHYSICAL.append(
-        (dtype, np.array, TEST_INPUT2, None, {"min_size": 3, "physical_scale": True, "pixdim": (2, 1)})
-    )
-    TESTS_PHYSICAL.append((dtype, MetaTensor, TEST_INPUT3, None, {"min_size": 3, "physical_scale": True}))
+    TESTS_PHYSICAL.append((dtype, np.array, TEST_INPUT2, None, {"min_size": 3, "in_mm3": True, "pixdim": (2, 1)}))
+    TESTS_PHYSICAL.append((dtype, MetaTensor, TEST_INPUT3, None, {"min_size": 3, "in_mm3": True}))
 
 
 @SkipIfNoModule("skimage.morphology")
@@ -74,7 +72,7 @@ class TestRemoveSmallObjects(unittest.TestCase):
     @parameterized.expand(TESTS_PHYSICAL)
     def test_remove_small_objects_physical(self, dtype, im_type, lbl, expected, params):
         params = params or {}
-        min_size = params["min_size"] * 2
+        min_size = params["min_size"] / 2
 
         if expected is None:
             dtype = bool if lbl.max() <= 1 else int


### PR DESCRIPTION
Fixes #7034.

### Description
Add `in_mm3` in `remove_small_objects`, if `in_mm3=True`, `min_size` will be divided by pixdim when the image is MetaTensor.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
