### PR TITLE
Workaround for B909 in flake8-bugbear

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         name: Unused noqa
         additional_dependencies:
           - flake8>=3.8.1
-          - flake8-bugbear
+          - flake8-bugbear<=24.2.6
           - flake8-comprehensions
           - pep8-naming
         exclude: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ scikit-image>=0.19.0
 tqdm>=4.47.0
 lmdb
 flake8>=3.8.1
-flake8-bugbear
+flake8-bugbear<=24.2.6  # https://github.com/Project-MONAI/MONAI/issues/7690
 flake8-comprehensions
 mccabe
 pep8-naming


### PR DESCRIPTION
Workaround for #7690

### Description
Updated with flake8-bugbear, causing the B909 error. A workaround fix was made for the flake8-bugbear version because the 24.4.21 update contained some false positives.
Fore more information, see https://github.com/PyCQA/flake8-bugbear/issues/467

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
