### PR TITLE
Add label smoothing param in DiceCELoss

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -733,7 +733,9 @@ class DiceCELoss(_Loss):
             weight=dice_weight,
         )
         if pytorch_after(1, 10):
-            self.cross_entropy = nn.CrossEntropyLoss(weight=weight, reduction=reduction, label_smoothing=label_smoothing)
+            self.cross_entropy = nn.CrossEntropyLoss(
+                weight=weight, reduction=reduction, label_smoothing=label_smoothing
+            )
         else:
             self.cross_entropy = nn.CrossEntropyLoss(weight=weight, reduction=reduction)
         self.binary_cross_entropy = nn.BCEWithLogitsLoss(pos_weight=weight, reduction=reduction)

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -705,8 +705,9 @@ class DiceCELoss(_Loss):
                 Defaults to 1.0.
             lambda_ce: the trade-off weight value for cross entropy loss. The value should be no less than 0.0.
                 Defaults to 1.0.
-            label_smoothing (float): a value in [0, 1] range. If > 0, the labels are smoothed by the given factor to reduce overfitting.
-                Default is 0.0.
+            label_smoothing: a value in [0, 1] range. If > 0, the labels are smoothed
+                by the given factor to reduce overfitting.
+                Defaults to 0.0.
 
         """
         super().__init__()

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -705,6 +705,8 @@ class DiceCELoss(_Loss):
                 Defaults to 1.0.
             lambda_ce: the trade-off weight value for cross entropy loss. The value should be no less than 0.0.
                 Defaults to 1.0.
+            label_smoothing (float): a value in [0, 1] range. If > 0, the labels are smoothed by the given factor to reduce overfitting.
+                Default is 0.0.
 
         """
         super().__init__()
@@ -738,7 +740,6 @@ class DiceCELoss(_Loss):
         self.lambda_dice = lambda_dice
         self.lambda_ce = lambda_ce
         self.old_pt_ver = not pytorch_after(1, 10)
-        self.label_smoothing = label_smoothing
 
     def ce(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -666,6 +666,7 @@ class DiceCELoss(_Loss):
         weight: torch.Tensor | None = None,
         lambda_dice: float = 1.0,
         lambda_ce: float = 1.0,
+        label_smoothing: float = 0.0,
     ) -> None:
         """
         Args:
@@ -728,7 +729,7 @@ class DiceCELoss(_Loss):
             batch=batch,
             weight=dice_weight,
         )
-        self.cross_entropy = nn.CrossEntropyLoss(weight=weight, reduction=reduction)
+        self.cross_entropy = nn.CrossEntropyLoss(weight=weight, reduction=reduction, label_smoothing=label_smoothing)
         self.binary_cross_entropy = nn.BCEWithLogitsLoss(pos_weight=weight, reduction=reduction)
         if lambda_dice < 0.0:
             raise ValueError("lambda_dice should be no less than 0.0.")
@@ -737,6 +738,7 @@ class DiceCELoss(_Loss):
         self.lambda_dice = lambda_dice
         self.lambda_ce = lambda_ce
         self.old_pt_ver = not pytorch_after(1, 10)
+        self.label_smoothing = label_smoothing
 
     def ce(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -732,7 +732,10 @@ class DiceCELoss(_Loss):
             batch=batch,
             weight=dice_weight,
         )
-        self.cross_entropy = nn.CrossEntropyLoss(weight=weight, reduction=reduction, label_smoothing=label_smoothing)
+        if pytorch_after(1, 10):
+            self.cross_entropy = nn.CrossEntropyLoss(weight=weight, reduction=reduction, label_smoothing=label_smoothing)
+        else:
+            self.cross_entropy = nn.CrossEntropyLoss(weight=weight, reduction=reduction)
         self.binary_cross_entropy = nn.BCEWithLogitsLoss(pos_weight=weight, reduction=reduction)
         if lambda_dice < 0.0:
             raise ValueError("lambda_dice should be no less than 0.0.")


### PR DESCRIPTION
Fixes #7957 

### Description
In this modified version I made the following changes:
1. Added `label_smoothing: float = 0.0` parameter in `__init__` method, default value is 0.0.
2. When creating the `self.cross_entropy` instance, pass the `label_smoothing` parameter to `nn.CrossEntropyLoss`.
3. Added `self.label_smoothing = label_smoothing` in the `__init__` method to save this parameter for access when needed.

For example:
```
from monai.losses import DiceCELoss

# Before
criterion = DiceCELoss()
criterion.cross_entropy.label_smoothing = 0.1

# Now
criterion = DiceCELoss(label_smoothing=0.1)
```

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
