### PR TITLE
8201 Fix DataFrame subsets indexing in CSVDataset()

### DIFF
--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -1500,7 +1500,7 @@ def convert_tables_to_dicts(
     if col_groups is not None:
         groups: dict[str, list] = {}
         for name, cols in col_groups.items():
-            groups[name] = df.loc[rows, cols].values
+            groups[name] = df.iloc[rows][cols].values
         # invert items of groups to every row of data
         data = [dict(d, **{k: v[i] for k, v in groups.items()}) for i, d in enumerate(data)]
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -1484,7 +1484,7 @@ def convert_tables_to_dicts(
                 rows.append(i)
 
     # convert to a list of dictionaries corresponding to every row
-    data_ = df.loc[rows] if col_names is None else df.loc[rows, col_names]
+    data_ = df.iloc[rows] if col_names is None else df.iloc[rows][col_names]
     if isinstance(col_types, dict):
         # fill default values for NaN
         defaults = {k: v["default"] for k, v in col_types.items() if v is not None and v.get("default") is not None}

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -1473,7 +1473,7 @@ def convert_tables_to_dicts(
     # parse row indices
     rows: list[int | str] = []
     if row_indices is None:
-        rows = slice(df.shape[0])  # type: ignore
+        rows = df.index.tolist()
     else:
         for i in row_indices:
             if isinstance(i, (tuple, list)):
@@ -1484,7 +1484,7 @@ def convert_tables_to_dicts(
                 rows.append(i)
 
     # convert to a list of dictionaries corresponding to every row
-    data_ = df.iloc[rows] if col_names is None else df.iloc[rows][col_names]
+    data_ = df.loc[rows] if col_names is None else df.loc[rows, col_names]
     if isinstance(col_types, dict):
         # fill default values for NaN
         defaults = {k: v["default"] for k, v in col_types.items() if v is not None and v.get("default") is not None}
@@ -1500,7 +1500,7 @@ def convert_tables_to_dicts(
     if col_groups is not None:
         groups: dict[str, list] = {}
         for name, cols in col_groups.items():
-            groups[name] = df.iloc[rows][cols].values
+            groups[name] = df.loc[rows, cols].values
         # invert items of groups to every row of data
         data = [dict(d, **{k: v[i] for k, v in groups.items()}) for i, d in enumerate(data)]
 

--- a/tests/data/test_csv_dataset.py
+++ b/tests/data/test_csv_dataset.py
@@ -186,6 +186,13 @@ class TestCSVDataset(unittest.TestCase):
             self.assertEqual(len(dataset), 3)
             np.testing.assert_allclose([round(i, 4) for i in dataset[1]["ehr"]], [3.3333, 3.2353, 3.4000])
 
+            # test pre-loaded DataFrame subset with row_indices != None
+            df = pd.read_csv(filepath1)
+            df_subset = df.iloc[[1, 3, 4]]
+            dataset = CSVDataset(src=df_subset, row_indices=[1, 3], col_groups={"ehr": [f"ehr_{i}" for i in range(3)]})
+            self.assertEqual(len(dataset), 2)
+            np.testing.assert_allclose([round(i, 4) for i in dataset[1]["ehr"]], [3.3333, 3.2353, 3.4000])
+
             # test pre-loaded multiple DataFrames, join tables with kwargs
             dfs = [pd.read_csv(i) for i in filepaths]
             dataset = CSVDataset(src=dfs, on="subject_id")

--- a/tests/data/test_csv_dataset.py
+++ b/tests/data/test_csv_dataset.py
@@ -179,6 +179,23 @@ class TestCSVDataset(unittest.TestCase):
                 },
             )
 
+            # test pre-loaded DataFrame subset
+            df = pd.read_csv(filepath1)
+            df_subset = df.iloc[[1, 3, 4]]
+            dataset = CSVDataset(src=df_subset)
+            self.assertDictEqual(
+                {k: round(v, 4) if not isinstance(v, str) else v for k, v in dataset[2].items()},
+                {
+                    "subject_id": "s000004",
+                    "label": 9,
+                    "image": "./imgs/s000004.png",
+                    "ehr_0": 6.4275,
+                    "ehr_1": 6.2549,
+                    "ehr_2": 5.9765,
+                },
+            )
+            self.assertEqual(len(dataset), 3)
+
             # test pre-loaded multiple DataFrames, join tables with kwargs
             dfs = [pd.read_csv(i) for i in filepaths]
             dataset = CSVDataset(src=dfs, on="subject_id")

--- a/tests/data/test_csv_dataset.py
+++ b/tests/data/test_csv_dataset.py
@@ -182,19 +182,12 @@ class TestCSVDataset(unittest.TestCase):
             # test pre-loaded DataFrame subset
             df = pd.read_csv(filepath1)
             df_subset = df.iloc[[1, 3, 4]]
-            dataset = CSVDataset(src=df_subset)
-            self.assertDictEqual(
-                {k: round(v, 4) if not isinstance(v, str) else v for k, v in dataset[2].items()},
-                {
-                    "subject_id": "s000004",
-                    "label": 9,
-                    "image": "./imgs/s000004.png",
-                    "ehr_0": 6.4275,
-                    "ehr_1": 6.2549,
-                    "ehr_2": 5.9765,
-                },
-            )
+            dataset = CSVDataset(src=df_subset, col_groups={"ehr": [f"ehr_{i}" for i in range(3)]})
             self.assertEqual(len(dataset), 3)
+            np.testing.assert_allclose(
+                [round(i, 4) for i in dataset[1]["ehr"]],
+                [3.3333, 3.2353, 3.4000],
+            )
 
             # test pre-loaded multiple DataFrames, join tables with kwargs
             dfs = [pd.read_csv(i) for i in filepaths]

--- a/tests/data/test_csv_dataset.py
+++ b/tests/data/test_csv_dataset.py
@@ -184,10 +184,7 @@ class TestCSVDataset(unittest.TestCase):
             df_subset = df.iloc[[1, 3, 4]]
             dataset = CSVDataset(src=df_subset, col_groups={"ehr": [f"ehr_{i}" for i in range(3)]})
             self.assertEqual(len(dataset), 3)
-            np.testing.assert_allclose(
-                [round(i, 4) for i in dataset[1]["ehr"]],
-                [3.3333, 3.2353, 3.4000],
-            )
+            np.testing.assert_allclose([round(i, 4) for i in dataset[1]["ehr"]], [3.3333, 3.2353, 3.4000])
 
             # test pre-loaded multiple DataFrames, join tables with kwargs
             dfs = [pd.read_csv(i) for i in filepaths]


### PR DESCRIPTION
Fixes #8201 .

### Description

`convert_tables_to_dicts` was using `.loc` to index DataFrames which was changed to `.iloc`. It was causing unexpected behavior in `CSVDataset` as demonstrated in #8201 because `.loc` expects labels, but was instead provided positions of the rows.
Unittest was added which fails before the change and passes afterwards.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
