### PR TITLE
Support specified filenames in `Saveimage`

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -458,14 +458,17 @@ class SaveImage(Transform):
             self.write_kwargs.update(write_kwargs)
         return self
 
-    def __call__(self, img: torch.Tensor | np.ndarray, meta_data: dict | None = None, filename: str | None = None):
+    def __call__(
+        self, img: torch.Tensor | np.ndarray, meta_data: dict | None = None, filename: str | PathLike | None = None
+    ):
         """
         Args:
             img: target data content that save into file. The image should be channel-first, shape: `[C,H,W,[D]]`.
             meta_data: key-value pairs of metadata corresponding to the data.
+            filename: str or file-like object which to save img.
+                If specified, will ignore `self.output_name_formatter` and `self.folder_layout`.
         """
         meta_data = img.meta if isinstance(img, MetaTensor) else meta_data
-        kw = self.fname_formatter(meta_data, self)
         if filename is not None:
             filename += (
                 f".{self.output_ext}"
@@ -473,6 +476,7 @@ class SaveImage(Transform):
                 else f"{self.output_ext}"
             )
         else:
+            kw = self.fname_formatter(meta_data, self)
             filename = self.folder_layout.filename(**kw)
 
         if meta_data:

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -414,7 +414,9 @@ class SaveImage(Transform):
             self.fname_formatter = output_name_formatter
 
         self.output_ext = output_ext.lower() or output_format.lower()
-        self.output_ext = f".{self.output_ext}" if self.output_ext and not self.output_ext.startswith(".") else self.output_ext
+        self.output_ext = (
+            f".{self.output_ext}" if self.output_ext and not self.output_ext.startswith(".") else self.output_ext
+        )
         if isinstance(writer, str):
             writer_, has_built_in = optional_import("monai.data", name=f"{writer}")  # search built-in
             if not has_built_in:

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -414,6 +414,7 @@ class SaveImage(Transform):
             self.fname_formatter = output_name_formatter
 
         self.output_ext = output_ext.lower() or output_format.lower()
+        self.output_ext = f".{self.output_ext}" if self.output_ext and not self.output_ext.startswith(".") else self.output_ext
         if isinstance(writer, str):
             writer_, has_built_in = optional_import("monai.data", name=f"{writer}")  # search built-in
             if not has_built_in:
@@ -470,11 +471,7 @@ class SaveImage(Transform):
         """
         meta_data = img.meta if isinstance(img, MetaTensor) else meta_data
         if filename is not None:
-            filename = str(filename) + (
-                f".{self.output_ext}"
-                if self.output_ext and not self.output_ext.startswith(".")
-                else f"{self.output_ext}"
-            )
+            filename = f"{filename}{self.output_ext}"
         else:
             kw = self.fname_formatter(meta_data, self)
             filename = self.folder_layout.filename(**kw)

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -458,7 +458,7 @@ class SaveImage(Transform):
             self.write_kwargs.update(write_kwargs)
         return self
 
-    def __call__(self, img: torch.Tensor | np.ndarray, meta_data: dict | None = None):
+    def __call__(self, img: torch.Tensor | np.ndarray, meta_data: dict | None = None, filename: str | None = None):
         """
         Args:
             img: target data content that save into file. The image should be channel-first, shape: `[C,H,W,[D]]`.
@@ -466,7 +466,11 @@ class SaveImage(Transform):
         """
         meta_data = img.meta if isinstance(img, MetaTensor) else meta_data
         kw = self.fname_formatter(meta_data, self)
-        filename = self.folder_layout.filename(**kw)
+        if filename is not None:
+            filename += f".{self.output_ext}" if self.output_ext and not self.output_ext.startswith(".") else f"{self.output_ext}"
+        else:
+            filename = self.folder_layout.filename(**kw)
+
         if meta_data:
             meta_spatial_shape = ensure_tuple(meta_data.get("spatial_shape", ()))
             if len(meta_spatial_shape) >= len(img.shape):

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -467,7 +467,11 @@ class SaveImage(Transform):
         meta_data = img.meta if isinstance(img, MetaTensor) else meta_data
         kw = self.fname_formatter(meta_data, self)
         if filename is not None:
-            filename += f".{self.output_ext}" if self.output_ext and not self.output_ext.startswith(".") else f"{self.output_ext}"
+            filename += (
+                f".{self.output_ext}"
+                if self.output_ext and not self.output_ext.startswith(".")
+                else f"{self.output_ext}"
+            )
         else:
             filename = self.folder_layout.filename(**kw)
 

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -470,7 +470,7 @@ class SaveImage(Transform):
         """
         meta_data = img.meta if isinstance(img, MetaTensor) else meta_data
         if filename is not None:
-            filename += (
+            filename = str(filename) + (
                 f".{self.output_ext}"
                 if self.output_ext and not self.output_ext.startswith(".")
                 else f"{self.output_ext}"

--- a/tests/test_save_image.py
+++ b/tests/test_save_image.py
@@ -37,6 +37,12 @@ TEST_CASE_4 = [
     False,
 ]
 
+TEST_CASE_5 = [
+    torch.randint(0, 255, (3, 2, 4, 5), dtype=torch.uint8),
+    ".dcm",
+    False,
+]
+
 
 @unittest.skipUnless(has_itk, "itk not installed")
 class TestSaveImage(unittest.TestCase):
@@ -57,6 +63,20 @@ class TestSaveImage(unittest.TestCase):
 
             filepath = "testfile0" if meta_data is not None else "0"
             self.assertTrue(os.path.exists(os.path.join(tempdir, filepath + "_trans" + output_ext)))
+
+    @parameterized.expand([TEST_CASE_5])
+    def test_saved_content_with_filename(self, test_data, output_ext, resample):
+        with tempfile.TemporaryDirectory() as tempdir:
+            trans = SaveImage(
+                output_dir=tempdir,
+                output_ext=output_ext,
+                resample=resample,
+                separate_folder=False,  # test saving into the same folder
+            )
+            filename = str(os.path.join(tempdir, "test"))
+            trans(test_data, filename=filename)
+
+            self.assertTrue(os.path.exists(filename + output_ext))
 
 
 if __name__ == "__main__":

--- a/tests/test_save_image.py
+++ b/tests/test_save_image.py
@@ -37,11 +37,7 @@ TEST_CASE_4 = [
     False,
 ]
 
-TEST_CASE_5 = [
-    torch.randint(0, 255, (3, 2, 4, 5), dtype=torch.uint8),
-    ".dcm",
-    False,
-]
+TEST_CASE_5 = [torch.randint(0, 255, (3, 2, 4, 5), dtype=torch.uint8), ".dcm", False]
 
 
 @unittest.skipUnless(has_itk, "itk not installed")


### PR DESCRIPTION
Fixes #7317 

### Description

Add support specified filename for users to save like nibabel.save.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
