### PR TITLE
Fix AttributeError when using torch.min and max

### DIFF
--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -480,7 +480,7 @@ def max(x: NdarrayTensor, dim: int | tuple | None = None, **kwargs) -> NdarrayTe
         else:
             ret = torch.max(x, int(dim), **kwargs)  # type: ignore
 
-    if isinstance(ret, tuple):
+    if isinstance(ret, (torch.return_types.max, torch.return_types.min)):
         return ret.values
     return ret
 
@@ -548,7 +548,7 @@ def min(x: NdarrayTensor, dim: int | tuple | None = None, **kwargs) -> NdarrayTe
         else:
             ret = torch.min(x, int(dim), **kwargs)  # type: ignore
 
-    if isinstance(ret, tuple):
+    if isinstance(ret, (torch.return_types.max, torch.return_types.min)):
         return ret.values
     return ret
 

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -480,9 +480,7 @@ def max(x: NdarrayTensor, dim: int | tuple | None = None, **kwargs) -> NdarrayTe
         else:
             ret = torch.max(x, int(dim), **kwargs)  # type: ignore
 
-    if isinstance(ret, (torch.return_types.max, torch.return_types.min)):
-        return ret.values
-    return ret
+    return ret[0] if isinstance(ret, tuple) else ret
 
 
 def mean(x: NdarrayTensor, dim: int | tuple | None = None, **kwargs) -> NdarrayTensor:
@@ -548,9 +546,7 @@ def min(x: NdarrayTensor, dim: int | tuple | None = None, **kwargs) -> NdarrayTe
         else:
             ret = torch.min(x, int(dim), **kwargs)  # type: ignore
 
-    if isinstance(ret, (torch.return_types.max, torch.return_types.min)):
-        return ret.values
-    return ret
+    return ret[0] if isinstance(ret, tuple) else ret
 
 
 def std(x: NdarrayTensor, dim: int | tuple | None = None, unbiased: bool = False) -> NdarrayTensor:

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -546,6 +546,8 @@ def min(x: NdarrayTensor, dim: int | tuple | None = None, **kwargs) -> NdarrayTe
         else:
             ret = torch.min(x, int(dim), **kwargs)  # type: ignore
 
+    if isinstance(ret, tuple):
+        return ret.values
     return ret
 
 

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -480,6 +480,8 @@ def max(x: NdarrayTensor, dim: int | tuple | None = None, **kwargs) -> NdarrayTe
         else:
             ret = torch.max(x, int(dim), **kwargs)  # type: ignore
 
+    if isinstance(ret, tuple):
+        return ret.values
     return ret
 
 

--- a/tests/test_utils_pytorch_numpy_unification.py
+++ b/tests/test_utils_pytorch_numpy_unification.py
@@ -17,7 +17,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.transforms.utils_pytorch_numpy_unification import min, max, mode, percentile
+from monai.transforms.utils_pytorch_numpy_unification import max, min, mode, percentile
 from monai.utils import set_determinism
 from tests.utils import TEST_NDARRAYS, assert_allclose, skip_if_quick
 

--- a/tests/test_utils_pytorch_numpy_unification.py
+++ b/tests/test_utils_pytorch_numpy_unification.py
@@ -17,7 +17,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.transforms.utils_pytorch_numpy_unification import mode, percentile, min
+from monai.transforms.utils_pytorch_numpy_unification import min, max, mode, percentile
 from monai.utils import set_determinism
 from tests.utils import TEST_NDARRAYS, assert_allclose, skip_if_quick
 
@@ -27,10 +27,12 @@ for p in TEST_NDARRAYS:
     TEST_MODE.append([p(np.array([3.1, 4.1, 4.1, 5.1])), p(4.1), False])
     TEST_MODE.append([p(np.array([3.1, 4.1, 4.1, 5.1])), p(4), True])
 
-TEST_MIN = []
+TEST_MIN_MAX = []
 for p in TEST_NDARRAYS:
-    TEST_MIN.append([p(np.array([1, 2, 3, 4, 4, 5])), {}, p(1)])
-    TEST_MIN.append([p(np.array([[3.1, 4.1, 4.1, 5.1], [3, 5, 4.1, 5]])), {"dim": 1}, p([3.1, 3. ])])
+    TEST_MIN_MAX.append([p(np.array([1, 2, 3, 4, 4, 5])), {}, min, p(1)])
+    TEST_MIN_MAX.append([p(np.array([[3.1, 4.1, 4.1, 5.1], [3, 5, 4.1, 5]])), {"dim": 1}, min, p([3.1, 3])])
+    TEST_MIN_MAX.append([p(np.array([1, 2, 3, 4, 4, 5])), {}, max, p(5)])
+    TEST_MIN_MAX.append([p(np.array([[3.1, 4.1, 4.1, 5.1], [3, 5, 4.1, 5]])), {"dim": 1}, max, p([5.1, 5])])
 
 
 class TestPytorchNumpyUnification(unittest.TestCase):
@@ -78,10 +80,10 @@ class TestPytorchNumpyUnification(unittest.TestCase):
     def test_mode(self, array, expected, to_long):
         res = mode(array, to_long=to_long)
         assert_allclose(res, expected)
-    
-    @parameterized.expand(TEST_MIN)
-    def test_min(self, array, input_params, expected):
-        res = min(array, **input_params)
+
+    @parameterized.expand(TEST_MIN_MAX)
+    def test_min_max(self, array, input_params, func, expected):
+        res = func(array, **input_params)
         assert_allclose(res, expected, type_test=False)
 
 

--- a/tests/test_utils_pytorch_numpy_unification.py
+++ b/tests/test_utils_pytorch_numpy_unification.py
@@ -17,7 +17,7 @@ import numpy as np
 import torch
 from parameterized import parameterized
 
-from monai.transforms.utils_pytorch_numpy_unification import mode, percentile
+from monai.transforms.utils_pytorch_numpy_unification import mode, percentile, min
 from monai.utils import set_determinism
 from tests.utils import TEST_NDARRAYS, assert_allclose, skip_if_quick
 
@@ -26,6 +26,11 @@ for p in TEST_NDARRAYS:
     TEST_MODE.append([p(np.array([1, 2, 3, 4, 4, 5])), p(4), False])
     TEST_MODE.append([p(np.array([3.1, 4.1, 4.1, 5.1])), p(4.1), False])
     TEST_MODE.append([p(np.array([3.1, 4.1, 4.1, 5.1])), p(4), True])
+
+TEST_MIN = []
+for p in TEST_NDARRAYS:
+    TEST_MIN.append([p(np.array([1, 2, 3, 4, 4, 5])), {}, p(1)])
+    TEST_MIN.append([p(np.array([[3.1, 4.1, 4.1, 5.1], [3, 5, 4.1, 5]])), {"dim": 1}, p([3.1, 3. ])])
 
 
 class TestPytorchNumpyUnification(unittest.TestCase):
@@ -73,6 +78,11 @@ class TestPytorchNumpyUnification(unittest.TestCase):
     def test_mode(self, array, expected, to_long):
         res = mode(array, to_long=to_long)
         assert_allclose(res, expected)
+    
+    @parameterized.expand(TEST_MIN)
+    def test_min(self, array, input_params, expected):
+        res = min(array, **input_params)
+        assert_allclose(res, expected, type_test=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #8040.

### Description

Only return values if got a namedtuple when using torch.min and max

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
