### PR TITLE
Using pure transforms for image and geometry data

### DIFF
--- a/monai/transforms/__init__.py
+++ b/monai/transforms/__init__.py
@@ -239,7 +239,7 @@ from .io.dictionary import LoadImaged, LoadImageD, LoadImageDict, SaveImaged, Sa
 from .lazy.array import ApplyPending
 from .lazy.dictionary import ApplyPendingd, ApplyPendingD, ApplyPendingDict
 from .lazy.functional import apply_pending
-from .lazy.utils import combine_transforms, resample
+from .lazy.utils import combine_transforms, resample_image
 from .meta_utility.dictionary import (
     FromMetaTensord,
     FromMetaTensorD,

--- a/monai/transforms/lazy/functional.py
+++ b/monai/transforms/lazy/functional.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Sequence, Tuple
 
+import copy
+
 import torch
 
 from monai.apps.utils import get_logger
@@ -123,6 +125,16 @@ def lazily_apply_op(
             return (result, op) if get_track_meta() is True else result
         else:
             return (tensor, op) if get_track_meta() is True else tensor
+
+
+def invert(
+        data: torch.tensor | MetaTensor,
+        lazy_evaluation=True
+):
+    metadata = data.applied_operations.pop()
+    inv_metadata = copy.deepcopy(metadata)
+    inv_metadata.invert()
+    return lazily_apply_op(data, inv_metadata, lazy_evaluation, False)
 
 
 def apply_pending_transforms(

--- a/monai/transforms/lazy/functional.py
+++ b/monai/transforms/lazy/functional.py
@@ -97,16 +97,19 @@ def lazily_apply_op(
     This function will immediately apply the op to the given tensor if `lazy_evaluation` is set to
     False. Its precise behaviour depends on whether it is passed a Tensor or MetaTensor:
 
+    If passed a Tensor, `lazily_apply_op` returns a tuple of Tensor and operation description:
+     - if `lazy_evaluation` is False, the transformed tensor and op is returned
+     - if `lazy_evaluation` is True, the tensor and op is returned
 
-    If passed a Tensor, it returns a tuple of Tensor, MetaMatrix:
-     - if the operation was applied, Tensor, None is returned
-     - if the operation was not applied, Tensor, MetaMatrix is returned
-
-    If passed a MetaTensor, only the tensor itself is returned
+    If passed a MetaTensor, only the tensor itself is returned:
+     - if `lazy_evaluation` is False, the transformed tensor is returned, with the op added to
+       the applied operations
+     - if `lazy_evaluation` is True, the untransformed tensor is returned, with the op added to
+       the pending operations
 
     Args:
           tensor: the tensor to have the operation lazily applied to
-          op: the MetaMatrix containing the transform and metadata
+          op: the operation description containing the transform and metadata
           lazy_evaluation: a boolean flag indicating whether to apply the operation lazily
     """
     if isinstance(tensor, MetaTensor):

--- a/monai/transforms/lazy/utils.py
+++ b/monai/transforms/lazy/utils.py
@@ -23,7 +23,7 @@ from monai.transforms.utils import Affine
 from monai.transforms.utils_pytorch_numpy_unification import allclose
 from monai.utils import LazyAttr, convert_to_numpy, convert_to_tensor, look_up_option
 
-__all__ = ["resample", "combine_transforms"]
+__all__ = ["resample_image", "combine_transforms"]
 
 
 def affine_from_pending(pending_item):
@@ -91,7 +91,7 @@ def requires_interp(matrix, atol=AFFINE_TOL):
 __override_lazy_keywords = {*list(LazyAttr), "atol"}
 
 
-def resample(data: torch.Tensor, matrix: NdarrayOrTensor, kwargs: dict | None = None):
+def resample_image(data: torch.Tensor, matrix: NdarrayOrTensor, kwargs: dict | None = None):
     """
     Resample `data` using the affine transformation defined by ``matrix``.
 
@@ -173,3 +173,8 @@ def resample(data: torch.Tensor, matrix: NdarrayOrTensor, kwargs: dict | None = 
     resampler.lazy = False  # resampler is a lazytransform
     with resampler.trace_transform(False):  # don't track this transform in `img`
         return resampler(img=img, **call_kwargs)
+
+
+def resample_points(data: torch.Tensor, matrix: NdarrayOrTensor, kwargs: dict | None = None):
+    # Handle all point resampling here
+    raise NotImplementedError()

--- a/monai/transforms/traits.py
+++ b/monai/transforms/traits.py
@@ -29,7 +29,7 @@ class LazyTrait:
     """
 
     @property
-    def lazy(self):
+    def lazy_evaluation(self):
         """
         Get whether lazy evaluation is enabled for this transform instance.
         Returns:
@@ -37,8 +37,8 @@ class LazyTrait:
         """
         raise NotImplementedError()
 
-    @lazy.setter
-    def lazy(self, enabled: bool):
+    @lazy_evaluation.setter
+    def lazy_evaluation(self, enabled: bool):
         """
         Set whether lazy evaluation is enabled for this transform instance.
         Args:

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -294,22 +294,22 @@ class LazyTransform(Transform, LazyTrait):
     dictionary transforms to simplify implementation of new lazy transforms.
     """
 
-    def __init__(self, lazy: bool | None = False):
-        if lazy is not None:
-            if not isinstance(lazy, bool):
-                raise TypeError(f"lazy must be a bool but is of type {type(lazy)}")
-        self._lazy = lazy
+    def __init__(self, lazy_evaluation: bool | None = False):
+        if lazy_evaluation is not None:
+            if not isinstance(lazy_evaluation, bool):
+                raise TypeError(f"lazy must be a bool but is of type {type(lazy_evaluation)}")
+        self._lazy = lazy_evaluation
 
     @property
-    def lazy(self):
+    def lazy_evaluation(self):
         return self._lazy
 
-    @lazy.setter
-    def lazy(self, lazy: bool | None):
-        if lazy is not None:
-            if not isinstance(lazy, bool):
-                raise TypeError(f"lazy must be a bool but is of type {type(lazy)}")
-        self._lazy = lazy
+    @lazy_evaluation.setter
+    def lazy_evaluation(self, lazy_evaluation: bool | None):
+        if lazy_evaluation is not None:
+            if not isinstance(lazy_evaluation, bool):
+                raise TypeError(f"lazy_evaluation must be a bool but is of type {type(lazy_evaluation)}")
+        self._lazy = lazy_evaluation
 
     @property
     def requires_current_data(self):

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -16,7 +16,7 @@ import unittest
 import torch
 from parameterized import parameterized
 
-from monai.transforms.lazy.functional import resample
+from monai.transforms.lazy.functional import resample_image
 from monai.utils import convert_to_tensor
 from tests.utils import assert_allclose, get_arange_img
 
@@ -37,12 +37,12 @@ RESAMPLE_FUNCTION_CASES = [
 class TestResampleFunction(unittest.TestCase):
     @parameterized.expand(RESAMPLE_FUNCTION_CASES)
     def test_resample_function_impl(self, img, matrix, expected):
-        out = resample(convert_to_tensor(img), matrix, {"lazy_shape": img.shape[1:], "lazy_padding_mode": "border"})
+        out = resample_image(convert_to_tensor(img), matrix, {"lazy_shape": img.shape[1:], "lazy_padding_mode": "border"})
         assert_allclose(out[0], expected, type_test=False)
 
         img = convert_to_tensor(img, dtype=torch.uint8)
-        out = resample(img, matrix, {"lazy_resample_mode": "auto", "lazy_dtype": torch.float})
-        out_1 = resample(img, matrix, {"lazy_resample_mode": "other value", "lazy_dtype": torch.float})
+        out = resample_image(img, matrix, {"lazy_resample_mode": "auto", "lazy_dtype": torch.float})
+        out_1 = resample_image(img, matrix, {"lazy_resample_mode": "other value", "lazy_dtype": torch.float})
         self.assertIs(out.dtype, out_1.dtype)  # testing dtype in different lazy_resample_mode
 
 


### PR DESCRIPTION
An approach to implement #4027 that uses pure transforms to minimise the need for additional transforms.

**NOTE**: the implementation is untested in its current form and is missing components. There should be enough here to demostrate the approach; please let me know if anything is unclear.
**NOTE**: although this PR talks about pure transforms, we don't actually need to reimplement the transforms; we could instead modify them to have geometry paths, although this adds to the already high-complexity of the spatial transform implementations.

# Introduction

This approach uses the concept of pure transforms. These are transforms that don't directly manipulate and resample data, but rather simply specify the operation that is to be carried out in terms of either an affine matrix or a deformation grid. This description is then given to a function that executes the transform, and does so depending on the nature of the data that is provided.

Initially, we should first go over the design principles that this PR adheres to

# Geometry preprocessing design principles

 - Geometry data should be handled in the same way as Image data (as much as is possible)
   - tensor with metadata including affine transform
   - There may be special parameters analogous to "mode"
   - Some primitives must be represented as more than one tensor
     - Our design / public API should be robust to this even if we don't implement it now
 
 - We should avoid Image and Geometry versions of each transform if possible
   - We shouldn't modify the APIs of any transforms if we can avoid it
 
 - We should support pure Geometry applications
   - Geometry is not subordinate to Images
     - Should not require the presence of Images

 - `Compose` and geometry:
   - Not all pipelines using Array transforms will be expressible via `Compose`
     - All pipelines using Arrays will be expressible
   - All pipelines using Dictionaries will be expressible via `Compose`

# Critical geometry design decisions

The principle design decision for geometry is what unit space looks like. Given the desire that geometry is not subordinate to image data, we should tie unit space to physical units (i.e. millimetres) rather than pixel / voxel space. This has the following consequences:
 - images
   - images generally have the concept of resolution, i.e. pixel/voxel extents in physical coordinates. We often resample images in a way that preserves the overall image extents by changing the resolution of the voxels as well as the number of voxels
     - e.g. 256 * 256 pixels @ (0.5 * 0.5) mm^2 = 128 * 128 mm^2  == 128 * 128 pixels @ (1.0 * 1.0) mm^2 = 128 * 128 mm^2
     - for the image being resampled, this can be done with the following affine transforms:
       - the first transform scales the image by 0.5mm / 1.0mm = 0.5. This also has the effect of doubling the viewport extents
       - the second transform scales the viewport extents by 0.5, which reduces the viewport back to the image border
     - the resulting transformation is defined here as being a _raster-space_ transform
     - although the resolution of the image has changed, the geometric transformation is identity
   - geometry has no concept of resolution and so is only affected by _world-space_ transformations

Why does this matter? We need to separate the notion of transforms for overall geometry and transforms for raster space. 
 - images are affected by both _raster-space_ and _world-space_ transformations
 - geometry is only affected by _world-space_ transformations

Most transforms express pure _world-space_ operations
 - e.g. `flip`, `orientation`, `rotate(keep_size=True)`, `rotate90`, `zoom` etc.
The transforms that are image specific express _raster-space_ operations that may or may not also have identity _world-space_ transforms
   - e.g. `resample`, `resample_to_match`, `rotate(keep_size=False)`, `spatial_resample`, `spacing`

Note that `rotate` is an interesting case. Rotate generally expresses pure _world-space_ operations, but when `keep_size` is False, it specifies a _raster-space_ transform that modifies the image viewport.


## Categorising transforms

### Not image-specific
 - transforms that, in principle, work the same for image and geometry
   - Affine(d), Flip(d), Orientation(d), Resize(d), Rotate(d), Rotate90(d), Zoom(d)
   - RandAffine(d), RandAxisFlip(d), RandFlip(d), RandRotate(d), RandRotate90(d), RandZoom(d)
 - the APIs for these functions should not need to change
 
### Image-specific transforms
 - need a strategy to support geometry
   - RandSimulateLowResolution(d), Resize(d), Spacing(d), SpatialResample(d)
   - this might be different at the dictionary, array and functional levels
 - Special case
   - ResampleToMatch(d)
     - Can this be co-opted to update geometry to match images?

### Transforms using grids
 - grid-based: what does a grid mean to geometry? does geometry just bypass the grid?
   - AffineGrid(d), RandAffineGrid(d)
 - distortion: how do grid-based distorions get applied to geometry?
   - GridPatch(d), GridSplit(d)
   - Rand2DElastic(d), Rand3DElastic(d), RandDeformGrid(d), GridDistortion(d), RandGridDistortion(d), RandGridPatch(d)


## Array and Dictionary
 - Array transforms that are image-specific may need extra arguments
 - Dictionary transforms that are image-specific can have "geom" arguments
   - specify geometry tensor entries by name

## Open questions
 - What does a grid mean to geometry?
   - Can grids just be applied to points?

# Geometry specific transforms
The following transforms have been identified as needing to exist in *some* form:
 - `LoadGeometry`
 - `TransformToImage`
 - `Translate`

## `LoadGeometry`
This transform loads geometric data. It can in theory wrap all identified geometric types but at a minimum it needs to support arrays of points.
 - The user can specify how to interpret those points
   - point cloud, open polygon, closed polygon (including winding), triangle soup
Later we might also support loading of indexed meshes and higher order geometric primitives
We might also want to support loading of other metadata such affine matrices

## `TransformToImage`
This transform takes geometry data and maps it to a given image. This is useful when the geometry data doesn't have a defined space and must be mapped to an image.
- Take on the image orientation
- Transform the coordinate system
- Centre relative to image center / specified corners

## `TransformLike`

`TransformLike` is a way of aligning point clouds tensors with image tensors following transforms that only really work on images. Transforms such as `Resize`/`Resized` calculate a scaling matrix  that can only be determined from the physical characteristics of an image. However, corresponding point cloud data still needs updating to match the transformed image. so `TransformLike` is provided to take the latest transform from applied or pending and either apply it or add it to pending on the point cloud tensors.

Note that `TransformLike` seems close in functionality to `ResampleToMatch` and extending the latter may be better than implementing the former.

# Modifications to existing transforms

## Array transforms

Array transforms specific to images might be modified so that geometry data can be updated. This can be done via additional operation parameters that take a tensor or tuple of tensors:

```python
class Spacing(InvertibleTransform, LazyTransform):
    def __call__(
        self, data_array, mode, padding_mode, align_corners, dtype, scale_extent, output_spatial_shape, lazy,
        inputs_to_update # New
    ):
```

Another way to achieve this would be to add an extra key field that indicates fields that should have the recent transform applied to them, but this would have to be added to all spatial dictionary transforms.


## Dictionary transforms

Dictionary transforms specific to images can refer to geometry by name rather than requiring to pass tensors in directly

```python
class Spacingd(MapTransform, InvertibleTransform, LazyTransform):
    def __init__(
        self, keys, pixdim, diagonal, mode, padding_mode, align_corners, dtype, scale_extent,
        recompute_affine, min_pixdim, max_pixdim, ensure_same_shape, allow_missing_keys,
        input_keys_to_update # New
    ):
```

# An example pure transform

All pure transforms are implemented as pure functions. The array and dictionary, class-based transforms simply wrap the functional transform and pass the necessary parameters to it. This is true for both deterministic and random transforms.

```python
def rotate(
        img: torch.Tensor,
        angle: Sequence[float] | float,
        keep_size: bool = True,
        mode: InterpolateMode | str = InterpolateMode.AREA,
        padding_mode: NumpyPadMode | GridSamplePadMode | str = NumpyPadMode.EDGE,
        align_corners: bool = False,
        dtype: DtypeLike | torch.dtype = None,
        shape_override: Sequence[int] | None = None,
        dtype_override: DtypeLike | torch.dtype = None,
        lazy: bool = False
):
    # get the various arguments into the expected form
    img_ = convert_to_tensor(img, track_meta=get_track_meta())
    mode_ = look_up_option(mode, GridSampleMode)
    padding_mode_ = look_up_option(padding_mode, GridSamplePadMode)
    dtype_ = get_equivalent_dtype(dtype or img_.dtype, torch.Tensor)

    # get the input shape and input dtype, either from the image itself or from the pending transforms
    input_shape, input_dtype = get_input_shape_and_dtype(shape_override, dtype_override, img_)

    # get the angles; ignore all but the first value if the data is 2D
    input_ndim = len(input_shape) - 1
    if input_ndim not in (2, 3):
        raise ValueError(f"Unsupported image dimension: {input_ndim}, available options are [2, 3].")
    angle_ = ensure_tuple_rep(angle, 1 if input_ndim == 2 else 3)

    # calculate the transform and the output shape for the image
    rotate_tx = create_rotate(input_ndim, angle_).astype(np.float64)
    output_shape = input_shape if keep_size is True else transform_shape(input_shape, rotate_tx)

    # create the full transform description
    metadata = {
        "transform": transform,
        "op": "rotate",
        "angle": angle,
        "keep_size": keep_size,
        LazyAttr.INTERP_MODE: mode_,
        LazyAttr.PADDING_MODE: padding_mode_,
        LazyAttr.ALIGN_CORNERS: align_corners,
        LazyAttr.IN_SHAPE: input_shape,
        LazyAttr.IN_DTYPE: input_dtype,
        LazyAttr.OUT_SHAPE: output_shape,
        LazyAttr.OUT_DTYPE: dtype_,
    }

    # depending on the state of the 'lazy' argument, either apply the transform now or add it to the pending list
    return lazily_apply_op(img_, metadata, lazy)
```

## Applying transform descriptions

Applying transform descriptions is simple matter of writing a resampler that knows how to handle point data. We add a `kind` property to `MetaTensor` (currently `"pixel"` and `"point"`) to indicate what kind of tensor data a given tensor contains and when we arrive at the point of resampling we check the tensor kind and call the appropriate function, `resample_image` or `resample_points`. This will update the tensor accordingly when passed either an affine matrix or a deformation field.

The call stack is
```
lazily_apply_op -> apply_pending -> resample_image | resample_points
```

## An example pipeline

```python
im_keys = ('image', 'label')
pt_keys = ('rater 1', 'rater 2')
[
    LoadImaged(keys='im_keys'),
    LoadPointsd(keys='pt_keys'), #not currently in this PR, should be the only points specific tx needed
    Resized(keys='im_keys', ...),
    TransformLiked(keys='pt_keys', reference_key='image'),
    Rotate(keys='im_keys' + 'pt_keys', ...),
]
```

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
