### PR TITLE
feat(img2tensorboard): plot multiple 2D images as cards in the same tag

### DIFF
--- a/monai/visualize/img2tensorboard.py
+++ b/monai/visualize/img2tensorboard.py
@@ -192,7 +192,7 @@ def plot_2d_or_3d_image(
         dataformats = "HW"
         for j, d2 in enumerate(d[:max_channels]):
             d2 = rescale_array(d2, 0, 1)
-            writer.add_image(f"{tag}_{dataformats}_{j}", d2, step, dataformats=dataformats)
+            writer.add_image(f"{tag}_{dataformats}/{j}", d2, step, dataformats=dataformats)
         return
 
     if d.ndim >= 4:


### PR DESCRIPTION
Fixes #7724.

### Description
This will change the [`plot_2d_or_3d_image`](https://github.com/Project-MONAI/MONAI/blob/dev/monai/visualize/img2tensorboard.py#L146-L211) function to plot multiple 2D images under the same tag as multiple cards rather than each image as a separate tag in TensorBoard. See #7724 for more information and examples at the bottom.

This might not be the optimal way to solve this issue, let me know if you have other ideas.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
