### PR TITLE
Fix test error in `test_soft_clipping_one_sided_high`

### DIFF
--- a/tests/test_clip_intensity_percentiles.py
+++ b/tests/test_clip_intensity_percentiles.py
@@ -17,7 +17,7 @@ from parameterized import parameterized
 
 from monai.transforms import ClipIntensityPercentiles
 from monai.transforms.utils import soft_clip
-from monai.transforms.utils_pytorch_numpy_unification import clip
+from monai.transforms.utils_pytorch_numpy_unification import clip, percentile
 from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, NumpyImageTestCase3D, assert_allclose
 
 
@@ -28,8 +28,8 @@ class TestClipIntensityPercentiles2D(NumpyImageTestCase2D):
         hard_clipper = ClipIntensityPercentiles(upper=95, lower=5)
         im = p(self.imt)
         result = hard_clipper(im)
-        lower, upper = np.percentile(self.imt, (5, 95))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (5, 95))
+        expected = clip(im, lower, upper)
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -37,8 +37,8 @@ class TestClipIntensityPercentiles2D(NumpyImageTestCase2D):
         hard_clipper = ClipIntensityPercentiles(upper=95, lower=None)
         im = p(self.imt)
         result = hard_clipper(im)
-        lower, upper = np.percentile(self.imt, (0, 95))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (0, 95))
+        expected = clip(im, lower, upper)
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -46,8 +46,8 @@ class TestClipIntensityPercentiles2D(NumpyImageTestCase2D):
         hard_clipper = ClipIntensityPercentiles(upper=None, lower=5)
         im = p(self.imt)
         result = hard_clipper(im)
-        lower, upper = np.percentile(self.imt, (5, 100))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (5, 100))
+        expected = clip(im, lower, upper)
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -55,8 +55,8 @@ class TestClipIntensityPercentiles2D(NumpyImageTestCase2D):
         soft_clipper = ClipIntensityPercentiles(upper=95, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper(im)
-        lower, upper = np.percentile(self.imt, (5, 95))
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=lower, maxv=upper)
+        lower, upper = percentile(im, (5, 95))
+        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=upper, dtype=im.dtype)
         # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-6, atol=0)
 
@@ -65,8 +65,8 @@ class TestClipIntensityPercentiles2D(NumpyImageTestCase2D):
         soft_clipper = ClipIntensityPercentiles(upper=95, lower=None, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper(im)
-        upper = np.percentile(self.imt, 95)
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=None, maxv=upper)
+        upper = percentile(im, 95)
+        expected = soft_clip(im, sharpness_factor=1.0, minv=None, maxv=upper, dtype=im.dtype)
         # the rtol is set to 5e-5 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result, p(expected), type_test="tensor", rtol=5e-5, atol=0)
 
@@ -75,8 +75,8 @@ class TestClipIntensityPercentiles2D(NumpyImageTestCase2D):
         soft_clipper = ClipIntensityPercentiles(upper=None, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper(im)
-        lower = np.percentile(self.imt, 5)
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=lower, maxv=None)
+        lower = percentile(im, 5)
+        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=None, dtype=im.dtype)
         # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-6, atol=0)
 
@@ -85,8 +85,8 @@ class TestClipIntensityPercentiles2D(NumpyImageTestCase2D):
         clipper = ClipIntensityPercentiles(upper=95, lower=5, channel_wise=True)
         im = p(self.imt)
         result = clipper(im)
-        for i, c in enumerate(self.imt):
-            lower, upper = np.percentile(c, (5, 95))
+        for i, c in enumerate(im):
+            lower, upper = percentile(c, (5, 95))
             expected = clip(c, lower, upper)
             assert_allclose(result[i], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
@@ -118,8 +118,8 @@ class TestClipIntensityPercentiles3D(NumpyImageTestCase3D):
         hard_clipper = ClipIntensityPercentiles(upper=95, lower=5)
         im = p(self.imt)
         result = hard_clipper(im)
-        lower, upper = np.percentile(self.imt, (5, 95))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (5, 95))
+        expected = clip(im, lower, upper)
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -127,8 +127,8 @@ class TestClipIntensityPercentiles3D(NumpyImageTestCase3D):
         hard_clipper = ClipIntensityPercentiles(upper=95, lower=None)
         im = p(self.imt)
         result = hard_clipper(im)
-        lower, upper = np.percentile(self.imt, (0, 95))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (0, 95))
+        expected = clip(im, lower, upper)
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -136,8 +136,8 @@ class TestClipIntensityPercentiles3D(NumpyImageTestCase3D):
         hard_clipper = ClipIntensityPercentiles(upper=None, lower=5)
         im = p(self.imt)
         result = hard_clipper(im)
-        lower, upper = np.percentile(self.imt, (5, 100))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (5, 100))
+        expected = clip(im, lower, upper)
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -145,8 +145,8 @@ class TestClipIntensityPercentiles3D(NumpyImageTestCase3D):
         soft_clipper = ClipIntensityPercentiles(upper=95, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper(im)
-        lower, upper = np.percentile(self.imt, (5, 95))
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=lower, maxv=upper)
+        lower, upper = percentile(im, (5, 95))
+        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=upper, dtype=im.dtype)
         # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-6, atol=0)
 
@@ -155,8 +155,8 @@ class TestClipIntensityPercentiles3D(NumpyImageTestCase3D):
         soft_clipper = ClipIntensityPercentiles(upper=95, lower=None, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper(im)
-        upper = np.percentile(self.imt, 95)
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=None, maxv=upper)
+        upper = percentile(im, 95)
+        expected = soft_clip(im, sharpness_factor=1.0, minv=None, maxv=upper, dtype=im.dtype)
         # the rtol is set to 5e-5 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result, p(expected), type_test="tensor", rtol=5e-5, atol=0)
 
@@ -165,8 +165,8 @@ class TestClipIntensityPercentiles3D(NumpyImageTestCase3D):
         soft_clipper = ClipIntensityPercentiles(upper=None, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper(im)
-        lower = np.percentile(self.imt, 5)
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=lower, maxv=None)
+        lower = percentile(im, 5)
+        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=None, dtype=im.dtype)
         # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result, p(expected), type_test="tensor", rtol=1e-6, atol=0)
 
@@ -175,8 +175,8 @@ class TestClipIntensityPercentiles3D(NumpyImageTestCase3D):
         clipper = ClipIntensityPercentiles(upper=95, lower=5, channel_wise=True)
         im = p(self.imt)
         result = clipper(im)
-        for i, c in enumerate(self.imt):
-            lower, upper = np.percentile(c, (5, 95))
+        for i, c in enumerate(im):
+            lower, upper = percentile(c, (5, 95))
             expected = clip(c, lower, upper)
             assert_allclose(result[i], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 

--- a/tests/test_clip_intensity_percentilesd.py
+++ b/tests/test_clip_intensity_percentilesd.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 
 from monai.transforms import ClipIntensityPercentilesd
 from monai.transforms.utils import soft_clip
-from monai.transforms.utils_pytorch_numpy_unification import clip
+from monai.transforms.utils_pytorch_numpy_unification import clip, percentile
 from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, NumpyImageTestCase3D, assert_allclose
 
 
@@ -30,8 +30,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = np.percentile(self.imt, (5, 95))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (5, 95))
+        expected = clip(im, lower, upper)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -40,8 +40,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=None)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = np.percentile(self.imt, (0, 95))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (0, 95))
+        expected = clip(im, lower, upper)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -50,8 +50,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=None, lower=5)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = np.percentile(self.imt, (5, 100))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (5, 100))
+        expected = clip(im, lower, upper)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -60,8 +60,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        lower, upper = np.percentile(self.imt, (5, 95))
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=lower, maxv=upper)
+        lower, upper = percentile(im, (5, 95))
+        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=upper, dtype=im.dtype)
         # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-6, atol=0)
 
@@ -71,8 +71,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=None, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        upper = np.percentile(self.imt, 95)
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=None, maxv=upper)
+        upper = percentile(im, 95)
+        expected = soft_clip(im, sharpness_factor=1.0, minv=None, maxv=upper, dtype=im.dtype)
         # the rtol is set to 5e-5 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=5e-5, atol=0)
 
@@ -82,8 +82,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=None, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        lower = np.percentile(self.imt, 5)
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=lower, maxv=None)
+        lower = percentile(im, 5)
+        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=None, dtype=im.dtype)
         # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-6, atol=0)
 
@@ -93,8 +93,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5, channel_wise=True)
         im = p(self.imt)
         result = clipper({key: im})
-        for i, c in enumerate(self.imt):
-            lower, upper = np.percentile(c, (5, 95))
+        for i, c in enumerate(im):
+            lower, upper = percentile(c, (5, 95))
             expected = clip(c, lower, upper)
             assert_allclose(result[key][i], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
@@ -132,8 +132,8 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = np.percentile(self.imt, (5, 95))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (5, 95))
+        expected = clip(im, lower, upper)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -142,8 +142,8 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=None)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = np.percentile(self.imt, (0, 95))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (0, 95))
+        expected = clip(im, lower, upper)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -152,8 +152,8 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=None, lower=5)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = np.percentile(self.imt, (5, 100))
-        expected = clip(self.imt, lower, upper)
+        lower, upper = percentile(im, (5, 100))
+        expected = clip(im, lower, upper)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -162,8 +162,8 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        lower, upper = np.percentile(self.imt, (5, 95))
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=lower, maxv=upper)
+        lower, upper = percentile(im, (5, 95))
+        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=upper, dtype=im.dtype)
         # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-6, atol=0)
 
@@ -173,8 +173,8 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=None, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        upper = np.percentile(self.imt, 95)
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=None, maxv=upper)
+        upper = percentile(im, 95)
+        expected = soft_clip(im, sharpness_factor=1.0, minv=None, maxv=upper, dtype=im.dtype)
         # the rtol is set to 5e-5 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=5e-5, atol=0)
 
@@ -184,8 +184,8 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=None, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        lower = np.percentile(self.imt, 5)
-        expected = soft_clip(self.imt, sharpness_factor=1.0, minv=lower, maxv=None)
+        lower = percentile(im, 5)
+        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=None, dtype=im.dtype)
         # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-6, atol=0)
 
@@ -195,8 +195,8 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5, channel_wise=True)
         im = p(self.imt)
         result = clipper({key: im})
-        for i, c in enumerate(self.imt):
-            lower, upper = np.percentile(c, (5, 95))
+        for i, c in enumerate(im):
+            lower, upper = percentile(c, (5, 95))
             expected = clip(c, lower, upper)
             assert_allclose(result[key][i], p(expected), type_test="tensor", rtol=1e-7, atol=0)
 


### PR DESCRIPTION
Fixes #7616


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
