### PR TITLE
ENH: generate_label_classes_crop_centers: warn only if ratio of missing class is not set to 0

### DIFF
--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -625,9 +625,12 @@ def generate_label_classes_crop_centers(
 
     for i, array in enumerate(indices):
         if len(array) == 0:
-            ratios_[i] = 0
-            if warn:
-                warnings.warn(f"no available indices of class {i} to crop, set the crop ratio of this class to zero.")
+            if ratios_[i] != 0:
+                ratios_[i] = 0
+                if warn:
+                    warnings.warn(
+                        f"no available indices of class {i} to crop, set the crop ratio of this class to zero."
+                    )
 
     centers = []
     classes = rand_state.choice(len(ratios_), size=num_samples, p=np.asarray(ratios_) / np.sum(ratios_))

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -629,7 +629,7 @@ def generate_label_classes_crop_centers(
                 ratios_[i] = 0
                 if warn:
                     warnings.warn(
-                        f"no available indices of class {i} to crop, set the crop ratio of this class to zero."
+                        f"no available indices of class {i} to crop, setting the crop ratio of this class to zero."
                     )
 
     centers = []


### PR DESCRIPTION
Fixes #7594 

### Description

Only warn users that the ratio of a missing class is set to 0, when it wasn't already set to 0 by the user, in `generate_label_classes_crop_centers`, function being used by `RandCropByLabelClasses` transform.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`. ⚠️ See notes
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`. ⚠️ See notes
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

### Notes regarding tests
Some tests were failing, see details:
<details>
======================================================================
ERROR: test_cuda_0_2_batches_1_dimensions_1_channels_2_classes_2_mixtures (tests.test_gmm.GMMTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2096, in _run_ninja_build
    subprocess.run(
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_gmm.py", line 288, in test_cuda
    gmm = GaussianMixtureModel(features_tensor.size(1), mixture_count, class_count, verbose_build=True)
  File "/home/szabolcslorincz/MONAI/monai/networks/layers/gmm.py", line 44, in __init__
    self.compiled_extension = load_module(
  File "/home/szabolcslorincz/MONAI/monai/_extensions/loader.py", line 89, in load_module
    module = load(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1306, in load
    return _jit_compile(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1710, in _jit_compile
    _write_ninja_file_and_build_library(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1823, in _write_ninja_file_and_build_library
    _run_ninja_build(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2112, in _run_ninja_build
    raise RuntimeError(message) from e
RuntimeError: Error building extension 'gmm_1_2_1_Linux_3_10_12_22_12_1'

======================================================================
ERROR: test_cuda_1_1_batches_1_dimensions_5_channels_2_classes_1_mixtures (tests.test_gmm.GMMTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2096, in _run_ninja_build
    subprocess.run(
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_gmm.py", line 288, in test_cuda
    gmm = GaussianMixtureModel(features_tensor.size(1), mixture_count, class_count, verbose_build=True)
  File "/home/szabolcslorincz/MONAI/monai/networks/layers/gmm.py", line 44, in __init__
    self.compiled_extension = load_module(
  File "/home/szabolcslorincz/MONAI/monai/_extensions/loader.py", line 89, in load_module
    module = load(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1306, in load
    return _jit_compile(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1710, in _jit_compile
    _write_ninja_file_and_build_library(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1823, in _write_ninja_file_and_build_library
    _run_ninja_build(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2112, in _run_ninja_build
    raise RuntimeError(message) from e
RuntimeError: Error building extension 'gmm_5_2_1_Linux_3_10_12_22_12_1'

======================================================================
ERROR: test_cuda_2_1_batches_2_dimensions_2_channels_4_classes_4_mixtures (tests.test_gmm.GMMTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2096, in _run_ninja_build
    subprocess.run(
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_gmm.py", line 288, in test_cuda
    gmm = GaussianMixtureModel(features_tensor.size(1), mixture_count, class_count, verbose_build=True)
  File "/home/szabolcslorincz/MONAI/monai/networks/layers/gmm.py", line 44, in __init__
    self.compiled_extension = load_module(
  File "/home/szabolcslorincz/MONAI/monai/_extensions/loader.py", line 89, in load_module
    module = load(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1306, in load
    return _jit_compile(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1710, in _jit_compile
    _write_ninja_file_and_build_library(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1823, in _write_ninja_file_and_build_library
    _run_ninja_build(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2112, in _run_ninja_build
    raise RuntimeError(message) from e
RuntimeError: Error building extension 'gmm_2_4_1_Linux_3_10_12_22_12_1'

======================================================================
ERROR: test_cuda_3_1_batches_3_dimensions_1_channels_2_classes_1_mixtures (tests.test_gmm.GMMTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2096, in _run_ninja_build
    subprocess.run(
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_gmm.py", line 288, in test_cuda
    gmm = GaussianMixtureModel(features_tensor.size(1), mixture_count, class_count, verbose_build=True)
  File "/home/szabolcslorincz/MONAI/monai/networks/layers/gmm.py", line 44, in __init__
    self.compiled_extension = load_module(
  File "/home/szabolcslorincz/MONAI/monai/_extensions/loader.py", line 89, in load_module
    module = load(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1306, in load
    return _jit_compile(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1710, in _jit_compile
    _write_ninja_file_and_build_library(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1823, in _write_ninja_file_and_build_library
    _run_ninja_build(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2112, in _run_ninja_build
    raise RuntimeError(message) from e
RuntimeError: Error building extension 'gmm_1_2_1_Linux_3_10_12_22_12_1_v1'

======================================================================
ERROR: test_load (tests.test_gmm.GMMTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2096, in _run_ninja_build
    subprocess.run(
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/tests/test_gmm.py", line 311, in test_load
    load_module("gmm", {"CHANNEL_COUNT": 2, "MIXTURE_COUNT": 2, "MIXTURE_SIZE": 3}, verbose_build=True)
  File "/home/szabolcslorincz/MONAI/monai/_extensions/loader.py", line 89, in load_module
    module = load(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1306, in load
    return _jit_compile(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1710, in _jit_compile
    _write_ninja_file_and_build_library(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1823, in _write_ninja_file_and_build_library
    _run_ninja_build(
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 2112, in _run_ninja_build
    raise RuntimeError(message) from e
RuntimeError: Error building extension 'gmm_2_2_3_Linux_3_10_12_22_12_1'

======================================================================
ERROR: test_spacing_35 (tests.test_spacing.TestSpacingCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_spacing.py", line 289, in test_spacing
    res: MetaTensor = tr(**call_param)  # type: ignore
  File "/home/szabolcslorincz/MONAI/monai/transforms/spatial/array.py", line 525, in __call__
    data_array = self.sp_resample(
  File "/home/szabolcslorincz/MONAI/monai/transforms/spatial/array.py", line 223, in __call__
    return spatial_resample(
  File "/home/szabolcslorincz/MONAI/monai/transforms/spatial/functional.py", line 178, in spatial_resample
    img = affine_xform(img.unsqueeze(0), theta=xform.to(img), spatial_size=spatial_size).squeeze(0)  # type: ignore
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1511, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/szabolcslorincz/MONAI/monai/networks/layers/spatial_transforms.py", line 584, in forward
    grid = nn.functional.affine_grid(theta=theta[:, :sr], size=list(dst_size), align_corners=self.align_corners)
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/nn/functional.py", line 4418, in affine_grid
    return torch.affine_grid_generator(theta, size, align_corners)
torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 840.00 MiB. GPU 0 has a total capacity of 8.00 GiB of which 0 bytes is free. Including non-PyTorch memory, this process has 17179869184.00 GiB memory in use. Of the allocated memory 6.47 GiB is allocated by PyTorch, and 156.63 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)

======================================================================
FAIL: test_seg_res_net_1_cuda (tests.test_convert_to_onnx.TestConvertToOnnx)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_convert_to_onnx.py", line 108, in test_seg_res_net
    onnx_model = convert_to_onnx(
  File "/home/szabolcslorincz/MONAI/monai/networks/utils.py", line 709, in convert_to_onnx
    assert_fn(r1.cpu(), convert_to_tensor(r2, dtype=r1.dtype), rtol=rtol, atol=atol)  # type: ignore
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/testing/_comparison.py", line 1520, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 233543 / 1451520 (16.1%)
Greatest absolute difference: 0.0014852285385131836 at index (0, 19, 12, 13, 22) (up to 0.0001 allowed)
Greatest relative difference: 589.0405883789062 at index (0, 32, 21, 16, 15) (up to 0.001 allowed)

======================================================================
FAIL: test_unet_4_cuda (tests.test_convert_to_onnx.TestConvertToOnnx)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_convert_to_onnx.py", line 57, in test_unet
    onnx_model = convert_to_onnx(
  File "/home/szabolcslorincz/MONAI/monai/networks/utils.py", line 709, in convert_to_onnx
    assert_fn(r1.cpu(), convert_to_tensor(r2, dtype=r1.dtype), rtol=rtol, atol=atol)  # type: ignore
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/testing/_comparison.py", line 1520, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 6705 / 49152 (13.6%)
Greatest absolute difference: 0.0015408992767333984 at index (11, 0, 21, 27) (up to 0.0001 allowed)
Greatest relative difference: 51.80112838745117 at index (14, 0, 25, 19) (up to 0.001 allowed)

======================================================================
FAIL: test_unet_5_cuda (tests.test_convert_to_onnx.TestConvertToOnnx)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_convert_to_onnx.py", line 57, in test_unet
    onnx_model = convert_to_onnx(
  File "/home/szabolcslorincz/MONAI/monai/networks/utils.py", line 709, in convert_to_onnx
    assert_fn(r1.cpu(), convert_to_tensor(r2, dtype=r1.dtype), rtol=rtol, atol=atol)  # type: ignore
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/testing/_comparison.py", line 1520, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 6218 / 49152 (12.7%)
Greatest absolute difference: 0.0015670061111450195 at index (2, 0, 23, 14) (up to 0.0001 allowed)
Greatest relative difference: 7.987473964691162 at index (8, 0, 27, 8) (up to 0.001 allowed)

======================================================================
FAIL: test_unet_6_cuda (tests.test_convert_to_onnx.TestConvertToOnnx)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_convert_to_onnx.py", line 57, in test_unet
    onnx_model = convert_to_onnx(
  File "/home/szabolcslorincz/MONAI/monai/networks/utils.py", line 709, in convert_to_onnx
    assert_fn(r1.cpu(), convert_to_tensor(r2, dtype=r1.dtype), rtol=rtol, atol=atol)  # type: ignore
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/testing/_comparison.py", line 1520, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 6743 / 49152 (13.7%)
Greatest absolute difference: 0.0015552043914794922 at index (1, 1, 9, 11) (up to 0.0001 allowed)
Greatest relative difference: 2.0317020416259766 at index (11, 0, 19, 21) (up to 0.001 allowed)

======================================================================
FAIL: test_unet_7_cuda (tests.test_convert_to_onnx.TestConvertToOnnx)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_convert_to_onnx.py", line 57, in test_unet
    onnx_model = convert_to_onnx(
  File "/home/szabolcslorincz/MONAI/monai/networks/utils.py", line 709, in convert_to_onnx
    assert_fn(r1.cpu(), convert_to_tensor(r2, dtype=r1.dtype), rtol=rtol, atol=atol)  # type: ignore
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/torch/testing/_comparison.py", line 1520, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 6823 / 49152 (13.9%)
Greatest absolute difference: 0.0018431544303894043 at index (10, 0, 9, 19) (up to 0.0001 allowed)
Greatest relative difference: 4.297887325286865 at index (13, 0, 12, 13) (up to 0.001 allowed)

======================================================================
FAIL: test_shape_2 (tests.test_multi_scale.TestMultiScale)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/szabolcslorincz/MONAI/tests/test_multi_scale.py", line 59, in test_shape
    np.testing.assert_allclose(result.detach().cpu().numpy(), expected_val, rtol=1e-5)
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 1504, in assert_allclose
    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
  File "/usr/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/home/szabolcslorincz/MONAI/venv/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 797, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=1e-05, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference: 0.
Max relative difference: 0.
 x: array(0.715212, dtype=float32)
 y: array(0.715228)

----------------------------------------------------------------------
Ran 14392 tests in 2252.916s

FAILED (failures=6, errors=6, skipped=450)