### PR TITLE
Change default value of `patch_norm` to False in `SwinUNETR`

### DIFF
--- a/monai/networks/nets/swin_unetr.py
+++ b/monai/networks/nets/swin_unetr.py
@@ -75,7 +75,7 @@ class SwinUNETR(nn.Module):
         dropout_path_rate: float = 0.0,
         normalize: bool = True,
         norm_layer: type[LayerNorm] = nn.LayerNorm,
-        patch_norm: bool = True,
+        patch_norm: bool = False,
         use_checkpoint: bool = False,
         spatial_dims: int = 3,
         downsample: str | nn.Module = "merging",
@@ -102,7 +102,7 @@ class SwinUNETR(nn.Module):
             dropout_path_rate: drop path rate.
             normalize: normalize output intermediate features in each stage.
             norm_layer: normalization layer.
-            patch_norm: whether to apply normalization to the patch embedding.
+            patch_norm: whether to apply normalization to the patch embedding. Default is False.
             use_checkpoint: use gradient checkpointing for reduced memory usage.
             spatial_dims: number of spatial dims.
             downsample: module used for downsampling, available options are `"mergingv2"`, `"merging"` and a


### PR DESCRIPTION
Fixes #8248

### Description

Update the default value of `patch_norm` to False in `SwinUNETR` to align with the default value in `SwinTransformer`. This [change](https://github.com/Project-MONAI/MONAI/commit/3ee4cd22a8cc7b6b4cb3c5fd228dfa9ef153e60c#diff-04583cc0f4aed09787775eec8cece2b1fd70290799a7a3a2671353f2a3cf9af3R105) modifies the default behavior of the model
https://github.com/Project-MONAI/MONAI/blob/e6cae1ced23f32feb2f42943d15b7dd49481c794/monai/networks/nets/swin_unetr.py#L960


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
