### PR TITLE
Fixing a minor bug in a test

### DIFF
--- a/tests/test_module_list.py
+++ b/tests/test_module_list.py
@@ -58,13 +58,17 @@ class TestAllImport(unittest.TestCase):
                 continue
             with self.subTest(n=n):
                 basename = n[:-1]  # Transformd basename is Transform
+
+                # remove aliases to check, do this before the assert below so that a failed assert does skip this
+                for postfix in ("D", "d", "Dict"):
+                    remained.remove(f"{basename}{postfix}")
+
                 for docname in (f"{basename}", f"{basename}d"):
                     if docname in to_exclude_docs:
                         continue
                     if (contents is not None) and f"`{docname}`" not in f"{contents}":
                         self.assertTrue(False, f"please add `{docname}` to docs/source/transforms.rst")
-                for postfix in ("D", "d", "Dict"):
-                    remained.remove(f"{basename}{postfix}")
+                
         self.assertFalse(remained)
 
 

--- a/tests/test_module_list.py
+++ b/tests/test_module_list.py
@@ -68,7 +68,7 @@ class TestAllImport(unittest.TestCase):
                         continue
                     if (contents is not None) and f"`{docname}`" not in f"{contents}":
                         self.assertTrue(False, f"please add `{docname}` to docs/source/transforms.rst")
-                
+
         self.assertFalse(remained)
 
 


### PR DESCRIPTION
### Description

There is a minor bug in a test which causes a second fail to occur when one does. In `test_module_list.py`, there is a list of classes to check which must have aliases removed from it. This must be done before the test assert so that in the event the assert fails this removal isn't skipped. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
