### PR TITLE
Fixup mypy 1.7.0 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ venv.bak/
 examples/scd_lvsegs.npz
 temp/
 .idea/
+.dmypy.json
 
 *~
 

--- a/monai/apps/auto3dseg/data_analyzer.py
+++ b/monai/apps/auto3dseg/data_analyzer.py
@@ -210,7 +210,7 @@ class DataAnalyzer:
             nprocs = torch.cuda.device_count()
             logger.info(f"Found {nprocs} GPUs for data analyzing!")
         if nprocs > 1:
-            tmp_ctx = get_context("forkserver")
+            tmp_ctx: Any = get_context("forkserver")
             with tmp_ctx.Manager() as manager:
                 manager_list = manager.list()
                 processes = []

--- a/monai/apps/deepgrow/interaction.py
+++ b/monai/apps/deepgrow/interaction.py
@@ -49,7 +49,7 @@ class Interaction:
         if not isinstance(transforms, Compose):
             transforms = Compose(transforms)
 
-        self.transforms = transforms
+        self.transforms: Compose = transforms
         self.max_interactions = max_interactions
         self.train = train
         self.key_probability = key_probability

--- a/monai/apps/pathology/metrics/lesion_froc.py
+++ b/monai/apps/pathology/metrics/lesion_froc.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Iterable
 
 import numpy as np
 

--- a/monai/apps/pathology/metrics/lesion_froc.py
+++ b/monai/apps/pathology/metrics/lesion_froc.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any, Iterable, TYPE_CHECKING
 
 import numpy as np
 
@@ -94,6 +94,9 @@ class LesionFROC:
         nms_outputs = self.nms(probs_map=prob_map, resolution_level=sample["level"])
 
         # separate nms outputs
+        probs: Iterable[Any]
+        x_coord: Iterable[Any]
+        y_coord: Iterable[Any]
         if nms_outputs:
             probs, x_coord, y_coord = zip(*nms_outputs)
         else:

--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import warnings
 from functools import lru_cache, partial
 from types import ModuleType
-from typing import Any, Sequence
+from typing import Any, Iterable, Sequence
 
 import numpy as np
 import torch
@@ -383,7 +383,7 @@ def remap_instance_id(pred: torch.Tensor, by_size: bool = False) -> torch.Tensor
         by_size: if True, largest instance will be assigned a smaller id.
 
     """
-    pred_id = list(pred.unique())
+    pred_id: Iterable[Any] = list(pred.unique())
     # the original implementation has the limitation that if there is no 0 in pred, error will happen
     pred_id = [i for i in pred_id if i != 0]
 

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -268,7 +268,7 @@ class LoadImage(Transform):
                         break
 
         if img is None or reader is None:
-            if isinstance(filename, tuple) and len(filename) == 1:
+            if isinstance(filename, Sequence) and len(filename) == 1:
                 filename = filename[0]
             msg = "\n".join([f"{e}" for e in err])
             raise RuntimeError(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ isort>=5.1
 ruff
 pytype>=2020.6.1; platform_system != "Windows"
 types-pkg_resources
-mypy>=0.790
+mypy>=1.5.0
 ninja
 torchvision
 psutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -228,10 +228,12 @@ pretty = False
 # Warns about per-module sections in the config file that do not match any files processed when invoking mypy.
 warn_unused_configs = True
 # Make arguments prepended via Concatenate be truly positional-only.
-strict_concatenate = True
+extra_checks = True
 # Allows variables to be redefined with an arbitrary type,
 # as long as the redefinition is in the same block and nesting level as the original definition.
 # allow_redefinition = True
+# ForkServerContext is not supported on Windows.
+platform = linux
 
 exclude = venv/
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -232,8 +232,6 @@ extra_checks = True
 # Allows variables to be redefined with an arbitrary type,
 # as long as the redefinition is in the same block and nesting level as the original definition.
 # allow_redefinition = True
-# ForkServerContext is not supported on Windows.
-platform = linux
 
 exclude = venv/
 


### PR DESCRIPTION
Fixes #7230.

### Description

Fix the typing issues and the deprecation.

Also always run type checking with Linux environment, since ForkServerContext is not available on Windows.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
