### PR TITLE
Expose EnesembleRunner in AutoRunner

### DIFF
--- a/monai/apps/auto3dseg/auto_runner.py
+++ b/monai/apps/auto3dseg/auto_runner.py
@@ -863,7 +863,7 @@ class AutoRunner:
 
         # step 4: model ensemble and write the prediction to disks.
         if self.ensemble:
-            ensemble_runner = EnsembleRunner(
+            self.ensemble_runner = EnsembleRunner(
                 data_src_cfg_name=self.data_src_cfg_name,
                 work_dir=self.work_dir,
                 num_fold=self.num_fold,
@@ -872,5 +872,5 @@ class AutoRunner:
                 **self.kwargs,  # for set_image_save_transform
                 **self.pred_params,
             )  # for inference
-            ensemble_runner.run(self.device_setting)
+            self.ensemble_runner.run(self.device_setting)
         logger.info("Auto3Dseg pipeline is completed successfully.")

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -448,6 +448,7 @@ class EnsembleRunner:
             "MN_START_METHOD": os.environ.get("MN_START_METHOD", "bcprun"),
             "CMD_PREFIX": os.environ.get("CMD_PREFIX", ""),
         }
+        self.ensembler = None
 
     def set_ensemble_method(self, ensemble_method_name: str = "AlgoEnsembleBestByFold", **kwargs: Any) -> None:
         """


### PR DESCRIPTION
Fixes #7204 

### Description

This PR makes `EnesembleRunner` instance be accessible via `AutoRunner` instance, so the use can get information about the ensembling after the models are trained and ensembled.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).