### PR TITLE
Replace single quotation marks with double quotation marks to install…

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -228,7 +228,7 @@ Alternatively, to install all optional dependencies:
 ```bash
 git clone https://github.com/Project-MONAI/MONAI.git
 cd MONAI/
-pip install -e '.[all]'
+pip install -e ".[all]"
 ```
 
 To install all optional dependencies with `pip` based on MONAI development environment settings:


### PR DESCRIPTION
… MONAI with all dependencies on Windows

Fixes #6118

### Description

The Windows shell doesn't recognize single quotes to delimit a string at all, so on Windows you'll need to use double quotes. It's the same command no matter which type of quotes you use; after the shell does its processing, the argument is passed to pip with the quotation marks already removed.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
