### PR TITLE
harmonization and clarification of dice losses variants docs and associated tests

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -1066,4 +1066,3 @@ dice_focal = DiceFocalLoss
 generalized_dice = GeneralizedDiceLoss
 generalized_dice_focal = GeneralizedDiceFocalLoss
 generalized_wasserstein_dice = GeneralizedWassersteinDiceLoss
-

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -1067,10 +1067,3 @@ generalized_dice = GeneralizedDiceLoss
 generalized_dice_focal = GeneralizedDiceFocalLoss
 generalized_wasserstein_dice = GeneralizedWassersteinDiceLoss
 
-if __name__ == "__main__":
-    loss = DiceFocalLoss(to_onehot_y=False, softmax=True)
-    input = torch.randn(1, 3, 128, 128, 128)
-    target = torch.randn(1, 4, 128, 128, 128)
-    print(input.dim())
-    print(target.dim())
-    loss(input, target)

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -778,7 +778,7 @@ class DiceCELoss(_Loss):
 
         Raises:
             ValueError: When number of dimensions for input and target are different.
-            ValueError: When the target channel isn't either one-hot encoded or categorical with the same shape of the input.
+            ValueError: When number of channels for target is neither 1 (without one-hot encoding) nor the same as input.
 
         Returns:
             torch.Tensor: value of the loss.
@@ -793,7 +793,7 @@ class DiceCELoss(_Loss):
 
         if target.shape[1] != 1 and target.shape[1] != input.shape[1]:
             raise ValueError(
-                "number of channels for target is neither 1 (with no one-hot encoding) nor the same as input, "
+                "number of channels for target is neither 1 (without one-hot encoding) nor the same as input, "
                 f"got shape {input.shape} and {target.shape}."
             )
 
@@ -909,7 +909,7 @@ class DiceFocalLoss(_Loss):
 
         Raises:
             ValueError: When number of dimensions for input and target are different.
-            ValueError: When the target channel isn't either one-hot encoded or categorical with the same shape of the input.
+            ValueError: When number of channels for target is neither 1 (without one-hot encoding) nor the same as input.
 
         Returns:
             torch.Tensor: value of the loss.
@@ -923,7 +923,7 @@ class DiceFocalLoss(_Loss):
 
         if target.shape[1] != 1 and target.shape[1] != input.shape[1]:
             raise ValueError(
-                "number of channels for target is neither 1 (with no one-hot encoding) nor the same as input, "
+                "number of channels for target is neither 1 (without one-hot encoding) nor the same as input, "
                 f"got shape {input.shape} and {target.shape}."
             )
 
@@ -1036,7 +1036,7 @@ class GeneralizedDiceFocalLoss(_Loss):
 
         Raises:
             ValueError: When number of dimensions for input and target are different.
-            ValueError: When the target channel isn't either one-hot encoded or categorical with the same shape of the input.
+            ValueError: When number of channels for target is neither 1 (without one-hot encoding) nor the same as input.
 
         Returns:
             torch.Tensor: value of the loss.
@@ -1050,7 +1050,7 @@ class GeneralizedDiceFocalLoss(_Loss):
 
         if target.shape[1] != 1 and target.shape[1] != input.shape[1]:
             raise ValueError(
-                "number of channels for target is neither 1 (with no one-hot encoding) nor the same as input, "
+                "number of channels for target is neither 1 (without one-hot encoding) nor the same as input, "
                 f"got shape {input.shape} and {target.shape}."
             )
 

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -776,8 +776,9 @@ class DiceCELoss(_Loss):
             input: the shape should be BNH[WD].
             target: the shape should be BNH[WD] or B1H[WD].
 
-        ValueError: When number of dimensions for input and target are different.
-        ValueError: When the target channel isn't either one-hot encoded or categorical with the same shape of the input.
+        Raises:
+            ValueError: When number of dimensions for input and target are different.
+            ValueError: When the target channel isn't either one-hot encoded or categorical with the same shape of the input.
 
         Returns:
             torch.Tensor: value of the loss.

--- a/tests/test_dice_ce_loss.py
+++ b/tests/test_dice_ce_loss.py
@@ -93,10 +93,20 @@ class TestDiceCELoss(unittest.TestCase):
         result = diceceloss(**input_data)
         np.testing.assert_allclose(result.detach().cpu().numpy(), expected_val, atol=1e-4, rtol=1e-4)
 
-    # def test_ill_shape(self):
-    #     loss = DiceCELoss()
-    #     with self.assertRaisesRegex(ValueError, ""):
-    #         loss(torch.ones((1, 2, 3)), torch.ones((1, 1, 2, 3)))
+    def test_ill_shape(self):
+        loss = DiceCELoss()
+        with self.assertRaises(AssertionError):
+            loss.forward(torch.ones((1, 2, 3)), torch.ones((1, 2, 5)))
+
+    def test_ill_shape2(self):
+        loss = DiceCELoss()
+        with self.assertRaises(ValueError):
+            loss.forward(torch.ones((1, 2, 3)), torch.ones((1, 1, 2, 3)))
+
+    def test_ill_shape3(self):
+        loss = DiceCELoss()
+        with self.assertRaises(ValueError):
+            loss.forward(torch.ones((1, 3, 4, 4)), torch.ones((1, 2, 4, 4)))
 
     # def test_ill_reduction(self):
     #     with self.assertRaisesRegex(ValueError, ""):

--- a/tests/test_dice_focal_loss.py
+++ b/tests/test_dice_focal_loss.py
@@ -69,8 +69,18 @@ class TestDiceFocalLoss(unittest.TestCase):
 
     def test_ill_shape(self):
         loss = DiceFocalLoss()
-        with self.assertRaisesRegex(ValueError, ""):
-            loss(torch.ones((1, 2, 3)), torch.ones((1, 1, 2, 3)))
+        with self.assertRaises(AssertionError):
+            loss.forward(torch.ones((1, 2, 3)), torch.ones((1, 2, 5)))
+
+    def test_ill_shape2(self):
+        loss = DiceFocalLoss()
+        with self.assertRaises(ValueError):
+            loss.forward(torch.ones((1, 2, 3)), torch.ones((1, 1, 2, 3)))
+
+    def test_ill_shape3(self):
+        loss = DiceFocalLoss()
+        with self.assertRaises(ValueError):
+            loss.forward(torch.ones((1, 3, 4, 4)), torch.ones((1, 2, 4, 4)))
 
     def test_ill_lambda(self):
         with self.assertRaisesRegex(ValueError, ""):

--- a/tests/test_generalized_dice_focal_loss.py
+++ b/tests/test_generalized_dice_focal_loss.py
@@ -59,8 +59,18 @@ class TestGeneralizedDiceFocalLoss(unittest.TestCase):
 
     def test_ill_shape(self):
         loss = GeneralizedDiceFocalLoss()
-        with self.assertRaisesRegex(ValueError, ""):
-            loss(torch.ones((1, 2, 3)), torch.ones((1, 1, 2, 3)))
+        with self.assertRaises(AssertionError):
+            loss.forward(torch.ones((1, 2, 3)), torch.ones((1, 2, 5)))
+
+    def test_ill_shape2(self):
+        loss = GeneralizedDiceFocalLoss()
+        with self.assertRaises(ValueError):
+            loss.forward(torch.ones((1, 2, 3)), torch.ones((1, 1, 2, 3)))
+
+    def test_ill_shape3(self):
+        loss = GeneralizedDiceFocalLoss()
+        with self.assertRaises(ValueError):
+            loss.forward(torch.ones((1, 3, 4, 4)), torch.ones((1, 2, 4, 4)))
 
     def test_ill_lambda(self):
         with self.assertRaisesRegex(ValueError, ""):


### PR DESCRIPTION
### Description

This PR aims to clarify and harmonise the code for the DiceLoss variants in the `monai/losses/dice.py` file. With the `to_onehot_y` `softmax` and `sigmoid` arguments, I didn't necessarily understand the ValueError that occurred when I passed a target of size NH[WD]. I had a bit of trouble reading the documentation and understanding it. I thought that they had to be the same shape as they are displayed, unlike the number of dimensions in the input, so I added that.
Besides, in the documentation is written:
```python
"""
raises:
      ValueError: When number of channels for target is neither 1 nor the same as input.

"""
```
Trying to reproduce this, we give an input with a number of channels $N$ and target a number of channels of $M$, with $M \neq N$ and $M > 1$.
```python
loss = DiceCELoss()
input = torch.rand(1, 4, 3, 3)
target = torch.randn(1, 2, 3, 3)
loss(input, target)
>: AssertionError: ground truth has different shape (torch.Size([1, 2, 3, 3])) from input (torch.Size([1, 4, 3, 3]))
```
This error in the Dice is an `AssertionError` and not a `ValueError` as expected and the explanation can be confusing and doesn't give a clear idea of the error here. The classes concerned and harmonised are `DiceFocalLoss`, `DiceCELoss` and `GeneralizedDiceFocalLoss` with the addition of tests that behave correctly and handle this harmonisation. 

Also, feel free to modify or make suggestions regarding the changes made in the docstring to make them more understandable (in my opinion, but other readers and users will probably have a different view).

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
