### PR TITLE
(WIP) onnx export 2nd batch

### DIFF
--- a/tests/test_segresnet.py
+++ b/tests/test_segresnet.py
@@ -19,7 +19,7 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.nets import SegResNet, SegResNetVAE
 from monai.utils import UpsampleMode
-from tests.utils import test_script_save
+from tests.utils import test_onnx_save, test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -100,6 +100,12 @@ class TestResNet(unittest.TestCase):
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
 
+    def test_onnx(self):
+        input_param, input_shape, expected_shape = TEST_CASE_SEGRESNET[0]
+        net = SegResNet(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=1e-4)
+
 
 class TestResNetVAE(unittest.TestCase):
     @parameterized.expand(TEST_CASE_SEGRESNET_VAE)
@@ -114,6 +120,12 @@ class TestResNetVAE(unittest.TestCase):
         net = SegResNetVAE(**input_param)
         test_data = torch.randn(input_shape)
         test_script_save(net, test_data)
+
+    def test_onnx(self):
+        input_param, input_shape, expected_shape = TEST_CASE_SEGRESNET_VAE[0]
+        net = SegResNetVAE(**input_param)
+        test_data = torch.randn(input_shape)
+        test_onnx_save(net, test_data, atol=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes # .
NA

### Description

onnx export had been enabled in a previous PR. It is necessary to extend test coverage on networks defined in Monai and used (or will be used) in model-zoo.

This PR is one of multiple PRs. It exports MONAI networks defined in the repo and validates exported onnx models.

Some networks cannot be exported to onnx due to various issues - there shall be separate efforts each for a specific network. It will likely involve support from pytorch onnx team.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
