### PR TITLE
make dynunet and mednext api compatible in deep supervsion mode

### DIFF
--- a/tests/test_mednext.py
+++ b/tests/test_mednext.py
@@ -75,8 +75,10 @@ class TestMedNeXt(unittest.TestCase):
         with eval_mode(net):
             result = net(torch.randn(input_shape).to(device))
             if input_param["deep_supervision"] and net.training:
-                assert isinstance(result, tuple)
-                self.assertEqual(result[0].shape, expected_shape, msg=str(input_param))
+                assert isinstance(result, torch.Tensor)
+                result = torch.unbind(result, dim=1)
+                for r in result:
+                    self.assertEqual(r.shape, expected_shape, msg=str(input_param))
             else:
                 self.assertEqual(result.shape, expected_shape, msg=str(input_param))
 
@@ -87,8 +89,10 @@ class TestMedNeXt(unittest.TestCase):
         net.train()
         result = net(torch.randn(input_shape).to(device))
         if input_param["deep_supervision"]:
-            assert isinstance(result, tuple)
-            self.assertEqual(result[0].shape, expected_shape, msg=str(input_param))
+            assert isinstance(result, torch.Tensor)
+            result = torch.unbind(result, dim=1)
+            for r in result:
+                self.assertEqual(r.shape, expected_shape, msg=str(input_param))
         else:
             assert isinstance(result, torch.Tensor)
             self.assertEqual(result.shape, expected_shape, msg=str(input_param))


### PR DESCRIPTION
Fixes #8315 

### Description
If deep supervision is set to true the DynUNet model returns a tensor with the second dimension containing the upscaled intermediate outputs of the model, whereas the new MedNeXt implementation returns a tuple with the tensors of the intermediate outputs in their original low res.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
