### PR TITLE
Remove deprecated `return_state_dict ` in bundle `load`

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -702,8 +702,6 @@ def load(
         3. If `load_ts_module` is `True`, return a triple that include a TorchScript module,
             the corresponding metadata dict, and extra files dict.
             please check `monai.data.load_net_with_metadata` for more details.
-        4. If `return_state_dict` is True, return model weights, only used for compatibility
-            when `model` and `net_name` are all `None`.
 
     """
     bundle_dir_ = _process_bundle_dir(bundle_dir)

--- a/tests/bundle/test_bundle_download.py
+++ b/tests/bundle/test_bundle_download.py
@@ -280,7 +280,6 @@ class TestLoad(unittest.TestCase):
                     source="github",
                     progress=False,
                     device=device,
-                    return_state_dict=True,
                 )
                 # prepare network
                 with open(os.path.join(bundle_root, bundle_files[2])) as f:
@@ -349,7 +348,6 @@ class TestLoad(unittest.TestCase):
                     source="monaihosting",
                     progress=False,
                     device=device,
-                    return_state_dict=False,
                 )
 
                 # prepare data and test

--- a/tests/bundle/test_bundle_download.py
+++ b/tests/bundle/test_bundle_download.py
@@ -268,11 +268,10 @@ class TestLoad(unittest.TestCase):
     @skip_if_quick
     def test_load_weights(self, bundle_files, bundle_name, repo, device, model_file):
         with skip_if_downloading_fails():
-            # download bundle, and load weights from the downloaded path
             with tempfile.TemporaryDirectory() as tempdir:
                 bundle_root = os.path.join(tempdir, bundle_name)
                 # load weights
-                weights = load(
+                model_1 = load(
                     name=bundle_name,
                     model_file=model_file,
                     bundle_dir=tempdir,
@@ -288,7 +287,7 @@ class TestLoad(unittest.TestCase):
                 del net_args["_target_"]
                 model = getattr(nets, model_name)(**net_args)
                 model.to(device)
-                model.load_state_dict(weights)
+                model.load_state_dict(model_1)
                 model.eval()
 
                 # prepare data and test
@@ -334,6 +333,7 @@ class TestLoad(unittest.TestCase):
                 output_3 = model_3.forward(input_tensor)
                 assert_allclose(output_3, expected_output, atol=1e-4, rtol=1e-4, type_test=False)
 
+
     @parameterized.expand([TEST_CASE_8])
     @skip_if_quick
     @skipUnless(has_huggingface_hub, "Requires `huggingface_hub`.")
@@ -369,7 +369,6 @@ class TestLoad(unittest.TestCase):
                     source="monaihosting",
                     progress=False,
                     device=device,
-                    return_state_dict=False,
                     net_override=net_override,
                 )
 

--- a/tests/bundle/test_bundle_download.py
+++ b/tests/bundle/test_bundle_download.py
@@ -311,13 +311,11 @@ class TestLoad(unittest.TestCase):
                     progress=False,
                     device=device,
                     source="github",
-                    return_state_dict=False,
                 )
                 model_2.eval()
                 output_2 = model_2.forward(input_tensor)
                 assert_allclose(output_2, expected_output, atol=1e-4, rtol=1e-4, type_test=False)
 
-                # test compatibility with return_state_dict=True.
                 model_3 = load(
                     name=bundle_name,
                     model_file=model_file,
@@ -326,7 +324,6 @@ class TestLoad(unittest.TestCase):
                     device=device,
                     net_name=model_name,
                     source="github",
-                    return_state_dict=False,
                     **net_args,
                 )
                 model_3.eval()

--- a/tests/bundle/test_bundle_download.py
+++ b/tests/bundle/test_bundle_download.py
@@ -333,7 +333,6 @@ class TestLoad(unittest.TestCase):
                 output_3 = model_3.forward(input_tensor)
                 assert_allclose(output_3, expected_output, atol=1e-4, rtol=1e-4, type_test=False)
 
-
     @parameterized.expand([TEST_CASE_8])
     @skip_if_quick
     @skipUnless(has_huggingface_hub, "Requires `huggingface_hub`.")
@@ -342,13 +341,7 @@ class TestLoad(unittest.TestCase):
             # download bundle, and load weights from the downloaded path
             with tempfile.TemporaryDirectory() as tempdir:
                 # load weights
-                model = load(
-                    name=bundle_name,
-                    bundle_dir=tempdir,
-                    source="monaihosting",
-                    progress=False,
-                    device=device,
-                )
+                model = load(name=bundle_name, bundle_dir=tempdir, source="monaihosting", progress=False, device=device)
 
                 # prepare data and test
                 input_tensor = torch.rand(1, 1, 96, 96, 96).to(device)

--- a/tests/ngc_bundle_download.py
+++ b/tests/ngc_bundle_download.py
@@ -88,7 +88,6 @@ class TestNgcBundleDownload(unittest.TestCase):
                     version=version,
                     bundle_dir=tempdir,
                     remove_prefix=remove_prefix,
-                    return_state_dict=False,
                 )
                 assert_allclose(
                     model.state_dict()[TESTCASE_WEIGHTS["key"]],

--- a/tests/ngc_bundle_download.py
+++ b/tests/ngc_bundle_download.py
@@ -83,11 +83,7 @@ class TestNgcBundleDownload(unittest.TestCase):
                 self.assertTrue(check_hash(filepath=full_file_path, val=hash_val))
 
                 model = load(
-                    name=bundle_name,
-                    source="ngc",
-                    version=version,
-                    bundle_dir=tempdir,
-                    remove_prefix=remove_prefix,
+                    name=bundle_name, source="ngc", version=version, bundle_dir=tempdir, remove_prefix=remove_prefix
                 )
                 assert_allclose(
                     model.state_dict()[TESTCASE_WEIGHTS["key"]],


### PR DESCRIPTION
Fixes #8453

### Description

Remove deprecated `return_state_dict ` in bundle `load`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
