### PR TITLE
Fix CommonKeys docstring

### DIFF
--- a/monai/utils/enums.py
+++ b/monai/utils/enums.py
@@ -335,7 +335,7 @@ class CommonKeys(StrEnum):
     `LABEL` is the training or evaluation label of segmentation or classification task.
     `PRED` is the prediction data of model output.
     `LOSS` is the loss value of current iteration.
-    `INFO` is some useful information during training or evaluation, like loss value, etc.
+    `METADATA` is some useful information during training or evaluation, like loss value, etc.
 
     """
 


### PR DESCRIPTION
### Description

`CommonKeys()` docstring mentions `INFO` which doesn't exist. Instead  there is a `METADATA` field, so the docstring was updated accordingly.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
