### PR TITLE
Update default overlap value in occlusion_sensitivity to 0.6

### DIFF
--- a/monai/visualize/occlusion_sensitivity.py
+++ b/monai/visualize/occlusion_sensitivity.py
@@ -80,7 +80,7 @@ class OcclusionSensitivity:
         n_batch: int = 16,
         verbose: bool = True,
         mode: str | float | Callable = "gaussian",
-        overlap: float = 0.25,
+        overlap: float = 0.6,
         activate: bool | Callable = True,
     ) -> None:
         """


### PR DESCRIPTION
Fixes # .

### Description

The current default overlap (0.25) in OcclusionSensitivity produces severe grid artifacts that render visualizations unusable in most cases（#8428,the 3d_classification/densenet_training_array.ipynb were created with the previous implementation(0.7.0) using stride=1 but not sliding_window）.The current default prioritizes performance at the expense of basic functionality. Since a visualization tool with unusable default output fails its primary purpose, changing the default is more appropriate than requiring users to modify tutorials or discover the correct parameter values.
refernce in tutorials（v.0.7.0):
![image](https://github.com/user-attachments/assets/94e403bf-2c30-46fa-9856-794043f0b44f)
0.25 overleap (v.1.4):
![image](https://github.com/user-attachments/assets/ba7151f6-b575-49f0-9e83-aa7ac3524d08)
0.6 overleap:
![image](https://github.com/user-attachments/assets/afd9ccf0-45d2-4619-bbe4-e486c3259bbd)
0.9 overleap:
![image](https://github.com/user-attachments/assets/2152e6e3-87f7-4c9d-ac68-d27c8a3469e6)


I think a setting of 0.99 is closer to the paper and the previous implementation of stride=1, but a setting of 0.6 would be able to have a nice visual effect with a relatively small amount of computation
I couldn't find a machine that could run version 0.7, so the reference images are the ones that came with the notes rather than the ones I ran, so the heatmaps may not look the same






### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
