### PR TITLE
Enable code coverage comment on PR

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -27,10 +27,10 @@ coverage:
 comment: # enable code coverage comment on PR
   layout: "diff, flags, files"
   behavior: default
-  require_changes: false  
-  require_base: false    
-  require_head: true    
-  hide_project_coverage: true 
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: true
 
 ignore:
   - "versioneer.py"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -24,8 +24,13 @@ coverage:
         flags: null
         paths: null
 
-# Disable comments on PR
-comment: false
+comment: # enable code coverage comment on PR
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false  
+  require_base: false    
+  require_head: true    
+  hide_project_coverage: true 
 
 ignore:
   - "versioneer.py"


### PR DESCRIPTION
Fixes #7290.

### Description
Enable code coverage comment on PR. Code coverage will be shown on the files diff. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
