### PR TITLE
implementation of masked autoencoder as a monai network

### DIFF
--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -616,7 +616,7 @@ Nets
   :members:
 
 `MaskedAutoEncoderViT`
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: MaskedAutoEncoderViT
   :members:
 

--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -615,6 +615,11 @@ Nets
 .. autoclass:: ViTAutoEnc
   :members:
 
+`MaskedAutoEncoderViT`
+~~~~~~~~~~~~
+.. autoclass:: MaskedAutoEncoderViT
+  :members:
+
 `FullyConnectedNet`
 ~~~~~~~~~~~~~~~~~~~
 .. autoclass:: FullyConnectedNet

--- a/monai/networks/nets/__init__.py
+++ b/monai/networks/nets/__init__.py
@@ -50,6 +50,7 @@ from .fullyconnectednet import FullyConnectedNet, VarFullyConnectedNet
 from .generator import Generator
 from .highresnet import HighResBlock, HighResNet
 from .hovernet import Hovernet, HoVernet, HoVerNet, HoverNet
+from .masked_autoencoder_vit import MaskedAutoEncoderViT
 from .milmodel import MILModel
 from .netadapter import NetAdapter
 from .quicknat import Quicknat

--- a/monai/networks/nets/masked_autoencoder_vit.py
+++ b/monai/networks/nets/masked_autoencoder_vit.py
@@ -1,0 +1,262 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from monai.networks.blocks.patchembedding import PatchEmbeddingBlock
+from monai.networks.blocks.pos_embed_utils import build_sincos_position_embedding
+from monai.networks.blocks.transformerblock import TransformerBlock
+from monai.networks.layers import trunc_normal_
+from monai.utils import ensure_tuple_rep, is_sqrt
+from monai.utils.module import look_up_option
+
+SUPPORTED_POS_EMBEDDING_TYPES = {"none", "learnable", "sincos"}
+
+__all__ = ["MaskedAutoEncoderViT"]
+
+
+class MaskedAutoEncoderViT(nn.Module):
+    """
+    Masked Autoencoder (ViT), based on: "Kaiming et al.,
+    Masked Autoencoders Are Scalable Vision Learners <https://arxiv.org/abs/2111.06377>"
+
+    Only some of the patches pass through the encoder and then the decoder tries to reconstruct
+    the hidden patches, which improves training speed.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        img_size: Sequence[int] | int,
+        patch_size: Sequence[int] | int,
+        hidden_size: int = 768,
+        mlp_dim: int = 512,
+        num_layers: int = 12,
+        num_heads: int = 16,
+        masking_ratio: float = 0.75,
+        decoder_hidden_size: int = 384,
+        decoder_mlp_dim: int = 512,
+        decoder_num_layers: int = 4,
+        decoder_num_heads: int = 16,
+        proj_type: str = "conv",
+        pos_embed_type: str = "learnable",
+        decoder_pos_embed_type: str = "learnable",
+        dropout_rate: float = 0.0,
+        spatial_dims: int = 3,
+        classification: bool = False,
+        qkv_bias: bool = False,
+        save_attn: bool = False,
+    ) -> None:
+        """
+        Args:
+            in_channels: dimension of input channels or the number of channels for input.
+            img_size: dimension of input image.
+            patch_size: dimension of patch size
+            hidden_size: dimension of hidden layer. Defaults to 768.
+            mlp_dim: dimension of feedforward layer. Defaults to 512.
+            num_layers:  number of transformer blocks. Defaults to 12.
+            num_heads: number of attention heads. Defaults to 16.
+            masking_ratio: ratio of patches to be masked. Defaults to 0.75.
+            decoder_hidden_size: dimension of hidden layer for decoder. Defaults to 384.
+            decoder_mlp_dim: dimension of feedforward layer for decoder. Defaults to 512.
+            decoder_num_layers: number of transformer blocks for decoder. Defaults to 4.
+            decoder_num_heads: number of attention heads for decoder. Defaults to 16.
+            proj_type: position embedding layer type. Defaults to "conv".
+            pos_embed_type: position embedding layer type. Defaults to "learnable".
+            decoder_pos_embed_type: position embedding layer type for decoder. Defaults to "learnable".
+            dropout_rate: fraction of the input units to drop. Defaults to 0.0.
+            spatial_dims: number of spatial dimensions. Defaults to 3.
+            qkv_bias: apply bias to the qkv linear layer in self attention block. Defaults to False.
+            save_attn: to make accessible the attention in self attention block. Defaults to False. Defaults to False.
+
+        Examples::
+
+            # for single channel input with image size of (96,96,96), and sin-cos positional encoding
+            >>> net = MaskedAutoencoderViT(in_channels=1, img_size=(96,96,96), patch_size=(16,16,16), pos_embed_type='sincos')
+
+            # for 3-channel with image size of (128,128,128) a learnable positional encoding and classification backbone
+            >>> net = MaskedAutoencoderViT(in_channels=3, img_size=(128,128,128), patch_size=(16,16,16), classification=True)
+
+            # for 3-channel with image size of (224,224) and a masking ratio of 0.25
+            >>> net = MaskedAutoencoderViT(in_channels=3, img_size=(224,224), patch_size=(16,16,16), masking_ratio=0.25)
+
+        """
+
+        super().__init__()
+        if not is_sqrt(patch_size):
+            raise ValueError(f"patch_size should be square number, got {patch_size}.")
+        self.patch_size = ensure_tuple_rep(patch_size, spatial_dims)
+        self.img_size = ensure_tuple_rep(img_size, spatial_dims)
+        self.spatial_dims = spatial_dims
+        for m, p in zip(self.img_size, self.patch_size):
+            if m % p != 0:
+                raise ValueError(f"patch_size={patch_size} should be divisible by img_size={img_size}.")
+
+        self.classification = classification
+        self.decoder_hidden_size = decoder_hidden_size
+        if masking_ratio <= 0 or masking_ratio >= 1:
+            raise ValueError(f"masking_ratio should be in the range (0, 1), got {masking_ratio}.")
+
+        self.masking_ratio = masking_ratio
+        self.proj_type = proj_type
+        if self.classification:
+            self.cls_token = nn.Parameter(torch.zeros(1, 1, hidden_size))
+
+        self.patch_embedding = PatchEmbeddingBlock(
+            in_channels=in_channels,
+            img_size=img_size,
+            patch_size=patch_size,
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            proj_type=proj_type,
+            pos_embed_type=pos_embed_type,
+            dropout_rate=dropout_rate,
+            spatial_dims=self.spatial_dims,
+        )
+        self.blocks = nn.ModuleList(
+            [
+                TransformerBlock(hidden_size, mlp_dim, num_heads, dropout_rate, qkv_bias, save_attn)
+                for i in range(num_layers)
+            ]
+        )
+        self.norm = nn.LayerNorm(hidden_size)
+
+        # decoder
+        self.decoder_embed = nn.Linear(hidden_size, decoder_hidden_size)
+
+        self.mask_tokens = nn.Parameter(torch.zeros(1, 1, decoder_hidden_size))
+
+        self.decoder_pos_embed_type = look_up_option(decoder_pos_embed_type, SUPPORTED_POS_EMBEDDING_TYPES)
+        self.decoder_pos_embedding = nn.Parameter(torch.zeros(1, self.patch_embedding.n_patches, decoder_hidden_size))
+
+        self.decoder_blocks = nn.ModuleList(
+            [
+                TransformerBlock(
+                    decoder_hidden_size, decoder_mlp_dim, decoder_num_heads, dropout_rate, qkv_bias, save_attn
+                )
+                for i in range(decoder_num_layers)
+            ]
+        )
+        self.decoder_norm = nn.LayerNorm(decoder_hidden_size)
+        self.decoder_pred = nn.Linear(decoder_hidden_size, int(np.prod(patch_size)) * in_channels)
+
+        self._initialize_weights()
+
+    def _initialize_weights(self):
+        """
+        adapted from monai/networks/blocks/patchembedding.py and https://github.com/facebookresearch/mae
+        """
+        if self.decoder_pos_embed_type == "none":
+            pass
+        elif self.decoder_pos_embed_type == "learnable":
+            trunc_normal_(self.decoder_pos_embedding, mean=0.0, std=0.02, a=-2.0, b=2.0)
+        elif self.decoder_pos_embed_type == "sincos":
+            grid_size = []
+            for in_size, pa_size in zip(self.img_size, self.patch_size):
+                grid_size.append(in_size // pa_size)
+
+            with torch.no_grad():
+                pos_embeddings = build_sincos_position_embedding(grid_size, self.decoder_hidden_size, self.spatial_dims)
+                self.decoder_pos_embedding.data.copy_(pos_embeddings.float())
+                self.decoder_pos_embedding.requires_grad = False
+        else:
+            raise ValueError(f"decoder_pos_embed_type {self.decoder_pos_embed_type} not supported.")
+
+        # initialize patch_embedding like nn.Linear (instead of nn.Conv2d)
+        if self.proj_type == "conv":
+            w = self.patch_embedding.patch_embeddings.weight.data
+            torch.nn.init.xavier_uniform_(w.view(w.shape[0], -1))
+
+        trunc_normal_(self.mask_tokens, mean=0.0, std=0.02, a=-2.0, b=2.0)
+        if self.classification:
+            trunc_normal_(self.cls_token, mean=0.0, std=0.02, a=-2.0, b=2.0)
+
+    def forward(self, x):
+        """
+        adapted from https://github.com/facebookresearch/mae
+        """
+        x = self.patch_embedding(x)
+        x, mask, ids_restore = self.random_masking(x)
+
+        if hasattr(self, "cls_token"):
+            cls_tokens = self.cls_token.expand(x.shape[0], -1, -1)
+            x = torch.cat((cls_tokens, x), dim=1)
+
+        for blk in self.blocks:
+            x = blk(x)
+        x = self.norm(x)
+
+        # decoder
+        x = self.decoder_embed(x)
+
+        if hasattr(self, "cls_token"):
+            mask_tokens = self.mask_tokens.repeat(x.shape[0], ids_restore.shape[1] + 1 - x.shape[1], 1)
+            x_ = torch.cat([x[:, 1:, :], mask_tokens], dim=1)  # no cls token
+            x_ = (
+                torch.gather(x_, dim=1, index=ids_restore.unsqueeze(-1).repeat(1, 1, x.shape[2]))
+                + self.decoder_pos_embedding
+            )
+            x = torch.cat([x[:, :1, :], x_], dim=1)
+        else:
+            mask_tokens = self.mask_tokens.repeat(x.shape[0], ids_restore.shape[1] - x.shape[1], 1)
+            x = torch.cat([x, mask_tokens], dim=1)  # no cls token
+            x = (
+                torch.gather(x, dim=1, index=ids_restore.unsqueeze(-1).repeat(1, 1, x.shape[2]))
+                + self.decoder_pos_embedding
+            )  # unshuffle
+
+        for blk in self.decoder_blocks:
+            x = blk(x)
+        x = self.decoder_norm(x)
+        x = self.decoder_pred(x)
+
+        if self.classification:
+            return x[:, 1:, :], mask
+
+        else:
+            return x, mask
+
+    def random_masking(self, x):
+        """
+        Random masking of patches in the input tensor x.
+        adapted from https://github.com/facebookresearch/mae
+
+        Returns:
+            x_masked: masked input tensor
+            mask: binary mask
+            ids_restore: indices to restore the original order
+        """
+        batch_size, num_tokens, dimension = x.shape
+
+        noise = torch.rand(batch_size, num_tokens, device=x.device)
+
+        # sort noise for each sample
+        ids_shuffle = torch.argsort(noise, dim=1)  # ascend: small is keep, large is remove
+        ids_restore = torch.argsort(ids_shuffle, dim=1)
+
+        # keep the first subset
+        number_of_tokens_to_keep = int(num_tokens * (1 - self.masking_ratio))
+        ids_keep = ids_shuffle[:, :number_of_tokens_to_keep]
+        x_masked = torch.gather(x, dim=1, index=ids_keep.unsqueeze(-1).repeat(1, 1, dimension))
+
+        # generate the binary mask: 0 is keep, 1 is remove
+        mask = torch.ones([batch_size, num_tokens], device=x.device)
+        mask[:, :number_of_tokens_to_keep] = 0
+        # unshuffle to get the binary mask
+        mask = torch.gather(mask, dim=1, index=ids_restore)
+
+        return x_masked, mask, ids_restore

--- a/tests/test_masked_autoencoder_vit.py
+++ b/tests/test_masked_autoencoder_vit.py
@@ -1,0 +1,275 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+from parameterized import parameterized
+
+from monai.networks import eval_mode
+from monai.networks.nets.masked_autoencoder_vit import MaskedAutoEncoderViT
+from tests.utils import SkipIfBeforePyTorchVersion, skip_if_quick, test_script_save
+
+TEST_CASE_MaskedAutoEncoderViT = []
+for masking_ratio in [0.5]:
+    for dropout_rate in [0.6]:
+        for in_channels in [4]:
+            for hidden_size in [768]:
+                for img_size in [96, 128]:
+                    for patch_size in [16]:
+                        for num_heads in [12]:
+                            for mlp_dim in [3072]:
+                                for num_layers in [4]:
+                                    for decoder_hidden_size in [384]:
+                                        for decoder_mlp_dim in [512]:
+                                            for decoder_num_layers in [4]:
+                                                for decoder_num_heads in [16]:
+                                                    for pos_embed_type in ["sincos", "learnable"]:
+                                                        for proj_type in ["conv", "perceptron"]:
+                                                            for classification in [False, True]:
+                                                                for nd in (2, 3):
+                                                                    test_case = [
+                                                                        {
+                                                                            "in_channels": in_channels,
+                                                                            "img_size": (img_size,) * nd,
+                                                                            "patch_size": (patch_size,) * nd,
+                                                                            "hidden_size": hidden_size,
+                                                                            "mlp_dim": mlp_dim,
+                                                                            "num_layers": num_layers,
+                                                                            "decoder_hidden_size": decoder_hidden_size,
+                                                                            "decoder_mlp_dim": decoder_mlp_dim,
+                                                                            "decoder_num_layers": decoder_num_layers,
+                                                                            "decoder_num_heads": decoder_num_heads,
+                                                                            "pos_embed_type": pos_embed_type,
+                                                                            "masking_ratio": masking_ratio,
+                                                                            "decoder_pos_embed_type": pos_embed_type,
+                                                                            "num_heads": num_heads,
+                                                                            "proj_type": proj_type,
+                                                                            "classification": classification,
+                                                                            "dropout_rate": dropout_rate,
+                                                                        },
+                                                                        (2, in_channels, *([img_size] * nd)),
+                                                                        (
+                                                                            2,
+                                                                            (img_size // patch_size) ** nd,
+                                                                            in_channels * (patch_size**nd),
+                                                                        ),
+                                                                    ]
+                                                                    if nd == 2:
+                                                                        test_case[0]["spatial_dims"] = 2  # type: ignore
+                                                                    TEST_CASE_MaskedAutoEncoderViT.append(test_case)
+
+
+@skip_if_quick
+class TestMaskedAutoencoderViT(unittest.TestCase):
+
+    @parameterized.expand(TEST_CASE_MaskedAutoEncoderViT)
+    def test_shape(self, input_param, input_shape, expected_shape):
+        net = MaskedAutoEncoderViT(**input_param)
+        with eval_mode(net):
+            result, _ = net(torch.randn(input_shape))
+            self.assertEqual(result.shape, expected_shape)
+
+    def test_ill_arg(self):
+        with self.assertRaises(ValueError):
+            MaskedAutoEncoderViT(
+                in_channels=1,
+                img_size=(128, 128, 128),
+                patch_size=(16, 16, 16),
+                hidden_size=128,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=12,
+                proj_type="conv",
+                classification=False,
+                dropout_rate=5.0,
+            )
+        with self.assertRaises(ValueError):
+            MaskedAutoEncoderViT(
+                in_channels=1,
+                img_size=(32, 32, 32),
+                patch_size=(64, 64, 64),
+                hidden_size=512,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=8,
+                pos_embed_type="sin",
+                classification=False,
+                dropout_rate=0.3,
+            )
+
+        with self.assertRaises(ValueError):
+            MaskedAutoEncoderViT(
+                in_channels=1,
+                img_size=(32, 32, 32),
+                patch_size=(64, 64, 64),
+                hidden_size=512,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=8,
+                decoder_pos_embed_type="sin",
+                classification=False,
+                dropout_rate=0.3,
+            )
+        with self.assertRaises(ValueError):
+            MaskedAutoEncoderViT(
+                in_channels=1,
+                img_size=(32, 32, 32),
+                patch_size=(64, 64, 64),
+                hidden_size=512,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=8,
+                proj_type="perceptron",
+                classification=False,
+                dropout_rate=0.3,
+            )
+
+        with self.assertRaises(ValueError):
+            MaskedAutoEncoderViT(
+                in_channels=1,
+                img_size=(96, 96, 96),
+                patch_size=(8, 8, 8),
+                hidden_size=512,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=14,
+                proj_type="conv",
+                classification=False,
+                dropout_rate=0.3,
+            )
+
+        with self.assertRaises(ValueError):
+            MaskedAutoEncoderViT(
+                in_channels=1,
+                img_size=(97, 97, 97),
+                patch_size=(4, 4, 4),
+                hidden_size=768,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=8,
+                proj_type="perceptron",
+                classification=True,
+                dropout_rate=0.3,
+            )
+
+        with self.assertRaises(ValueError):
+            MaskedAutoEncoderViT(
+                in_channels=4,
+                img_size=(96, 96, 96),
+                patch_size=(16, 16, 16),
+                hidden_size=768,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=12,
+                proj_type="perc",
+                classification=False,
+                dropout_rate=0.3,
+            )
+        with self.assertRaises(ValueError):
+            MaskedAutoEncoderViT(
+                in_channels=4,
+                img_size=(96, 96, 96),
+                patch_size=(16, 16, 16),
+                hidden_size=768,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=12,
+                proj_type="conv",
+                classification=False,
+                dropout_rate=0.3,
+                masking_ratio=1.1,
+            )
+        with self.assertRaises(ValueError):
+            MaskedAutoEncoderViT(
+                in_channels=4,
+                img_size=(96, 96, 96),
+                patch_size=(16, 16, 16),
+                hidden_size=768,
+                mlp_dim=3072,
+                num_layers=12,
+                num_heads=12,
+                proj_type="conv",
+                classification=False,
+                dropout_rate=0.3,
+                masking_ratio=-0.1,
+            )
+
+    @parameterized.expand(TEST_CASE_MaskedAutoEncoderViT)
+    @SkipIfBeforePyTorchVersion((1, 9))
+    def test_script(self, input_param, input_shape, _):
+        net = MaskedAutoEncoderViT(**(input_param))
+        net.eval()
+        with torch.no_grad():
+            torch.jit.script(net)
+
+        test_data = torch.randn(input_shape)
+        test_script_save(net, test_data)
+
+    def test_access_attn_matrix(self):
+        # input format
+        in_channels = 1
+        img_size = (96, 96, 96)
+        patch_size = (16, 16, 16)
+        in_shape = (1, in_channels, img_size[0], img_size[1], img_size[2])
+
+        # no data in the matrix
+        no_matrix_acess_blk = MaskedAutoEncoderViT(in_channels=in_channels, img_size=img_size, patch_size=patch_size)
+        no_matrix_acess_blk(torch.randn(in_shape))
+        assert isinstance(no_matrix_acess_blk.blocks[0].attn.att_mat, torch.Tensor)
+        # no of elements is zero
+        assert no_matrix_acess_blk.blocks[0].attn.att_mat.nelement() == 0
+
+        # be able to acess the attention matrix
+        matrix_acess_blk = MaskedAutoEncoderViT(
+            in_channels=in_channels, img_size=img_size, patch_size=patch_size, save_attn=True
+        )
+        matrix_acess_blk(torch.randn(in_shape))
+        assert matrix_acess_blk.blocks[0].attn.att_mat.shape == (in_shape[0], 16, 54, 54)
+
+    def test_masking_ratio(self):
+        # input format
+        in_channels = 1
+        img_size = (96, 96, 96)
+        patch_size = (16, 16, 16)
+        in_shape = (1, in_channels, img_size[0], img_size[1], img_size[2])
+
+        # masking ratio 0.25
+        masking_ratio_blk = MaskedAutoEncoderViT(
+            in_channels=in_channels, img_size=img_size, patch_size=patch_size, masking_ratio=0.25, save_attn=True
+        )
+        masking_ratio_blk(torch.randn(in_shape))
+        desired_num_tokens = int(
+            (img_size[0] // patch_size[0])
+            * (img_size[1] // patch_size[1])
+            * (img_size[2] // patch_size[2])
+            * (1 - 0.25)
+        )
+        assert masking_ratio_blk.blocks[0].attn.att_mat.shape[-1] == desired_num_tokens
+
+        # masking ratio 0.33
+        masking_ratio_blk = MaskedAutoEncoderViT(
+            in_channels=in_channels, img_size=img_size, patch_size=patch_size, masking_ratio=0.33, save_attn=True
+        )
+        masking_ratio_blk(torch.randn(in_shape))
+        desired_num_tokens = int(
+            (img_size[0] // patch_size[0])
+            * (img_size[1] // patch_size[1])
+            * (img_size[2] // patch_size[2])
+            * (1 - 0.33)
+        )
+        assert masking_ratio_blk.blocks[0].attn.att_mat.shape[-1] == desired_num_tokens
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

Implementation of the Masked Autoencoder as described in the paper: [Masked Autoencoders Are Scalable Vision Learners](https://arxiv.org/pdf/2111.06377.pdf) from Kaiming et al.

Masked autoencoders are a type of deep learning model that learn to reconstruct input data from partially masked or obscured versions of that data. They are structured to first "mask" or remove parts of the input image, and then attempt to reconstruct the missing pieces based solely on the available (unmasked) information. 

This allows us to be much faster with fewer tokens being passed through the encoder. In addition, most representation learning methods are based on augmentations or different views of the same image and the quality of the representations depends heavily on the augmentations in question, which can be restrictive in the context of medical imaging. Masked autoencoders go some way towards overcoming this problem.
Its effectiveness has already been demonstrated in the literature for medical tasks in the paper [Self Pre-training with Masked Autoencoders for Medical Image Classification and Segmentation](https://arxiv.org/abs/2203.05573).

The PR concerns the implementation of this method and the associated tests (note currently the tests take 48seconds to pass that might be a bit long tell me).

So far 2D training on CIFAR data 
![cifar_mae](https://github.com/Project-MONAI/MONAI/assets/67736918/5dccf0ee-33ce-4b65-b16d-3e627c827e19)
went well


and 3d training on BraTS2021 data yields this
<img width="425" alt="brain_mae" src="https://github.com/Project-MONAI/MONAI/assets/67736918/76661b19-d299-4777-bb0e-cecdda6ad4f7">

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
