### PR TITLE
Add direct links to github source code to docs

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -2,3 +2,19 @@
 body{font-family:'Roboto',sans-serif;}.wy-menu-vertical p.caption{color:#7cccc7;}
 *{font-variant-ligatures: none;}.autoclasstoc td {padding:0.2rem;line-height:normal;}
 dl.field-list>dt{word-break: normal}
+
+
+/* Instead of showing the [source] link for the github link, show a github icon */
+/* Give the empty span some content to make the background image show up */
+a.external > span.viewcode-link:after {
+    content: "\00a0\00a0\00a0";
+}
+a.external > span.viewcode-link {
+    background: url(https://github.com/favicon.ico);
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+/* Hide the [source] text */
+a.external > span.viewcode-link > span.pre {
+    display:none;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -2,19 +2,3 @@
 body{font-family:'Roboto',sans-serif;}.wy-menu-vertical p.caption{color:#7cccc7;}
 *{font-variant-ligatures: none;}.autoclasstoc td {padding:0.2rem;line-height:normal;}
 dl.field-list>dt{word-break: normal}
-
-
-/* Instead of showing the [source] link for the github link, show a github icon */
-/* Give the empty span some content to make the background image show up */
-a.external > span.viewcode-link:after {
-    content: "\00a0\00a0\00a0";
-}
-a.external > span.viewcode-link {
-    background: url(https://github.com/favicon.ico);
-    background-size: contain;
-    background-repeat: no-repeat;
-}
-/* Hide the [source] text */
-a.external > span.viewcode-link > span.pre {
-    display:none;
-}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -177,11 +177,14 @@ repository = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY)
 base_code_url = f"https://github.com/{repository}/blob/{git_ref}"
 MODULE_ROOT_FOLDER = "monai"
 
+
 # Adjusted from https://github.com/python-websockets/websockets/blob/main/docs/conf.py
 def linkcode_resolve(domain, info):
     if domain != "py":
-        raise ValueError(f"expected domain to be 'py', got {domain}."
-                         "Please adjust linkcode_resolve to either handle this domain or ignore it.")
+        raise ValueError(
+            f"expected domain to be 'py', got {domain}."
+            "Please adjust linkcode_resolve to either handle this domain or ignore it."
+        )
 
     mod = importlib.import_module(info["module"])
     if "." in info["fullname"]:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,8 @@
 import os
 import subprocess
 import sys
+import importlib
+import inspect
 
 sys.path.insert(0, os.path.abspath(".."))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
@@ -96,6 +98,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
+    "sphinx.ext.linkcode",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.autosummary",
     "sphinx_autodoc_typehints",
@@ -162,3 +165,47 @@ def setup(app):
     # Hook to allow for automatic generation of API docs
     # before doc deployment begins.
     app.connect("builder-inited", generate_apidocs)
+
+
+# -- Linkcode configuration --------------------------------------------------
+DEFAULT_REF = "main"
+git_ref = os.environ.get("GITHUB_SHA", DEFAULT_REF)
+
+DEFAULT_REPOSITORY = "Project-MONAI/MONAI"
+repository = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY)
+
+base_code_url = f"https://github.com/{repository}/blob/{git_ref}"
+MODULE_ROOT_FOLDER = "monai"
+
+# Adjusted from https://github.com/python-websockets/websockets/blob/main/docs/conf.py
+def linkcode_resolve(domain, info):
+    if domain != "py":
+        raise ValueError(f"expected domain to be 'py', got {domain}."
+                         "Please adjust linkcode_resolve to either handle this domain or ignore it.")
+
+    mod = importlib.import_module(info["module"])
+    if "." in info["fullname"]:
+        objname, attrname = info["fullname"].split(".")
+        obj = getattr(mod, objname)
+        try:
+            # object is a method of a class
+            obj = getattr(obj, attrname)
+        except AttributeError:
+            # object is an attribute of a class
+            return None
+    else:
+        obj = getattr(mod, info["fullname"])
+
+    try:
+        file = inspect.getsourcefile(obj)
+        lines = inspect.getsourcelines(obj)
+    except TypeError:
+        # e.g. object is a typing.Union
+        return None
+    file = os.path.relpath(file, os.path.abspath(".."))
+    if not file.startswith(MODULE_ROOT_FOLDER):
+        # e.g. object is a typing.NewType
+        return None
+    start, end = lines[1], lines[1] + len(lines[0]) - 1
+    url = f"{base_code_url}/{file}#L{start}-L{end}"
+    return url

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,7 +97,6 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
-    "sphinx.ext.viewcode",
     "sphinx.ext.linkcode",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.autosummary",
@@ -168,8 +167,12 @@ def setup(app):
 
 
 # -- Linkcode configuration --------------------------------------------------
-DEFAULT_REF = "main"
-git_ref = os.environ.get("GITHUB_SHA", DEFAULT_REF)
+DEFAULT_REF = "dev"
+if os.environ.get("GITHUB_REF_TYPE", "branch") == "tag":
+    # When building a tag, link to the tag itself
+    git_ref = os.environ.get("GITHUB_REF", DEFAULT_REF)
+else:
+    git_ref = os.environ.get("GITHUB_SHA", DEFAULT_REF)
 
 DEFAULT_REPOSITORY = "Project-MONAI/MONAI"
 repository = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY)
@@ -201,7 +204,7 @@ def linkcode_resolve(domain, info):
 
     try:
         file = inspect.getsourcefile(obj)
-        lines = inspect.getsourcelines(obj)
+        source, lineno = inspect.getsourcelines(obj)
     except TypeError:
         # e.g. object is a typing.Union
         return None
@@ -209,6 +212,6 @@ def linkcode_resolve(domain, info):
     if not file.startswith(MODULE_ROOT_FOLDER):
         # e.g. object is a typing.NewType
         return None
-    start, end = lines[1], lines[1] + len(lines[0]) - 1
+    start, end = lineno, lineno + len(source) - 1
     url = f"{base_code_url}/{file}#L{start}-L{end}"
     return url


### PR DESCRIPTION

### Description

This adds direct links to the respective source code of classes, methods, etc. to the docs.
In my opinion these nicer and more useful than viewing the source code in copy in the docs.
![image](https://github.com/Project-MONAI/MONAI/assets/20091488/4a6a2650-9fd2-4cd9-a2a1-084cc3a5fb36)

I currently added it in addition to the links to the source files copied into the docs. If desired this could also be done instead of.
I also used a github logo instead of another `[source]` link.
I am not sure whether there is any easier way to change that into the logo than the way I have done, but this one seems to work.


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
