### PR TITLE
6627 reading dcm folder filtering filenames

### DIFF
--- a/monai/apps/tcia/__init__.py
+++ b/monai/apps/tcia/__init__.py
@@ -12,4 +12,11 @@
 from __future__ import annotations
 
 from .label_desc import TCIA_LABEL_DICT
-from .utils import download_tcia_series_instance, get_tcia_metadata, get_tcia_ref_uid, match_tcia_ref_uid_in_study
+from .utils import (
+    BASE_URL,
+    DCM_FILENAME_REGEX,
+    download_tcia_series_instance,
+    get_tcia_metadata,
+    get_tcia_ref_uid,
+    match_tcia_ref_uid_in_study,
+)

--- a/monai/apps/tcia/utils.py
+++ b/monai/apps/tcia/utils.py
@@ -21,9 +21,17 @@ from monai.utils import optional_import
 requests_get, has_requests = optional_import("requests", name="get")
 pd, has_pandas = optional_import("pandas")
 
-__all__ = ["get_tcia_metadata", "download_tcia_series_instance", "get_tcia_ref_uid", "match_tcia_ref_uid_in_study"]
-
+DCM_FILENAME_REGEX = r"^(?!.*LICENSE).*"  # excluding the file with "LICENSE" in its name
 BASE_URL = "https://services.cancerimagingarchive.net/nbia-api/services/v1/"
+
+__all__ = [
+    "get_tcia_metadata",
+    "download_tcia_series_instance",
+    "get_tcia_ref_uid",
+    "match_tcia_ref_uid_in_study",
+    "DCM_FILENAME_REGEX",
+    "BASE_URL",
+]
 
 
 def get_tcia_metadata(query: str, attribute: str | None = None) -> list:

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -405,8 +405,8 @@ class PydicomReader(ImageReader):
             Keys of the dict are the classes, and values are the corresponding class number. For example:
             for TCIA collection "C4KC-KiTS", it can be: {"Kidney": 0, "Renal Tumor": 1}.
         fname_regex: a regular expression to match the file names when the input is a folder.
-            If provided, only the matched files will be included.
-            For example, if the file name is "image_0001.dcm", and the regular expression is `".*image_(\\d+).dcm"`.
+            If provided, only the matched files will be included. For example, to include the file name
+            "image_0001.dcm", the regular expression could be `".*image_(\\d+).dcm"`.
             Default to `"^(?!.*LICENSE).*"`, ignoring any file name containing `"LICENSE"`.
         kwargs: additional args for `pydicom.dcmread` API. more details about available args:
             https://pydicom.github.io/pydicom/stable/reference/generated/pydicom.filereader.dcmread.html

--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -406,8 +406,7 @@ class PydicomReader(ImageReader):
             for TCIA collection "C4KC-KiTS", it can be: {"Kidney": 0, "Renal Tumor": 1}.
         fname_regex: a regular expression to match the file names when the input is a folder.
             If provided, only the matched files will be included. For example, to include the file name
-            "image_0001.dcm", the regular expression could be `".*image_(\\d+).dcm"`.
-            Default to `"^(?!.*LICENSE).*"`, ignoring any file name containing `"LICENSE"`.
+            "image_0001.dcm", the regular expression could be `".*image_(\\d+).dcm"`. Default to `""`.
         kwargs: additional args for `pydicom.dcmread` API. more details about available args:
             https://pydicom.github.io/pydicom/stable/reference/generated/pydicom.filereader.dcmread.html
             If the `get_data` function will be called
@@ -423,7 +422,7 @@ class PydicomReader(ImageReader):
         swap_ij: bool = True,
         prune_metadata: bool = True,
         label_dict: dict | None = None,
-        fname_regex: str = r"^(?!.*LICENSE).*",
+        fname_regex: str = "",
         **kwargs,
     ):
         super().__init__()

--- a/tests/test_load_image.py
+++ b/tests/test_load_image.py
@@ -229,6 +229,7 @@ class TestLoadImage(unittest.TestCase):
     def test_no_files(self):
         with self.assertRaisesRegex(RuntimeError, "list index out of range"):  # fname_regex excludes everything
             LoadImage(image_only=True, reader="PydicomReader", fname_regex=r"^(?!.*).*")("tests/testing_data/CT_DICOM")
+        LoadImage(image_only=True, reader="PydicomReader", fname_regex=None)("tests/testing_data/CT_DICOM")
 
     def test_itk_dicom_series_reader_single(self):
         result = LoadImage(image_only=True, reader="ITKReader")(self.data_dir)

--- a/tests/test_load_image.py
+++ b/tests/test_load_image.py
@@ -226,6 +226,10 @@ class TestLoadImage(unittest.TestCase):
         )
         self.assertTupleEqual(result.shape, expected_np_shape)
 
+    def test_no_files(self):
+        with self.assertRaisesRegex(RuntimeError, "list index out of range"):  # fname_regex excludes everything
+            LoadImage(image_only=True, reader="PydicomReader", fname_regex=r"^(?!.*).*")("tests/testing_data/CT_DICOM")
+
     def test_itk_dicom_series_reader_single(self):
         result = LoadImage(image_only=True, reader="ITKReader")(self.data_dir)
         self.assertEqual(result.meta["filename_or_obj"], f"{Path(self.data_dir)}")

--- a/tests/test_tciadataset.py
+++ b/tests/test_tciadataset.py
@@ -16,7 +16,7 @@ import shutil
 import unittest
 
 from monai.apps import TciaDataset
-from monai.apps.tcia import TCIA_LABEL_DICT
+from monai.apps.tcia import DCM_FILENAME_REGEX, TCIA_LABEL_DICT
 from monai.data import MetaTensor
 from monai.transforms import Compose, EnsureChannelFirstd, LoadImaged, ScaleIntensityd
 from tests.utils import skip_if_downloading_fails, skip_if_quick
@@ -32,7 +32,12 @@ class TestTciaDataset(unittest.TestCase):
 
         transform = Compose(
             [
-                LoadImaged(keys=["image", "seg"], reader="PydicomReader", label_dict=TCIA_LABEL_DICT[collection]),
+                LoadImaged(
+                    keys=["image", "seg"],
+                    reader="PydicomReader",
+                    fname_regex=DCM_FILENAME_REGEX,
+                    label_dict=TCIA_LABEL_DICT[collection],
+                ),
                 EnsureChannelFirstd(keys="image", channel_dim="no_channel"),
                 ScaleIntensityd(keys="image"),
             ]
@@ -82,10 +87,24 @@ class TestTciaDataset(unittest.TestCase):
         self.assertTupleEqual(data[0]["image"].shape, (256, 256, 24))
         self.assertEqual(len(data), int(download_len * val_frac))
         data = TciaDataset(
-            root_dir=testing_dir, collection=collection, section="validation", download=False, val_frac=val_frac
+            root_dir=testing_dir,
+            collection=collection,
+            section="validation",
+            download=False,
+            fname_regex=DCM_FILENAME_REGEX,
+            val_frac=val_frac,
         )
         self.assertTupleEqual(data[0]["image"].shape, (256, 256, 24))
         self.assertEqual(len(data), download_len)
+        with self.assertRaises(RuntimeError):
+            data = TciaDataset(
+                root_dir=testing_dir,
+                collection=collection,
+                section="validation",
+                fname_regex=".*",  # all files including 'LICENSE' is not a valid input
+                download=False,
+                val_frac=val_frac,
+            )[0]
 
         shutil.rmtree(os.path.join(testing_dir, collection))
         try:

--- a/tests/test_tciadataset.py
+++ b/tests/test_tciadataset.py
@@ -96,7 +96,7 @@ class TestTciaDataset(unittest.TestCase):
         )
         self.assertTupleEqual(data[0]["image"].shape, (256, 256, 24))
         self.assertEqual(len(data), download_len)
-        with self.assertRaises(RuntimeError):
+        with self.assertWarns(UserWarning):
             data = TciaDataset(
                 root_dir=testing_dir,
                 collection=collection,


### PR DESCRIPTION
Fixes #6627

### Description
adding a `fname_regex` option to the pydicom reader

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
