### PR TITLE
Adapt to use assert raises

### DIFF
--- a/tests/test_decathlondataset.py
+++ b/tests/test_decathlondataset.py
@@ -80,7 +80,7 @@ class TestDecathlonDataset(unittest.TestCase):
         self.assertDictEqual(properties["labels"], {"0": "background", "1": "Anterior", "2": "Posterior"})
 
         shutil.rmtree(os.path.join(testing_dir, "Task04_Hippocampus"))
-        try:
+        with self.assertRaisesRegex(RuntimeError, "^Cannot find dataset directory"):
             DecathlonDataset(
                 root_dir=testing_dir,
                 task="Task04_Hippocampus",
@@ -88,9 +88,6 @@ class TestDecathlonDataset(unittest.TestCase):
                 section="validation",
                 download=False,
             )
-        except RuntimeError as e:
-            print(str(e))
-            self.assertTrue(str(e).startswith("Cannot find dataset directory"))
 
 
 if __name__ == "__main__":

--- a/tests/test_mednistdataset.py
+++ b/tests/test_mednistdataset.py
@@ -65,11 +65,8 @@ class TestMedNISTDataset(unittest.TestCase):
         self.assertEqual(data[0]["class_name"], "AbdomenCT")
         self.assertEqual(data[0]["label"], 0)
         shutil.rmtree(os.path.join(testing_dir, "MedNIST"))
-        try:
+        with self.assertRaisesRegex(RuntimeError, "^Cannot find dataset directory"):
             MedNISTDataset(root_dir=testing_dir, transform=transform, section="test", download=False)
-        except RuntimeError as e:
-            print(str(e))
-            self.assertTrue(str(e).startswith("Cannot find dataset directory"))
 
 
 if __name__ == "__main__":

--- a/tests/test_monai_utils_misc.py
+++ b/tests/test_monai_utils_misc.py
@@ -92,12 +92,11 @@ class TestCommandRunner(unittest.TestCase):
         cmd2 = "-c"
         cmd3 = 'import sys; print("\\tThis is on stderr\\n", file=sys.stderr); sys.exit(1)'
         os.environ["MONAI_DEBUG"] = str(True)
-        try:
+        with self.assertRaises(RuntimeError) as cm:
             run_cmd([cmd1, cmd2, cmd3], check=True)
-        except RuntimeError as err:
-            self.assertIn("This is on stderr", str(err))
-            self.assertNotIn("\\n", str(err))
-            self.assertNotIn("\\t", str(err))
+        self.assertIn("This is on stderr", str(cm.exception))
+        self.assertNotIn("\\n", str(cm.exception))
+        self.assertNotIn("\\t", str(cm.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_tciadataset.py
+++ b/tests/test_tciadataset.py
@@ -108,7 +108,7 @@ class TestTciaDataset(unittest.TestCase):
             )[0]
 
         shutil.rmtree(os.path.join(testing_dir, collection))
-        try:
+        with self.assertRaisesRegex(RuntimeError, "^Cannot find dataset directory"):
             TciaDataset(
                 root_dir=testing_dir,
                 collection=collection,
@@ -117,8 +117,6 @@ class TestTciaDataset(unittest.TestCase):
                 download=False,
                 val_frac=val_frac,
             )
-        except RuntimeError as e:
-            self.assertTrue(str(e).startswith("Cannot find dataset directory"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

Some test cases use try/except command, instead of catch exceptions with assertRaise. This will cause extra execution time according to the experimental tests.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
