### PR TITLE
add prediction type for rflow scheduler

### DIFF
--- a/monai/networks/schedulers/rectified_flow.py
+++ b/monai/networks/schedulers/rectified_flow.py
@@ -34,9 +34,20 @@ import numpy as np
 import torch
 from torch.distributions import LogisticNormal
 
+from monai.utils import StrEnum
+
 from .scheduler import Scheduler
+from .ddpm import DDPMPredictionType
 
 
+class RFlowPredictionType(StrEnum):
+    """
+    Set of valid prediction type names for the RFlow scheduler's `prediction_type` argument.
+
+    v_prediction: velocity prediction, see section 2.4 https://imagen.research.google/video/paper.pdf
+    """
+    V_PREDICTION = DDPMPredictionType.V_PREDICTION
+    
 def timestep_transform(
     t, input_img_size_numel, base_img_size_numel=32 * 32 * 32, scale=1.0, num_train_timesteps=1000, spatial_dim=3
 ):
@@ -143,6 +154,9 @@ class RFlowScheduler(Scheduler):
         base_img_size_numel: int = 32 * 32 * 32,
         spatial_dim: int = 3,
     ):
+        # rectified flow only accepts velocity prediction
+        self.prediction_type = RFlowPredictionType.V_PREDICTION
+        
         self.num_train_timesteps = num_train_timesteps
         self.use_discrete_timesteps = use_discrete_timesteps
         self.base_img_size_numel = base_img_size_numel

--- a/monai/networks/schedulers/rectified_flow.py
+++ b/monai/networks/schedulers/rectified_flow.py
@@ -36,8 +36,8 @@ from torch.distributions import LogisticNormal
 
 from monai.utils import StrEnum
 
-from .scheduler import Scheduler
 from .ddpm import DDPMPredictionType
+from .scheduler import Scheduler
 
 
 class RFlowPredictionType(StrEnum):
@@ -46,7 +46,9 @@ class RFlowPredictionType(StrEnum):
 
     v_prediction: velocity prediction, see section 2.4 https://imagen.research.google/video/paper.pdf
     """
+
     V_PREDICTION = DDPMPredictionType.V_PREDICTION
+
 
 def timestep_transform(
     t, input_img_size_numel, base_img_size_numel=32 * 32 * 32, scale=1.0, num_train_timesteps=1000, spatial_dim=3

--- a/monai/networks/schedulers/rectified_flow.py
+++ b/monai/networks/schedulers/rectified_flow.py
@@ -47,7 +47,7 @@ class RFlowPredictionType(StrEnum):
     v_prediction: velocity prediction, see section 2.4 https://imagen.research.google/video/paper.pdf
     """
     V_PREDICTION = DDPMPredictionType.V_PREDICTION
-    
+
 def timestep_transform(
     t, input_img_size_numel, base_img_size_numel=32 * 32 * 32, scale=1.0, num_train_timesteps=1000, spatial_dim=3
 ):
@@ -156,7 +156,7 @@ class RFlowScheduler(Scheduler):
     ):
         # rectified flow only accepts velocity prediction
         self.prediction_type = RFlowPredictionType.V_PREDICTION
-        
+
         self.num_train_timesteps = num_train_timesteps
         self.use_discrete_timesteps = use_discrete_timesteps
         self.base_img_size_numel = base_img_size_numel


### PR DESCRIPTION
Add prediction type to RFlow

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
