### PR TITLE
Fix transpose and patch coords bug

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -35,9 +35,11 @@ pydicom
 h5py
 nni; platform_system == "Linux"
 optuna
+opencv-python-headless
 onnx>=1.13.0
 onnxruntime; python_version <= '3.10'
 zarr
 huggingface_hub
 pyamg>=5.0.0
 packaging
+polygraphy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -35,7 +35,6 @@ pydicom
 h5py
 nni; platform_system == "Linux"
 optuna
-opencv-python-headless
 onnx>=1.13.0
 onnxruntime; python_version <= '3.10'
 zarr

--- a/monai/apps/vista3d/sampler.py
+++ b/monai/apps/vista3d/sampler.py
@@ -58,16 +58,16 @@ def sample_prompt_pairs(
         labels: [1, 1, H, W, D], ground truth labels.
         label_set: the label list for the specific dataset. Note if 0 is included in label_set,
             it will be added into automatic branch training. Recommend removing 0 from label_set
-            for multi-partially-labeled-dataset training, and adding 0 for finetuning specific dataset.
-            The reason is region with 0 in one partially labeled dataset may contain foregrounds in
-            another dataset.
+            for multi-partially-labeled-dataset training, and adding 0 for finetuning specific dataset. 
+            The reason is region with 0 in one partially labeled dataset may contain foregrounds in 
+            another dataset. 
         max_prompt: int, max number of total prompt, including foreground and background.
         max_foreprompt: int, max number of prompt from foreground.
         max_backprompt: int, max number of prompt from background.
         max_point: maximum number of points for each object.
         include_background: if include 0 into training prompt. If included, background 0 is treated
-            the same as foreground. Always be False for multi-partial-dataset training. If needed,
-            can be true for finetuning specific dataset, .
+            the same as foreground and points will be sampled. Can be true only if user want to segment 
+            background 0 with point clicks, otherwise always be false. 
         drop_label_prob: probability to drop label prompt.
         drop_point_prob: probability to drop point prompt.
         point_sampler: sampler to augment masks with supervoxel.
@@ -76,12 +76,13 @@ def sample_prompt_pairs(
     Returns:
         label_prompt: [B, 1]. The classes used for training automatic segmentation.
         point: [B, N, 3]. The corresponding points for each class.
-        Note that background label prompt requires matching point as well ([0,0,0] is used).
+            Note that background label prompt requires matching point as well ([0,0,0] is used).
         point_label: [B, N]. The corresponding point labels for each point (negative or positive).
-        -1 is used for padding the background label prompt and will be ignored.
+            -1 is used for padding the background label prompt and will be ignored.
         prompt_class: [B, 1], exactly the same with label_prompt for label indexing for training loss.
         label_prompt can be None, and prompt_class is used to identify point classes.
     """
+
     # class label number
     if not labels.shape[0] == 1:
         raise ValueError("only support batch size 1")

--- a/monai/apps/vista3d/sampler.py
+++ b/monai/apps/vista3d/sampler.py
@@ -37,7 +37,6 @@ def _get_point_label(id: int) -> tuple[int, int]:
     else:
         return 0, 1
 
-
 def sample_prompt_pairs(
     labels: Tensor,
     label_set: Sequence[int],

--- a/monai/apps/vista3d/sampler.py
+++ b/monai/apps/vista3d/sampler.py
@@ -58,16 +58,16 @@ def sample_prompt_pairs(
         labels: [1, 1, H, W, D], ground truth labels.
         label_set: the label list for the specific dataset. Note if 0 is included in label_set,
             it will be added into automatic branch training. Recommend removing 0 from label_set
-            for multi-partially-labeled-dataset training, and adding 0 for finetuning specific dataset. 
-            The reason is region with 0 in one partially labeled dataset may contain foregrounds in 
-            another dataset. 
+            for multi-partially-labeled-dataset training, and adding 0 for finetuning specific dataset.
+            The reason is region with 0 in one partially labeled dataset may contain foregrounds in
+            another dataset.
         max_prompt: int, max number of total prompt, including foreground and background.
         max_foreprompt: int, max number of prompt from foreground.
         max_backprompt: int, max number of prompt from background.
         max_point: maximum number of points for each object.
         include_background: if include 0 into training prompt. If included, background 0 is treated
-            the same as foreground and points will be sampled. Can be true only if user want to segment 
-            background 0 with point clicks, otherwise always be false. 
+            the same as foreground and points will be sampled. Can be true only if user want to segment
+            background 0 with point clicks, otherwise always be false.
         drop_label_prob: probability to drop label prompt.
         drop_point_prob: probability to drop point prompt.
         point_sampler: sampler to augment masks with supervoxel.

--- a/monai/apps/vista3d/sampler.py
+++ b/monai/apps/vista3d/sampler.py
@@ -22,6 +22,7 @@ from torch import Tensor
 
 __all__ = ["sample_prompt_pairs"]
 
+
 ENABLE_SPECIAL = True
 SPECIAL_INDEX = (23, 24, 25, 26, 27, 57, 128)
 MERGE_LIST = {
@@ -82,7 +83,6 @@ def sample_prompt_pairs(
         prompt_class: [B, 1], exactly the same with label_prompt for label indexing for training loss.
             label_prompt can be None, and prompt_class is used to identify point classes.
     """
-
     # class label number
     if not labels.shape[0] == 1:
         raise ValueError("only support batch size 1")

--- a/monai/apps/vista3d/sampler.py
+++ b/monai/apps/vista3d/sampler.py
@@ -37,6 +37,7 @@ def _get_point_label(id: int) -> tuple[int, int]:
     else:
         return 0, 1
 
+
 def sample_prompt_pairs(
     labels: Tensor,
     label_set: Sequence[int],
@@ -74,16 +75,16 @@ def sample_prompt_pairs(
 
     Returns:
         tuple:
-            - label_prompt (Tensor | None): Tensor of shape [B, 1] containing the classes used for 
+            - label_prompt (Tensor | None): Tensor of shape [B, 1] containing the classes used for
               training automatic segmentation.
-            - point (Tensor | None): Tensor of shape [B, N, 3] representing the corresponding points 
-              for each class. Note that background label prompts require matching points as well 
+            - point (Tensor | None): Tensor of shape [B, N, 3] representing the corresponding points
+              for each class. Note that background label prompts require matching points as well
               (e.g., [0, 0, 0] is used).
-            - point_label (Tensor | None): Tensor of shape [B, N] representing the corresponding point 
-              labels for each point (negative or positive). -1 is used for padding the background 
+            - point_label (Tensor | None): Tensor of shape [B, N] representing the corresponding point
+              labels for each point (negative or positive). -1 is used for padding the background
               label prompt and will be ignored.
-            - prompt_class (Tensor | None): Tensor of shape [B, 1], exactly the same as label_prompt 
-              for label indexing during training. If label_prompt is None, prompt_class is used to 
+            - prompt_class (Tensor | None): Tensor of shape [B, 1], exactly the same as label_prompt
+              for label indexing during training. If label_prompt is None, prompt_class is used to
               identify point classes.
 
     """

--- a/monai/apps/vista3d/sampler.py
+++ b/monai/apps/vista3d/sampler.py
@@ -73,13 +73,19 @@ def sample_prompt_pairs(
         point_sampler_kwargs: arguments for point_sampler.
 
     Returns:
-        label_prompt: [B, 1]. The classes used for training automatic segmentation.
-        point: [B, N, 3]. The corresponding points for each class.
-            Note that background label prompt requires matching point as well ([0,0,0] is used).
-        point_label: [B, N]. The corresponding point labels for each point (negative or positive).
-            -1 is used for padding the background label prompt and will be ignored.
-        prompt_class: [B, 1], exactly the same with label_prompt for label indexing for training loss.
-            label_prompt can be None, and prompt_class is used to identify point classes.
+        tuple:
+            - label_prompt (Tensor | None): Tensor of shape [B, 1] containing the classes used for 
+              training automatic segmentation.
+            - point (Tensor | None): Tensor of shape [B, N, 3] representing the corresponding points 
+              for each class. Note that background label prompts require matching points as well 
+              (e.g., [0, 0, 0] is used).
+            - point_label (Tensor | None): Tensor of shape [B, N] representing the corresponding point 
+              labels for each point (negative or positive). -1 is used for padding the background 
+              label prompt and will be ignored.
+            - prompt_class (Tensor | None): Tensor of shape [B, 1], exactly the same as label_prompt 
+              for label indexing during training. If label_prompt is None, prompt_class is used to 
+              identify point classes.
+
     """
 
     # class label number

--- a/monai/apps/vista3d/sampler.py
+++ b/monai/apps/vista3d/sampler.py
@@ -20,9 +20,6 @@ import numpy as np
 import torch
 from torch import Tensor
 
-__all__ = ["sample_prompt_pairs"]
-
-
 ENABLE_SPECIAL = True
 SPECIAL_INDEX = (23, 24, 25, 26, 27, 57, 128)
 MERGE_LIST = {
@@ -30,6 +27,8 @@ MERGE_LIST = {
     4: [24],  # pancreatic tumor merge into pancreas
     132: [57],  # overlap with trachea merge into airway
 }
+
+__all__ = ["sample_prompt_pairs"]
 
 
 def _get_point_label(id: int) -> tuple[int, int]:
@@ -83,6 +82,7 @@ def sample_prompt_pairs(
         prompt_class: [B, 1], exactly the same with label_prompt for label indexing for training loss.
             label_prompt can be None, and prompt_class is used to identify point classes.
     """
+
     # class label number
     if not labels.shape[0] == 1:
         raise ValueError("only support batch size 1")

--- a/monai/apps/vista3d/sampler.py
+++ b/monai/apps/vista3d/sampler.py
@@ -80,7 +80,7 @@ def sample_prompt_pairs(
         point_label: [B, N]. The corresponding point labels for each point (negative or positive).
             -1 is used for padding the background label prompt and will be ignored.
         prompt_class: [B, 1], exactly the same with label_prompt for label indexing for training loss.
-        label_prompt can be None, and prompt_class is used to identify point classes.
+            label_prompt can be None, and prompt_class is used to identify point classes.
     """
 
     # class label number

--- a/monai/networks/nets/vista3d.py
+++ b/monai/networks/nets/vista3d.py
@@ -336,11 +336,11 @@ class VISTA3D(nn.Module):
     def forward(
         self,
         input_images: torch.Tensor,
+        patch_coords: Sequence[slice] | None = None,
         point_coords: torch.Tensor | None = None,
         point_labels: torch.Tensor | None = None,
         class_vector: torch.Tensor | None = None,
         prompt_class: torch.Tensor | None = None,
-        patch_coords: Sequence[slice] | None = None,
         labels: torch.Tensor | None = None,
         label_set: Sequence[int] | None = None,
         prev_mask: torch.Tensor | None = None,
@@ -421,7 +421,10 @@ class VISTA3D(nn.Module):
                     point_coords, point_labels = None, None
 
         if point_coords is None and class_vector is None:
-            return self.NINF_VALUE + torch.zeros([bs, 1, *image_size], device=device)
+            logits = self.NINF_VALUE + torch.zeros([bs, 1, *image_size], device=device)
+            if transpose:
+                logits = logits.transpose(1, 0)
+            return logits
 
         if self.image_embeddings is not None and kwargs.get("keep_cache", False) and class_vector is None:
             out, out_auto = self.image_embeddings, None


### PR DESCRIPTION
Fixes # .

### Description

Fix the bug that causes wrong results in model zoo finetuning. Patch coords was not passed from sliding window to vista3d.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
