### PR TITLE
MedicalNetPerceptualSimilarity: Add multi-channel

### DIFF
--- a/monai/losses/perceptual.py
+++ b/monai/losses/perceptual.py
@@ -103,11 +103,13 @@ class PerceptualLoss(nn.Module):
         self.spatial_dims = spatial_dims
         self.perceptual_function: nn.Module
         if spatial_dims == 3 and is_fake_3d is False:
-            self.perceptual_function = MedicalNetPerceptualSimilarity(net=network_type, verbose=False,
-                                                                      channelwise=channelwise)
+            self.perceptual_function = MedicalNetPerceptualSimilarity(
+                net=network_type, verbose=False, channelwise=channelwise
+            )
         elif "radimagenet_" in network_type:
-            self.perceptual_function = RadImageNetPerceptualSimilarity(net=network_type, verbose=False,
-                                                                       channelwise=channelwise)
+            self.perceptual_function = RadImageNetPerceptualSimilarity(
+                net=network_type, verbose=False, channelwise=channelwise
+            )
         elif network_type == "resnet50":
             self.perceptual_function = TorchvisionModelPerceptualSimilarity(
                 net=network_type,
@@ -193,10 +195,9 @@ class MedicalNetPerceptualSimilarity(nn.Module):
                 Defaults to ``False``.
     """
 
-    def __init__(self,
-                 net: str = "medicalnet_resnet10_23datasets",
-                 verbose: bool = False,
-                 channelwise: bool = False) -> None:
+    def __init__(
+        self, net: str = "medicalnet_resnet10_23datasets", verbose: bool = False, channelwise: bool = False
+    ) -> None:
         super().__init__()
         torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
         self.model = torch.hub.load("warvito/MedicalNet-models", model=net, verbose=verbose)

--- a/monai/losses/perceptual.py
+++ b/monai/losses/perceptual.py
@@ -224,7 +224,7 @@ class MedicalNetPerceptualSimilarity(nn.Module):
         target = medicalnet_intensity_normalisation(target)
 
         # Get model outputs
-        feats_per_ch = None
+        feats_per_ch = 0
         for ch_idx in range(input.shape[1]):
             input_channel = input[:, ch_idx, ...].unsqueeze(1)
             target_channel = target[:, ch_idx, ...].unsqueeze(1)

--- a/monai/losses/perceptual.py
+++ b/monai/losses/perceptual.py
@@ -179,9 +179,15 @@ class PerceptualLoss(nn.Module):
             loss = loss_sagittal + loss_axial + loss_coronal
         else:
             # 2D and real 3D cases
-            loss = self.perceptual_function(input, target).squeeze()
+            loss = self.perceptual_function(input, target)
 
-        return torch.mean(loss, dim=0)
+        if self.channel_wise:
+            loss = loss.squeeze()
+            loss = torch.mean(loss, dim=0)
+        else:
+            loss = torch.mean(loss)
+
+        return loss
 
 
 class MedicalNetPerceptualSimilarity(nn.Module):

--- a/monai/losses/perceptual.py
+++ b/monai/losses/perceptual.py
@@ -45,7 +45,7 @@ class PerceptualLoss(nn.Module):
 
     The fake 3D implementation is based on a 2.5D approach where we calculate the 2D perceptual loss on slices from all
     three axes and average. The full 3D approach uses a 3D network to calculate the perceptual loss.
-    MedicalNet networks are only compatible with 3D inputs and support channelwise loss.
+    MedicalNet networks are only compatible with 3D inputs and support channel-wise loss.
 
     Args:
         spatial_dims: number of spatial dimensions.
@@ -91,7 +91,7 @@ class PerceptualLoss(nn.Module):
             )
 
         if channel_wise and "medicalnet_" not in network_type:
-            raise ValueError("Channelwise loss is only compatible with MedicalNet networks.")
+            raise ValueError("Channel-wise loss is only compatible with MedicalNet networks.")
 
         if network_type.lower() not in list(PercetualNetworkType):
             raise ValueError(

--- a/monai/losses/perceptual.py
+++ b/monai/losses/perceptual.py
@@ -211,8 +211,16 @@ class MedicalNetPerceptualSimilarity(nn.Module):
         target = medicalnet_intensity_normalisation(target)
 
         # Get model outputs
-        outs_input = self.model.forward(input)
-        outs_target = self.model.forward(target)
+        for ch_idx in range(input.shape[1]):
+            input_channel = input[:, ch_idx, ...].unsqueeze(1)
+            target_channel = target[:, ch_idx, ...].unsqueeze(1)
+
+            if ch_idx == 0:
+                outs_input = self.model.forward(input_channel)
+                outs_target = self.model.forward(target_channel)
+            else:
+                outs_input = torch.cat([outs_input, self.model.forward(input_channel)], dim=1)
+                outs_target = torch.cat([outs_target, self.model.forward(target_channel)], dim=1)
 
         # Normalise through the channels
         feats_input = normalize_tensor(outs_input)

--- a/monai/losses/perceptual.py
+++ b/monai/losses/perceptual.py
@@ -182,8 +182,7 @@ class PerceptualLoss(nn.Module):
             loss = self.perceptual_function(input, target)
 
         if self.channel_wise:
-            loss = loss.squeeze()
-            loss = torch.mean(loss, dim=0)
+            loss = torch.mean(loss.squeeze(), dim=0)
         else:
             loss = torch.mean(loss)
 

--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -37,8 +37,13 @@ TEST_CASES = [
         (2, 1, 64, 64, 64),
     ],
     [
-        {"spatial_dims": 3, "network_type": "radimagenet_resnet50", "is_fake_3d": True, "fake_3d_ratio": 0.1,
-         'channelwise': True},
+        {
+            "spatial_dims": 3,
+            "network_type": "radimagenet_resnet50",
+            "is_fake_3d": True,
+            "fake_3d_ratio": 0.1,
+            "channelwise": True,
+        },
         (2, 1, 64, 64, 64),
         (2, 1, 64, 64, 64),
     ],
@@ -91,7 +96,7 @@ class TestPerceptualLoss(unittest.TestCase):
             loss = PerceptualLoss(**input_param)
         result = loss(torch.randn(input_shape), torch.randn(target_shape))
 
-        if 'channelwise' in input_param.keys() and input_param['channelwise']:
+        if "channelwise" in input_param.keys() and input_param["channelwise"]:
             self.assertEqual(result.shape, torch.Size([input_shape[1]]))
         else:
             self.assertEqual(result.shape, torch.Size([]))
@@ -103,7 +108,7 @@ class TestPerceptualLoss(unittest.TestCase):
         tensor = torch.randn(input_shape)
         result = loss(tensor, tensor)
 
-        if 'channelwise' in input_param.keys() and input_param['channelwise']:
+        if "channelwise" in input_param.keys() and input_param["channelwise"]:
             self.assertEqual(result, torch.Tensor([0.0] * input_shape[1]))
         else:
             self.assertEqual(result, torch.Tensor([0.0]))

--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.losses import PerceptualLoss
 from monai.utils import optional_import
-from tests.utils import SkipIfBeforePyTorchVersion, skip_if_downloading_fails, skip_if_quick
+from tests.utils import SkipIfBeforePyTorchVersion, assert_allclose, skip_if_downloading_fails, skip_if_quick
 
 _, has_torchvision = optional_import("torchvision")
 TEST_CASES = [
@@ -30,20 +30,8 @@ TEST_CASES = [
     ],
     [{"spatial_dims": 2, "network_type": "radimagenet_resnet50"}, (2, 1, 64, 64), (2, 1, 64, 64)],
     [{"spatial_dims": 2, "network_type": "radimagenet_resnet50"}, (2, 3, 64, 64), (2, 3, 64, 64)],
-    [{"spatial_dims": 2, "network_type": "radimagenet_resnet50", "channelwise": True}, (2, 3, 64, 64), (2, 3, 64, 64)],
     [
         {"spatial_dims": 3, "network_type": "radimagenet_resnet50", "is_fake_3d": True, "fake_3d_ratio": 0.1},
-        (2, 1, 64, 64, 64),
-        (2, 1, 64, 64, 64),
-    ],
-    [
-        {
-            "spatial_dims": 3,
-            "network_type": "radimagenet_resnet50",
-            "is_fake_3d": True,
-            "fake_3d_ratio": 0.1,
-            "channelwise": True,
-        },
         (2, 1, 64, 64, 64),
         (2, 1, 64, 64, 64),
     ],
@@ -77,11 +65,6 @@ TEST_CASES = [
         (2, 1, 64, 64, 64),
         (2, 1, 64, 64, 64),
     ],
-    [
-        {"spatial_dims": 3, "network_type": "resnet50", "pretrained": True, "fake_3d_ratio": 0.2, "channelwise": True},
-        (2, 3, 64, 64, 64),
-        (2, 3, 64, 64, 64),
-    ],
 ]
 
 
@@ -109,7 +92,7 @@ class TestPerceptualLoss(unittest.TestCase):
         result = loss(tensor, tensor)
 
         if "channelwise" in input_param.keys() and input_param["channelwise"]:
-            self.assertEqual(result, torch.Tensor([0.0] * input_shape[1]))
+            assert_allclose(result, torch.Tensor([0.0] * input_shape[1]))
         else:
             self.assertEqual(result, torch.Tensor([0.0]))
 

--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -46,7 +46,12 @@ TEST_CASES = [
         (2, 6, 64, 64, 64),
     ],
     [
-        {"spatial_dims": 3, "network_type": "medicalnet_resnet10_23datasets", "is_fake_3d": False, "channel_wise": True},
+        {
+            "spatial_dims": 3,
+            "network_type": "medicalnet_resnet10_23datasets",
+            "is_fake_3d": False,
+            "channel_wise": True,
+        },
         (2, 6, 64, 64, 64),
         (2, 6, 64, 64, 64),
     ],

--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -46,7 +46,7 @@ TEST_CASES = [
         (2, 6, 64, 64, 64),
     ],
     [
-        {"spatial_dims": 3, "network_type": "medicalnet_resnet10_23datasets", "is_fake_3d": False, "channelwise": True},
+        {"spatial_dims": 3, "network_type": "medicalnet_resnet10_23datasets", "is_fake_3d": False, "channel_wise": True},
         (2, 6, 64, 64, 64),
         (2, 6, 64, 64, 64),
     ],
@@ -79,7 +79,7 @@ class TestPerceptualLoss(unittest.TestCase):
             loss = PerceptualLoss(**input_param)
         result = loss(torch.randn(input_shape), torch.randn(target_shape))
 
-        if "channelwise" in input_param.keys() and input_param["channelwise"]:
+        if "channel_wise" in input_param.keys() and input_param["channel_wise"]:
             self.assertEqual(result.shape, torch.Size([input_shape[1]]))
         else:
             self.assertEqual(result.shape, torch.Size([]))
@@ -91,7 +91,7 @@ class TestPerceptualLoss(unittest.TestCase):
         tensor = torch.randn(input_shape)
         result = loss(tensor, tensor)
 
-        if "channelwise" in input_param.keys() and input_param["channelwise"]:
+        if "channel_wise" in input_param.keys() and input_param["channel_wise"]:
             assert_allclose(result, torch.Tensor([0.0] * input_shape[1]))
         else:
             self.assertEqual(result, torch.Tensor([0.0]))

--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -41,9 +41,19 @@ TEST_CASES = [
         (2, 1, 64, 64, 64),
     ],
     [
+        {"spatial_dims": 3, "network_type": "medicalnet_resnet10_23datasets", "is_fake_3d": False},
+        (2, 6, 64, 64, 64),
+        (2, 6, 64, 64, 64),
+    ],
+    [
         {"spatial_dims": 3, "network_type": "medicalnet_resnet50_23datasets", "is_fake_3d": False},
         (2, 1, 64, 64, 64),
         (2, 1, 64, 64, 64),
+    ],
+    [
+        {"spatial_dims": 3, "network_type": "medicalnet_resnet50_23datasets", "is_fake_3d": False},
+        (2, 6, 64, 64, 64),
+        (2, 6, 64, 64, 64),
     ],
     [
         {"spatial_dims": 3, "network_type": "resnet50", "is_fake_3d": True, "pretrained": True, "fake_3d_ratio": 0.2},


### PR DESCRIPTION
Fixes #7567 .

### Description
 MedicalNetPerceptualSimilarity: Add multi-channel support for 3Dvolumes. 
The current version of the code in the dev branch already largely supports that besides the following:
medicalnet_* require inputs to have a single channel. 
This PR passes the multi-channel volume channel-wise to the networks and concatenates the resulting feature vectors. 
The existing code takes care of averaging over channels and spatially.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
