### PR TITLE
Add platform-specific constraints to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,10 +61,10 @@ all =
     tqdm>=4.47.0
     lmdb
     psutil
-    cucim-cu12; python_version >= '3.9' and python_version <= '3.10'
+    cucim-cu12; platform_system == "Linux" and python_version >= '3.9' and python_version <= '3.10'
     openslide-python
-    tifffile
-    imagecodecs
+    tifffile; platform_system == "Linux" or platform_system == "Darwin"
+    imagecodecs; platform_system == "Linux" or platform_system == "Darwin"
     pandas
     einops
     transformers>=4.36.0, <4.41.0; python_version <= '3.10'
@@ -78,7 +78,7 @@ all =
     pynrrd
     pydicom
     h5py
-    nni
+    nni; platform_system == "Linux" and "arm" not in platform_machine and "aarch" not in platform_machine
     optuna
     onnx>=1.13.0
     onnxruntime; python_version <= '3.10'
@@ -116,13 +116,13 @@ lmdb =
 psutil =
     psutil
 cucim =
-    cucim-cu12
+    cucim-cu12; platform_system == "Linux" and python_version >= '3.9' and python_version <= '3.10'
 openslide =
     openslide-python
 tifffile =
-    tifffile
+    tifffile; platform_system == "Linux" or platform_system == "Darwin"
 imagecodecs =
-    imagecodecs
+    imagecodecs; platform_system == "Linux" or platform_system == "Darwin"
 pandas =
     pandas
 einops =
@@ -152,7 +152,7 @@ pydicom =
 h5py =
     h5py
 nni =
-    nni
+    nni; platform_system == "Linux" and "arm" not in platform_machine and "aarch" not in platform_machine
 optuna =
     optuna
 onnx =


### PR DESCRIPTION
Fixes #8258 

### Description

Include platform_system conditions for dependencies in setup.cfg

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
