### PR TITLE
Refactored others type of subotimal asserts

### DIFF
--- a/tests/test_bundle_ckpt_export.py
+++ b/tests/test_bundle_ckpt_export.py
@@ -72,9 +72,9 @@ class TestCKPTExport(unittest.TestCase):
             _, metadata, extra_files = load_net_with_metadata(
                 ts_file, more_extra_files=["inference.json", "def_args.json"]
             )
-            self.assertTrue("schema" in metadata)
-            self.assertTrue("meta_file" in json.loads(extra_files["def_args.json"]))
-            self.assertTrue("network_def" in json.loads(extra_files["inference.json"]))
+            self.assertIn("schema", metadata)
+            self.assertIn("meta_file", json.loads(extra_files["def_args.json"]))
+            self.assertIn("network_def", json.loads(extra_files["inference.json"]))
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_default_value(self, key_in_ckpt, use_trace):

--- a/tests/test_bundle_get_data.py
+++ b/tests/test_bundle_get_data.py
@@ -51,8 +51,8 @@ class TestGetBundleData(unittest.TestCase):
     def test_get_all_bundles_list(self, params):
         with skip_if_downloading_fails():
             output = get_all_bundles_list(**params)
-            self.assertTrue(isinstance(output, list))
-            self.assertTrue(isinstance(output[0], tuple))
+            self.assertIsInstance(output, list)
+            self.assertIsInstance(output[0], tuple)
             self.assertTrue(len(output[0]) == 2)
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_5])
@@ -60,16 +60,17 @@ class TestGetBundleData(unittest.TestCase):
     def test_get_bundle_versions(self, params):
         with skip_if_downloading_fails():
             output = get_bundle_versions(**params)
-            self.assertTrue(isinstance(output, dict))
-            self.assertTrue("latest_version" in output and "all_versions" in output)
-            self.assertTrue("0.1.0" in output["all_versions"])
+            self.assertIsInstance(output, dict)
+            self.assertIn("latest_version", output)
+            self.assertIn("all_versions", output)
+            self.assertIn("0.1.0", output["all_versions"])
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     @skip_if_quick
     def test_get_bundle_info(self, params):
         with skip_if_downloading_fails():
             output = get_bundle_info(**params)
-            self.assertTrue(isinstance(output, dict))
+            self.assertIsInstance(output, dict)
             for key in ["id", "name", "size", "download_count", "browser_download_url"]:
                 self.assertTrue(key in output)
 
@@ -78,7 +79,7 @@ class TestGetBundleData(unittest.TestCase):
     def test_get_bundle_info_monaihosting(self, params):
         with skip_if_downloading_fails():
             output = get_bundle_info(**params)
-            self.assertTrue(isinstance(output, dict))
+            self.assertIsInstance(output, dict)
             for key in ["name", "browser_download_url"]:
                 self.assertTrue(key in output)
 

--- a/tests/test_bundle_get_data.py
+++ b/tests/test_bundle_get_data.py
@@ -55,7 +55,6 @@ class TestGetBundleData(unittest.TestCase):
             self.assertIsInstance(output[0], tuple)
             self.assertTrue(len(output[0]) == 2)
 
-
     @parameterized.expand([TEST_CASE_1, TEST_CASE_5])
     @skip_if_quick
     def test_get_bundle_versions(self, params):

--- a/tests/test_bundle_trt_export.py
+++ b/tests/test_bundle_trt_export.py
@@ -91,9 +91,9 @@ class TestTRTExport(unittest.TestCase):
             _, metadata, extra_files = load_net_with_metadata(
                 ts_file, more_extra_files=["inference.json", "def_args.json"]
             )
-            self.assertTrue("schema" in metadata)
-            self.assertTrue("meta_file" in json.loads(extra_files["def_args.json"]))
-            self.assertTrue("network_def" in json.loads(extra_files["inference.json"]))
+            self.assertIn("schema", metadata)
+            self.assertIn("meta_file", json.loads(extra_files["def_args.json"]))
+            self.assertIn("network_def", json.loads(extra_files["inference.json"]))
 
     @parameterized.expand([TEST_CASE_3, TEST_CASE_4])
     @unittest.skipUnless(
@@ -129,9 +129,9 @@ class TestTRTExport(unittest.TestCase):
             _, metadata, extra_files = load_net_with_metadata(
                 ts_file, more_extra_files=["inference.json", "def_args.json"]
             )
-            self.assertTrue("schema" in metadata)
-            self.assertTrue("meta_file" in json.loads(extra_files["def_args.json"]))
-            self.assertTrue("network_def" in json.loads(extra_files["inference.json"]))
+            self.assertIn("schema", metadata)
+            self.assertIn("meta_file", json.loads(extra_files["def_args.json"]))
+            self.assertIn("network_def", json.loads(extra_files["inference.json"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_bundle_workflow.py
+++ b/tests/test_bundle_workflow.py
@@ -138,11 +138,11 @@ class TestBundleWorkflow(unittest.TestCase):
         self.assertListEqual(trainer.check_properties(), [])
         # test read / write the properties
         dataset = trainer.train_dataset
-        self.assertTrue(isinstance(dataset, Dataset))
+        self.assertIsInstance(dataset, Dataset)
         inferer = trainer.train_inferer
-        self.assertTrue(isinstance(inferer, SimpleInferer))
+        self.assertIsInstance(inferer, SimpleInferer)
         # test optional properties get
-        self.assertTrue(trainer.train_key_metric is None)
+        self.assertIsNone(trainer.train_key_metric)
         trainer.train_dataset = deepcopy(dataset)
         trainer.train_inferer = deepcopy(inferer)
         # test optional properties set

--- a/tests/test_component_store.py
+++ b/tests/test_component_store.py
@@ -48,17 +48,17 @@ class TestComponentStore(unittest.TestCase):
         self.cs.add("test_obj2", "Test object", test_obj2)
 
         self.assertEqual(len(self.cs), 2)
-        self.assertTrue("test_obj1" in self.cs)
-        self.assertTrue("test_obj2" in self.cs)
+        self.assertIn("test_obj1", self.cs)
+        self.assertIn("test_obj2", self.cs)
 
     def test_add_def(self):
-        self.assertFalse("test_func" in self.cs)
+        self.assertNotIn("test_func", self.cs)
 
         @self.cs.add_def("test_func", "Test function")
         def test_func():
             return 123
 
-        self.assertTrue("test_func" in self.cs)
+        self.assertIn("test_func", self.cs)
 
         self.assertEqual(len(self.cs), 1)
         self.assertEqual(list(self.cs), [("test_func", test_func)])

--- a/tests/test_compute_ho_ver_maps.py
+++ b/tests/test_compute_ho_ver_maps.py
@@ -67,8 +67,8 @@ class ComputeHoVerMapsTests(unittest.TestCase):
     def test_horizontal_certical_maps(self, in_type, arguments, mask, hv_mask):
         input_image = in_type(mask)
         result = ComputeHoVerMaps(**arguments)(input_image)
-        self.assertTrue(isinstance(result, torch.Tensor))
-        self.assertTrue(str(result.dtype).split(".")[1] == arguments.get("dtype", "float32"))
+        self.assertIsInstance(result, torch.Tensor)
+        self.assertEqual(str(result.dtype).split(".")[1], arguments.get("dtype", "float32"))
         assert_allclose(result, hv_mask, type_test="tensor")
 
 

--- a/tests/test_compute_ho_ver_maps_d.py
+++ b/tests/test_compute_ho_ver_maps_d.py
@@ -71,8 +71,8 @@ class ComputeHoVerMapsDictTests(unittest.TestCase):
         for k in mask.keys():
             input_image[k] = in_type(mask[k])
         result = ComputeHoVerMapsd(keys="mask", **arguments)(input_image)[hv_key]
-        self.assertTrue(isinstance(result, torch.Tensor))
-        self.assertTrue(str(result.dtype).split(".")[1] == arguments.get("dtype", "float32"))
+        self.assertIsInstance(result, torch.Tensor)
+        self.assertEqual(str(result.dtype).split(".")[1], arguments.get("dtype", "float32"))
         assert_allclose(result, hv_mask[hv_key], type_test="tensor")
 
 

--- a/tests/test_concat_itemsd.py
+++ b/tests/test_concat_itemsd.py
@@ -30,7 +30,7 @@ class TestConcatItemsd(unittest.TestCase):
             "img2": torch.tensor([[0, 1], [1, 2]], device=device),
         }
         result = ConcatItemsd(keys=["img1", "img2"], name="cat_img")(input_data)
-        self.assertTrue("cat_img" in result)
+        self.assertIn("cat_img", result)
         result["cat_img"] += 1
         assert_allclose(result["img1"], torch.tensor([[0, 1], [1, 2]], device=device))
         assert_allclose(result["cat_img"], torch.tensor([[1, 2], [2, 3], [1, 2], [2, 3]], device=device))
@@ -42,8 +42,8 @@ class TestConcatItemsd(unittest.TestCase):
             "img2": MetaTensor([[0, 1], [1, 2]], device=device),
         }
         result = ConcatItemsd(keys=["img1", "img2"], name="cat_img")(input_data)
-        self.assertTrue("cat_img" in result)
-        self.assertTrue(isinstance(result["cat_img"], MetaTensor))
+        self.assertIn("cat_img", result)
+        self.assertIsInstance(result["cat_img"], MetaTensor)
         self.assertEqual(result["img1"].meta, result["cat_img"].meta)
         result["cat_img"] += 1
         assert_allclose(result["img1"], torch.tensor([[0, 1], [1, 2]], device=device))
@@ -52,7 +52,7 @@ class TestConcatItemsd(unittest.TestCase):
     def test_numpy_values(self):
         input_data = {"img1": np.array([[0, 1], [1, 2]]), "img2": np.array([[0, 1], [1, 2]])}
         result = ConcatItemsd(keys=["img1", "img2"], name="cat_img")(input_data)
-        self.assertTrue("cat_img" in result)
+        self.assertIn("cat_img", result)
         result["cat_img"] += 1
         np.testing.assert_allclose(result["img1"], np.array([[0, 1], [1, 2]]))
         np.testing.assert_allclose(result["cat_img"], np.array([[1, 2], [2, 3], [1, 2], [2, 3]]))

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -185,7 +185,7 @@ class TestConfigParser(unittest.TestCase):
             if id in ("compute", "cls_compute"):
                 parser[f"{id}#_mode_"] = "callable"
             func = parser.get_parsed_content(id=id)
-            self.assertTrue(id in parser.ref_resolver.resolved_content)
+            self.assertIn(id, parser.ref_resolver.resolved_content)
             if id == "error_func":
                 with self.assertRaises(TypeError):
                     func(1, 2)

--- a/tests/test_cucim_dict_transform.py
+++ b/tests/test_cucim_dict_transform.py
@@ -80,8 +80,8 @@ class TestCuCIMDict(unittest.TestCase):
     def test_tramsforms_numpy_single(self, params, input, expected):
         input = {"image": input}
         output = CuCIMd(keys="image", **params)(input)["image"]
-        self.assertTrue(output.dtype == expected.dtype)
-        self.assertTrue(isinstance(output, np.ndarray))
+        self.assertEqual(output.dtype, expected.dtype)
+        self.assertIsInstance(output, np.ndarray)
         cp.testing.assert_allclose(output, expected)
 
     @parameterized.expand(
@@ -98,8 +98,8 @@ class TestCuCIMDict(unittest.TestCase):
         input = {"image": input[cp.newaxis, ...]}
         expected = expected[cp.newaxis, ...]
         output = CuCIMd(keys="image", **params)(input)["image"]
-        self.assertTrue(output.dtype == expected.dtype)
-        self.assertTrue(isinstance(output, np.ndarray))
+        self.assertEqual(output.dtype, expected.dtype)
+        self.assertIsInstance(output, np.ndarray)
         cp.testing.assert_allclose(output, expected)
 
     @parameterized.expand(
@@ -116,8 +116,8 @@ class TestCuCIMDict(unittest.TestCase):
         input = {"image": cp.asarray(input)}
         expected = cp.asarray(expected)
         output = CuCIMd(keys="image", **params)(input)["image"]
-        self.assertTrue(output.dtype == expected.dtype)
-        self.assertTrue(isinstance(output, cp.ndarray))
+        self.assertEqual(output.dtype, expected.dtype)
+        self.assertIsInstance(output, cp.ndarray)
         cp.testing.assert_allclose(output, expected)
 
     @parameterized.expand(
@@ -134,8 +134,8 @@ class TestCuCIMDict(unittest.TestCase):
         input = {"image": cp.asarray(input)[cp.newaxis, ...]}
         expected = cp.asarray(expected)[cp.newaxis, ...]
         output = CuCIMd(keys="image", **params)(input)["image"]
-        self.assertTrue(output.dtype == expected.dtype)
-        self.assertTrue(isinstance(output, cp.ndarray))
+        self.assertEqual(output.dtype, expected.dtype)
+        self.assertIsInstance(output, cp.ndarray)
         cp.testing.assert_allclose(output, expected)
 
 

--- a/tests/test_cucim_transform.py
+++ b/tests/test_cucim_transform.py
@@ -79,8 +79,8 @@ class TestCuCIM(unittest.TestCase):
     )
     def test_tramsforms_numpy_single(self, params, input, expected):
         output = CuCIM(**params)(input)
-        self.assertTrue(output.dtype == expected.dtype)
-        self.assertTrue(isinstance(output, np.ndarray))
+        self.assertEqual(output.dtype, expected.dtype)
+        self.assertIsInstance(output, np.ndarray)
         cp.testing.assert_allclose(output, expected)
 
     @parameterized.expand(
@@ -97,8 +97,8 @@ class TestCuCIM(unittest.TestCase):
         input = input[cp.newaxis, ...]
         expected = expected[cp.newaxis, ...]
         output = CuCIM(**params)(input)
-        self.assertTrue(output.dtype == expected.dtype)
-        self.assertTrue(isinstance(output, np.ndarray))
+        self.assertEqual(output.dtype, expected.dtype)
+        self.assertIsInstance(output, np.ndarray)
         cp.testing.assert_allclose(output, expected)
 
     @parameterized.expand(
@@ -115,8 +115,8 @@ class TestCuCIM(unittest.TestCase):
         input = cp.asarray(input)
         expected = cp.asarray(expected)
         output = CuCIM(**params)(input)
-        self.assertTrue(output.dtype == expected.dtype)
-        self.assertTrue(isinstance(output, cp.ndarray))
+        self.assertEqual(output.dtype, expected.dtype)
+        self.assertIsInstance(output, cp.ndarray)
         cp.testing.assert_allclose(output, expected)
 
     @parameterized.expand(
@@ -133,8 +133,8 @@ class TestCuCIM(unittest.TestCase):
         input = cp.asarray(input)[cp.newaxis, ...]
         expected = cp.asarray(expected)[cp.newaxis, ...]
         output = CuCIM(**params)(input)
-        self.assertTrue(output.dtype == expected.dtype)
-        self.assertTrue(isinstance(output, cp.ndarray))
+        self.assertEqual(output.dtype, expected.dtype)
+        self.assertIsInstance(output, cp.ndarray)
         cp.testing.assert_allclose(output, expected)
 
 

--- a/tests/test_detect_envelope.py
+++ b/tests/test_detect_envelope.py
@@ -147,7 +147,7 @@ class TestDetectEnvelope(unittest.TestCase):
         elif method == "__call__":
             self.assertRaises(ValueError, DetectEnvelope(**arguments), image)
         else:
-            raise ValueError("Expected raising method invalid. Should be __init__ or __call__.")
+            self.fail("Expected raising method invalid. Should be __init__ or __call__.")
 
 
 @SkipIfModule("torch.fft")

--- a/tests/test_ensure_typed.py
+++ b/tests/test_ensure_typed.py
@@ -33,8 +33,8 @@ class TestEnsureTyped(unittest.TestCase):
                     keys="data", data_type=dtype, dtype=np.float32 if dtype == "NUMPY" else None, device="cpu"
                 )({"data": test_data})["data"]
                 if dtype == "NUMPY":
-                    self.assertTrue(result.dtype == np.float32)
-                self.assertTrue(isinstance(result, torch.Tensor if dtype == "tensor" else np.ndarray))
+                    self.assertEqual(result.dtype, np.float32)
+                self.assertIsInstance(result, torch.Tensor if dtype == "tensor" else np.ndarray)
                 assert_allclose(result, test_data, type_test=False)
                 self.assertTupleEqual(result.shape, (2, 2))
 
@@ -45,7 +45,7 @@ class TestEnsureTyped(unittest.TestCase):
         for test_data in test_datas:
             for dtype in ("tensor", "numpy"):
                 result = EnsureTyped(keys="data", data_type=dtype)({"data": test_data})["data"]
-                self.assertTrue(isinstance(result, torch.Tensor if dtype == "tensor" else np.ndarray))
+                self.assertIsInstance(result, torch.Tensor if dtype == "tensor" else np.ndarray)
                 if isinstance(test_data, bool):
                     self.assertFalse(result)
                 else:
@@ -56,11 +56,11 @@ class TestEnsureTyped(unittest.TestCase):
         for dtype in ("tensor", "numpy"):
             # string input
             result = EnsureTyped(keys="data", data_type=dtype)({"data": "test_string"})["data"]
-            self.assertTrue(isinstance(result, str))
+            self.assertIsInstance(result, str)
             self.assertEqual(result, "test_string")
             # numpy array of string
             result = EnsureTyped(keys="data", data_type=dtype)({"data": np.array(["test_string"])})["data"]
-            self.assertTrue(isinstance(result, np.ndarray))
+            self.assertIsInstance(result, np.ndarray)
             self.assertEqual(result[0], "test_string")
 
     def test_list_tuple(self):
@@ -68,15 +68,15 @@ class TestEnsureTyped(unittest.TestCase):
             result = EnsureTyped(keys="data", data_type=dtype, wrap_sequence=False, track_meta=True)(
                 {"data": [[1, 2], [3, 4]]}
             )["data"]
-            self.assertTrue(isinstance(result, list))
-            self.assertTrue(isinstance(result[0][1], MetaTensor if dtype == "tensor" else np.ndarray))
+            self.assertIsInstance(result, list)
+            self.assertIsInstance(result[0][1], MetaTensor if dtype == "tensor" else np.ndarray)
             assert_allclose(result[1][0], torch.as_tensor(3), type_test=False)
             # tuple of numpy arrays
             result = EnsureTyped(keys="data", data_type=dtype, wrap_sequence=False)(
                 {"data": (np.array([1, 2]), np.array([3, 4]))}
             )["data"]
-            self.assertTrue(isinstance(result, tuple))
-            self.assertTrue(isinstance(result[0], torch.Tensor if dtype == "tensor" else np.ndarray))
+            self.assertIsInstance(result, tuple)
+            self.assertIsInstance(result[0], torch.Tensor if dtype == "tensor" else np.ndarray)
             assert_allclose(result[1], torch.as_tensor([3, 4]), type_test=False)
 
     def test_dict(self):
@@ -92,19 +92,19 @@ class TestEnsureTyped(unittest.TestCase):
             )
             for key in ("data", "label"):
                 result = trans[key]
-                self.assertTrue(isinstance(result, dict))
-                self.assertTrue(isinstance(result["img"], torch.Tensor if dtype == "tensor" else np.ndarray))
-                self.assertTrue(isinstance(result["meta"]["size"], torch.Tensor if dtype == "tensor" else np.ndarray))
+                self.assertIsInstance(result, dict)
+                self.assertIsInstance(result["img"], torch.Tensor if dtype == "tensor" else np.ndarray)
+                self.assertIsInstance(result["meta"]["size"], torch.Tensor if dtype == "tensor" else np.ndarray)
                 self.assertEqual(result["meta"]["path"], "temp/test")
                 self.assertEqual(result["extra"], None)
                 assert_allclose(result["img"], torch.as_tensor([1.0, 2.0]), type_test=False)
                 assert_allclose(result["meta"]["size"], torch.as_tensor([1, 2, 3]), type_test=False)
             if dtype == "numpy":
-                self.assertTrue(trans["data"]["img"].dtype == np.float32)
-                self.assertTrue(trans["label"]["img"].dtype == np.int8)
+                self.assertEqual(trans["data"]["img"].dtype, np.float32)
+                self.assertEqual(trans["label"]["img"].dtype, np.int8)
             else:
-                self.assertTrue(trans["data"]["img"].dtype == torch.float32)
-                self.assertTrue(trans["label"]["img"].dtype == torch.int8)
+                self.assertEqual(trans["data"]["img"].dtype, torch.float32)
+                self.asseassertEqualrtTrue(trans["label"]["img"].dtype, torch.int8)
 
 
 if __name__ == "__main__":

--- a/tests/test_ensure_typed.py
+++ b/tests/test_ensure_typed.py
@@ -104,7 +104,7 @@ class TestEnsureTyped(unittest.TestCase):
                 self.assertEqual(trans["label"]["img"].dtype, np.int8)
             else:
                 self.assertEqual(trans["data"]["img"].dtype, torch.float32)
-                self.asseassertEqualrtTrue(trans["label"]["img"].dtype, torch.int8)
+                self.assertEqual(trans["label"]["img"].dtype, torch.int8)
 
 
 if __name__ == "__main__":

--- a/tests/test_flipd.py
+++ b/tests/test_flipd.py
@@ -78,7 +78,7 @@ class TestFlipd(NumpyImageTestCase2D):
     def test_meta_dict(self):
         xform = Flipd("image", [0, 1])
         res = xform({"image": torch.zeros(1, 3, 4)})
-        self.assertTrue(res["image"].applied_operations == res["image_transforms"])
+        self.assertEqual(res["image"].applied_operations, res["image_transforms"])
 
 
 if __name__ == "__main__":

--- a/tests/test_freeze_layers.py
+++ b/tests/test_freeze_layers.py
@@ -40,9 +40,9 @@ class TestModuleState(unittest.TestCase):
 
         for name, param in model.named_parameters():
             if "class_layer" in name:
-                self.assertEqual(param.requires_grad, False)
+                self.assertFalse(param.requires_grad)
             else:
-                self.assertEqual(param.requires_grad, True)
+                self.assertTrue(param.requires_grad)
 
     @parameterized.expand(TEST_CASES)
     def test_exclude_vars(self, device):
@@ -53,9 +53,9 @@ class TestModuleState(unittest.TestCase):
 
         for name, param in model.named_parameters():
             if "class_layer" in name:
-                self.assertEqual(param.requires_grad, True)
+                self.assertTrue(param.requires_grad)
             else:
-                self.assertEqual(param.requires_grad, False)
+                self.assertFalse(param.requires_grad)
 
 
 if __name__ == "__main__":

--- a/tests/test_generalized_dice_loss.py
+++ b/tests/test_generalized_dice_loss.py
@@ -184,7 +184,7 @@ class TestGeneralizedDiceLoss(unittest.TestCase):
 
         generalized_dice_loss = GeneralizedDiceLoss()
         loss = generalized_dice_loss(prediction, target)
-        self.assertNotEqual(loss.grad_fn, None)
+        self.assertIsNotNone(loss.grad_fn)
 
     def test_batch(self):
         prediction = torch.zeros(2, 3, 3, 3)
@@ -194,7 +194,7 @@ class TestGeneralizedDiceLoss(unittest.TestCase):
 
         generalized_dice_loss = GeneralizedDiceLoss(batch=True)
         loss = generalized_dice_loss(prediction, target)
-        self.assertNotEqual(loss.grad_fn, None)
+        self.assertIsNotNone(loss.grad_fn)
 
     def test_script(self):
         loss = GeneralizedDiceLoss()

--- a/tests/test_get_package_version.py
+++ b/tests/test_get_package_version.py
@@ -23,7 +23,7 @@ class TestGetVersion(unittest.TestCase):
         self.assertIn("UNKNOWN", output)
 
         output = get_package_version("numpy")
-        self.assertIn("UNKNOWN", output)
+        self.assertNotIn("UNKNOWN", output)
 
     def test_msg(self):
         output = get_package_version("42foobarnoexist", "test")

--- a/tests/test_get_package_version.py
+++ b/tests/test_get_package_version.py
@@ -20,14 +20,14 @@ class TestGetVersion(unittest.TestCase):
 
     def test_default(self):
         output = get_package_version("42foobarnoexist")
-        self.assertTrue("UNKNOWN" in output)
+        self.assertIn("UNKNOWN", output)
 
         output = get_package_version("numpy")
-        self.assertFalse("UNKNOWN" in output)
+        self.assertIn("UNKNOWN", output)
 
     def test_msg(self):
         output = get_package_version("42foobarnoexist", "test")
-        self.assertTrue("test" in output)
+        self.assertIn("test", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_grid_patch.py
+++ b/tests/test_grid_patch.py
@@ -124,11 +124,11 @@ class TestGridPatch(unittest.TestCase):
             self.assertTrue(output.meta["path"] == expected_meta[0]["path"])
         for output_patch, expected_patch, expected_patch_meta in zip(output, expected, expected_meta):
             assert_allclose(output_patch, expected_patch, type_test=False)
-            self.assertTrue(isinstance(output_patch, MetaTensor))
-            self.assertTrue(output_patch.meta["location"] == expected_patch_meta["location"])
+            self.assertIsInstance(output_patch, MetaTensor)
+            self.assertEqual(output_patch.meta["location"], expected_patch_meta["location"])
             self.assertTrue(output_patch.meta["spatial_shape"], list(output_patch.shape[1:]))
             if "path" in expected_meta[0]:
-                self.assertTrue(output_patch.meta["path"] == expected_patch_meta["path"])
+                self.assertEqual(output_patch.meta["path"], expected_patch_meta["path"])
 
 
 if __name__ == "__main__":

--- a/tests/test_integration_bundle_run.py
+++ b/tests/test_integration_bundle_run.py
@@ -135,9 +135,9 @@ class TestBundleRun(unittest.TestCase):
         command_run = cmd + ["run", "training", "--config_file", config_file, "--meta_file", meta_file]
         completed_process = subprocess.run(command_run, check=True, capture_output=True, text=True)
         output = repr(completed_process.stdout).replace("\\n", "\n").replace("\\t", "\t")  # Get the captured output
-        print(output)
+        # print(output)
 
-        self.assertTrue(expected_condition in output)
+        self.assertIn(expected_condition, output)
         command_run_workflow = cmd + [
             "run_workflow",
             "--run_id",
@@ -149,8 +149,8 @@ class TestBundleRun(unittest.TestCase):
         ]
         completed_process = subprocess.run(command_run_workflow, check=True, capture_output=True, text=True)
         output = repr(completed_process.stdout).replace("\\n", "\n").replace("\\t", "\t")  # Get the captured output
-        print(output)
-        self.assertTrue(expected_condition in output)
+        # print(output)
+        self.assertIn(expected_condition, output)
 
         # test missing meta file
         self.assertIn("ERROR", command_line_tests(cmd + ["run", "training", "--config_file", config_file]))

--- a/tests/test_integration_bundle_run.py
+++ b/tests/test_integration_bundle_run.py
@@ -135,7 +135,6 @@ class TestBundleRun(unittest.TestCase):
         command_run = cmd + ["run", "training", "--config_file", config_file, "--meta_file", meta_file]
         completed_process = subprocess.run(command_run, check=True, capture_output=True, text=True)
         output = repr(completed_process.stdout).replace("\\n", "\n").replace("\\t", "\t")  # Get the captured output
-        # print(output)
 
         self.assertIn(expected_condition, output)
         command_run_workflow = cmd + [
@@ -149,7 +148,6 @@ class TestBundleRun(unittest.TestCase):
         ]
         completed_process = subprocess.run(command_run_workflow, check=True, capture_output=True, text=True)
         output = repr(completed_process.stdout).replace("\\n", "\n").replace("\\t", "\t")  # Get the captured output
-        # print(output)
         self.assertIn(expected_condition, output)
 
         # test missing meta file

--- a/tests/test_inverse_collation.py
+++ b/tests/test_inverse_collation.py
@@ -133,7 +133,7 @@ class TestInverseCollation(unittest.TestCase):
             d = decollate_batch(item)
             self.assertTrue(len(d) <= self.batch_size)
             for b in d:
-                self.assertTrue(isinstance(b["image"], MetaTensor))
+                self.assertIsInstance(b["image"], MetaTensor)
                 np.testing.assert_array_equal(
                     b["image"].applied_operations[-1]["orig_size"], b["label"].applied_operations[-1]["orig_size"]
                 )

--- a/tests/test_load_imaged.py
+++ b/tests/test_load_imaged.py
@@ -190,7 +190,7 @@ class TestLoadImagedMeta(unittest.TestCase):
                 self.assertTrue(hasattr(r, "affine"))
                 self.assertIsInstance(r.affine, torch.Tensor)
                 self.assertEqual(r.meta["space"], "RAS")
-                self.assertTrue("qform_code" not in r.meta)
+                self.assertNotIn("qform_code", r.meta)
             else:
                 self.assertIsInstance(r, torch.Tensor)
                 self.assertNotIsInstance(r, MetaTensor)

--- a/tests/test_look_up_option.py
+++ b/tests/test_look_up_option.py
@@ -56,7 +56,7 @@ class TestLookUpOption(unittest.TestCase):
 
     def test_str_enum(self):
         output = look_up_option("C", {"A", "B"}, default=None)
-        self.assertEqual(output, None)
+        self.assertIsNone(output)
         self.assertEqual(list(_CaseStrEnum), ["A", "B"])
         self.assertEqual(_CaseStrEnum.MODE_A, "A")
         self.assertEqual(str(_CaseStrEnum.MODE_A), "A")

--- a/tests/test_matshow3d.py
+++ b/tests/test_matshow3d.py
@@ -78,7 +78,7 @@ class TestMatshow3d(unittest.TestCase):
         fig, mat = matshow3d(
             [im[keys] for im in ims], title=f"testing {keys}", figsize=(2, 2), frames_per_row=5, every_n=2, show=False
         )
-        self.assertTrue(mat.dtype == np.float32)
+        self.assertEqual(mat.dtype, np.float32)
 
         with tempfile.TemporaryDirectory() as tempdir:
             tempimg = f"{tempdir}/matshow3d_patch_test.png"

--- a/tests/test_mednistdataset.py
+++ b/tests/test_mednistdataset.py
@@ -41,7 +41,7 @@ class TestMedNISTDataset(unittest.TestCase):
             self.assertEqual(len(dataset), int(MEDNIST_FULL_DATASET_LENGTH * dataset.test_frac))
             self.assertTrue("image" in dataset[0])
             self.assertTrue("label" in dataset[0])
-            self.assertTrue(isinstance(dataset[0]["image"], MetaTensor))
+            self.assertIsInstance(dataset[0]["image"], MetaTensor)
             self.assertTupleEqual(dataset[0]["image"].shape, (1, 64, 64))
 
         with skip_if_downloading_fails():

--- a/tests/test_meta_tensor.py
+++ b/tests/test_meta_tensor.py
@@ -222,9 +222,9 @@ class TestMetaTensor(unittest.TestCase):
 
     def test_get_set_meta_fns(self):
         set_track_meta(False)
-        self.assertEqual(get_track_meta(), False)
+        self.assertFalse(get_track_meta())
         set_track_meta(True)
-        self.assertEqual(get_track_meta(), True)
+        self.assertTrue(get_track_meta())
 
     @parameterized.expand(TEST_DEVICES)
     def test_torchscript(self, device):

--- a/tests/test_mmar_download.py
+++ b/tests/test_mmar_download.py
@@ -142,7 +142,7 @@ class TestMMMARDownload(unittest.TestCase):
     def test_unique(self):
         # model ids are unique
         keys = sorted(m["id"] for m in MODEL_DESC)
-        self.assertTrue(keys == sorted(set(keys)))
+        self.assertEqual(keys, sorted(set(keys)))
 
     def test_search(self):
         self.assertEqual(_get_val({"a": 1, "b": 2}, key="b"), 2)

--- a/tests/test_rand_affined.py
+++ b/tests/test_rand_affined.py
@@ -240,7 +240,7 @@ class TestRandAffined(unittest.TestCase):
             resampler.lazy = False
 
         if input_param.get("cache_grid", False):
-            self.assertTrue(g.rand_affine._cached_grid is not None)
+            self.assertIsNotNone(g.rand_affine._cached_grid)
         for key in res:
             if isinstance(key, str) and key.endswith("_transforms"):
                 continue

--- a/tests/test_rand_bias_field.py
+++ b/tests/test_rand_bias_field.py
@@ -39,7 +39,7 @@ class TestRandBiasField(unittest.TestCase):
                 img = p(np.random.rand(*img_shape))
                 output = bias_field(img)
                 np.testing.assert_equal(output.shape, img_shape)
-                self.assertTrue(output.dtype in (np.float32, torch.float32))
+                self.assertIn(output.dtype, (np.float32, torch.float32))
 
                 img_zero = np.zeros([*img_shape])
                 output_zero = bias_field(img_zero)

--- a/tests/test_rand_weighted_cropd.py
+++ b/tests/test_rand_weighted_cropd.py
@@ -154,7 +154,7 @@ class TestRandWeightedCrop(unittest.TestCase):
         crop = RandWeightedCropd(**init_params)
         crop.set_random_state(10)
         result = crop(input_data)
-        self.assertTrue(len(result) == init_params["num_samples"])
+        self.assertEqual(len(result), init_params["num_samples"])
         _len = len(tuple(input_data.keys()))
         self.assertTupleEqual(tuple(result[0].keys())[:_len], tuple(input_data.keys()))
 

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -211,7 +211,7 @@ class TestResNet(unittest.TestCase):
             if input_param.get("feed_forward", True):
                 self.assertEqual(result.shape, expected_shape)
             else:
-                self.assertTrue(result.shape in expected_shape)
+                self.assertIn(result.shape, expected_shape)
 
     @parameterized.expand(PRETRAINED_TEST_CASES)
     @skip_if_quick

--- a/tests/test_to_cupy.py
+++ b/tests/test_to_cupy.py
@@ -62,8 +62,8 @@ class TestToCupy(unittest.TestCase):
         test_data = np.rot90(test_data)
         self.assertFalse(test_data.flags["C_CONTIGUOUS"])
         result = ToCupy(np.uint8)(test_data)
-        self.assertTrue(result.dtype == cp.uint8)
-        self.assertTrue(isinstance(result, cp.ndarray))
+        self.assertEqual(result.dtype, cp.uint8)
+        self.assertIsInstance(result, cp.ndarray)
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         cp.testing.assert_allclose(result, test_data)
 
@@ -72,8 +72,8 @@ class TestToCupy(unittest.TestCase):
         test_data = test_data.rot90()
         self.assertFalse(test_data.is_contiguous())
         result = ToCupy()(test_data)
-        self.assertTrue(result.dtype == cp.float32)
-        self.assertTrue(isinstance(result, cp.ndarray))
+        self.assertEqual(result.dtype, cp.float32)
+        self.assertIsInstance(result, cp.ndarray)
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         cp.testing.assert_allclose(result, test_data)
 
@@ -83,8 +83,8 @@ class TestToCupy(unittest.TestCase):
         test_data = test_data.rot90()
         self.assertFalse(test_data.is_contiguous())
         result = ToCupy()(test_data)
-        self.assertTrue(result.dtype == cp.float32)
-        self.assertTrue(isinstance(result, cp.ndarray))
+        self.assertEqual(result.dtype, cp.float32)
+        self.assertIsInstance(result, cp.ndarray)
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         cp.testing.assert_allclose(result, test_data)
 
@@ -95,8 +95,8 @@ class TestToCupy(unittest.TestCase):
         self.assertFalse(test_data.is_contiguous())
 
         result = ToCupy(dtype="float32")(test_data)
-        self.assertTrue(result.dtype == cp.float32)
-        self.assertTrue(isinstance(result, cp.ndarray))
+        self.assertEqual(result.dtype, cp.float32)
+        self.assertIsInstance(result, cp.ndarray)
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         cp.testing.assert_allclose(result, test_data)
 

--- a/tests/test_to_numpy.py
+++ b/tests/test_to_numpy.py
@@ -32,7 +32,7 @@ class TestToNumpy(unittest.TestCase):
         test_data = cp.rot90(test_data)
         self.assertFalse(test_data.flags["C_CONTIGUOUS"])
         result = ToNumpy()(test_data)
-        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertIsInstance(result, np.ndarray)
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         assert_allclose(result, test_data.get(), type_test=False)
 
@@ -41,8 +41,8 @@ class TestToNumpy(unittest.TestCase):
         test_data = np.rot90(test_data)
         self.assertFalse(test_data.flags["C_CONTIGUOUS"])
         result = ToNumpy(dtype="float32")(test_data)
-        self.assertTrue(isinstance(result, np.ndarray))
-        self.assertTrue(result.dtype == np.float32)
+        self.assertIsInstance(result, np.ndarray)
+        self.assertEqual(result.dtype, np.float32)
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         assert_allclose(result, test_data, type_test=False)
 
@@ -51,7 +51,7 @@ class TestToNumpy(unittest.TestCase):
         test_data = test_data.rot90()
         self.assertFalse(test_data.is_contiguous())
         result = ToNumpy(dtype=torch.uint8)(test_data)
-        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertIsInstance(result, np.ndarray)
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         assert_allclose(result, test_data, type_test=False)
 
@@ -61,7 +61,7 @@ class TestToNumpy(unittest.TestCase):
         test_data = test_data.rot90()
         self.assertFalse(test_data.is_contiguous())
         result = ToNumpy()(test_data)
-        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertIsInstance(result, np.ndarray)
         self.assertTrue(result.flags["C_CONTIGUOUS"])
         assert_allclose(result, test_data, type_test=False)
 
@@ -71,13 +71,13 @@ class TestToNumpy(unittest.TestCase):
         assert_allclose(result, np.asarray(test_data), type_test=False)
         test_data = ((1, 2), (3, 4))
         result = ToNumpy(wrap_sequence=False)(test_data)
-        self.assertTrue(type(result), tuple)
+        self.assertIsInstance(result, tuple)
         assert_allclose(result, ((np.asarray(1), np.asarray(2)), (np.asarray(3), np.asarray(4))))
 
     def test_single_value(self):
         for test_data in [5, np.array(5), torch.tensor(5)]:
             result = ToNumpy(dtype=np.uint8)(test_data)
-            self.assertTrue(isinstance(result, np.ndarray))
+            self.assertIsInstance(result, np.ndarray)
             assert_allclose(result, np.asarray(test_data), type_test=False)
             self.assertEqual(result.ndim, 0)
 

--- a/tests/test_torchvision_fc_model.py
+++ b/tests/test_torchvision_fc_model.py
@@ -195,8 +195,8 @@ class TestLookup(unittest.TestCase):
         mod = look_up_named_module("model.1.submodule.1.submodule.1.submodule.0.conv", net)
         self.assertTrue(str(mod).startswith("Conv2d"))
         self.assertIsInstance(set_named_module(net, "model", torch.nn.Identity()).model, torch.nn.Identity)
-        self.assertEqual(look_up_named_module("model.1.submodule.1.submodule.1.submodule.conv", net), None)
-        self.assertEqual(look_up_named_module("test attribute", net), None)
+        self.assertIsNone(look_up_named_module("model.1.submodule.1.submodule.1.submodule.conv", net))
+        self.assertIsNone(look_up_named_module("test attribute", net))
 
 
 if __name__ == "__main__":

--- a/tests/test_traceable_transform.py
+++ b/tests/test_traceable_transform.py
@@ -33,12 +33,12 @@ class TestTraceable(unittest.TestCase):
         expected_key = "_transforms"
         a = _TraceTest()
         for x in a.transform_info_keys():
-            self.assertTrue(x in a.get_transform_info())
+            self.assertIn(x, a.get_transform_info())
         self.assertEqual(a.trace_key(), expected_key)
 
         data = {"image": "test"}
         data = a(data)  # adds to the stack
-        self.assertTrue(isinstance(data[expected_key], list))
+        self.assertIsInstance(data[expected_key], list)
         self.assertEqual(data[expected_key][0]["class"], "_TraceTest")
 
         data = a(data)  # adds to the stack


### PR DESCRIPTION
### Description

As discussed in PR #7609, I tried to break the suboptimal test refactors to smaller pieces. In this PR all asserts are checking textual content or instance of a parameter.

Suboptimal Assert: Instead of using statements such as assertIsNone, assertIsInstance, always simply use assertTrue or assertFalse. This will decrease the code overall readability and increase the execution time as extra logic needed.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
