### PR TITLE
Remove nested error propagation on `ConfigComponent` instantiate

### DIFF
--- a/monai/bundle/config_item.py
+++ b/monai/bundle/config_item.py
@@ -289,10 +289,7 @@ class ConfigComponent(ConfigItem, Instantiable):
         mode = self.get_config().get("_mode_", CompInitMode.DEFAULT)
         args = self.resolve_args()
         args.update(kwargs)
-        try:
-            return instantiate(modname, mode, **args)
-        except Exception as e:
-            raise RuntimeError(f"Failed to instantiate {self}") from e
+        return instantiate(modname, mode, **args)
 
 
 class ConfigExpression(ConfigItem):

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -272,7 +272,7 @@ def instantiate(__path: str, __mode: str, **kwargs: Any) -> Any:
             return pdb.runcall(component, **kwargs)
     except Exception as e:
         raise RuntimeError(
-            f"Failed to instantiate component '{__path}' with kwargs: {kwargs}"
+            f"Failed to instantiate component '{__path}' with keywords: {','.join(kwargs.keys())}"
             f"\n set '_mode_={CompInitMode.DEBUG}' to enter the debugging mode."
         ) from e
 


### PR DESCRIPTION
Fixes #7451

### Description
Reduces the length of error messages and error messages being propagated twice. This helps debug better when long `ConfigComponent`s are being instantiated. Refer to issue #7451 for more details

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
