### PR TITLE
Fix B026 unrecommanded star-arg unpacking after a keyword argument

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -1300,7 +1300,7 @@ class NrrdReader(ImageReader):
         kwargs_ = self.kwargs.copy()
         kwargs_.update(kwargs)
         for name in filenames:
-            nrrd_image = NrrdImage(*nrrd.read(name, index_order=self.index_order, *kwargs_))
+            nrrd_image = NrrdImage(*nrrd.read(name, index_order=self.index_order, **kwargs_))
             img_.append(nrrd_image)
         return img_ if len(filenames) > 1 else img_[0]
 

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -584,10 +584,10 @@ class SlidingWindowInfererAdapt(SlidingWindowInferer):
                 return super().__call__(
                     inputs,
                     network,
+                    *args,
                     device=inputs.device if gpu_stitching else torch.device("cpu"),
                     buffer_steps=buffer_steps if buffered_stitching else None,
                     buffer_dim=buffer_dim,
-                    *args,
                     **kwargs,
                 )
             except RuntimeError as e:

--- a/tests/test_video_datasets.py
+++ b/tests/test_video_datasets.py
@@ -39,7 +39,7 @@ class Base:
             return self.video_source
 
         def get_ds(self, *args, **kwargs) -> VideoDataset:
-            return self.ds(video_source=self.get_video_source(), transform=TRANSFORMS, *args, **kwargs)  # type: ignore
+            return self.ds(*args, video_source=self.get_video_source(), transform=TRANSFORMS, **kwargs)  # type: ignore
 
         @unittest.skipIf(has_cv2, "Only tested when OpenCV not installed.")
         def test_no_opencv_raises(self):


### PR DESCRIPTION
Fixes #7261

### Description
Remove star-arg unpacking before a keyword argument.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
