### PR TITLE
Add activation parameter to ResNet

### DIFF
--- a/monai/networks/nets/resnet.py
+++ b/monai/networks/nets/resnet.py
@@ -140,7 +140,7 @@ class ResNetBottleneck(nn.Module):
             spatial_dims: number of spatial dimensions of the input image.
             stride: stride to use for second conv layer.
             downsample: which downsample layer to use.
-            act: activation type and arguments. Defaults to m.
+            act: activation type and arguments. Defaults to relu.
         """
 
         super().__init__()

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -107,7 +107,7 @@ TEST_CASE_3 = [  # 1D, batch 1, 2 input channels
         "num_classes": 3,
         "conv1_t_size": [3],
         "conv1_t_stride": 1,
-        "act": ("relu", {"inplace": False})
+        "act": ("relu", {"inplace": False}),
     },
     (1, 2, 32),
     (1, 3),
@@ -196,7 +196,8 @@ TEST_CASE_8 = [
         "num_classes": 3,
         "conv1_t_size": [3],
         "conv1_t_stride": 1,
-        "act": ("relu", {"inplace": False})},
+        "act": ("relu", {"inplace": False}),
+    },
     (1, 2, 32),
     (1, 3),
 ]

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -107,6 +107,7 @@ TEST_CASE_3 = [  # 1D, batch 1, 2 input channels
         "num_classes": 3,
         "conv1_t_size": [3],
         "conv1_t_stride": 1,
+        "act": ("relu", {"inplace": False})
     },
     (1, 2, 32),
     (1, 3),
@@ -185,13 +186,28 @@ TEST_CASE_7 = [  # 1D, batch 1, 2 input channels, bias_downsample
     (1, 3),
 ]
 
+TEST_CASE_8 = [
+    {
+        "block": "bottleneck",
+        "layers": [3, 4, 6, 3],
+        "block_inplanes": [64, 128, 256, 512],
+        "spatial_dims": 1,
+        "n_input_channels": 2,
+        "num_classes": 3,
+        "conv1_t_size": [3],
+        "conv1_t_stride": 1,
+        "act": ("relu", {"inplace": False})},
+    (1, 2, 32),
+    (1, 3),
+]
+
 TEST_CASES = []
 PRETRAINED_TEST_CASES = []
 for case in [TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_2_A, TEST_CASE_3_A]:
     for model in [resnet10, resnet18, resnet34, resnet50, resnet101, resnet152, resnet200]:
         TEST_CASES.append([model, *case])
         PRETRAINED_TEST_CASES.append([model, *case])
-for case in [TEST_CASE_5, TEST_CASE_5_A, TEST_CASE_6, TEST_CASE_7]:
+for case in [TEST_CASE_5, TEST_CASE_5_A, TEST_CASE_6, TEST_CASE_7, TEST_CASE_8]:
     TEST_CASES.append([ResNet, *case])
 
 TEST_SCRIPT_CASES = [


### PR DESCRIPTION
Fixes #7653 .

### Description
Includes an `act` parameter to `ResNet` and its submodules to allow for passing the `inplace` param. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
