### PR TITLE
update `rm -rf /opt/hostedtoolcache` avoid change the python version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,9 +12,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   # This is to trigger building/testing docker image from dev only.
   workflow_dispatch:
-  pull_request:
-    branches:
-        - dev
 
 jobs:
   versioning_dev:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   # This is to trigger building/testing docker image from dev only.
   workflow_dispatch:
+  pull_request:
+    branches:
+        - dev
 
 jobs:
   versioning_dev:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,7 @@ jobs:
     - name: docker_build
       shell: bash
       run: |
-        rm -rf /opt/hostedtoolcache
+        find /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         docker --version
         # get tag info for versioning
         cat _version.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
       - main
     tags:
       - '*'
-  pull_request:
-    branches:
-        - dev
 
 jobs:
   packaging:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - main
     tags:
       - '*'
+  pull_request:
+    branches:
+        - dev
 
 jobs:
   packaging:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install --user --upgrade setuptools wheel
     - name: Build and test source archive and wheel file
       run: |
-        rm -rf /opt/hostedtoolcache
+        find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
         root_dir=$PWD
         echo "$root_dir"
@@ -102,7 +102,7 @@ jobs:
           python-version: '3.9'
       - shell: bash
         run: |
-          rm -rf /opt/hostedtoolcache
+          find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
           git describe
           python -m pip install --user --upgrade setuptools wheel
           python setup.py build
@@ -143,7 +143,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.versioning.outputs.tag }}
         shell: bash
         run: |
-          rm -rf /opt/hostedtoolcache
+          find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
           # get tag info for versioning
           mv _version.py monai/
           # version checks

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -9,9 +9,6 @@ on:
       - releasing/*
       - feature/*
       - dev
-  pull_request:
-    branches:
-        - dev
 
 concurrency:
   # automatically cancel the previously triggered workflows when there's a newer version

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -9,6 +9,9 @@ on:
       - releasing/*
       - feature/*
       - dev
+  pull_request:
+    branches:
+        - dev
 
 concurrency:
   # automatically cancel the previously triggered workflows when there's a newer version

--- a/.github/workflows/setupapp.yml
+++ b/.github/workflows/setupapp.yml
@@ -100,7 +100,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ steps.pip-cache.outputs.datew }}
     - name: Install the dependencies
       run: |
-        rm -rf /opt/hostedtoolcache
+        find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         python -m pip install --upgrade pip wheel
         python -m pip install -r requirements-dev.txt
     - name: Run quick tests CPU ubuntu
@@ -146,7 +146,7 @@ jobs:
     - name: Install the default branch with build (dev branch only)
       if: github.ref == 'refs/heads/dev'
       run: |
-        rm -rf /opt/hostedtoolcache
+        find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
         BUILD_MONAI=1 pip install git+https://github.com/Project-MONAI/MONAI#egg=MONAI
         python -c 'import monai; monai.config.print_config()'
     - name: Get the test cases (dev branch only)

--- a/monai/transforms/smooth_field/array.py
+++ b/monai/transforms/smooth_field/array.py
@@ -91,12 +91,12 @@ class SmoothField(Randomizable):
         self.crand_size = (self.channels,) + self.rand_size
 
         pad_slice = slice(None) if self.pad == 0 else slice(self.pad, -self.pad)
-        self.rand_slices = (0, slice(None)) + (pad_slice,) * len(self.rand_size)  # type: ignore[index]
+        self.rand_slices = (0, slice(None)) + (pad_slice,) * len(self.rand_size)
 
         self.set_spatial_size(spatial_size)
 
     def randomize(self, data: Any | None = None) -> None:
-        self.field[self.rand_slices] = torch.from_numpy(self.R.uniform(self.low, self.high, self.crand_size))
+        self.field[self.rand_slices] = torch.from_numpy(self.R.uniform(self.low, self.high, self.crand_size))  # type: ignore[index]
 
     def set_spatial_size(self, spatial_size: Sequence[int] | None) -> None:
         """

--- a/monai/transforms/smooth_field/array.py
+++ b/monai/transforms/smooth_field/array.py
@@ -91,7 +91,7 @@ class SmoothField(Randomizable):
         self.crand_size = (self.channels,) + self.rand_size
 
         pad_slice = slice(None) if self.pad == 0 else slice(self.pad, -self.pad)
-        self.rand_slices = (0, slice(None)) + (pad_slice,) * len(self.rand_size)
+        self.rand_slices = (0, slice(None)) + (pad_slice,) * len(self.rand_size)  # type: ignore[index]
 
         self.set_spatial_size(spatial_size)
 


### PR DESCRIPTION
Fixes #7416

### Description

update `rm -rf /opt/hostedtoolcache` avoid change the python version

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
