### PR TITLE
:hammer: [dataset] Handle corrupted cached file in PersistentDataset

### DIFF
--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -387,6 +387,12 @@ class PersistentDataset(Dataset):
             except PermissionError as e:
                 if sys.platform != "win32":
                     raise e
+            except RuntimeError as e:
+                if "Invalid magic number; corrupt file" in str(e):
+                    print(f"Corrupt cache file detected: {hashfile}. Deleting and recomputing.")
+                    hashfile.unlink()
+                else:
+                    raise e
 
         _item_transformed = self._pre_transform(deepcopy(item_transformed))  # keep the original hashed
         if hashfile is None:

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -389,7 +389,7 @@ class PersistentDataset(Dataset):
                     raise e
             except RuntimeError as e:
                 if "Invalid magic number; corrupt file" in str(e):
-                    print(f"Corrupt cache file detected: {hashfile}. Deleting and recomputing.")
+                    warnings.warn(f"Corrupt cache file detected: {hashfile}. Deleting and recomputing.")
                     hashfile.unlink()
                 else:
                     raise e


### PR DESCRIPTION
Fixes #5723

### Description
Corrupted cached files in the PersistentDataset cause the exception:
`RuntimeError: Invalid magic number; corrupt file?`

With this PR we handle that case in the try-except block and continue the usual functionality if the cached file was absent.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
