### PR TITLE
Fix typo in the PerceptualNetworkType Enum

### DIFF
--- a/monai/losses/perceptual.py
+++ b/monai/losses/perceptual.py
@@ -29,7 +29,7 @@ class PercetualNetworkType(StrEnum):
     squeeze = "squeeze"
     radimagenet_resnet50 = "radimagenet_resnet50"
     medicalnet_resnet10_23datasets = "medicalnet_resnet10_23datasets"
-    medical_resnet50_23datasets = "medical_resnet50_23datasets"
+    medicalnet_resnet50_23datasets = "medicalnet_resnet50_23datasets"
     resnet50 = "resnet50"
 
 

--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -41,6 +41,11 @@ TEST_CASES = [
         (2, 1, 64, 64, 64),
     ],
     [
+        {"spatial_dims": 3, "network_type": "medicalnet_resnet50_23datasets", "is_fake_3d": False},
+        (2, 1, 64, 64, 64),
+        (2, 1, 64, 64, 64),
+    ],
+    [
         {"spatial_dims": 3, "network_type": "resnet50", "is_fake_3d": True, "pretrained": True, "fake_3d_ratio": 0.2},
         (2, 1, 64, 64, 64),
         (2, 1, 64, 64, 64),


### PR DESCRIPTION
Fixes #7547 

### Description
Previously it was 'medical_resnet50_23datasets' for both identifier and string, which doesn't correspond to the name in the hubconf.py of Warvito's repo. Now it is the correct version (according to Warvitos repo) 'medicalnet_resnet50_23datasets'.

The docs state it correctly already. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ x] New tests added to cover the changes.
- [ x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
