### PR TITLE
Fixed four test issues within test code.

### DIFF
--- a/tests/test_auto3dseg.py
+++ b/tests/test_auto3dseg.py
@@ -367,7 +367,6 @@ class TestDataAnalyzer(unittest.TestCase):
         for batch_data in self.dataset:
             d = transform(batch_data[0])
             assert DataStatsKeys.BY_CASE_IMAGE_PATH in d
-            assert DataStatsKeys.BY_CASE_IMAGE_PATH in d
 
     def test_filename_case_analyzer_image_only(self):
         analyzer_image = FilenameStats("image", DataStatsKeys.BY_CASE_IMAGE_PATH)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -716,15 +716,15 @@ class TestComposeExecuteWithFlags(unittest.TestCase):
                 for k in actual.keys():
                     self.assertEqual(expected[k], actual[k])
             else:
-                self.assertTrue(expected, actual)
+                self.assertEqual(expected, actual)
 
             p = deepcopy(pipeline)
             actual = execute_compose(execute_compose(data, p, start=0, end=cutoff, **flags), p, start=cutoff, **flags)
             if isinstance(actual, dict):
                 for k in actual.keys():
-                    self.assertTrue(expected[k], actual[k])
+                    self.assertEqual(expected[k], actual[k])
             else:
-                self.assertTrue(expected, actual)
+                self.assertEqual(expected, actual)
 
 
 class TestComposeCallableInput(unittest.TestCase):

--- a/tests/test_pad_collation.py
+++ b/tests/test_pad_collation.py
@@ -117,7 +117,7 @@ class TestPadCollation(unittest.TestCase):
             batch_inverse = BatchInverseTransform(dataset.transform, loader)
             for data in loader:
                 output = batch_inverse(data)
-                self.assertTrue(output[0]["image"].shape, (1, 10, 9))
+                self.assertEqual(output[0]["image"].shape, (1, 10, 9))
 
 
 if __name__ == "__main__":

--- a/tests/test_to_numpy.py
+++ b/tests/test_to_numpy.py
@@ -71,7 +71,7 @@ class TestToNumpy(unittest.TestCase):
         assert_allclose(result, np.asarray(test_data), type_test=False)
         test_data = ((1, 2), (3, 4))
         result = ToNumpy(wrap_sequence=False)(test_data)
-        self.assertTrue(type(result), tuple)
+        self.assertIsInstance(result, tuple)
         assert_allclose(result, ((np.asarray(1), np.asarray(2)), (np.asarray(3), np.asarray(4))))
 
     def test_single_value(self):


### PR DESCRIPTION
### Description

This PR fixed the three issues within the test code that could cause problems during CICD.

Three issues:

tests/test_pad_collation.py line 120: supposed to be assertEqual, but not assertTure? or it will always be true.
tests/test_to_numpy.py line 74: Same as above.
tests/test_auto3dseg.py line 370: typo? two same asserts next to each other.
tests/test_compose.py line 719, 725, 727: Should be assertEqual instead of assertTrue

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
