### PR TITLE
Refactor `self.weight` in `DiceLoss` and `FocalLoss`

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -113,6 +113,7 @@ class DiceLoss(_Loss):
         self.batch = batch
         weight = torch.as_tensor(weight) if weight is not None else None
         self.register_buffer("class_weight", weight)
+        self.class_weight: None | torch.Tensor
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """
@@ -190,7 +191,6 @@ class DiceLoss(_Loss):
         f: torch.Tensor = 1.0 - (2.0 * intersection + self.smooth_nr) / (denominator + self.smooth_dr)
 
         num_of_classes = target.shape[1]
-        self.class_weight: None | torch.Tensor
         if self.class_weight is not None and num_of_classes != 1:
             # make sure the lengths of weights are equal to the number of classes
             if self.class_weight.ndim == 0:

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -190,6 +190,7 @@ class DiceLoss(_Loss):
         f: torch.Tensor = 1.0 - (2.0 * intersection + self.smooth_nr) / (denominator + self.smooth_dr)
 
         num_of_classes = target.shape[1]
+        self.class_weight: None | torch.Tensor
         if self.class_weight is not None and num_of_classes != 1:
             # make sure the lengths of weights are equal to the number of classes
             if self.class_weight.ndim == 0:

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -111,8 +111,9 @@ class DiceLoss(_Loss):
         self.smooth_nr = float(smooth_nr)
         self.smooth_dr = float(smooth_dr)
         self.batch = batch
-        self.weight = weight
-        self.register_buffer("class_weight", torch.ones(1))
+        if weight is not None:
+            weight = torch.as_tensor(weight)
+        self.register_buffer("class_weight", weight)
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """
@@ -189,13 +190,13 @@ class DiceLoss(_Loss):
 
         f: torch.Tensor = 1.0 - (2.0 * intersection + self.smooth_nr) / (denominator + self.smooth_dr)
 
-        if self.weight is not None and target.shape[1] != 1:
+        num_of_classes = target.shape[1]
+        if self.class_weight is not None and num_of_classes != 1:
             # make sure the lengths of weights are equal to the number of classes
-            num_of_classes = target.shape[1]
-            if isinstance(self.weight, (float, int)):
-                self.class_weight = torch.as_tensor([self.weight] * num_of_classes)
+            if self.class_weight.ndim == 0:
+                self.class_weight = torch.as_tensor([self.class_weight] * num_of_classes)
             else:
-                self.class_weight = torch.as_tensor(self.weight)
+                self.class_weight = torch.as_tensor(self.class_weight)
                 if self.class_weight.shape[0] != num_of_classes:
                     raise ValueError(
                         """the length of the `weight` sequence should be the same as the number of classes.

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -111,8 +111,7 @@ class DiceLoss(_Loss):
         self.smooth_nr = float(smooth_nr)
         self.smooth_dr = float(smooth_dr)
         self.batch = batch
-        if weight is not None:
-            weight = torch.as_tensor(weight)
+        weight = torch.as_tensor(weight) if weight is not None else None
         self.register_buffer("class_weight", weight)
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
@@ -196,7 +195,6 @@ class DiceLoss(_Loss):
             if self.class_weight.ndim == 0:
                 self.class_weight = torch.as_tensor([self.class_weight] * num_of_classes)
             else:
-                self.class_weight = torch.as_tensor(self.class_weight)
                 if self.class_weight.shape[0] != num_of_classes:
                     raise ValueError(
                         """the length of the `weight` sequence should be the same as the number of classes.

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -113,8 +113,7 @@ class FocalLoss(_Loss):
         self.alpha = alpha
         self.weight = weight
         self.use_softmax = use_softmax
-        if weight is not None:
-            weight = torch.as_tensor(weight)
+        weight = torch.as_tensor(weight) if weight is not None else None
         self.register_buffer("class_weight", weight)
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
@@ -170,7 +169,6 @@ class FocalLoss(_Loss):
             if self.class_weight.ndim == 0:
                 self.class_weight = torch.as_tensor([self.class_weight] * num_of_classes)
             else:
-                self.class_weight = torch.as_tensor(self.class_weight)
                 if self.class_weight.shape[0] != num_of_classes:
                     raise ValueError(
                         """the length of the `weight` sequence should be the same as the number of classes.

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -164,6 +164,7 @@ class FocalLoss(_Loss):
             loss = sigmoid_focal_loss(input, target, self.gamma, self.alpha)
 
         num_of_classes = target.shape[1]
+        self.class_weight: None | torch.Tensor
         if self.class_weight is not None and num_of_classes != 1:
             # make sure the lengths of weights are equal to the number of classes
             if self.class_weight.ndim == 0:

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -115,6 +115,7 @@ class FocalLoss(_Loss):
         self.use_softmax = use_softmax
         weight = torch.as_tensor(weight) if weight is not None else None
         self.register_buffer("class_weight", weight)
+        self.class_weight: None | torch.Tensor
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """
@@ -164,7 +165,6 @@ class FocalLoss(_Loss):
             loss = sigmoid_focal_loss(input, target, self.gamma, self.alpha)
 
         num_of_classes = target.shape[1]
-        self.class_weight: None | torch.Tensor
         if self.class_weight is not None and num_of_classes != 1:
             # make sure the lengths of weights are equal to the number of classes
             if self.class_weight.ndim == 0:


### PR DESCRIPTION
Fixes #7065

### Description
Remove `self.weight` in `DiceLoss` and `FocalLoss`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
