### PR TITLE
Move PyType test to weekly test

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -1,8 +1,11 @@
 name: weekly-preview
 
 on:
-  schedule:
-  - cron: "0 2 * * 0"  # 02:00 of every Sunday
+  # schedule:
+  # - cron: "0 2 * * 0"  # 02:00 of every Sunday
+  pull_request:
+    head_ref-ignore:
+      - dev
 
 jobs:
   flake8-py3:

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -1,11 +1,8 @@
 name: weekly-preview
 
 on:
-  # schedule:
-  # - cron: "0 2 * * 0"  # 02:00 of every Sunday
-  pull_request:
-    head_ref-ignore:
-      - dev
+  schedule:
+  - cron: "0 2 * * 0"  # 02:00 of every Sunday
 
 jobs:
   flake8-py3:

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -5,6 +5,39 @@ on:
   - cron: "0 2 * * 0"  # 02:00 of every Sunday
 
 jobs:
+  flake8-py3:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        opt: ["codeformat", "pytype", "mypy"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - name: cache weekly timestamp
+      id: pip-cache
+      run: |
+        echo "datew=$(date '+%Y-%V')" >> $GITHUB_OUTPUT
+    - name: cache for pip
+      uses: actions/cache@v4
+      id: cache
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
+    - name: Install dependencies
+      run: |
+        find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
+        python -m pip install --upgrade pip wheel
+        python -m pip install -r requirements-dev.txt
+    - name: Lint and type check
+      run: |
+        # clean up temporary files
+        $(pwd)/runtests.sh --build --clean
+        # Github actions have 2 cores, so parallelize pytype
+        $(pwd)/runtests.sh --build --${{ matrix.opt }} -j 2
+
   packaging:
     if: github.repository == 'Project-MONAI/MONAI'
     runs-on: ubuntu-latest
@@ -19,7 +52,7 @@ jobs:
         python-version: '3.9'
     - name: Install setuptools
       run: |
-        python -m pip install --user --upgrade setuptools wheel
+        python -m pip install --user --upgrade setuptools wheel packaging
     - name: Build distribution
       run: |
         export HEAD_COMMIT_ID=$(git rev-parse HEAD)


### PR DESCRIPTION
Fixes #8022

### Description

- Add format test to weekly test
- Set pytype test as not required in each PR
- Add packaging in weekly-preview pipeline

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
