### PR TITLE
Fixes #6840

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -989,6 +989,8 @@ class NibabelReader(ImageReader):
 
         for i, filename in zip(ensure_tuple(img), self.filenames):
             header = self._get_meta_dict(i)
+            if MetaKeys.PIXDIM in header:
+                header[MetaKeys.ORIGINAL_PIXDIM] = np.array(header[MetaKeys.PIXDIM], copy=True)
             header[MetaKeys.AFFINE] = self._get_affine(i)
             header[MetaKeys.ORIGINAL_AFFINE] = self._get_affine(i)
             header["as_closest_canonical"] = self.as_closest_canonical

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -477,6 +477,10 @@ class MetaTensor(MetaObj, torch.Tensor):
             return [affine_to_spacing(a) for a in self.affine]
         return affine_to_spacing(self.affine)
 
+    def set_pixdim(self) -> None:
+        """Update pixdim based on current affine."""
+        self.meta[MetaKeys.PIXDIM][1 : 1 + len(self.pixdim)] = affine_to_spacing(self.affine)
+
     def peek_pending_shape(self):
         """
         Get the currently expected spatial shape as if all the pending operations are executed.

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -535,6 +535,9 @@ class Spacing(InvertibleTransform, LazyTransform):
             dtype=dtype,
             lazy=lazy_,
         )
+        if isinstance(data_array, MetaTensor) and "pixdim" in data_array.meta:
+            data_array = data_array.clone()
+            data_array.set_pixdim()
         if self.recompute_affine and isinstance(data_array, MetaTensor):
             if lazy_:
                 raise NotImplementedError("recompute_affine is not supported with lazy evaluation.")

--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -528,6 +528,8 @@ class MetaKeys(StrEnum):
     Typical keys for MetaObj.meta
     """
 
+    PIXDIM = "pixdim"  # MetaTensor.pixdim
+    ORIGINAL_PIXDIM = "original_pixdim"  # the pixdim after image loading before any data processing
     AFFINE = "affine"  # MetaTensor.affine
     ORIGINAL_AFFINE = "original_affine"  # the affine after image loading before any data processing
     SPATIAL_SHAPE = "spatial_shape"  # optional key for the length in each spatial dimension


### PR DESCRIPTION
Fixes #6840

### Description
According to the issue, this PR addresses on the meta dictionary `data['pixdim']` of NIfTI images does not update after applying the `spacing` or `spacingd`. To align with `affine`, we update `data['pixdim']` and keep the original metainfo in `data['original_pixdim']`. Additionally, this PR also update the metainfo `key_{meta_key_postfix}['pixdim']` in NIfTI images, consistent with `spaced_data_dict['image_meta_dict']['pixdim']` in issue #6832.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
