### PR TITLE
Add options to skip operations for RestoreLabeld Transform

### DIFF
--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -803,6 +803,14 @@ class RestoreLabeld(MapTransform):
         original_shape_key: key that records original shape for foreground.
         cropped_shape_key: key that records cropped shape for foreground.
         allow_missing_keys: don't raise exception if key is missing.
+        restore_resizing: used to enable or disable resizing restoration, default is True.
+            If True, the transform will resize the items back to its original shape using metadata information.
+        restore_cropping: used to enable or disable cropping restoration, default is True.
+            If True, the transform will restore the items to its uncropped size using the stored coordinates of the original bounding box.
+        restore_spacing: used to enable or disable spacing restoration, default is True.
+            If True, the transform will use metadata to resample the items back to the spacing it had before being altered.
+        restore_slicing: used to enable or disable slicing restoration, default is True.
+            If True, the transform will reassemble the full volume by restoring the slices to their original positions.
     """
 
     def __init__(
@@ -819,8 +827,8 @@ class RestoreLabeld(MapTransform):
         original_shape_key: str = "foreground_original_shape",
         cropped_shape_key: str = "foreground_cropped_shape",
         allow_missing_keys: bool = False,
-        restore_resize: bool = True,
-        restore_crop: bool = True,
+        restore_resizing: bool = True,
+        restore_cropping: bool = True,
         restore_spacing: bool = True,
         restore_slicing: bool = True,
     ) -> None:
@@ -837,8 +845,8 @@ class RestoreLabeld(MapTransform):
         self.end_coord_key = end_coord_key
         self.original_shape_key = original_shape_key
         self.cropped_shape_key = cropped_shape_key
-        self.restore_resize = restore_resize
-        self.restore_crop = restore_crop
+        self.restore_resizing = restore_resizing
+        self.restore_cropping = restore_cropping
         self.restore_spacing = restore_spacing
         self.restore_slicing = restore_slicing
 
@@ -850,7 +858,7 @@ class RestoreLabeld(MapTransform):
             image = d[key]
 
             # Undo Resize
-            if self.restore_resize:
+            if self.restore_resizing:
                 current_shape = image.shape
                 cropped_shape = meta_dict[self.cropped_shape_key]
                 if np.any(np.not_equal(current_shape, cropped_shape)):
@@ -858,7 +866,7 @@ class RestoreLabeld(MapTransform):
                     image = resizer(image, mode=mode, align_corners=align_corners)
 
             # Undo Crop
-            if self.restore_crop:
+            if self.restore_cropping:
                 original_shape = meta_dict[self.original_shape_key]
                 result = np.zeros(original_shape, dtype=np.float32)
                 box_start = meta_dict[self.start_coord_key]

--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -886,7 +886,7 @@ class RestoreLabeld(MapTransform):
             # Undo Slicing
             slice_idx = meta_dict.get("slice_idx")
             final_result: NdarrayOrTensor
-            if self.restore_slicing == False:
+            if not self.restore_slicing:  # do nothing if restore slicing isn't requested
                 final_result = result
             elif slice_idx is None or self.slice_only:
                 final_result = result if len(result.shape) <= 3 else result[0]

--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -804,11 +804,11 @@ class RestoreLabeld(MapTransform):
         cropped_shape_key: key that records cropped shape for foreground.
         allow_missing_keys: don't raise exception if key is missing.
         restore_resizing: used to enable or disable resizing restoration, default is True.
-            If True, the transform will resize the items back to its original shape using metadata information.
+            If True, the transform will resize the items back to its original shape.
         restore_cropping: used to enable or disable cropping restoration, default is True.
-            If True, the transform will restore the items to its uncropped size using the stored coordinates of the original bounding box.
+            If True, the transform will restore the items to its uncropped size.
         restore_spacing: used to enable or disable spacing restoration, default is True.
-            If True, the transform will use metadata to resample the items back to the spacing it had before being altered.
+            If True, the transform will resample the items back to the spacing it had before being altered.
         restore_slicing: used to enable or disable slicing restoration, default is True.
             If True, the transform will reassemble the full volume by restoring the slices to their original positions.
     """

--- a/tests/test_deepgrow_transforms.py
+++ b/tests/test_deepgrow_transforms.py
@@ -328,8 +328,8 @@ RESULT[4:8, 4:8, 4:8] = np.array(
 )
 
 RESTORE_LABEL_TEST_CASE_2 = [
-    {"keys": ["pred"], "ref_image": "image", "mode": "nearest"}, 
-    DATA_11, 
+    {"keys": ["pred"], "ref_image": "image", "mode": "nearest"},
+    DATA_11,
     RESULT
 ]
 
@@ -348,13 +348,13 @@ for layer in range(5, 10):
 
 RESTORE_LABEL_TEST_CASE_3 = [
     {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_crop": False},
-    DATA_11, 
+    DATA_11,
     RESTORE_LABEL_TEST_CASE_3_RESULT,
 ]
 
 RESTORE_LABEL_TEST_CASE_4 = [
-    {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_resize": False, "restore_spacing": False, "restore_slicing": False, "restore_crop": False}, 
-    DATA_11, 
+    {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_resize": False, "restore_spacing": False, "restore_slicing": False, "restore_crop": False},
+    DATA_11,
     np.array([[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]),
 ]
 

--- a/tests/test_deepgrow_transforms.py
+++ b/tests/test_deepgrow_transforms.py
@@ -362,20 +362,10 @@ RESTORE_LABEL_TEST_CASE_3 = [
 
 RESTORE_LABEL_TEST_CASE_4_RESULT = np.zeros((4, 8, 8))
 RESTORE_LABEL_TEST_CASE_4_RESULT[1, 2:6, 2:6] = np.array(
-    [
-        [10., 10., 20., 20.],
-        [10., 10., 20., 20.],
-        [30., 30., 40., 40.],
-        [30., 30., 40., 40.]
-    ]
+    [[10.0, 10.0, 20.0, 20.0], [10.0, 10.0, 20.0, 20.0], [30.0, 30.0, 40.0, 40.0], [30.0, 30.0, 40.0, 40.0]]
 )
 RESTORE_LABEL_TEST_CASE_4_RESULT[2, 2:6, 2:6] = np.array(
-    [
-        [50., 50., 60., 60.],
-        [50., 50., 60., 60.],
-        [70., 70., 80., 80.],
-        [70., 70., 80., 80.]
-    ]
+    [[50.0, 50.0, 60.0, 60.0], [50.0, 50.0, 60.0, 60.0], [70.0, 70.0, 80.0, 80.0], [70.0, 70.0, 80.0, 80.0]]
 )
 
 RESTORE_LABEL_TEST_CASE_4 = [
@@ -385,18 +375,8 @@ RESTORE_LABEL_TEST_CASE_4 = [
 ]
 
 RESTORE_LABEL_TEST_CASE_5_RESULT = np.zeros((4, 4, 4))
-RESTORE_LABEL_TEST_CASE_5_RESULT[1, 1:3, 1:3] = np.array(
-    [
-        [10., 20.],
-        [30., 40.]
-    ]
-)
-RESTORE_LABEL_TEST_CASE_5_RESULT[2, 1:3, 1:3] = np.array(
-    [
-        [50., 60.],
-        [70., 80.]
-    ]
-)
+RESTORE_LABEL_TEST_CASE_5_RESULT[1, 1:3, 1:3] = np.array([[10.0, 20.0], [30.0, 40.0]])
+RESTORE_LABEL_TEST_CASE_5_RESULT[2, 1:3, 1:3] = np.array([[50.0, 60.0], [70.0, 80.0]])
 
 RESTORE_LABEL_TEST_CASE_5 = [
     {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_spacing": False},
@@ -406,20 +386,10 @@ RESTORE_LABEL_TEST_CASE_5 = [
 
 RESTORE_LABEL_TEST_CASE_6_RESULT = np.zeros((1, 4, 8, 8))
 RESTORE_LABEL_TEST_CASE_6_RESULT[-1, 1, 2:6, 2:6] = np.array(
-    [
-        [10., 10., 20., 20.],
-        [10., 10., 20., 20.],
-        [30., 30., 40., 40.],
-        [30., 30., 40., 40.]
-    ]
+    [[10.0, 10.0, 20.0, 20.0], [10.0, 10.0, 20.0, 20.0], [30.0, 30.0, 40.0, 40.0], [30.0, 30.0, 40.0, 40.0]]
 )
 RESTORE_LABEL_TEST_CASE_6_RESULT[-1, 2, 2:6, 2:6] = np.array(
-    [
-        [50., 50., 60., 60.],
-        [50., 50., 60., 60.],
-        [70., 70., 80., 80.],
-        [70., 70., 80., 80.]
-    ]
+    [[50.0, 50.0, 60.0, 60.0], [50.0, 50.0, 60.0, 60.0], [70.0, 70.0, 80.0, 80.0], [70.0, 70.0, 80.0, 80.0]]
 )
 
 RESTORE_LABEL_TEST_CASE_6 = [
@@ -566,7 +536,7 @@ class TestRestoreLabeld(unittest.TestCase):
             RESTORE_LABEL_TEST_CASE_4,
             RESTORE_LABEL_TEST_CASE_5,
             RESTORE_LABEL_TEST_CASE_6,
-            RESTORE_LABEL_TEST_CASE_7
+            RESTORE_LABEL_TEST_CASE_7,
         ]
     )
     def test_correct_results(self, arguments, input_data, expected_result):

--- a/tests/test_deepgrow_transforms.py
+++ b/tests/test_deepgrow_transforms.py
@@ -312,7 +312,7 @@ RESIZE_GUIDANCE_TEST_CASE_1 = [
 ]
 
 RESTORE_LABEL_TEST_CASE_1 = [
-    {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_resize": True, "restore_crop": True, "restore_spacing": True, "restore_slicing": True},
+    {"keys": ["pred"], "ref_image": "image", "mode": "nearest"},
     DATA_10,
     np.array([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]),
 ]

--- a/tests/test_deepgrow_transforms.py
+++ b/tests/test_deepgrow_transforms.py
@@ -312,7 +312,7 @@ RESIZE_GUIDANCE_TEST_CASE_1 = [
 ]
 
 RESTORE_LABEL_TEST_CASE_1 = [
-    {"keys": ["pred"], "ref_image": "image", "mode": "nearest"},
+    {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_resize": True, "restore_crop": True, "restore_spacing": True, "restore_slicing": True},
     DATA_10,
     np.array([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]),
 ]
@@ -327,7 +327,36 @@ RESULT[4:8, 4:8, 4:8] = np.array(
     ]
 )
 
-RESTORE_LABEL_TEST_CASE_2 = [{"keys": ["pred"], "ref_image": "image", "mode": "nearest"}, DATA_11, RESULT]
+RESTORE_LABEL_TEST_CASE_2 = [
+    {"keys": ["pred"], "ref_image": "image", "mode": "nearest"}, 
+    DATA_11, 
+    RESULT
+]
+
+RESTORE_LABEL_TEST_CASE_3_RESULT = np.zeros((10, 20, 20))
+for layer in range(5):
+    RESTORE_LABEL_TEST_CASE_3_RESULT[layer, 0:10, 0:10] = 1
+    RESTORE_LABEL_TEST_CASE_3_RESULT[layer, 0:10, 10:20] = 2
+    RESTORE_LABEL_TEST_CASE_3_RESULT[layer, 10:20, 0:10] = 3
+    RESTORE_LABEL_TEST_CASE_3_RESULT[layer, 10:20, 10:20] = 4
+
+for layer in range(5, 10):
+    RESTORE_LABEL_TEST_CASE_3_RESULT[layer, 0:10, 0:10] = 5
+    RESTORE_LABEL_TEST_CASE_3_RESULT[layer, 0:10, 10:20] = 6
+    RESTORE_LABEL_TEST_CASE_3_RESULT[layer, 10:20, 0:10] = 7
+    RESTORE_LABEL_TEST_CASE_3_RESULT[layer, 10:20, 10:20] = 8
+
+RESTORE_LABEL_TEST_CASE_3 = [
+    {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_crop": False},
+    DATA_11, 
+    RESTORE_LABEL_TEST_CASE_3_RESULT,
+]
+
+RESTORE_LABEL_TEST_CASE_4 = [
+    {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_resize": False, "restore_spacing": False, "restore_slicing": False, "restore_crop": False}, 
+    DATA_11, 
+    np.array([[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]),
+]
 
 FETCH_2D_SLICE_TEST_CASE_1 = [
     {"keys": ["image"], "guidance": "guidance"},
@@ -445,7 +474,7 @@ class TestResizeGuidanced(unittest.TestCase):
 
 class TestRestoreLabeld(unittest.TestCase):
 
-    @parameterized.expand([RESTORE_LABEL_TEST_CASE_1, RESTORE_LABEL_TEST_CASE_2])
+    @parameterized.expand([RESTORE_LABEL_TEST_CASE_1, RESTORE_LABEL_TEST_CASE_2, RESTORE_LABEL_TEST_CASE_3, RESTORE_LABEL_TEST_CASE_4])
     def test_correct_results(self, arguments, input_data, expected_result):
         result = RestoreLabeld(**arguments)(input_data)
         np.testing.assert_allclose(result["pred"], expected_result)

--- a/tests/test_deepgrow_transforms.py
+++ b/tests/test_deepgrow_transforms.py
@@ -327,11 +327,7 @@ RESULT[4:8, 4:8, 4:8] = np.array(
     ]
 )
 
-RESTORE_LABEL_TEST_CASE_2 = [
-    {"keys": ["pred"], "ref_image": "image", "mode": "nearest"},
-    DATA_11,
-    RESULT
-]
+RESTORE_LABEL_TEST_CASE_2 = [{"keys": ["pred"], "ref_image": "image", "mode": "nearest"}, DATA_11, RESULT]
 
 RESTORE_LABEL_TEST_CASE_3_RESULT = np.zeros((10, 20, 20))
 for layer in range(5):
@@ -347,13 +343,21 @@ for layer in range(5, 10):
     RESTORE_LABEL_TEST_CASE_3_RESULT[layer, 10:20, 10:20] = 8
 
 RESTORE_LABEL_TEST_CASE_3 = [
-    {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_crop": False},
+    {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_cropping": False},
     DATA_11,
     RESTORE_LABEL_TEST_CASE_3_RESULT,
 ]
 
 RESTORE_LABEL_TEST_CASE_4 = [
-    {"keys": ["pred"], "ref_image": "image", "mode": "nearest", "restore_resize": False, "restore_spacing": False, "restore_slicing": False, "restore_crop": False},
+    {
+        "keys": ["pred"],
+        "ref_image": "image",
+        "mode": "nearest",
+        "restore_resizing": False,
+        "restore_cropping": False,
+        "restore_spacing": False,
+        "restore_slicing": False,
+    },
     DATA_11,
     np.array([[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]),
 ]
@@ -474,7 +478,9 @@ class TestResizeGuidanced(unittest.TestCase):
 
 class TestRestoreLabeld(unittest.TestCase):
 
-    @parameterized.expand([RESTORE_LABEL_TEST_CASE_1, RESTORE_LABEL_TEST_CASE_2, RESTORE_LABEL_TEST_CASE_3, RESTORE_LABEL_TEST_CASE_4])
+    @parameterized.expand(
+        [RESTORE_LABEL_TEST_CASE_1, RESTORE_LABEL_TEST_CASE_2, RESTORE_LABEL_TEST_CASE_3, RESTORE_LABEL_TEST_CASE_4]
+    )
     def test_correct_results(self, arguments, input_data, expected_result):
         result = RestoreLabeld(**arguments)(input_data)
         np.testing.assert_allclose(result["pred"], expected_result)

--- a/tests/test_deepgrow_transforms.py
+++ b/tests/test_deepgrow_transforms.py
@@ -560,12 +560,12 @@ class TestRestoreLabeld(unittest.TestCase):
 
     @parameterized.expand(
         [
-            RESTORE_LABEL_TEST_CASE_1, 
-            RESTORE_LABEL_TEST_CASE_2, 
-            RESTORE_LABEL_TEST_CASE_3, 
-            RESTORE_LABEL_TEST_CASE_4, 
-            RESTORE_LABEL_TEST_CASE_5, 
-            RESTORE_LABEL_TEST_CASE_6, 
+            RESTORE_LABEL_TEST_CASE_1,
+            RESTORE_LABEL_TEST_CASE_2,
+            RESTORE_LABEL_TEST_CASE_3,
+            RESTORE_LABEL_TEST_CASE_4,
+            RESTORE_LABEL_TEST_CASE_5,
+            RESTORE_LABEL_TEST_CASE_6,
             RESTORE_LABEL_TEST_CASE_7
         ]
     )

--- a/tests/test_spade_vaegan.py
+++ b/tests/test_spade_vaegan.py
@@ -62,9 +62,7 @@ def create_semantic_data(shape: list, semantic_regions: int):
                 start_point[0] : (start_point[0] + shape_square[0]),
                 start_point[1] : (start_point[1] + shape_square[1]),
                 start_point[2] : (start_point[2] + shape_square[2]),
-            ] = (
-                base_intensity + torch.randn(shape_square) * 0.1
-            )
+            ] = (base_intensity + torch.randn(shape_square) * 0.1)
         else:
             ValueError("Supports only 2D and 3D tensors")
 

--- a/tests/test_spade_vaegan.py
+++ b/tests/test_spade_vaegan.py
@@ -62,7 +62,9 @@ def create_semantic_data(shape: list, semantic_regions: int):
                 start_point[0] : (start_point[0] + shape_square[0]),
                 start_point[1] : (start_point[1] + shape_square[1]),
                 start_point[2] : (start_point[2] + shape_square[2]),
-            ] = (base_intensity + torch.randn(shape_square) * 0.1)
+            ] = (
+                base_intensity + torch.randn(shape_square) * 0.1
+            )
         else:
             ValueError("Supports only 2D and 3D tensors")
 


### PR DESCRIPTION
Fixes #6380 

### Description

Four new bool parameters are added into `RestoreLabeld` to allow users to selectively enable or disable each restoration operation as needed, and a corresponding test case is added to verify that the function runs correctly.

This design allows users to selectively enable or disable each restoration operation as needed, providing greater flexibility.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
