### PR TITLE
Allow an arbitrary mask to be used in the self attention

### DIFF
--- a/monai/networks/blocks/selfattention.py
+++ b/monai/networks/blocks/selfattention.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import Tuple, Union
+from typing import Tuple, Union, Optional
 
 import torch
 import torch.nn as nn
@@ -154,7 +154,7 @@ class SABlock(nn.Module):
         )
         self.input_size = input_size
 
-    def forward(self, x, attn_mask: torch.Tensor | None = None):
+    def forward(self, x, attn_mask: Optional[torch.Tensor] = None):
         """
         Args:
             x (torch.Tensor): input tensor. B x (s_dim_1 * ... * s_dim_n) x C

--- a/monai/networks/blocks/selfattention.py
+++ b/monai/networks/blocks/selfattention.py
@@ -194,7 +194,8 @@ class SABlock(nn.Module):
                 att_mat = self.rel_positional_embedding(x, att_mat, q)
 
             if self.causal:
-                assert attn_mask is None, "Causal attention does not support attention masks."
+                if attn_mask is not None:
+                    raise ValueError("Causal attention does not support attention masks.")
                 att_mat = att_mat.masked_fill(self.causal_mask[:, :, : x.shape[-2], : x.shape[-2]] == 0, float("-inf"))
 
             if attn_mask is not None:

--- a/monai/networks/blocks/selfattention.py
+++ b/monai/networks/blocks/selfattention.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import Tuple, Union, Optional
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn

--- a/monai/networks/blocks/transformerblock.py
+++ b/monai/networks/blocks/transformerblock.py
@@ -90,8 +90,10 @@ class TransformerBlock(nn.Module):
             use_flash_attention=use_flash_attention,
         )
 
-    def forward(self, x: torch.Tensor, context: Optional[torch.Tensor] = None) -> torch.Tensor:
-        x = x + self.attn(self.norm1(x))
+    def forward(
+        self, x: torch.Tensor, context: Optional[torch.Tensor] = None, attn_mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), attn_mask=attn_mask)
         if self.with_cross_attention:
             x = x + self.cross_attn(self.norm_cross_attn(x), context=context)
         x = x + self.mlp(self.norm2(x))

--- a/tests/test_selfattention.py
+++ b/tests/test_selfattention.py
@@ -134,7 +134,7 @@ class TestResBlock(unittest.TestCase):
         assert torch.allclose(att_mat[:, ~mask.squeeze(0)], torch.zeros_like(att_mat[:, ~mask.squeeze(0)]))
 
     def test_causal_and_mask(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             block = SABlock(hidden_size=128, num_heads=1, causal=True, sequence_length=64)
             inputs = torch.randn(2, 64, 128)
             mask = torch.randint(0, 2, (2, 64)).bool()

--- a/tests/test_selfattention.py
+++ b/tests/test_selfattention.py
@@ -123,19 +123,22 @@ class TestResBlock(unittest.TestCase):
         assert torch.triu(block.att_mat, diagonal=1).sum() == 0
 
     def test_masked_selfattention(self):
-        n = 4
+        n = 64
         block = SABlock(hidden_size=128, num_heads=1, dropout_rate=0.1, sequence_length=16, save_attn=True)
         input_shape = (1, n, 128)
-        mask = torch.tensor([[1, 1, 1, 0]]).bool()
+        # generate a mask randomly with zeros and ones of shape (1, n)
+        mask = torch.randint(0, 2, (1, n)).bool()
         block(torch.randn(input_shape), attn_mask=mask)
-        att_mat = block.att_mat.squeeze(1)
-        # get the masked row and the remaining ones based on mask 0 values
-        rows_true = att_mat[mask, :]
-        rows_false = att_mat[~mask, :]
-        # check that in false rows every element is equal to 1/4
-        assert torch.allclose(rows_false, torch.ones_like(rows_false) / n)
-        # check that in true rows the mask column is zero
-        assert torch.allclose(rows_true[:, -1], torch.zeros_like(rows_true[:, -1]))
+        att_mat = block.att_mat.squeeze()
+        # ensure all masked columns are zeros
+        assert torch.allclose(att_mat[:, ~mask.squeeze(0)], torch.zeros_like(att_mat[:, ~mask.squeeze(0)]))
+
+    def test_causal_and_mask(self):
+        with self.assertRaises(AssertionError):
+            block = SABlock(hidden_size=128, num_heads=1, causal=True, sequence_length=64)
+            inputs = torch.randn(2, 64, 128)
+            mask = torch.randint(0, 2, (2, 64)).bool()
+            block(inputs, attn_mask=mask)
 
     @skipUnless(has_einops, "Requires einops")
     def test_access_attn_matrix(self):


### PR DESCRIPTION
### Description

The aim of this PR is to enable the use of an arbitrary mask in the self attention module, which is very useful in the case of missing data or masked modeling.

Official torch implementations allow the use of an arbitrary mask, and in MONAI the use of a mask is also made possible with the `causal` argument. Here, it's just a generalization directly in the forward pass.

In the `SABlock` and `TransformerBlock`, it is now possible to input a boolean mask of size `(BS, Seq_length)`.
Only the columns of the masked token are set to `-inf` and not the rows, as is rarely the case in common implementations. Masked tokens don't contribute to the gradient anyway. 
In cases where causal attention is required, inputting a mask is not supported to avoid masks overlapping.  

I haven't implemented the addition mask to the attention matrix, which allows you to use values other than `-inf` in certain cases, as may be the case here: https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html

If you think it's relevant, it could be added.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
