### PR TITLE
Re-adding load_submodules 

### DIFF
--- a/monai/__init__.py
+++ b/monai/__init__.py
@@ -80,24 +80,28 @@ if sys.version_info.major != PY_REQUIRED_MAJOR or sys.version_info.minor < PY_RE
     )
 
 
-from . import (  # noqa: E402
-    apps,
-    auto3dseg,
-    bundle,
-    config,
-    data,
-    engines,
-    fl,
-    handlers,
-    inferers,
-    losses,
-    metrics,
-    networks,
-    optimizers,
-    transforms,
-    utils,
-    visualize,
+from .utils.module import load_submodules  # noqa: E402
+
+# handlers_* have some external decorators the users may not have installed
+# *.so files and folder "_C" may not exist when the cpp extensions are not compiled
+excludes = "|".join(
+    [
+        "(^(monai.handlers))",
+        "(^(monai.bundle))",
+        "(^(monai.fl))",
+        "((\\.so)$)",
+        "(^(monai._C))",
+        "(.*(__main__)$)",
+        "(.*(video_dataset)$)",
+        "(.*(nnunet).*$)",
+    ]
 )
+
+# load directory modules only, skip loading individual files
+load_submodules(sys.modules[__name__], False, exclude_pattern=excludes)
+
+# load all modules, this will trigger all export decorations
+load_submodules(sys.modules[__name__], True, exclude_pattern=excludes)
 
 __all__ = [
     "apps",

--- a/monai/utils/__init__.py
+++ b/monai/utils/__init__.py
@@ -112,6 +112,7 @@ from .module import (
     get_package_version,
     get_torch_version_tuple,
     instantiate,
+    load_submodules,
     look_up_option,
     min_version,
     optional_import,

--- a/tests/min_tests.py
+++ b/tests/min_tests.py
@@ -232,6 +232,12 @@ def run_testsuit():
 
 
 if __name__ == "__main__":
+    # testing import submodules
+    from monai.utils.module import load_submodules
+
+    _, err_mod = load_submodules(sys.modules["monai"], True)
+    assert not err_mod, f"err_mod={err_mod} not empty"
+
     # testing all modules
     test_runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=2)
     result = test_runner.run(run_testsuit())


### PR DESCRIPTION
### Description

This restores load_modules for now to resolve importation issues. Doing a two-pass loading process seems to allow some references which normally Python wouldn't permit. The fact that these issues weren't caught in testing is rather strange, and only showed up when symbols in `monai.apps` were references in bundles. I'm not sure if this is all related to circular imports, if parts of MONAI aren't being tested properly, or the way the symbol resolution works within `monai.bundle` should be improved. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
