### PR TITLE
Fix the computation of the crop region end index

### DIFF
--- a/monai/apps/detection/transforms/dictionary.py
+++ b/monai/apps/detection/transforms/dictionary.py
@@ -1137,11 +1137,14 @@ class RandCropBoxByPosNegLabeld(Randomizable, MapTransform):
                 extended_boxes[:, axis] = boxes_start[:, axis] - self.spatial_size[axis] // 2 + 1
                 extended_boxes[:, axis + spatial_dims] = boxes_stop[:, axis] + self.spatial_size[axis] // 2 - 1
             else:
+                # the cropper will extend an additional pixel to the left side when the size is even
+                radius_left = self.spatial_size[axis] // 2
+                radius_right = self.spatial_size[axis] - radius_left - 1  # we subtract 1 for the center voxel
                 # extended box start
-                extended_boxes[:, axis] = boxes_stop[:, axis] - self.spatial_size[axis] // 2 - 1
+                extended_boxes[:, axis] = boxes_stop[:, axis] - radius_right
                 extended_boxes[:, axis] = np.minimum(extended_boxes[:, axis], boxes_start[:, axis])
                 # extended box stop
-                extended_boxes[:, axis + spatial_dims] = extended_boxes[:, axis] + self.spatial_size[axis] // 2
+                extended_boxes[:, axis + spatial_dims] = boxes_start[:, axis] + radius_left
                 extended_boxes[:, axis + spatial_dims] = np.maximum(
                     extended_boxes[:, axis + spatial_dims], boxes_stop[:, axis]
                 )


### PR DESCRIPTION
Fixes #7824.

### Description

The main impact of the PR is to change the computation of the end index for the extended box that `RandCropBoxByPosNegLabeld` uses to sample foreground centers in when `self.whole_box = True`. The problem and the fix is described in detail in the issue. 

The PR furthermore makes a minor change to the computation of the start index of the extended box to ensure a center chosen at the margin will fully contain the original box.

I have not run the full test suite, but I have checked that I do not break the relevant unit-test: test_rand_crop_by_pos_neg_labeld.py

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
