### PR TITLE
Add __repr__ and __str__ to Metrics baseclass

### DIFF
--- a/monai/apps/nnunet/nnunetv2_runner.py
+++ b/monai/apps/nnunet/nnunetv2_runner.py
@@ -37,6 +37,7 @@ class nnUNetV2Runner:  # noqa: N801
     """
     ``nnUNetV2Runner`` provides an interface in MONAI to use `nnU-Net` V2 library to analyze, train, and evaluate
     neural networks for medical image segmentation tasks.
+    A version of nnunetv2 higher than 2.2 is needed for this class.
 
     ``nnUNetV2Runner`` can be used in two ways:
 
@@ -770,7 +771,7 @@ class nnUNetV2Runner:  # noqa: N801
     def predict(
         self,
         list_of_lists_or_source_folder: str | list[list[str]],
-        output_folder: str,
+        output_folder: str | None | list[str],
         model_training_output_dir: str,
         use_folds: tuple[int, ...] | str | None = None,
         tile_step_size: float = 0.5,
@@ -824,7 +825,7 @@ class nnUNetV2Runner:  # noqa: N801
         """
         os.environ["CUDA_VISIBLE_DEVICES"] = f"{gpu_id}"
 
-        from nnunetv2.inference.predict_from_raw_data import predict_from_raw_data
+        from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor
 
         n_processes_preprocessing = (
             self.default_num_processes if num_processes_preprocessing < 0 else num_processes_preprocessing
@@ -832,20 +833,21 @@ class nnUNetV2Runner:  # noqa: N801
         n_processes_segmentation_export = (
             self.default_num_processes if num_processes_segmentation_export < 0 else num_processes_segmentation_export
         )
-
-        predict_from_raw_data(
-            list_of_lists_or_source_folder=list_of_lists_or_source_folder,
-            output_folder=output_folder,
-            model_training_output_dir=model_training_output_dir,
-            use_folds=use_folds,
+        predictor = nnUNetPredictor(
             tile_step_size=tile_step_size,
             use_gaussian=use_gaussian,
             use_mirroring=use_mirroring,
-            perform_everything_on_gpu=perform_everything_on_gpu,
+            perform_everything_on_device=perform_everything_on_gpu,
             verbose=verbose,
+        )
+        predictor.initialize_from_trained_model_folder(
+            model_training_output_dir=model_training_output_dir, use_folds=use_folds, checkpoint_name=checkpoint_name
+        )
+        predictor.predict_from_files(
+            list_of_lists_or_source_folder=list_of_lists_or_source_folder,
+            output_folder_or_list_of_truncated_output_files=output_folder,
             save_probabilities=save_probabilities,
             overwrite=overwrite,
-            checkpoint_name=checkpoint_name,
             num_processes_preprocessing=n_processes_preprocessing,
             num_processes_segmentation_export=n_processes_segmentation_export,
             folder_with_segs_from_prev_stage=folder_with_segs_from_prev_stage,

--- a/monai/metrics/metric.py
+++ b/monai/metrics/metric.py
@@ -37,9 +37,6 @@ class Metric(ABC):
         """
         raise NotImplementedError(f"Subclass {self.__class__.__name__} must implement this method.")
 
-    def __repr__(self):
-        return self.__class__.__name__
-
     def __str__(self):
         return self.__class__.__name__
 

--- a/monai/metrics/metric.py
+++ b/monai/metrics/metric.py
@@ -37,6 +37,12 @@ class Metric(ABC):
         """
         raise NotImplementedError(f"Subclass {self.__class__.__name__} must implement this method.")
 
+    def __repr__(self):
+        return self.__class__.__name__
+
+    def __str__(self):
+        return self.__class__.__name__
+
 
 class IterationMetric(Metric):
     """


### PR DESCRIPTION
### Description

When training a model using MONAI metrics for experiment tracking, I tend to log which metrics I am using. Unfortunately, just sending the metrics objects to Tensorboard will result in a list like [CustomMetric1, CustomMetric2, <monai.metrics.Metric ...>, etc.]

Adding `__repr__` and `__str__` methods to the base class will solve this small annoyance. The current implementation will only return the class name, but if a certain metric would wish to report more data for its `__repr__` string, this can be easily overridden in any subclass.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.