### PR TITLE
Replace deprecated pkgutil.find_loader use

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -167,7 +167,7 @@ function clang_format {
 }
 
 function is_pip_installed() {
-	return $("${PY_EXE}" -c "import sys, pkgutil; sys.exit(0 if pkgutil.find_loader(sys.argv[1]) else 1)" $1)
+	return $("${PY_EXE}" -c "import sys, importlib.util; sys.exit(0 if importlib.util.find_spec(sys.argv[1]) else 1)" $1)
 }
 
 function clean_py {


### PR DESCRIPTION
### Description

Replace deprecated function with modern version

<string>:1: DeprecationWarning: 'pkgutil.find_loader' is deprecated and slated for removal in Python 3.14; use importlib.util.find_spec() instead


### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
