### PR TITLE
Fix precision issue in TestClipIntensityPercentiles3D 

### DIFF
--- a/tests/test_clip_intensity_percentilesd.py
+++ b/tests/test_clip_intensity_percentilesd.py
@@ -19,7 +19,9 @@ from parameterized import parameterized
 from monai.transforms import ClipIntensityPercentilesd
 from monai.transforms.utils import soft_clip
 from monai.transforms.utils_pytorch_numpy_unification import clip, percentile
+from monai.utils.type_conversion import convert_to_tensor
 from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D, NumpyImageTestCase3D, assert_allclose
+from .test_clip_intensity_percentiles import test_hard_clip_func, test_soft_clip_func
 
 
 class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
@@ -30,8 +32,7 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = percentile(im, (5, 95))
-        expected = clip(im, lower, upper)
+        expected = test_hard_clip_func(im, 5, 95)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -40,8 +41,7 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=None)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = percentile(im, (0, 95))
-        expected = clip(im, lower, upper)
+        expected = test_hard_clip_func(im, 0, 95)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -50,8 +50,7 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=None, lower=5)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = percentile(im, (5, 100))
-        expected = clip(im, lower, upper)
+        expected = test_hard_clip_func(im, 5, 100)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -60,9 +59,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        lower, upper = percentile(im, (5, 95))
-        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=upper, dtype=torch.float32)
-        # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
+        expected = test_soft_clip_func(im, 5, 95)
+        # the rtol is set to 1e-4 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -71,9 +69,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=None, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        upper = percentile(im, 95)
-        expected = soft_clip(im, sharpness_factor=1.0, minv=None, maxv=upper, dtype=torch.float32)
-        # the rtol is set to 5e-5 because the logaddexp function used in softplus is not stable accross torch and numpy
+        expected = test_soft_clip_func(im, None, 95)
+        # the rtol is set to 1e-4 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -82,9 +79,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=None, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        lower = percentile(im, 5)
-        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=None, dtype=torch.float32)
-        # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
+        expected = test_soft_clip_func(im, 5, None)
+        # the rtol is set to 1e-4 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -93,7 +89,8 @@ class TestClipIntensityPercentilesd2D(NumpyImageTestCase2D):
         clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5, channel_wise=True)
         im = p(self.imt)
         result = clipper({key: im})
-        for i, c in enumerate(im):
+        im_t = convert_to_tensor(self.imt)
+        for i, c in enumerate(im_t):
             lower, upper = percentile(c, (5, 95))
             expected = clip(c, lower, upper)
             assert_allclose(result[key][i], p(expected), type_test="tensor", rtol=1e-3, atol=0)
@@ -132,8 +129,7 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = percentile(im, (5, 95))
-        expected = clip(im, lower, upper)
+        expected = test_hard_clip_func(im, 5, 95)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -142,8 +138,7 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=None)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = percentile(im, (0, 95))
-        expected = clip(im, lower, upper)
+        expected = test_hard_clip_func(im, 0, 95)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -152,8 +147,7 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         hard_clipper = ClipIntensityPercentilesd(keys=[key], upper=None, lower=5)
         im = p(self.imt)
         result = hard_clipper({key: im})
-        lower, upper = percentile(im, (5, 100))
-        expected = clip(im, lower, upper)
+        expected = test_hard_clip_func(im, 5, 100)
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -162,8 +156,7 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        lower, upper = percentile(im, (5, 95))
-        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=upper, dtype=torch.float32)
+        expected = test_soft_clip_func(im, 5, 95)
         # the rtol is set to 1e-4 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
@@ -173,9 +166,8 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=None, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        upper = percentile(im, 95)
-        expected = soft_clip(im, sharpness_factor=1.0, minv=None, maxv=upper, dtype=torch.float32)
-        # the rtol is set to 5e-5 because the logaddexp function used in softplus is not stable accross torch and numpy
+        expected = test_soft_clip_func(im, None, 95)
+        # the rtol is set to 1e-4 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
     @parameterized.expand([[p] for p in TEST_NDARRAYS])
@@ -184,8 +176,7 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         soft_clipper = ClipIntensityPercentilesd(keys=[key], upper=None, lower=5, sharpness_factor=1.0)
         im = p(self.imt)
         result = soft_clipper({key: im})
-        lower = percentile(im, 5)
-        expected = soft_clip(im, sharpness_factor=1.0, minv=lower, maxv=None, dtype=torch.float32)
+        expected = test_soft_clip_func(im, 5, None)
         # the rtol is set to 1e-6 because the logaddexp function used in softplus is not stable accross torch and numpy
         assert_allclose(result[key], p(expected), type_test="tensor", rtol=1e-4, atol=0)
 
@@ -195,7 +186,8 @@ class TestClipIntensityPercentilesd3D(NumpyImageTestCase3D):
         clipper = ClipIntensityPercentilesd(keys=[key], upper=95, lower=5, channel_wise=True)
         im = p(self.imt)
         result = clipper({key: im})
-        for i, c in enumerate(im):
+        im_t = convert_to_tensor(im)
+        for i, c in enumerate(im_t):
             lower, upper = percentile(c, (5, 95))
             expected = clip(c, lower, upper)
             assert_allclose(result[key][i], p(expected), type_test="tensor", rtol=1e-4, atol=0)


### PR DESCRIPTION
Fixes #7797

### Description
Ensure the same dtype when test to avoid precision issue.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
