### PR TITLE
7143 fixes resnet pretrained test

### DIFF
--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.losses import PerceptualLoss
 from monai.utils import optional_import
-from tests.utils import SkipIfBeforePyTorchVersion, skip_if_downloading_fails
+from tests.utils import SkipIfBeforePyTorchVersion, skip_if_downloading_fails, skip_if_quick
 
 _, has_torchvision = optional_import("torchvision")
 TEST_CASES = [
@@ -50,6 +50,7 @@ TEST_CASES = [
 
 @SkipIfBeforePyTorchVersion((1, 11))
 @unittest.skipUnless(has_torchvision, "Requires torchvision")
+@skip_if_quick
 class TestPerceptualLoss(unittest.TestCase):
     @parameterized.expand(TEST_CASES)
     def test_shape(self, input_param, input_shape, target_shape):

--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -53,7 +53,8 @@ TEST_CASES = [
 class TestPerceptualLoss(unittest.TestCase):
     @parameterized.expand(TEST_CASES)
     def test_shape(self, input_param, input_shape, target_shape):
-        loss = PerceptualLoss(**input_param)
+        with skip_if_downloading_fails():
+            loss = PerceptualLoss(**input_param)
         result = loss(torch.randn(input_shape), torch.randn(target_shape))
         self.assertEqual(result.shape, torch.Size([]))
 

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -224,7 +224,7 @@ class TestResNet(unittest.TestCase):
         # Custom pretrained weights
         cp_input_param["pretrained"] = self.tmp_ckpt_filename
         pretrained_net = model(**cp_input_param)
-        self.assertTrue(equal_state_dict(net.state_dict(), pretrained_net.state_dict()))
+        equal_state_dict(net.state_dict(), pretrained_net.state_dict())
 
         if has_hf_modules:
             # True flag
@@ -260,7 +260,7 @@ class TestResNet(unittest.TestCase):
                     medicalnet_state_dict = {
                         key.replace("module.", ""): value for key, value in medicalnet_state_dict.items()
                     }
-                    self.assertTrue(equal_state_dict(pretrained_net.state_dict(), medicalnet_state_dict))
+                    equal_state_dict(pretrained_net.state_dict(), medicalnet_state_dict)
 
     @parameterized.expand(TEST_SCRIPT_CASES)
     def test_script(self, model, input_param, input_shape, expected_shape):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -827,19 +827,12 @@ def command_line_tests(cmd, copy_env=True):
 
 def equal_state_dict(st_1, st_2):
     """
-    Compare 2 torch state dicts.
+    assert equal state_dict (for the shared keys between st_1 and st_2).
     """
-    r = True
     for key_st_1, val_st_1 in st_1.items():
         if key_st_1 in st_2:
             val_st_2 = st_2.get(key_st_1)
-            if not torch.equal(val_st_1, val_st_2):
-                r = False
-                break
-        else:
-            r = False
-            break
-    return r
+            assert_allclose(val_st_1, val_st_2)
 
 
 TEST_TORCH_TENSORS: tuple = (torch.as_tensor,)


### PR DESCRIPTION
Fixes #7143


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
