### PR TITLE
Fix download failing on FIPS machines

### DIFF
--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -135,7 +135,12 @@ def check_hash(filepath: PathLike, val: str | None = None, hash_type: str = "md5
         logger.info(f"Expected {hash_type} is None, skip {hash_type} check for file {filepath}.")
         return True
     actual_hash_func = look_up_option(hash_type.lower(), SUPPORTED_HASH_TYPES)
-    actual_hash = actual_hash_func()
+
+    if sys.version_info >= (3, 9):
+        actual_hash = actual_hash_func(usedforsecurity=False)
+    else:
+        actual_hash = actual_hash_func()
+
     try:
         with open(filepath, "rb") as f:
             for chunk in iter(lambda: f.read(1024 * 1024), b""):

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -137,7 +137,7 @@ def check_hash(filepath: PathLike, val: str | None = None, hash_type: str = "md5
     actual_hash_func = look_up_option(hash_type.lower(), SUPPORTED_HASH_TYPES)
 
     if sys.version_info >= (3, 9):
-        actual_hash = actual_hash_func(usedforsecurity=False)
+        actual_hash = actual_hash_func(usedforsecurity=False)  # allows checks on FIPS enabled machines
     else:
         actual_hash = actual_hash_func()
 


### PR DESCRIPTION
### Description
This PR fixes downloads failing on FIPS enabled machines due to insecure MD5 hashing. The two solutions are to disable MD5 hashing (SHA1 is allowed and faster), or use the `usedforsecurity=False` flag. This PR uses the second method. However, the `usedforsecurity` flag only works for Python 3.9 and later (which was accounted for). Let me know if you have a better implementation to solve this issue.

The error thrown on FIPS enabled machine is:
```ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS```

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
