### PR TITLE
Remove segment-anything in setup.cfg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install setuptools
       run: |
-        python -m pip install --user --upgrade setuptools wheel
+        python -m pip install --user --upgrade setuptools wheel packaging
     - name: Build and test source archive and wheel file
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
@@ -104,7 +104,7 @@ jobs:
         run: |
           find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
           git describe
-          python -m pip install --user --upgrade setuptools wheel
+          python -m pip install --user --upgrade setuptools wheel packaging
           python setup.py build
           cat build/lib/monai/_version.py
       - name: Upload version

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,6 @@ all =
     nvidia-ml-py
     huggingface_hub
     pyamg>=5.0.0
-    segment-anything
 nibabel =
     nibabel
 ninja =
@@ -168,8 +167,8 @@ huggingface_hub =
     huggingface_hub
 pyamg =
     pyamg>=5.0.0
-segment-anything =
-    segment-anything @ git+https://github.com/facebookresearch/segment-anything@6fdee8f2727f4506cfbbe553e23b895e27956588#egg=segment-anything
+# segment-anything =
+#     segment-anything @ git+https://github.com/facebookresearch/segment-anything@6fdee8f2727f4506cfbbe553e23b895e27956588#egg=segment-anything
 
 [flake8]
 select = B,C,E,F,N,P,T4,W,B9

--- a/tests/ngc_bundle_download.py
+++ b/tests/ngc_bundle_download.py
@@ -127,7 +127,7 @@ class TestAllDownloadingMMAR(unittest.TestCase):
                 in_channels=1,
                 img_size=(96, 96, 96),
                 patch_size=(16, 16, 16),
-                pos_embed="conv",
+                proj_type="conv",
                 hidden_size=768,
                 mlp_dim=3072,
             )

--- a/tests/test_handler_ignite_metric.py
+++ b/tests/test_handler_ignite_metric.py
@@ -172,7 +172,7 @@ class TestHandlerIgniteMetricHandler(unittest.TestCase):
     @parameterized.expand(TEST_CASES[0:2])
     def test_old_ignite_metric(self, input_param, input_data, expected_val):
         loss_fn = DiceLoss(**input_param)
-        ignite_metric = IgniteMetric(loss_fn=loss_fn, output_transform=from_engine(["pred", "label"]))
+        ignite_metric = IgniteMetricHandler(loss_fn=loss_fn, output_transform=from_engine(["pred", "label"]))
 
         def _val_func(engine, batch):
             pass

--- a/tests/test_handler_ignite_metric.py
+++ b/tests/test_handler_ignite_metric.py
@@ -16,7 +16,7 @@ import unittest
 import torch
 from parameterized import parameterized
 
-from monai.handlers import IgniteMetric, IgniteMetricHandler, from_engine
+from monai.handlers import IgniteMetricHandler, from_engine
 from monai.losses import DiceLoss
 from monai.metrics import LossMetric
 from tests.utils import SkipIfNoModule, assert_allclose, optional_import

--- a/tests/test_patchembedding.py
+++ b/tests/test_patchembedding.py
@@ -43,7 +43,7 @@ for dropout_rate in (0.5,):
                                             "patch_size": (patch_size,) * nd,
                                             "hidden_size": hidden_size,
                                             "num_heads": num_heads,
-                                            "pos_embed": proj_type,
+                                            "proj_type": proj_type,
                                             "pos_embed_type": pos_embed_type,
                                             "dropout_rate": dropout_rate,
                                         },
@@ -127,7 +127,7 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
                 patch_size=(16, 16, 16),
                 hidden_size=128,
                 num_heads=12,
-                pos_embed="conv",
+                proj_type="conv",
                 pos_embed_type="sincos",
                 dropout_rate=5.0,
             )
@@ -139,7 +139,7 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
                 patch_size=(64, 64, 64),
                 hidden_size=512,
                 num_heads=8,
-                pos_embed="perceptron",
+                proj_type="perceptron",
                 pos_embed_type="sincos",
                 dropout_rate=0.3,
             )
@@ -151,7 +151,7 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
                 patch_size=(8, 8, 8),
                 hidden_size=512,
                 num_heads=14,
-                pos_embed="conv",
+                proj_type="conv",
                 dropout_rate=0.3,
             )
 
@@ -162,7 +162,7 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
                 patch_size=(4, 4, 4),
                 hidden_size=768,
                 num_heads=8,
-                pos_embed="perceptron",
+                proj_type="perceptron",
                 dropout_rate=0.3,
             )
         with self.assertRaises(ValueError):
@@ -183,7 +183,7 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
                 patch_size=(16, 16, 16),
                 hidden_size=768,
                 num_heads=12,
-                pos_embed="perc",
+                proj_type="perc",
                 dropout_rate=0.3,
             )
 

--- a/tests/test_unetr.py
+++ b/tests/test_unetr.py
@@ -30,7 +30,7 @@ for dropout_rate in [0.4]:
                         for num_heads in [8]:
                             for mlp_dim in [3072]:
                                 for norm_name in ["instance"]:
-                                    for pos_embed in ["perceptron"]:
+                                    for proj_type in ["perceptron"]:
                                         for nd in (2, 3):
                                             test_case = [
                                                 {
@@ -42,7 +42,7 @@ for dropout_rate in [0.4]:
                                                     "norm_name": norm_name,
                                                     "mlp_dim": mlp_dim,
                                                     "num_heads": num_heads,
-                                                    "pos_embed": pos_embed,
+                                                    "proj_type": proj_type,
                                                     "dropout_rate": dropout_rate,
                                                     "conv_block": True,
                                                     "res_block": False,
@@ -75,7 +75,7 @@ class TestUNETR(unittest.TestCase):
                 hidden_size=128,
                 mlp_dim=3072,
                 num_heads=12,
-                pos_embed="conv",
+                proj_type="conv",
                 norm_name="instance",
                 dropout_rate=5.0,
             )
@@ -89,7 +89,7 @@ class TestUNETR(unittest.TestCase):
                 hidden_size=512,
                 mlp_dim=3072,
                 num_heads=12,
-                pos_embed="conv",
+                proj_type="conv",
                 norm_name="instance",
                 dropout_rate=0.5,
             )
@@ -103,7 +103,7 @@ class TestUNETR(unittest.TestCase):
                 hidden_size=512,
                 mlp_dim=3072,
                 num_heads=14,
-                pos_embed="conv",
+                proj_type="conv",
                 norm_name="batch",
                 dropout_rate=0.4,
             )
@@ -117,7 +117,7 @@ class TestUNETR(unittest.TestCase):
                 hidden_size=768,
                 mlp_dim=3072,
                 num_heads=12,
-                pos_embed="perc",
+                proj_type="perc",
                 norm_name="instance",
                 dropout_rate=0.2,
             )

--- a/tests/test_vitautoenc.py
+++ b/tests/test_vitautoenc.py
@@ -23,7 +23,7 @@ TEST_CASE_Vitautoenc = []
 for in_channels in [1, 4]:
     for img_size in [64, 96, 128]:
         for patch_size in [16]:
-            for pos_embed in ["conv", "perceptron"]:
+            for proj_type in ["conv", "perceptron"]:
                 for nd in [2, 3]:
                     test_case = [
                         {
@@ -34,7 +34,7 @@ for in_channels in [1, 4]:
                             "mlp_dim": 3072,
                             "num_layers": 4,
                             "num_heads": 12,
-                            "pos_embed": pos_embed,
+                            "proj_type": proj_type,
                             "dropout_rate": 0.6,
                             "spatial_dims": nd,
                         },
@@ -54,7 +54,7 @@ TEST_CASE_Vitautoenc.append(
             "mlp_dim": 3072,
             "num_layers": 4,
             "num_heads": 12,
-            "pos_embed": "conv",
+            "proj_type": "conv",
             "dropout_rate": 0.6,
             "spatial_dims": 3,
         },
@@ -93,7 +93,7 @@ class TestVitAutoenc(unittest.TestCase):
         ]
     )
     def test_ill_arg(
-        self, in_channels, img_size, patch_size, hidden_size, mlp_dim, num_layers, num_heads, pos_embed, dropout_rate
+        self, in_channels, img_size, patch_size, hidden_size, mlp_dim, num_layers, num_heads, proj_type, dropout_rate
     ):
         with self.assertRaises(ValueError):
             ViTAutoEnc(
@@ -104,7 +104,7 @@ class TestVitAutoenc(unittest.TestCase):
                 mlp_dim=mlp_dim,
                 num_layers=num_layers,
                 num_heads=num_heads,
-                pos_embed=pos_embed,
+                proj_type=proj_type,
                 dropout_rate=dropout_rate,
             )
 


### PR DESCRIPTION
Fixes #8009

### Description

Remove segment-anything in setup.cfg

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
