### PR TITLE
Give more useful exception when batch is considered during matrix multiplication

### DIFF
--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -189,7 +189,7 @@ class TraceableTransform(Transform):
                 affine = orig_affine @ to_affine_nd(len(orig_affine) - 1, affine, dtype=torch.float64)
             except RuntimeError as e:
                 raise RuntimeError(
-                    f"mismatch affine matrix, ensured that the batch dimension is not included in the calculation."
+                    "mismatch affine matrix, ensured that the batch dimension is not included in the calculation."
                 ) from e
             out_obj.meta[MetaKeys.AFFINE] = convert_to_tensor(affine, device=torch.device("cpu"), dtype=torch.float64)
 

--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -185,7 +185,12 @@ class TraceableTransform(Transform):
             # not lazy evaluation, directly update the metatensor affine (don't push to the stack)
             orig_affine = data_t.peek_pending_affine()
             orig_affine = convert_to_dst_type(orig_affine, affine, dtype=torch.float64)[0]
-            affine = orig_affine @ to_affine_nd(len(orig_affine) - 1, affine, dtype=torch.float64)
+            try:
+                affine = orig_affine @ to_affine_nd(len(orig_affine) - 1, affine, dtype=torch.float64)
+            except RuntimeError as e:
+                raise RuntimeError(
+                    f"mismatch affine matrix, ensured that the batch dimension is not included in the calculation."
+                ) from e
             out_obj.meta[MetaKeys.AFFINE] = convert_to_tensor(affine, device=torch.device("cpu"), dtype=torch.float64)
 
         if not (get_track_meta() and transform_info and transform_info.get(TraceKeys.TRACING)):


### PR DESCRIPTION
Fixes #7323

### Description

Give more useful exception when batch is considered during matrix multiplication.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
