### PR TITLE
Always convert input to C-order in distance_transform_edt

### DIFF
--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -2190,7 +2190,7 @@ def distance_transform_edt(
         if return_distances:
             dtype = torch.float64 if float64_distances else torch.float32
             if distances is None:
-                distances = torch.zeros_like(img, dtype=dtype)  # type: ignore
+                distances = torch.zeros_like(img.contiguous(), dtype=dtype)  # type: ignore
             else:
                 if not isinstance(distances, torch.Tensor) and distances.device != img.device:
                     raise TypeError("distances must be a torch.Tensor on the same device as img")

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -2190,7 +2190,7 @@ def distance_transform_edt(
         if return_distances:
             dtype = torch.float64 if float64_distances else torch.float32
             if distances is None:
-                distances = torch.zeros_like(img.contiguous(), dtype=dtype)  # type: ignore
+                distances = torch.zeros_like(img, memory_format=torch.contiguous_format, dtype=dtype)  # type: ignore
             else:
                 if not isinstance(distances, torch.Tensor) and distances.device != img.device:
                     raise TypeError("distances must be a torch.Tensor on the same device as img")

--- a/tests/test_clip_intensity_percentiles.py
+++ b/tests/test_clip_intensity_percentiles.py
@@ -18,7 +18,6 @@ from parameterized import parameterized
 from monai.transforms import ClipIntensityPercentiles
 from monai.transforms.utils import soft_clip
 from monai.transforms.utils_pytorch_numpy_unification import clip, percentile
-from monai.utils.type_conversion import convert_to_tensor
 from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, NumpyImageTestCase3D, assert_allclose
 
 
@@ -30,8 +29,8 @@ class TestClipIntensityPercentiles2D(NumpyImageTestCase2D):
         im = p(self.imt)
         result = hard_clipper(im)
         lower, upper = percentile(im, (5, 95))
-        expected = clip(convert_to_tensor(im), lower, upper)
-        assert_allclose(result, p(expected), type_test="tensor", rtol=1e-7, atol=0)
+        expected = clip(im, lower, upper)
+        assert_allclose(result, p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
     def test_hard_clipping_one_sided_high(self, p):


### PR DESCRIPTION
Fixes #7660

`indices_` may not always be a shallow copy for F-order input as it constantly converts to C-order
https://github.com/Project-MONAI/MONAI/blob/ffd4454b576abd4eaae30b364f41c213e30dca4c/monai/transforms/utils.py#L2209
https://github.com/Project-MONAI/MONAI/blob/ffd4454b576abd4eaae30b364f41c213e30dca4c/monai/utils/type_conversion.py#L262

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
