### PR TITLE
Add integration with HF Hub

### DIFF
--- a/monai/networks/nets/ahnet.py
+++ b/monai/networks/nets/ahnet.py
@@ -21,6 +21,8 @@ import torch.nn.functional as F
 
 from monai.networks.blocks.fcn import FCN
 from monai.networks.layers.factories import Act, Conv, Norm, Pool
+from monai.utils import MonaiHubMixin
+
 
 __all__ = ["AHnet", "Ahnet", "AHNet"]
 
@@ -300,7 +302,7 @@ class PSP(nn.Module):
         return x
 
 
-class AHNet(nn.Module):
+class AHNet(nn.Module, MonaiHubMixin):
     """
     AHNet based on `Anisotropic Hybrid Network <https://arxiv.org/pdf/1711.08580.pdf>`_.
     Adapted from `lsqshr's official code <https://github.com/lsqshr/AH-Net/blob/master/net3d.py>`_.

--- a/monai/networks/nets/basic_unet.py
+++ b/monai/networks/nets/basic_unet.py
@@ -19,7 +19,8 @@ import torch.nn as nn
 
 from monai.networks.blocks import Convolution, UpSample
 from monai.networks.layers.factories import Conv, Pool
-from monai.utils import ensure_tuple_rep
+from monai.utils import ensure_tuple_rep, MonaiHubMixin
+
 
 __all__ = ["BasicUnet", "Basicunet", "basicunet", "BasicUNet"]
 
@@ -175,7 +176,7 @@ class UpCat(nn.Module):
         return x
 
 
-class BasicUNet(nn.Module):
+class BasicUNet(nn.Module, MonaiHubMixin):
 
     def __init__(
         self,

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -151,3 +151,4 @@ from .type_conversion import (
     get_numpy_dtype_from_string,
     get_torch_dtype_from_string,
 )
+from .hub_mixin import MonaiHubMixin

--- a/monai/utils/hub_mixin.py
+++ b/monai/utils/hub_mixin.py
@@ -1,0 +1,37 @@
+from monai.utils import OptionalImportError
+
+__all__ = ["MonaiHubMixin"]
+
+
+class DummyPyTorchModelHubMixin:
+
+    error_message = "To use `{}` method please required packages: `pip install huggingface_hub safetensors`."
+
+    def __init_subclass__(cls, *args, **kwargs):
+        super().__init_subclass__()
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        raise OptionalImportError(cls.error_message.format("from_pretrained"))
+
+    def save_pretrained(self, *args, **kwargs):
+        raise OptionalImportError(self.error_message.format("save_pretrained"))
+
+    def push_to_hub(self, *args, **kwargs):
+        raise OptionalImportError(self.error_message.format("push_to_hub"))
+
+
+try:
+    from huggingface_hub import PyTorchModelHubMixin
+except ImportError:
+    PyTorchModelHubMixin = DummyPyTorchModelHubMixin
+
+
+class MonaiHubMixin(
+    PyTorchModelHubMixin,
+    library_name="monai",
+    repo_url="https://github.com/Project-MONAI/MONAI",
+    docs_url="https://docs.monai.io/en/",
+    tags=["monai"],
+):
+    pass


### PR DESCRIPTION
### Description

Hi! Amazing repo!

I added [PytorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) to a few models in the repo. This mixin adds a few methods to make it possible to save/load models and share them with the HF hub.

Here is a short example:

```python
from monai.networks.nets import AHNet

net = AHNet()

# save to a local folder
net.save_pretrained("qubvel-hf/ahnet")

# push to HF hub
net.push_to_hub("qubvel-hf/ahnet")

# load form local folder or HF hub
net = AHNet.from_pretrained("qubvel-hf/ahnet")
```

I believe the repo and community may benefit from sharing pretrained models built with this framework!
Let me know it it aligns with your roadmap, I will be happy to complete the PR!

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
