### PR TITLE
Geom api

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -268,6 +268,7 @@ class ResampleToMatch(SpatialResample):
         align_corners: bool | None = None,
         dtype: DtypeLike = None,
         lazy: bool | None = None,
+        update_to_match: Sequence[NdarrayOrTensor] | None = None,
     ) -> torch.Tensor:
         """
         Args:
@@ -321,6 +322,8 @@ class ResampleToMatch(SpatialResample):
                     original_fname = img.meta.get(Key.FILENAME_OR_OBJ, "resample_to_match_source")
                     img.meta = deepcopy(img_dst.meta)
                     img.meta[Key.FILENAME_OR_OBJ] = original_fname  # keep the original name, the others are overwritten
+                for t in update_to_match or []:
+                    t.apply_transform(dst_affine, lazy=False) # PROBLEM: this is in-place; we'd have to return the transforms
         else:
             if isinstance(img, MetaTensor) and isinstance(img_dst, MetaTensor):
                 original_fname = img.meta.get(Key.FILENAME_OR_OBJ, "resample_to_match_source")
@@ -329,6 +332,8 @@ class ResampleToMatch(SpatialResample):
                     meta_dict.pop(k, None)
                 img.meta.update(meta_dict)
                 img.meta[Key.FILENAME_OR_OBJ] = original_fname  # keep the original name, the others are overwritten
+                for t in update_to_match or []:
+                    t.apply_transform(img.get_latest_transform(), lazy=True) # Not a problem as it is lazy
         return img
 
 

--- a/monai/transforms/transform.py
+++ b/monai/transforms/transform.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Hashable, Iterable, Mapping
-from typing import Any, Tuple, TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 import torch
@@ -490,7 +490,7 @@ class MapTransform(Transform):
 
 
 
-    def first_key(self, data: dict[Hashable, Any], kind: KindType | None = None) -> Hashable | Tuple:
+    def first_key(self, data: dict[Hashable, Any], kind: KindType | None = None) -> Hashable | tuple:
         """
         Get the first available key of `self.keys` in the input `data` dictionary.
         If no available key, return an empty tuple `()`.


### PR DESCRIPTION
Fixes #7486.

This PR is an investigation of the API changes required to implement #7486. As it stands, it isn't yet intended to be _the_ PR for the API changes, but it could turn into it if everyone is happy with it.

### Description

API changes required to support raster and geometry tensors. So far this means:
 - MapTransform minor API extension
 - Spatial dictionary transforms (which may need no API extension)
 - Spatial array transforms (which will likely need API extensions)

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
