### PR TITLE
Fix docstring indentation in `SaveImage`

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -307,11 +307,11 @@ class SaveImage(Transform):
 
     Args:
         output_dir: output image directory.
-        Handled by ``folder_layout`` instead, if ``folder_layout`` is not ``None``.
+            Handled by ``folder_layout`` instead, if ``folder_layout`` is not ``None``.
         output_postfix: a string appended to all output file names, default to `trans`.
-        Handled by ``folder_layout`` instead, if ``folder_layout`` is not ``None``.
+            Handled by ``folder_layout`` instead, if ``folder_layout`` is not ``None``.
         output_ext: output file extension name.
-        Handled by ``folder_layout`` instead, if ``folder_layout`` is not ``None``.
+            Handled by ``folder_layout`` instead, if ``folder_layout`` is not ``None``.
         output_dtype: data type (if not None) for saving data. Defaults to ``np.float32``.
         resample: whether to resample image (if needed) before saving the data array,
             based on the ``"spatial_shape"`` (and ``"original_affine"``) from metadata.


### PR DESCRIPTION
### Description

The docstring for `monai.transforms.io.array.SaveImage` had some faulty indentation, causing weirdly formatted documentation on the website. This pull request fixes the indentation.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
