### PR TITLE
Fix doc source links for read the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,7 +168,11 @@ def setup(app):
 
 # -- Linkcode configuration --------------------------------------------------
 DEFAULT_REF = "dev"
-if os.environ.get("GITHUB_REF_TYPE", "branch") == "tag":
+if git_ref := os.environ.get("READTHEDOCS_GIT_IDENTIFIER", None):
+    # When building on ReadTheDocs, link to the specific commit
+    # https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS_GIT_IDENTIFIER
+    git_ref = git_ref
+elif os.environ.get("GITHUB_REF_TYPE", "branch") == "tag":
     # When building a tag, link to the tag itself
     git_ref = os.environ.get("GITHUB_REF", DEFAULT_REF)
 else:
@@ -179,7 +183,7 @@ repository = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY)
 
 base_code_url = f"https://github.com/{repository}/blob/{git_ref}"
 MODULE_ROOT_FOLDER = "monai"
-
+repo_root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 # Adjusted from https://github.com/python-websockets/websockets/blob/main/docs/conf.py
 def linkcode_resolve(domain, info):
@@ -208,7 +212,7 @@ def linkcode_resolve(domain, info):
     except TypeError:
         # e.g. object is a typing.Union
         return None
-    file = os.path.relpath(file, os.path.abspath(".."))
+    file = os.path.relpath(file, repo_root_path)
     if not file.startswith(MODULE_ROOT_FOLDER):
         # e.g. object is a typing.NewType
         return None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -185,6 +185,7 @@ base_code_url = f"https://github.com/{repository}/blob/{git_ref}"
 MODULE_ROOT_FOLDER = "monai"
 repo_root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
+
 # Adjusted from https://github.com/python-websockets/websockets/blob/main/docs/conf.py
 def linkcode_resolve(domain, info):
     if domain != "py":

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,10 +168,11 @@ def setup(app):
 
 # -- Linkcode configuration --------------------------------------------------
 DEFAULT_REF = "dev"
-if git_ref := os.environ.get("READTHEDOCS_GIT_IDENTIFIER", None):
+read_the_docs_ref = os.environ.get("READTHEDOCS_GIT_IDENTIFIER", None)
+if read_the_docs_ref:
     # When building on ReadTheDocs, link to the specific commit
     # https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS_GIT_IDENTIFIER
-    git_ref = git_ref
+    git_ref = read_the_docs_ref
 elif os.environ.get("GITHUB_REF_TYPE", "branch") == "tag":
     # When building a tag, link to the tag itself
     git_ref = os.environ.get("GITHUB_REF", DEFAULT_REF)


### PR DESCRIPTION
Fixes the current docs build.
Currently no [source] links are shown anymore.
It seems like read the docs uses a different working directory, therefore breaking the source links. It also will not have the correct git tag referenced. This should fix both of these issues. 

If there is a way to test if this fix works without merging to dev, let me know.

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
