### PR TITLE
Apply pyupgrade fixes for Python 3.9+ syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -26,15 +26,15 @@ repos:
         args: ['--autofix', '--no-sort-keys', '--indent=4']
       - id: end-of-file-fixer
       - id: mixed-line-ending
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.3.5
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.0
     hooks:
     -   id: ruff
         args:
         - --fix
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -52,7 +52,7 @@ repos:
         files: (?x)(^monai/networks/)
 
   - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: yesqa
         name: Unused noqa

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: v3.19.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
         name: Upgrade code excluding monai networks
         exclude: |
           (?x)(
@@ -49,7 +49,7 @@ repos:
               ^monai/data/grid_dataset.py
           )
       - id: pyupgrade
-        args: [--py37-plus, --keep-runtime-typing]
+        args: [--py38-plus, --keep-runtime-typing]
         name: Upgrade monai networks
         files: (?x)(
                    ^monai/networks/|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,25 +37,16 @@ repos:
     rev: v3.19.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
-        name: Upgrade code excluding monai networks
+        args: [--py38-plus, --keep-runtime-typing]
+        name: Upgrade code with exceptions
         exclude: |
           (?x)(
               ^versioneer.py|
               ^monai/_version.py|
-              ^monai/networks/|  # no PEP 604 for torchscript tensorrt
-              ^monai/losses/|  # no PEP 604 for torchscript tensorrt
-              ^monai/data/utils.py|
-              ^monai/data/grid_dataset.py
+              ^monai/networks/| # avoid typing rewrites
+              ^monai/apps/detection/utils/anchor_utils.py| # avoid typing rewrites
+              ^tests/test_compute_panoptic_quality.py # avoid typing rewrites
           )
-      - id: pyupgrade
-        args: [--py38-plus, --keep-runtime-typing]
-        name: Upgrade monai networks
-        files: (?x)(
-                   ^monai/networks/|
-                   ^monai/data/utils.py|
-                   ^monai/data/grid_dataset.py
-                )
 
   - repo: https://github.com/asottile/yesqa
     rev: v1.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,12 +44,18 @@ repos:
               ^versioneer.py|
               ^monai/_version.py|
               ^monai/networks/|  # no PEP 604 for torchscript tensorrt
-              ^monai/losses/  # no PEP 604 for torchscript tensorrt
+              ^monai/losses/|  # no PEP 604 for torchscript tensorrt
+              ^monai/data/utils.py|
+              ^monai/data/grid_dataset.py
           )
       - id: pyupgrade
         args: [--py37-plus, --keep-runtime-typing]
         name: Upgrade monai networks
-        files: (?x)(^monai/networks/)
+        files: (?x)(
+                   ^monai/networks/|
+                   ^monai/data/utils.py|
+                   ^monai/data/grid_dataset.py
+                )
 
   - repo: https://github.com/asottile/yesqa
     rev: v1.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: v3.19.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus, --keep-runtime-typing]
+        args: [--py39-plus, --keep-runtime-typing]
         name: Upgrade code with exceptions
         exclude: |
           (?x)(

--- a/monai/__init__.py
+++ b/monai/__init__.py
@@ -11,12 +11,12 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
-import logging
 import warnings
-from ._version import get_versions
 
+from ._version import get_versions
 
 old_showwarning = warnings.showwarning
 

--- a/monai/apps/detection/networks/retinanet_network.py
+++ b/monai/apps/detection/networks/retinanet_network.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import math
 import warnings
 from collections.abc import Callable, Sequence
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor, nn
@@ -330,7 +330,7 @@ class RetinaNet(nn.Module):
         features = self.feature_extractor(images)
         if isinstance(features, Tensor):
             feature_maps = [features]
-        elif torch.jit.isinstance(features, Dict[str, Tensor]):
+        elif torch.jit.isinstance(features, dict[str, Tensor]):
             feature_maps = list(features.values())
         else:
             feature_maps = list(features)

--- a/monai/apps/detection/transforms/array.py
+++ b/monai/apps/detection/transforms/array.py
@@ -15,7 +15,9 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any
+
+from collections.abc import Sequence
 
 import numpy as np
 import torch

--- a/monai/apps/detection/transforms/array.py
+++ b/monai/apps/detection/transforms/array.py
@@ -15,9 +15,8 @@ https://github.com/Project-MONAI/MONAI/wiki/MONAI_Design
 
 from __future__ import annotations
 
-from typing import Any
-
 from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import torch

--- a/monai/apps/generation/maisi/networks/autoencoderkl_maisi.py
+++ b/monai/apps/generation/maisi/networks/autoencoderkl_maisi.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import gc
 import logging
-from typing import Sequence
+from collections.abc import Sequence
 
 import torch
 import torch.nn as nn

--- a/monai/apps/generation/maisi/networks/controlnet_maisi.py
+++ b/monai/apps/generation/maisi/networks/controlnet_maisi.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import torch
 

--- a/monai/apps/pathology/engines/utils.py
+++ b/monai/apps/pathology/engines/utils.py
@@ -11,9 +11,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from collections.abc import Sequence
+from typing import Any
 
 import torch
 

--- a/monai/apps/pathology/engines/utils.py
+++ b/monai/apps/pathology/engines/utils.py
@@ -11,7 +11,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any
+
+from collections.abc import Sequence
 
 import torch
 

--- a/monai/apps/pathology/inferers/inferer.py
+++ b/monai/apps/pathology/inferers/inferer.py
@@ -11,7 +11,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence
+from typing import Any, Callable
+
+from collections.abc import Sequence
 
 import numpy as np
 import torch

--- a/monai/apps/pathology/inferers/inferer.py
+++ b/monai/apps/pathology/inferers/inferer.py
@@ -11,9 +11,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
-
 from collections.abc import Sequence
+from typing import Any, Callable
 
 import numpy as np
 import torch

--- a/monai/apps/pathology/metrics/lesion_froc.py
+++ b/monai/apps/pathology/metrics/lesion_froc.py
@@ -11,9 +11,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
 from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 

--- a/monai/apps/pathology/metrics/lesion_froc.py
+++ b/monai/apps/pathology/metrics/lesion_froc.py
@@ -11,7 +11,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
+
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -12,7 +12,9 @@
 from __future__ import annotations
 
 import warnings
-from typing import Callable, Sequence
+from typing import Callable
+
+from collections.abc import Sequence
 
 import numpy as np
 import torch

--- a/monai/apps/pathology/transforms/post/array.py
+++ b/monai/apps/pathology/transforms/post/array.py
@@ -12,9 +12,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import Callable
-
 from collections.abc import Sequence
+from typing import Callable
 
 import numpy as np
 import torch

--- a/monai/apps/tcia/utils.py
+++ b/monai/apps/tcia/utils.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable
+from collections.abc import Iterable
 
 import monai
 from monai.config.type_definitions import PathLike

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -136,10 +136,7 @@ def check_hash(filepath: PathLike, val: str | None = None, hash_type: str = "md5
         return True
     actual_hash_func = look_up_option(hash_type.lower(), SUPPORTED_HASH_TYPES)
 
-    if sys.version_info >= (3, 9):
-        actual_hash = actual_hash_func(usedforsecurity=False)  # allows checks on FIPS enabled machines
-    else:
-        actual_hash = actual_hash_func()
+    actual_hash = actual_hash_func(usedforsecurity=False)  # allows checks on FIPS enabled machines
 
     try:
         with open(filepath, "rb") as f:

--- a/monai/apps/vista3d/transforms.py
+++ b/monai/apps/vista3d/transforms.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 import torch

--- a/monai/bundle/reference_resolver.py
+++ b/monai/bundle/reference_resolver.py
@@ -13,10 +13,8 @@ from __future__ import annotations
 
 import re
 import warnings
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import Any
-
-from collections.abc import Iterator
 
 from monai.bundle.config_item import ConfigComponent, ConfigExpression, ConfigItem
 from monai.bundle.utils import DEPRECATED_ID_MAPPING, ID_REF_KEY, ID_SEP_KEY

--- a/monai/bundle/reference_resolver.py
+++ b/monai/bundle/reference_resolver.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Sequence
-from typing import Any, Iterator
+from typing import Any
+
+from collections.abc import Iterator
 
 from monai.bundle.config_item import ConfigComponent, ConfigExpression, ConfigItem
 from monai.bundle.utils import DEPRECATED_ID_MAPPING, ID_REF_KEY, ID_SEP_KEY

--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -16,12 +16,11 @@ import os
 import sys
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from copy import copy
 from logging.config import fileConfig
 from pathlib import Path
 from typing import Any
-
-from collections.abc import Sequence
 
 from monai.apps.utils import get_logger
 from monai.bundle.config_parser import ConfigParser

--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -19,7 +19,9 @@ from abc import ABC, abstractmethod
 from copy import copy
 from logging.config import fileConfig
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
+
+from collections.abc import Sequence
 
 from monai.apps.utils import get_logger
 from monai.bundle.config_parser import ConfigParser

--- a/monai/config/type_definitions.py
+++ b/monai/config/type_definitions.py
@@ -12,9 +12,8 @@
 from __future__ import annotations
 
 import os
-from typing import TypeVar, Union
-
 from collections.abc import Collection, Hashable, Iterable, Sequence
+from typing import TypeVar, Union
 
 import numpy as np
 import torch

--- a/monai/config/type_definitions.py
+++ b/monai/config/type_definitions.py
@@ -12,7 +12,9 @@
 from __future__ import annotations
 
 import os
-from typing import Collection, Hashable, Iterable, Sequence, TypeVar, Union
+from typing import TypeVar, Union
+
+from collections.abc import Collection, Hashable, Iterable, Sequence
 
 import numpy as np
 import torch

--- a/monai/data/meta_obj.py
+++ b/monai/data/meta_obj.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import itertools
 import pprint
 from copy import deepcopy
-from typing import Any, Iterable
+from typing import Any
+
+from collections.abc import Iterable
 
 import numpy as np
 import torch

--- a/monai/data/meta_obj.py
+++ b/monai/data/meta_obj.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 
 import itertools
 import pprint
+from collections.abc import Iterable
 from copy import deepcopy
 from typing import Any
-
-from collections.abc import Iterable
 
 import numpy as np
 import torch

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 
 import functools
 import warnings
+from collections.abc import Sequence
 from copy import deepcopy
 from typing import Any
-
-from collections.abc import Sequence
 
 import numpy as np
 import torch

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import functools
 import warnings
 from copy import deepcopy
-from typing import Any, Sequence
+from typing import Any
+
+from collections.abc import Sequence
 
 import numpy as np
 import torch

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -12,7 +12,9 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable
+
+from collections.abc import Iterable, Sequence
 
 import torch
 from torch.utils.data import DataLoader

--- a/monai/engines/evaluator.py
+++ b/monai/engines/evaluator.py
@@ -12,9 +12,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Callable
-
 from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable
 
 import torch
 from torch.utils.data import DataLoader

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -12,9 +12,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Callable
-
 from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable
 
 import torch
 from torch.optim.optimizer import Optimizer

--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -12,7 +12,9 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable
+
+from collections.abc import Iterable, Sequence
 
 import torch
 from torch.optim.optimizer import Optimizer

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any, Mapping, cast
+from typing import TYPE_CHECKING, Any, cast
+
+from collections.abc import Mapping
 
 import torch
 import torch.nn as nn

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -12,10 +12,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
-
-from collections.abc import Mapping
 
 import torch
 import torch.nn as nn

--- a/monai/handlers/clearml_handlers.py
+++ b/monai/handlers/clearml_handlers.py
@@ -11,9 +11,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
 from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 from monai.utils import optional_import
 

--- a/monai/handlers/clearml_handlers.py
+++ b/monai/handlers/clearml_handlers.py
@@ -11,7 +11,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
+
+from collections.abc import Mapping, Sequence
 
 from monai.utils import optional_import
 

--- a/monai/inferers/utils.py
+++ b/monai/inferers/utils.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Iterable
+from typing import Any
+
+from collections.abc import Iterable
 
 import numpy as np
 import torch

--- a/monai/inferers/utils.py
+++ b/monai/inferers/utils.py
@@ -12,10 +12,8 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any
-
-from collections.abc import Iterable
 
 import numpy as np
 import torch

--- a/monai/losses/hausdorff_loss.py
+++ b/monai/losses/hausdorff_loss.py
@@ -79,7 +79,7 @@ class HausdorffDTLoss(_Loss):
                 Incompatible values.
 
         """
-        super(HausdorffDTLoss, self).__init__(reduction=LossReduction(reduction).value)
+        super().__init__(reduction=LossReduction(reduction).value)
         if other_act is not None and not callable(other_act):
             raise TypeError(f"other_act must be None or callable but is {type(other_act).__name__}.")
         if int(sigmoid) + int(softmax) > 1:

--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -12,11 +12,10 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Iterable, Sequence
 from functools import lru_cache, partial
 from types import ModuleType
 from typing import Any
-
-from collections.abc import Iterable, Sequence
 
 import numpy as np
 import torch

--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import warnings
 from functools import lru_cache, partial
 from types import ModuleType
-from typing import Any, Iterable, Sequence
+from typing import Any
+
+from collections.abc import Iterable, Sequence
 
 import numpy as np
 import torch

--- a/monai/networks/nets/swin_unetr.py
+++ b/monai/networks/nets/swin_unetr.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Sequence
+from typing import Final
 
 import numpy as np
 import torch
@@ -20,7 +21,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
 from torch.nn import LayerNorm
-from typing import Final
 
 from monai.networks.blocks import MLPBlock as Mlp
 from monai.networks.blocks import PatchEmbed, UnetOutBlock, UnetrBasicBlock, UnetrUpBlock

--- a/monai/networks/nets/swin_unetr.py
+++ b/monai/networks/nets/swin_unetr.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
 from torch.nn import LayerNorm
-from typing_extensions import Final
+from typing import Final
 
 from monai.networks.blocks import MLPBlock as Mlp
 from monai.networks.blocks import PatchEmbed, UnetOutBlock, UnetrBasicBlock, UnetrUpBlock

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -17,9 +17,8 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 
 from __future__ import annotations
 
-from typing import Callable
-
 from collections.abc import Hashable, Mapping, Sequence
+from typing import Callable
 
 import numpy as np
 

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -17,7 +17,9 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 
 from __future__ import annotations
 
-from typing import Callable, Hashable, Mapping, Sequence
+from typing import Callable
+
+from collections.abc import Hashable, Mapping, Sequence
 
 import numpy as np
 

--- a/monai/transforms/lazy/functional.py
+++ b/monai/transforms/lazy/functional.py
@@ -11,7 +11,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from typing import Any
+
+from collections.abc import Mapping, Sequence
 
 import torch
 

--- a/monai/transforms/lazy/functional.py
+++ b/monai/transforms/lazy/functional.py
@@ -11,9 +11,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from collections.abc import Mapping, Sequence
+from typing import Any
 
 import torch
 

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -15,12 +15,10 @@ A collection of "vanilla" transforms for spatial operations.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from copy import deepcopy
 from itertools import zip_longest
 from typing import Any, Optional, Union, cast
-
-from collections.abc import Sequence
 
 import numpy as np
 import torch

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -18,7 +18,9 @@ import warnings
 from collections.abc import Callable
 from copy import deepcopy
 from itertools import zip_longest
-from typing import Any, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Optional, Union, cast
+
+from collections.abc import Sequence
 
 import numpy as np
 import torch
@@ -116,7 +118,7 @@ __all__ = [
     "RandSimulateLowResolution",
 ]
 
-RandRange = Optional[Union[Sequence[Union[Tuple[float, float], float]], float]]
+RandRange = Optional[Union[Sequence[Union[tuple[float, float], float]], float]]
 
 
 class SpatialResample(InvertibleTransform, LazyTransform):

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -18,11 +18,9 @@ Class names are ended with 'd' to denote dictionary-based transforms.
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Hashable, Mapping
+from collections.abc import Callable, Hashable, Mapping, Sequence
 from copy import deepcopy
 from typing import Any, cast
-
-from collections.abc import Sequence
 
 import numpy as np
 import torch

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import re
 from collections.abc import Callable, Hashable, Mapping
 from copy import deepcopy
-from typing import Any, Sequence, cast
+from typing import Any, cast
+
+from collections.abc import Sequence
 
 import numpy as np
 import torch

--- a/monai/transforms/utils_morphological_ops.py
+++ b/monai/transforms/utils_morphological_ops.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import torch
 import torch.nn.functional as F

--- a/monai/utils/component_store.py
+++ b/monai/utils/component_store.py
@@ -12,11 +12,10 @@
 from __future__ import annotations
 
 from collections import namedtuple
+from collections.abc import Iterable
 from keyword import iskeyword
 from textwrap import dedent, indent
 from typing import Any, Callable, TypeVar
-
-from collections.abc import Iterable
 
 T = TypeVar("T")
 

--- a/monai/utils/component_store.py
+++ b/monai/utils/component_store.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 from collections import namedtuple
 from keyword import iskeyword
 from textwrap import dedent, indent
-from typing import Any, Callable, Iterable, TypeVar
+from typing import Any, Callable, TypeVar
+
+from collections.abc import Iterable
 
 T = TypeVar("T")
 

--- a/monai/utils/decorators.py
+++ b/monai/utils/decorators.py
@@ -15,9 +15,8 @@ from functools import wraps
 
 __all__ = ["RestartGenerator", "MethodReplacer"]
 
-from typing import Callable
-
 from collections.abc import Generator
+from typing import Callable
 
 
 class RestartGenerator:

--- a/monai/utils/decorators.py
+++ b/monai/utils/decorators.py
@@ -15,7 +15,9 @@ from functools import wraps
 
 __all__ = ["RestartGenerator", "MethodReplacer"]
 
-from typing import Callable, Generator
+from typing import Callable
+
+from collections.abc import Generator
 
 
 class RestartGenerator:

--- a/monai/utils/dist.py
+++ b/monai/utils/dist.py
@@ -14,10 +14,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Callable
 from logging import Filter
-
-from typing import Literal
-
-from typing import overload
+from typing import Literal, overload
 
 import torch
 import torch.distributed as dist

--- a/monai/utils/dist.py
+++ b/monai/utils/dist.py
@@ -11,13 +11,11 @@
 
 from __future__ import annotations
 
-import sys
 import warnings
 from collections.abc import Callable
 from logging import Filter
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
+from typing import Literal
 
 from typing import overload
 

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -25,7 +25,9 @@ from pkgutil import walk_packages
 from pydoc import locate
 from re import match
 from types import FunctionType, ModuleType
-from typing import Any, Iterable, cast
+from typing import Any, cast
+
+from collections.abc import Iterable
 
 import torch
 

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -18,7 +18,7 @@ import pdb
 import re
 import sys
 import warnings
-from collections.abc import Callable, Collection, Hashable, Mapping
+from collections.abc import Callable, Collection, Hashable, Iterable, Mapping
 from functools import partial, wraps
 from importlib import import_module
 from pkgutil import walk_packages
@@ -26,8 +26,6 @@ from pydoc import locate
 from re import match
 from types import FunctionType, ModuleType
 from typing import Any, cast
-
-from collections.abc import Iterable
 
 import torch
 

--- a/monai/utils/state_cacher.py
+++ b/monai/utils/state_cacher.py
@@ -16,7 +16,9 @@ import os
 import pickle
 import tempfile
 from types import ModuleType
-from typing import Any, Hashable
+from typing import Any
+
+from collections.abc import Hashable
 
 import torch
 from torch.serialization import DEFAULT_PROTOCOL

--- a/monai/utils/state_cacher.py
+++ b/monai/utils/state_cacher.py
@@ -15,10 +15,9 @@ import copy
 import os
 import pickle
 import tempfile
+from collections.abc import Hashable
 from types import ModuleType
 from typing import Any
-
-from collections.abc import Hashable
 
 import torch
 from torch.serialization import DEFAULT_PROTOCOL

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -13,9 +13,8 @@ from __future__ import annotations
 
 import platform
 import unittest
-from typing import Any
-
 from collections.abc import Sequence
+from typing import Any
 
 import torch
 from parameterized import parameterized

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 
 import platform
 import unittest
-from typing import Any, Sequence
+from typing import Any
+
+from collections.abc import Sequence
 
 import torch
 from parameterized import parameterized

--- a/tests/test_network_consistency.py
+++ b/tests/test_network_consistency.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 import json
 import os
 import unittest
-from glob import glob
 from collections.abc import Sequence
+from glob import glob
 from unittest.case import skipIf
 
 import torch

--- a/tests/test_network_consistency.py
+++ b/tests/test_network_consistency.py
@@ -15,7 +15,7 @@ import json
 import os
 import unittest
 from glob import glob
-from typing import Sequence
+from collections.abc import Sequence
 from unittest.case import skipIf
 
 import torch


### PR DESCRIPTION
### Description

Included is a commit here applying pyupgrade changes for Python 3.8+ syntax. This should have been included in https://github.com/Project-MONAI/MONAI/commit/104a360f953b5d720b3eb8f5b1a0546540e5e391 when Python 3.7 support was dropped.

Also included is a commit here apply pyupgrade changes for Python 3.9+ syntax. This should have been included in https://github.com/Project-MONAI/MONAI/commit/14b086b553693f5d344ff054f37d12ce6839da06 when Python 3.8 support was dropped.

I've also run the pre-commit autoupdate command to use the latest versions of the various pre-commit hook repos. It appears that pre-commit.ci bot has not been doing this on the quarterly schedule as expected? It appears the last time it submitted the PR to update the pre-commit hook repos was back in https://github.com/Project-MONAI/MONAI/pull/6286 from April 2023.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).