### PR TITLE
Fix incorrect repo name during bundle download

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -438,7 +438,7 @@ def download(
     if repo_ is None:
         org_ = os.getenv("NGC_ORG", None)
         team_ = os.getenv("NGC_TEAM", None)
-        if org_ is not None:
+        if org_ is not None and source_ == "ngc_private":
             repo_ = f"org/{org_}/team/{team_}" if team_ is not None else f"org/{org_}"
         else:
             repo_ = "Project-MONAI/model-zoo/hosting_storage_v1"


### PR DESCRIPTION
Fixes #7928

### Description

Only use env var when source is `ngc_private`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
