### PR TITLE
Update monaihosting download method

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -209,10 +209,10 @@ def _download_from_monaihosting(download_path: Path, filename: str, version: str
 
 
 def _download_from_bundle_info(download_path: Path, filename: str, version: str, progress: bool) -> None:
-    bundle_info = get_bundle_info(name=filename, version=version)
+    bundle_info = get_bundle_info(bundle_name=filename, version=version)
     if not bundle_info:
         raise ValueError(f"Bundle info not found for {filename} v{version}.")
-    url = bundle_info["source"]
+    url = bundle_info["browser_download_url"]
     filepath = download_path / f"{filename}_v{version}.zip"
     download_url(url=url, filepath=filepath, hash_val=None, progress=progress)
     extractall(filepath=filepath, output_dir=download_path, has_base=True)


### PR DESCRIPTION
Related to https://github.com/Project-MONAI/model-zoo/pull/723.

### Description

Currently, bundle download on source "monaihosting" uses fixed download url according to the function `_get_monaihosting_bundle_url`.
A possible enhancement if to support on bundles that are hosted in different places.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
