### PR TITLE
Fix deprecated usage in zarr

### DIFF
--- a/monai/inferers/merger.py
+++ b/monai/inferers/merger.py
@@ -247,6 +247,7 @@ class ZarrAvgMerger(Merger):
         self.value_dtype = value_dtype
         self.count_dtype = count_dtype
         self.store = store
+        self.tmpdir: TemporaryDirectory | None
         if version_geq(get_package_version("zarr"), "3.0.0"):
             if value_store is None:
                 self.tmpdir = TemporaryDirectory()

--- a/monai/inferers/merger.py
+++ b/monai/inferers/merger.py
@@ -249,13 +249,13 @@ class ZarrAvgMerger(Merger):
         self.store = store
         if version_geq(get_package_version("zarr"), "3.0.0"):
             if value_store is None:
-                with TemporaryDirectory() as tmpdir:
-                    self.value_store = zarr.storage.LocalStore(tmpdir)
+                tmpdir = TemporaryDirectory()
+                self.value_store = zarr.storage.LocalStore(tmpdir.name)
             else:
                 self.value_store = value_store
             if count_store is None:
-                with TemporaryDirectory() as tmpdir:
-                    self.count_store = zarr.storage.LocalStore(tmpdir)
+                tmpdir = TemporaryDirectory()
+                self.count_store = zarr.storage.LocalStore(tmpdir.name)
             else:
                 self.count_store = count_store
         else:

--- a/tests/test_zarr_avg_merger.py
+++ b/tests/test_zarr_avg_merger.py
@@ -289,13 +289,17 @@ class ZarrAvgMergerTests(unittest.TestCase):
     def test_zarr_avg_merger_patches(self, arguments, patch_locations, expected):
         if "compressor" in arguments:
             if arguments["compressor"] != "default":
-                arguments["compressor"] = zarr.codec_registry[arguments["compressor"].lower()]()
+                arguments["compressor"] = numcodecs.registry.codec_registry[arguments["compressor"].lower()]()
         if "value_compressor" in arguments:
             if arguments["value_compressor"] != "default":
-                arguments["value_compressor"] = zarr.codec_registry[arguments["value_compressor"].lower()]()
+                arguments["value_compressor"] = numcodecs.registry.codec_registry[
+                    arguments["value_compressor"].lower()
+                ]()
         if "count_compressor" in arguments:
             if arguments["count_compressor"] != "default":
-                arguments["count_compressor"] = zarr.codec_registry[arguments["count_compressor"].lower()]()
+                arguments["count_compressor"] = numcodecs.registry.codec_registry[
+                    arguments["count_compressor"].lower()
+                ]()
         merger = ZarrAvgMerger(**arguments)
         for pl in patch_locations:
             merger.aggregate(pl[0], pl[1])

--- a/tests/test_zarr_avg_merger.py
+++ b/tests/test_zarr_avg_merger.py
@@ -287,19 +287,16 @@ class ZarrAvgMergerTests(unittest.TestCase):
         ]
     )
     def test_zarr_avg_merger_patches(self, arguments, patch_locations, expected):
+        codec_reg = numcodecs.registry.codec_registry
         if "compressor" in arguments:
             if arguments["compressor"] != "default":
-                arguments["compressor"] = numcodecs.registry.codec_registry[arguments["compressor"].lower()]()
+                arguments["compressor"] = codec_reg[arguments["compressor"].lower()]()
         if "value_compressor" in arguments:
             if arguments["value_compressor"] != "default":
-                arguments["value_compressor"] = numcodecs.registry.codec_registry[
-                    arguments["value_compressor"].lower()
-                ]()
+                arguments["value_compressor"] = codec_reg[arguments["value_compressor"].lower()]()
         if "count_compressor" in arguments:
             if arguments["count_compressor"] != "default":
-                arguments["count_compressor"] = numcodecs.registry.codec_registry[
-                    arguments["count_compressor"].lower()
-                ]()
+                arguments["count_compressor"] = codec_reg[arguments["count_compressor"].lower()]()
         merger = ZarrAvgMerger(**arguments)
         for pl in patch_locations:
             merger.aggregate(pl[0], pl[1])


### PR DESCRIPTION
Fixes #8298


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
