### PR TITLE
BUG: fixed wrong space directions interpretation in nrrd reader

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -1359,7 +1359,7 @@ class NrrdReader(ImageReader):
         x, y = direction.shape
         affine_diam = min(x, y) + 1
         affine: np.ndarray = np.eye(affine_diam)
-        affine[:x, :y] = direction
+        affine[:x, :y] = direction.T
         affine[: (affine_diam - 1), -1] = origin  # len origin is always affine_diam - 1
         return affine
 

--- a/tests/test_nrrd_reader.py
+++ b/tests/test_nrrd_reader.py
@@ -40,8 +40,8 @@ TEST_CASE_8 = [
         "dimension": 4,
         "space": "left-posterior-superior",
         "sizes": [3, 4, 4, 1],
-        "space directions": [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
-        "space origin": [0.0, 0.0, 0.0],
+        "space directions": [[0.7, 0.0, 0.0], [0.0, 0.0, -0.8], [0.0, 0.9, 0.0]],
+        "space origin": [1.0, 5.0, 20.0],
     },
 ]
 
@@ -110,6 +110,10 @@ class TestNrrdReader(unittest.TestCase):
         np.testing.assert_allclose(image_array, test_image)
         self.assertIsInstance(image_header, dict)
         self.assertTupleEqual(tuple(image_header["spatial_shape"]), expected_shape)
+        np.testing.assert_allclose(
+            image_header["affine"],
+            np.array([[-0.7, 0.0, 0.0, -1.0], [0.0, 0.0, -0.9, -5.0], [0.0, -0.8, 0.0, 20.0], [0.0, 0.0, 0.0, 1.0]]),
+        )
 
     @parameterized.expand([TEST_CASE_8])
     def test_read_with_header_index_order_c(self, data_shape, filename, expected_shape, dtype, reference_header):


### PR DESCRIPTION
the vectors presented for space directions are column vectors

ref: https://teem.sourceforge.net/nrrd/format.html#spacedirections

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
