### PR TITLE
enhance download_and_extract

### DIFF
--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -327,7 +327,47 @@ def download_and_extract(
             be False.
         progress: whether to display progress bar.
     """
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        filename = filepath or Path(tmp_dir, _basename(url)).resolve()
-        download_url(url=url, filepath=filename, hash_val=hash_val, hash_type=hash_type, progress=progress)
-        extractall(filepath=filename, output_dir=output_dir, file_type=file_type, has_base=has_base)
+def download_and_extract(
+    url: str,
+    filepath: PathLike = "",
+    output_dir: PathLike = ".",
+    hash_val: str | None = None,
+    hash_type: str = "md5",
+    file_type: str = "",
+    has_base: bool = True,
+    progress: bool = True,
+) -> None:
+    """
+    Download file from URL and extract it to the output directory.
+
+    Args:
+        url: source URL link to download file.
+        filepath: the file path of the downloaded compressed file.
+            use this option to keep the directly downloaded compressed file, to avoid further repeated downloads.
+        output_dir: target directory to save extracted files.
+            default is the current directory.
+        hash_val: expected hash value to validate the downloaded file.
+            if None, skip hash validation.
+        hash_type: 'md5' or 'sha1', defaults to 'md5'.
+        file_type: string of file type for decompressing. Leave it empty to infer the type from url's base file name.
+        has_base: whether the extracted files have a base folder. This flag is used when checking if the existing
+            folder is a result of `extractall`, if it is, the extraction is skipped. For example, if A.zip is unzipped
+            to folder structure `A/*.png`, this flag should be True; if B.zip is unzipped to `*.png`, this flag should
+            be False.
+        progress: whether to display progress bar.
+    """
+    urlFilenameExtension = ''.join(Path(".", _basename(url)).resolve().suffixes)
+    if filepath:
+        FilepathExtenstion = ''.join(Path(".", _basename(filepath)).resolve().suffixes)
+        if urlFilenameExtension != FilepathExtenstion:
+            raise NotImplementedError(
+                f'The file types do not match: url={urlFilenameExtension}, but filepath={FilepathExtenstion}'
+            )
+    else:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            if filepath:
+                filename = filepath
+            else:
+                filename = Path(tmp_dir, _basename(url)).resolve()
+            download_url(url=url, filepath=filename, hash_val=hash_val, hash_type=hash_type, progress=progress)
+            extractall(filepath=filename, output_dir=output_dir, file_type=file_type, has_base=has_base)


### PR DESCRIPTION
Fixes #5463 

### Description
@wyli 
@KumoLiu 
@ericspod 

According to issue, the error messages are not very intuitive.
I think maybe  we can check if the file name matches the downloaded file’s base name before starting the download. 
If it doesn’t match, it will notify user.

```python
>>> import monai
>>> url = "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/MedNIST.tar.gz"
>>> monai.apps.utils.download_and_extract(url, filepath="./test")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/yuan/Desktop/OSS/MONAI/monai/apps/utils.py", line 363, in download_and_extract
    raise NotImplementedError(
NotImplementedError: The file types do not match: url=.tar.gz, but filepath=
```

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
