### PR TITLE
Fix Ruff Numpy2 deprecation rules

### DIFF
--- a/monai/metrics/fid.py
+++ b/monai/metrics/fid.py
@@ -82,7 +82,7 @@ def _cov(input_data: torch.Tensor, rowvar: bool = True) -> torch.Tensor:
 
 def _sqrtm(input_data: torch.Tensor) -> torch.Tensor:
     """Compute the square root of a matrix."""
-    scipy_res, _ = scipy.linalg.sqrtm(input_data.detach().cpu().numpy().astype(np.float_), disp=False)
+    scipy_res, _ = scipy.linalg.sqrtm(input_data.detach().cpu().numpy().astype(np.float64), disp=False)
     return torch.from_numpy(scipy_res)
 
 

--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -88,7 +88,7 @@ def moveaxis(x: NdarrayOrTensor, src: int | Sequence[int], dst: int | Sequence[i
 def in1d(x, y):
     """`np.in1d` with equivalent implementation for torch."""
     if isinstance(x, np.ndarray):
-        return np.in1d(x, y)
+        return np.isin(x, y)
     return (x[..., None] == torch.tensor(y, device=x.device)).any(-1).view(-1)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ extend-ignore = [
   "E741", # ambiguous variable name
   "F401", # unused import
   "NPY002", # numpy-legacy-random
-  "NPY201", # numpy2 deprecation
 ]
 
 [tool.pytype]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,16 @@ exclude = "monai/bundle/__main__.py"
 
 [tool.ruff]
 line-length = 133
-lint.ignore = ["F401", "E741"]
+target-version = "py39"
+
+[tool.ruff.lint]
+select = [
+  "E", "F", "W", # flake8
+]
+extend-ignore = [
+  "E741", # ambiguous variable name
+  "F401", # unused import
+]
 
 [tool.pytype]
 # Space-separated list of files or directories to exclude.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,13 @@ target-version = "py39"
 [tool.ruff.lint]
 select = [
   "E", "F", "W", # flake8
+  "NPY",         # NumPy specific rules
 ]
 extend-ignore = [
   "E741", # ambiguous variable name
   "F401", # unused import
+  "NPY002", # numpy-legacy-random
+  "NPY201", # numpy2 deprecation
 ]
 
 [tool.pytype]

--- a/tests/test_compute_f_beta.py
+++ b/tests/test_compute_f_beta.py
@@ -59,7 +59,7 @@ class TestFBetaScore(unittest.TestCase):
         metric = FBetaScore(get_not_nans=True)
         metric(
             y_pred=torch.Tensor([[1, 1, 1], [1, 1, 1], [1, 1, 1]]),
-            y=torch.Tensor([[1, 0, 1], [np.NaN, np.NaN, np.NaN], [1, 0, 1]]),
+            y=torch.Tensor([[1, 0, 1], [np.nan, np.nan, np.nan], [1, 0, 1]]),
         )
         assert_allclose(metric.aggregate()[0][0], torch.Tensor([0.727273]), atol=1e-6, rtol=1e-6)
 


### PR DESCRIPTION
### Description

This addresses expired numpy deprecations that happened with the numpy 2 release. This code is compatible with numpy 1 and 2 to support future enablement of numpy2 for monai.

See https://docs.astral.sh/ruff/rules/numpy2-deprecation/

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
