### PR TITLE
Add onnx output option for trt_compiler

### DIFF
--- a/monai/networks/trt_compiler.py
+++ b/monai/networks/trt_compiler.py
@@ -474,7 +474,7 @@ class TrtCompiler:
             # Use temporary directory for easy cleanup in case of external weights
             with tempfile.TemporaryDirectory() as tmpdir:
                 if self.onnx_path is not None:
-                    onnx_path = Path(self.onnx_path) / "model.onnx"
+                    onnx_path = Path(self.onnx_path)
                 else:
                     onnx_path = Path(tmpdir) / "model.onnx"
                 self.logger.info(


### PR DESCRIPTION
Fixes # .

### Description

So far, it's onnx model is in a tmp folder and will be removed after execution. For users that need onnx model, it will be more convenient to add an option to save it to a specified path.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
