### PR TITLE
Fix 'load_module()' deprecated in Python 3.12

### DIFF
--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 
 import enum
 import functools
+import importlib.util
 import os
 import pdb
 import re
 import sys
 import warnings
-import importlib.util
 from collections.abc import Callable, Collection, Hashable, Mapping
 from functools import partial, wraps
 from importlib import import_module

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -209,7 +209,7 @@ def load_submodules(
     ):
         if (is_pkg or load_all) and name not in sys.modules and match(exclude_pattern, name) is None:
             try:
-                mod_spec = importer.find_spec(name)
+                mod_spec = importer.find_spec(name)  # type: ignore
                 if mod_spec and mod_spec.loader:
                     mod = importlib.util.module_from_spec(mod_spec)
                     mod_spec.loader.exec_module(mod)


### PR DESCRIPTION
Fixes #7880

### Description

use `exec_module` instead.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
