### PR TITLE
Restrict PyTorch Version to Below 2.7

### DIFF
--- a/.github/workflows/pythonapp-min.yml
+++ b/.github/workflows/pythonapp-min.yml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pytorch-version: ['2.3.1', '2.4.1', '2.5.1', 'latest']
+        pytorch-version: ['2.4.1', '2.5.1', '2.6.0']  # FIXME: add 'latest' back once PyTorch 2.7 issues are resolved
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -155,7 +155,7 @@ jobs:
         # install the latest pytorch for testing
         # however, "pip install monai*.tar.gz" will build cpp/cuda with an isolated
         # fresh torch installation according to pyproject.toml
-        python -m pip install torch>=2.3.0 torchvision
+        python -m pip install torch>=2.4.1 torchvision
     - name: Check packages
       run: |
         pip uninstall monai

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -f https://download.pytorch.org/whl/cpu/torch-2.3.0%2Bcpu-cp39-cp39-linux_x86_64.whl
-torch>=2.3.0
+torch>=2.4.1, <2.7.0
 pytorch-ignite==0.4.11
 numpy>=1.20
 itk>=5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,14 @@
 requires = [
   "wheel",
   "setuptools",
-  "torch>=2.3.0",
+  "torch>=2.4.1, <2.7.0",
   "ninja",
   "packaging"
 ]
 
 [tool.black]
 line-length = 120
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py39', 'py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-torch>=2.3.0; sys_platform != 'win32'
-torch>=2.4.1; sys_platform == 'win32'
+torch>=2.4.1, <2.7.0
 numpy>=1.24,<3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,7 @@ setup_requires =
     ninja
     packaging
 install_requires =
-    torch>=2.3.0; sys_platform != 'win32'
-    torch>=2.4.1; sys_platform == 'win32'
+    torch>=2.4.1, <2.7.0
     numpy>=1.24,<3.0
 
 [options.extras_require]


### PR DESCRIPTION
### Description

This restricts the version of PyTorch to be less than 2.7. This avoids compatibility issues with that version and TensorRT, and avoids the illegal instruction bug discussed [here](https://github.com/Project-MONAI/MONAI/pull/8429).

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
