### PR TITLE
 Temporarily Restrict setuptools Version to 79.0.1

### DIFF
--- a/.github/workflows/pythonapp-min.yml
+++ b/.github/workflows/pythonapp-min.yml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pytorch-version: ['2.3.1', '2.4.1', '2.5.1', 'latest']
+        pytorch-version: ['2.4.1', '2.5.1', '2.6.0']  # FIXME: add 'latest' back once PyTorch 2.7 issues are resolved
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -155,7 +155,7 @@ jobs:
         # install the latest pytorch for testing
         # however, "pip install monai*.tar.gz" will build cpp/cuda with an isolated
         # fresh torch installation according to pyproject.toml
-        python -m pip install torch>=2.3.0 torchvision
+        python -m pip install torch>=2.4.1 torchvision
     - name: Check packages
       run: |
         pip uninstall monai

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -f https://download.pytorch.org/whl/cpu/torch-2.3.0%2Bcpu-cp39-cp39-linux_x86_64.whl
-torch>=2.3.0
+torch>=2.4.1, <2.7.0
 pytorch-ignite==0.4.11
 numpy>=1.20
 itk>=5.2

--- a/monai/networks/schedulers/ddpm.py
+++ b/monai/networks/schedulers/ddpm.py
@@ -238,7 +238,7 @@ class DDPMScheduler(Scheduler):
         pred_prev_sample = pred_original_sample_coeff * pred_original_sample + current_sample_coeff * sample
 
         # 6. Add noise
-        variance = 0
+        variance: torch.Tensor = torch.tensor(0)
         if timestep > 0:
             noise = torch.randn(
                 model_output.size(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,14 @@
 requires = [
   "wheel",
   "setuptools",
-  "torch>=2.3.0",
+  "torch>=2.4.1, <2.7.0",
   "ninja",
   "packaging"
 ]
 
 [tool.black]
 line-length = 120
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py39', 'py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ mccabe
 pep8-naming
 pycodestyle
 pyflakes
-black>=22.12
+black>=25.1.0
 isort>=5.1, <6.0
 ruff
 pytype>=2020.6.1; platform_system != "Windows"

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,7 +1,7 @@
 # Requirements for minimal tests
 -r requirements.txt
 setuptools>=50.3.0,<66.0.0,!=60.6.0 ; python_version < "3.12"
-setuptools>=70.2.0; python_version >= "3.12"
+setuptools>=70.2.0,<=79.0.1; python_version >= "3.12"
 coverage>=5.5
 parameterized
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-torch>=2.3.0; sys_platform != 'win32'
-torch>=2.4.1; sys_platform == 'win32'
+torch>=2.4.1, <2.7.0
 numpy>=1.24,<3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,7 @@ setup_requires =
     ninja
     packaging
 install_requires =
-    torch>=2.3.0; sys_platform != 'win32'
-    torch>=2.4.1; sys_platform == 'win32'
+    torch>=2.4.1, <2.7.0
     numpy>=1.24,<3.0
 
 [options.extras_require]


### PR DESCRIPTION
workaround for #8439

### Description

This PR temporarily restricts the setuptools version to 79.0.1 to maintain compatibility with our current setup. In future updates, we need to review and update our setup configurations to accommodate later versions of setuptools. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
