### PR TITLE
Fix OptionalImportError: required package `openslide` is not installed

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,6 +29,7 @@ torchvision
 psutil
 cucim-cu12; platform_system == "Linux" and python_version >= "3.9" and python_version <= "3.10"
 openslide-python
+openslide-bin
 imagecodecs; platform_system == "Linux" or platform_system == "Darwin"
 tifffile; platform_system == "Linux" or platform_system == "Darwin"
 pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ all =
     psutil
     cucim-cu12; platform_system == "Linux" and python_version >= '3.9' and python_version <= '3.10'
     openslide-python
+    openslide-bin
     tifffile; platform_system == "Linux" or platform_system == "Darwin"
     imagecodecs; platform_system == "Linux" or platform_system == "Darwin"
     pandas
@@ -120,6 +121,7 @@ cucim =
     cucim-cu12; platform_system == "Linux" and python_version >= '3.9' and python_version <= '3.10'
 openslide =
     openslide-python
+    openslide-bin
 tifffile =
     tifffile; platform_system == "Linux" or platform_system == "Darwin"
 imagecodecs =


### PR DESCRIPTION
The full error message was:

`monai.utils.module.OptionalImportError: required package `openslide` is not installed or the version doesn't match requirement.`

More details in:
https://github.com/Project-MONAI/tutorials/discussions/1949

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
