### PR TITLE
Add morphological ops to maisi utils

### DIFF
--- a/monai/apps/generation/maisi/utils/morphological_ops.py
+++ b/monai/apps/generation/maisi/utils/morphological_ops.py
@@ -110,7 +110,10 @@ def get_morphological_filter_result_t(mask_t: Tensor, filter_size: int|Sequence[
     )
 
     # Apply filter operation
-    output = F.conv3d(input_padded, structuring_element, padding=0)/torch.sum(structuring_element)
+    if spatial_dims == 2:
+        output = F.conv2d(input_padded, structuring_element, padding=0)/torch.sum(structuring_element)
+    if spatial_dims == 3:
+        output = F.conv3d(input_padded, structuring_element, padding=0)/torch.sum(structuring_element)
 
     return output
     
@@ -132,7 +135,7 @@ def erode_t(mask_t: Tensor, filter_size: int|Sequence[int] = 3, pad_value: float
     # Set output values based on the minimum value within the structuring element
     output = torch.where(output == 1.0, 1.0, 0.0)
 
-    return output.squeeze(0).squeeze(0)
+    return output
 
 
 def dilate_t(mask_t: Tensor, filter_size: int|Sequence[int] = 3, pad_value: float = 0.0) -> Tensor:
@@ -152,6 +155,6 @@ def dilate_t(mask_t: Tensor, filter_size: int|Sequence[int] = 3, pad_value: floa
     # Set output values based on the minimum value within the structuring element
     output = torch.where(output > 0, 1.0, 0.0)
 
-    return output.squeeze(0).squeeze(0)
+    return output
 
 

--- a/monai/apps/generation/maisi/utils/morphological_ops.py
+++ b/monai/apps/generation/maisi/utils/morphological_ops.py
@@ -37,7 +37,7 @@ def erode(mask: NdarrayOrTensor, filter_size: int|Sequence[int] = 3, pad_value: 
     Args:
         mask: input 2D/3D binary mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
         filter_size: erosion filter size, has to be odd numbers, default to be 3.
-        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
+        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input. Usually use default value and not changed.
 
     Return:
         eroded mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
@@ -55,7 +55,7 @@ def dilate(mask: NdarrayOrTensor, filter_size: int|Sequence[int] = 3, pad_value:
     Args:
         mask: input 2D/3D binary mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
         filter_size: dilation filter size, has to be odd numbers, default to be 3.
-        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
+        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input. Usually use default value and not changed.
 
     Return:
         dilated mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
@@ -107,9 +107,9 @@ def get_morphological_filter_result_t(mask_t: Tensor, filter_size: int|Sequence[
 
     # Apply filter operation
     if spatial_dims == 2:
-        output = F.conv2d(input_padded, structuring_element, padding=0)/torch.sum(structuring_element)
+        output = F.conv2d(input_padded, structuring_element, padding=0)/torch.sum(structuring_element[0,...])
     if spatial_dims == 3:
-        output = F.conv3d(input_padded, structuring_element, padding=0)/torch.sum(structuring_element)
+        output = F.conv3d(input_padded, structuring_element, padding=0)/torch.sum(structuring_element[0,...])
 
     return output
     
@@ -120,7 +120,7 @@ def erode_t(mask_t: Tensor, filter_size: int|Sequence[int] = 3, pad_value: float
     Args:
         mask_t: input 2D/3D binary mask, [N,C,M,N] or [N,C,M,N,P] torch tensor.
         filter_size: erosion filter size, has to be odd numbers, default to be 3.
-        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
+        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input. Usually use default value and not changed.
 
     Return:
         eroded mask, [N,C,M,N] or [N,C,M,N,P] torch tensor
@@ -141,7 +141,7 @@ def dilate_t(mask_t: Tensor, filter_size: int|Sequence[int] = 3, pad_value: floa
     Args:
         mask_t: input 2D/3D binary mask, [N,C,M,N] or [N,C,M,N,P] torch tensor.
         filter_size: dilation filter size, has to be odd numbers, default to be 3.
-        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
+        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input. Usually use default value and not changed.
 
     Return:
         dilated mask, [N,C,M,N] or [N,C,M,N,P] torch tensor

--- a/monai/apps/generation/maisi/utils/morphological_ops.py
+++ b/monai/apps/generation/maisi/utils/morphological_ops.py
@@ -30,7 +30,7 @@ from monai.config import DtypeLike, NdarrayOrTensor
 from monai.bundle import ConfigParser
 from monai.utils.type_conversion import convert_data_type, convert_to_dst_type
 
-def erode(mask: NdarrayTensor, filter_size: int|Sequence[int] = 3, pad_value: float = 1.0) -> NdarrayTensor:
+def erode(mask: NdarrayOrTensor, filter_size: int|Sequence[int] = 3, pad_value: float = 1.0) -> NdarrayOrTensor:
     """
     Erode 2D/3D binary mask.
 
@@ -48,7 +48,7 @@ def erode(mask: NdarrayTensor, filter_size: int|Sequence[int] = 3, pad_value: fl
     res_mask, *_ = convert_to_dst_type(src=res_mask_t, dst=mask)
     return res_mask
 
-def dilate(mask: NdarrayTensor, filter_size: int|Sequence[int] = 3, pad_value: float = 0.0) -> NdarrayTensor:
+def dilate(mask: NdarrayOrTensor, filter_size: int|Sequence[int] = 3, pad_value: float = 0.0) -> NdarrayOrTensor:
     """
     Dilate 2D/3D binary mask.
 

--- a/monai/apps/generation/maisi/utils/morphological_ops.py
+++ b/monai/apps/generation/maisi/utils/morphological_ops.py
@@ -93,17 +93,13 @@ def get_morphological_filter_result_t(mask_t: Tensor, filter_size: int|Sequence[
     )
 
     # Pad the input tensor to handle border pixels
-    pad_size = [
-            filter_size[0] // 2,
-            filter_size[0] // 2,
-            filter_size[1] // 2,
-            filter_size[1] // 2
-    ]
-    if spatial_dims == 3:
-        pad_size = pad_size + [filter_size[2] // 2, filter_size[2] // 2]
+    # Calculate padding size
+    pad_size = []
+    for size in filter_size:
+        pad_size.extend([size // 2, size // 2])
     
     input_padded = F.pad(
-        mask_t.float().unsqueeze(0).unsqueeze(0),
+        mask_t.float(),
         pad_size,
         mode="constant",
         value=pad_value,

--- a/monai/apps/generation/maisi/utils/morphological_ops.py
+++ b/monai/apps/generation/maisi/utils/morphological_ops.py
@@ -41,6 +41,18 @@ def erode(mask: NdarrayOrTensor, filter_size: int|Sequence[int] = 3, pad_value: 
 
     Return:
         eroded mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
+
+    Example:
+
+        .. code-block:: python
+
+            # define a naive network
+            mask = torch.zeros(3,2,3,3,3)
+            mask[:,:,1,1,1] = 1.0
+            filter_size = 3
+            erode_result = morphological_ops.erode(mask,filter_size) # expect torch.zeros(3,2,3,3,3)
+            dilate_result = morphological_ops.dilate(mask,filter_size) # expect torch.ones(3,2,3,3,3)
+            
     """
     mask_t, *_ = convert_data_type(mask, torch.Tensor)
     res_mask_t = erode_t(mask_t, filter_size=filter_size, pad_value=pad_value)
@@ -59,6 +71,17 @@ def dilate(mask: NdarrayOrTensor, filter_size: int|Sequence[int] = 3, pad_value:
 
     Return:
         dilated mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
+
+    Example:
+
+        .. code-block:: python
+
+            # define a naive network
+            mask = torch.zeros(3,2,3,3,3)
+            mask[:,:,1,1,1] = 1.0
+            filter_size = 3
+            erode_result = morphological_ops.erode(mask,filter_size) # expect torch.zeros(3,2,3,3,3)
+            dilate_result = morphological_ops.dilate(mask,filter_size) # expect torch.ones(3,2,3,3,3)
     """
     mask_t, *_ = convert_data_type(mask, torch.Tensor)
     res_mask_t = dilate_t(mask_t, filter_size=filter_size, pad_value=pad_value)

--- a/monai/apps/generation/maisi/utils/morphological_ops.py
+++ b/monai/apps/generation/maisi/utils/morphological_ops.py
@@ -1,0 +1,157 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Sequence
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+import copy
+import numpy as np
+import skimage
+from scipy import stats
+
+from monai.utils import (
+    TransformBackends,
+    convert_data_type,
+    convert_to_dst_type,
+    get_equivalent_dtype,
+    ensure_tuple_rep,
+)
+from monai.config import DtypeLike, NdarrayOrTensor
+from monai.bundle import ConfigParser
+from monai.utils.type_conversion import convert_data_type, convert_to_dst_type
+
+def erode(mask: NdarrayTensor, filter_size: int|Sequence[int] = 3, pad_value: float = 1.0) -> NdarrayTensor:
+    """
+    Erode 2D/3D binary mask.
+
+    Args:
+        mask: input 2D/3D binary mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
+        filter_size: erosion filter size, has to be odd numbers, default to be 3.
+        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
+
+    Return:
+        eroded mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
+    """
+    mask_t, *_ = convert_data_type(mask, torch.Tensor)
+    res_mask_t = erode_t(mask_t, filter_size=filter_size, pad_value=pad_value)
+    res_mask: NdarrayOrTensor
+    res_mask, *_ = convert_to_dst_type(src=res_mask_t, dst=mask)
+    return res_mask
+
+def dilate(mask: NdarrayTensor, filter_size: int|Sequence[int] = 3, pad_value: float = 0.0) -> NdarrayTensor:
+    """
+    Dilate 2D/3D binary mask.
+
+    Args:
+        mask: input 2D/3D binary mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
+        filter_size: dilation filter size, has to be odd numbers, default to be 3.
+        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
+
+    Return:
+        dilated mask, [N,C,M,N] or [N,C,M,N,P] torch tensor or ndarray.
+    """
+    mask_t, *_ = convert_data_type(mask, torch.Tensor)
+    res_mask_t = dilate_t(mask_t, filter_size=filter_size, pad_value=pad_value)
+    res_mask: NdarrayOrTensor
+    res_mask, *_ = convert_to_dst_type(src=res_mask_t, dst=mask)
+    return res_mask
+
+def get_morphological_filter_result_t(mask_t: Tensor, filter_size: int|Sequence[int], pad_value: float) -> Tensor:
+    """
+    Get morphological filter result for 2D/3D mask with data type as torch tensor.
+
+    Args:
+        mask_t: input 2D/3D binary mask, [N,C,M,N] or [N,C,M,N,P] torch tensor.
+        filter_size: morphological filter size, has to be odd numbers.
+        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
+
+    Return:
+        morphological filter result mask, [N,C,M,N] or [N,C,M,N,P] torch tensor
+    """
+    spatial_dims = len(mask_t.shape)-2
+    if spatial_dims not in [2,3]:
+        raise ValueError(f"spatial_dims must be either 2 or 3, yet got spatial_dims={spatial_dims} for mask tensor with shape of {mask_t.shape}.")
+    
+    # Define the structuring element
+    filter_size = ensure_tuple_rep(filter_size, spatial_dims)
+    if any(size % 2 == 0 for size in filter_size):
+        raise ValueError(f"All dimensions in filter_size must be odd numbers, yet got {filter_size}.")
+    
+    filter_shape = [1,1]+list(filter_size)
+    structuring_element = torch.ones(filter_shape).to(
+        mask_t.device
+    )
+
+    # Pad the input tensor to handle border pixels
+    pad_size = [
+            filter_size[0] // 2,
+            filter_size[0] // 2,
+            filter_size[1] // 2,
+            filter_size[1] // 2
+    ]
+    if spatial_dims == 3:
+        pad_size = pad_size + [filter_size[2] // 2, filter_size[2] // 2]
+    
+    input_padded = F.pad(
+        mask_t.float().unsqueeze(0).unsqueeze(0),
+        pad_size,
+        mode="constant",
+        value=pad_value,
+    )
+
+    # Apply erosion operation
+    output = F.conv3d(input_padded, structuring_element, padding=0)
+
+    return output
+    
+def erode_t(mask_t: Tensor, filter_size: int|Sequence[int] = 3, pad_value: float = 1.0) -> Tensor:
+    """
+    Erode 2D/3D binary mask with data type as torch tensor.
+
+    Args:
+        mask_t: input 2D/3D binary mask, [N,C,M,N] or [N,C,M,N,P] torch tensor.
+        filter_size: erosion filter size, has to be odd numbers, default to be 3.
+        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
+
+    Return:
+        eroded mask, [N,C,M,N] or [N,C,M,N,P] torch tensor
+    """
+    
+    output = get_morphological_filter_result_t(mask_t, filter_size, pad_value)
+
+    # Set output values based on the minimum value within the structuring element
+    output = torch.where(output == torch.sum(structuring_element), 1.0, 0.0)
+
+    return output.squeeze(0).squeeze(0)
+
+
+def dilate_t(mask_t: Tensor, filter_size: int|Sequence[int] = 3, pad_value: float = 0.0) -> Tensor:
+    """
+    Dilate 2D/3D binary mask with data type as torch tensor.
+
+    Args:
+        mask_t: input 2D/3D binary mask, [N,C,M,N] or [N,C,M,N,P] torch tensor.
+        filter_size: dilation filter size, has to be odd numbers, default to be 3.
+        pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
+
+    Return:
+        dilated mask, [N,C,M,N] or [N,C,M,N,P] torch tensor
+    """
+    output = get_morphological_filter_result_t(mask_t, filter_size, pad_value)
+
+    # Set output values based on the minimum value within the structuring element
+    output = torch.where(output > 0, 1.0, 0.0)
+
+    return output.squeeze(0).squeeze(0)
+
+

--- a/monai/apps/generation/maisi/utils/morphological_ops.py
+++ b/monai/apps/generation/maisi/utils/morphological_ops.py
@@ -76,7 +76,7 @@ def get_morphological_filter_result_t(mask_t: Tensor, filter_size: int|Sequence[
         pad_value: the filled value for padding. We need to pad the input before filtering to keep the output with the same size as input.
 
     Return:
-        morphological filter result mask, [N,C,M,N] or [N,C,M,N,P] torch tensor
+        Morphological filter result mask, [N,C,M,N] or [N,C,M,N,P] torch tensor
     """
     spatial_dims = len(mask_t.shape)-2
     if spatial_dims not in [2,3]:
@@ -87,7 +87,7 @@ def get_morphological_filter_result_t(mask_t: Tensor, filter_size: int|Sequence[
     if any(size % 2 == 0 for size in filter_size):
         raise ValueError(f"All dimensions in filter_size must be odd numbers, yet got {filter_size}.")
     
-    filter_shape = [1,1]+list(filter_size)
+    filter_shape = [mask_t.shape[1],mask_t.shape[1]]+list(filter_size)
     structuring_element = torch.ones(filter_shape).to(
         mask_t.device
     )

--- a/monai/apps/generation/maisi/utils/morphological_ops.py
+++ b/monai/apps/generation/maisi/utils/morphological_ops.py
@@ -109,8 +109,8 @@ def get_morphological_filter_result_t(mask_t: Tensor, filter_size: int|Sequence[
         value=pad_value,
     )
 
-    # Apply erosion operation
-    output = F.conv3d(input_padded, structuring_element, padding=0)
+    # Apply filter operation
+    output = F.conv3d(input_padded, structuring_element, padding=0)/torch.sum(structuring_element)
 
     return output
     
@@ -130,7 +130,7 @@ def erode_t(mask_t: Tensor, filter_size: int|Sequence[int] = 3, pad_value: float
     output = get_morphological_filter_result_t(mask_t, filter_size, pad_value)
 
     # Set output values based on the minimum value within the structuring element
-    output = torch.where(output == torch.sum(structuring_element), 1.0, 0.0)
+    output = torch.where(output == 1.0, 1.0, 0.0)
 
     return output.squeeze(0).squeeze(0)
 

--- a/tests/test_morphological_ops.py
+++ b/tests/test_morphological_ops.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import unittest
+import torch
 from tests.utils import TEST_NDARRAYS, assert_allclose
 
 from parameterized import parameterized
@@ -28,13 +29,46 @@ for p in TEST_NDARRAYS:
             [1,1,5,5,5],
         ]
     )
+    mask = torch.zeros(3,2,5,5,5)
+    filter_size = 5
+    TESTS_SHAPE.append(
+        [
+            {"mask": p(mask), "filter_size": filter_size},
+            [3,2,5,5,5],
+        ]
+    )
+    mask = torch.zeros(1,1,1,1,1)
+    filter_size = 5
+    TESTS_SHAPE.append(
+        [
+            {"mask": p(mask), "filter_size": filter_size},
+            [1,1,1,1,1],
+        ]
+    )
 
-class TestMorph_shape(unittest.TestCase):
+TESTS_VALUE = []
+for p in TEST_NDARRAYS:
+    mask = torch.zeros(1,1,5,5,5)
+    filter_size = 3
+    TESTS_VALUE.append(
+        [
+            {"mask": p(mask), "filter_size": filter_size},
+            [1,1,5,5,5],
+        ]
+    )
+
+
+class TestMorph(unittest.TestCase):
 
     @parameterized.expand(TESTS_SHAPE)
+    def test_shape(self, input_data, expected_result):
+        result1 = morphological_ops.erode(input_data["mask"],input_data["filter_size"])
+        assert_allclose(result1.shape, expected_result, type_test=False, device_test=False, atol=0.0)
+
+    @parameterized.expand(TESTS_VALUE)
     def test_value(self, input_data, expected_result):
         result1 = morphological_ops.erode(input_data["mask"],input_data["filter_size"])
-        assert_allclose(result2.shape, expected_result, type_test=False, device_test=False, atol=0.0)
+        assert_allclose(result1.shape, expected_result, type_test=False, device_test=False, atol=0.0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_morphological_ops.py
+++ b/tests/test_morphological_ops.py
@@ -1,0 +1,40 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+from tests.utils import TEST_NDARRAYS, assert_allclose
+
+from parameterized import parameterized
+
+from monai.generation.maisi.utils import morphological_ops
+
+TESTS = []
+for p in TEST_NDARRAYS:
+    mask = torch.zeros(1,1,5,5,5)
+    filter_size = 3
+    TESTS.append(
+        [
+            {"mask": p(mask), "filter_size": filter_size},
+            p(torch.zeros(1,1,5,5,5)),
+        ]
+    )
+
+class TestMorph(unittest.TestCase):
+
+    @parameterized.expand(TESTS)
+    def test_value(self, input_data, expected_result):
+        result1 = morphological_ops.erode(input_data["mask"],input_data["filter_size"])
+        assert_allclose(result2, expected_box, type_test=True, device_test=True, atol=0.0)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_morphological_ops.py
+++ b/tests/test_morphological_ops.py
@@ -46,14 +46,61 @@ for p in TEST_NDARRAYS:
         ]
     )
 
+TESTS_VALUE_T = []
+mask = torch.ones(3,2,3,3,3)
+filter_size = 3
+TESTS_VALUE_T.append(
+    [
+        {"mask": mask, "filter_size": filter_size, "pad_value":1.0},
+        torch.ones(3,2,3,3,3)
+    ]
+)
+mask = torch.zeros(3,2,3,3,3)
+filter_size = 3
+TESTS_VALUE_T.append(
+    [
+        {"mask": mask, "filter_size": filter_size, "pad_value":0.0},
+       torch.zeros(3,2,3,3,3)
+    ]
+)
+
 TESTS_VALUE = []
 for p in TEST_NDARRAYS:
-    mask = torch.zeros(1,1,5,5,5)
+    mask = torch.zeros(3,2,5,5,5)
     filter_size = 3
     TESTS_VALUE.append(
         [
             {"mask": p(mask), "filter_size": filter_size},
-            [1,1,5,5,5],
+            p(torch.zeros(3,2,5,5,5)),
+            p(torch.zeros(3,2,5,5,5)),
+        ]
+    )
+    mask = torch.ones(1,1,3,3,3)
+    filter_size = 3
+    TESTS_VALUE.append(
+        [
+            {"mask": p(mask), "filter_size": filter_size},
+            p(torch.ones(1,1,3,3,3)),
+            p(torch.ones(1,1,3,3,3)),
+        ]
+    )
+    mask = torch.ones(1,2,3,3,3)
+    filter_size = 3
+    TESTS_VALUE.append(
+        [
+            {"mask": p(mask), "filter_size": filter_size},
+            p(torch.ones(1,2,3,3,3)),
+            p(torch.ones(1,2,3,3,3)),
+        ]
+    )
+    mask = torch.zeros(3,2,3,3,3)
+    mask[:,:,1,1,1] = 1.0
+    filter_size = 3
+    TESTS_VALUE.append(
+        [
+            {"mask": p(mask), "filter_size": filter_size},
+            p(torch.zeros(3,2,3,3,3)),
+            p(torch.ones(3,2,3,3,3)),
         ]
     )
 
@@ -65,10 +112,19 @@ class TestMorph(unittest.TestCase):
         result1 = morphological_ops.erode(input_data["mask"],input_data["filter_size"])
         assert_allclose(result1.shape, expected_result, type_test=False, device_test=False, atol=0.0)
 
+    @parameterized.expand(TESTS_VALUE_T)
+    def test_value_t(self, input_data, expected_result):
+        result1 = morphological_ops.get_morphological_filter_result_t(input_data["mask"],input_data["filter_size"],input_data["pad_value"])
+        # result1 = morphological_ops.erode(input_data["mask"],input_data["filter_size"])
+        # assert_allclose(result1, expected_erode_result, type_test=True, device_test=True, atol=0.0)
+        assert_allclose(result1, expected_result, type_test=False, device_test=False, atol=0.0)
+
     @parameterized.expand(TESTS_VALUE)
-    def test_value(self, input_data, expected_result):
+    def test_value(self, input_data, expected_erode_result, expected_dilate_result):
         result1 = morphological_ops.erode(input_data["mask"],input_data["filter_size"])
-        assert_allclose(result1.shape, expected_result, type_test=False, device_test=False, atol=0.0)
+        assert_allclose(result1, expected_erode_result, type_test=True, device_test=True, atol=0.0)
+        result2 = morphological_ops.dilate(input_data["mask"],input_data["filter_size"])
+        assert_allclose(result2, expected_dilate_result, type_test=True, device_test=True, atol=0.0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_morphological_ops.py
+++ b/tests/test_morphological_ops.py
@@ -16,25 +16,25 @@ from tests.utils import TEST_NDARRAYS, assert_allclose
 
 from parameterized import parameterized
 
-from monai.generation.maisi.utils import morphological_ops
+from monai.apps.generation.maisi.utils import morphological_ops
 
-TESTS = []
+TESTS_SHAPE = []
 for p in TEST_NDARRAYS:
     mask = torch.zeros(1,1,5,5,5)
     filter_size = 3
-    TESTS.append(
+    TESTS_SHAPE.append(
         [
             {"mask": p(mask), "filter_size": filter_size},
-            p(torch.zeros(1,1,5,5,5)),
+            [1,1,5,5,5],
         ]
     )
 
-class TestMorph(unittest.TestCase):
+class TestMorph_shape(unittest.TestCase):
 
-    @parameterized.expand(TESTS)
+    @parameterized.expand(TESTS_SHAPE)
     def test_value(self, input_data, expected_result):
         result1 = morphological_ops.erode(input_data["mask"],input_data["filter_size"])
-        assert_allclose(result2, expected_box, type_test=True, device_test=True, atol=0.0)
+        assert_allclose(result2.shape, expected_result, type_test=False, device_test=False, atol=0.0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes # .

### Description

Add morphological ops to maisi utils

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
