### PR TITLE
Removed outdated `torch` version checks from transform functions

### DIFF
--- a/monai/transforms/utils_pytorch_numpy_unification.py
+++ b/monai/transforms/utils_pytorch_numpy_unification.py
@@ -18,7 +18,6 @@ import numpy as np
 import torch
 
 from monai.config.type_definitions import NdarrayOrTensor, NdarrayTensor
-from monai.utils.misc import is_module_ver_at_least
 from monai.utils.type_conversion import convert_data_type, convert_to_dst_type
 
 __all__ = [
@@ -215,10 +214,9 @@ def floor_divide(a: NdarrayOrTensor, b) -> NdarrayOrTensor:
         Element-wise floor division between two arrays/tensors.
     """
     if isinstance(a, torch.Tensor):
-        if is_module_ver_at_least(torch, (1, 8, 0)):
-            return torch.div(a, b, rounding_mode="floor")
         return torch.floor_divide(a, b)
-    return np.floor_divide(a, b)
+    else:
+        return np.floor_divide(a, b)
 
 
 def unravel_index(idx, shape) -> NdarrayOrTensor:

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -599,6 +599,7 @@ def is_module_ver_at_least(module, version):
         `True` if module is the given version or newer.
     """
     test_ver = ".".join(map(str, version))
+
     return module.__version__ != test_ver and version_leq(test_ver, module.__version__)
 
 

--- a/monai/utils/misc.py
+++ b/monai/utils/misc.py
@@ -599,7 +599,6 @@ def is_module_ver_at_least(module, version):
         `True` if module is the given version or newer.
     """
     test_ver = ".".join(map(str, version))
-
     return module.__version__ != test_ver and version_leq(test_ver, module.__version__)
 
 


### PR DESCRIPTION
Fixes #8348

### Description

Support for `torch` versions prior to `1.13` has been dropped, so those `1.8` version checks are not required anymore. Furthermore, as reported in the issue description, those checks led to unstable behaviour when using certain transforms in data pipelines.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
