### PR TITLE
Enable dynamo onnx export of BasicUNet

### DIFF
--- a/monai/networks/nets/basic_unet.py
+++ b/monai/networks/nets/basic_unet.py
@@ -159,7 +159,7 @@ class UpCat(nn.Module):
         """
         x_0 = self.upsample(x)
 
-        if x_e is not None and torch.jit.isinstance(x_e, torch.Tensor):
+        if x_e is not None and isinstance(x_e, torch.Tensor):
             if self.is_pad:
                 # handling spatial shapes due to the 2x maxpooling with odd edge lengths.
                 dimensions = len(x.shape) - 2

--- a/monai/networks/nets/netadapter.py
+++ b/monai/networks/nets/netadapter.py
@@ -109,7 +109,11 @@ class NetAdapter(torch.nn.Module):
         x = self.features(x)
         if isinstance(x, tuple):
             x = x[0]  # it might be a namedtuple such as torchvision.model.InceptionOutputs
-        elif torch.jit.isinstance(x, Dict[str, torch.Tensor]):
+        elif (
+            isinstance(x, Dict)
+            and all(isinstance(el, str) for el in x.keys())
+            and all(isinstance(el, torch.Tensor) for el in x.values())
+        ):
             x = x[self.node_name]  # torchvision create_feature_extractor
         if self.pool is not None:
             x = self.pool(x)


### PR DESCRIPTION
### Enable dynamo onnx export of BasicUNet models

TorchDynamo based ONNX export does not support `torch.jit.isinstance()`. To enable the export via dynamo, I've updated the calls to `torch.jit.isinstance` to `isinstance`. I've also verified that the TorchScript based ONNX export still works with this change. These changes enable the export of BasicUNet, BasicUNetPlusPlus, FlexibleUNet, TorchvisionFC models.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`. - Errors caused due to dataloader
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`. - Errors caused due to dataloader
