### PR TITLE
Fix bundle download error from ngc source

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -218,7 +218,7 @@ def _remove_ngc_prefix(name: str, prefix: str = "monai_") -> str:
     return name
 
 
-def _get_all_download_files(request_url, headers=None) -> list[str]:
+def _get_all_download_files(request_url: str, headers: dict | None = None) -> list[str]:
     if not has_requests:
         raise ValueError("requests package is required, please install it.")
     headers = {} if headers is None else headers


### PR DESCRIPTION
Fixes #8306

This previous api has been deprecated, update based on:
https://docs.ngc.nvidia.com/api/?urls.primaryName=Private%20Artifacts%20(Models)%20API#/artifact-file-controller/downloadAllArtifactFiles

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
