### PR TITLE
#7437 issue: Raise ModuleNotFoundError for missing dependencies in Lo…

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -180,10 +180,10 @@ class LoadImage(Transform):
         for r in SUPPORTED_READERS:  # set predefined readers as default
             try:
                 self.register(SUPPORTED_READERS[r](*args, **kwargs))
-            except OptionalImportError:
-                logging.getLogger(self.__class__.__name__).debug(
-                    f"required package for reader {r} is not installed, or the version doesn't match requirement."
-                )
+            except OptionalImportError as err:
+                raise ModuleNotFoundError(
+                    f"The required package for reader {r} is not installed, or the version doesn't match requirement."
+                ) from err
             except TypeError:  # the reader doesn't have the corresponding args/kwargs
                 logging.getLogger(self.__class__.__name__).debug(
                     f"{r} is not supported with the given parameters {args} {kwargs}."


### PR DESCRIPTION
Fixes #7437 .

### Description

This commit modifies the LoadImage constructor to raise a ModuleNotFoundError
when encountering missing dependencies for specified readers. Previously, the
constructor logged debug messages or raised warnings, which could lead to
unexpected behavior when required packages were not installed.

### Changes Made:
- Modified the constructor to raise a ModuleNotFoundError when a required package
  for a specified reader is not installed. 
These changes ensure consistent error handling and provide clearer feedback to
users about missing dependencies in the LoadImage constructor.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

Screen shot showing the changes
![changes](https://github.com/Project-MONAI/MONAI/assets/130189437/95118923-c437-4660-9cc9-1b453b9fdd52)

Passed the linting tests
![passed_linting_testspng](https://github.com/Project-MONAI/MONAI/assets/130189437/7bfce51c-b22c-44c2-8766-11ca987d1fa3)


