### PR TITLE
8274 Relax gpu load check

### DIFF
--- a/tests/test_load_image.py
+++ b/tests/test_load_image.py
@@ -233,7 +233,7 @@ class TestLoadImage(unittest.TestCase):
             input_param_cpu = input_param.copy()
             input_param_cpu["to_gpu"] = False
             result_cpu = LoadImage(image_only=True, **input_param_cpu)(filenames)
-            self.assertTrue(torch.allclose(result_cpu, result.cpu(), atol=1e-6))
+            assert_allclose(result_cpu, result.cpu(), atol=1e-6)
 
     @parameterized.expand([TEST_CASE_6, TEST_CASE_7, TEST_CASE_8, TEST_CASE_8_1, TEST_CASE_9])
     def test_itk_reader(self, input_param, filenames, expected_shape):

--- a/tests/test_load_image.py
+++ b/tests/test_load_image.py
@@ -233,7 +233,7 @@ class TestLoadImage(unittest.TestCase):
             input_param_cpu = input_param.copy()
             input_param_cpu["to_gpu"] = False
             result_cpu = LoadImage(image_only=True, **input_param_cpu)(filenames)
-            self.assertTrue(torch.equal(result_cpu, result.cpu()))
+            self.assertTrue(torch.allclose(result_cpu, result.cpu(), atol=1e-6))
 
     @parameterized.expand([TEST_CASE_6, TEST_CASE_7, TEST_CASE_8, TEST_CASE_8_1, TEST_CASE_9])
     def test_itk_reader(self, input_param, filenames, expected_shape):


### PR DESCRIPTION
Related to #8274 , this PR is used to check potential issues. When I used the same environment as the nightly test, the error was not reproduced. Therefore, I hope the new change can show more information about the error.

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
