### PR TITLE
Adding Support Policy + Doc Updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,9 +105,9 @@ MONAI tests are located under `tests/`.
 A bash script (`runtests.sh`) is provided to run all tests locally.
 Please run ``./runtests.sh -h`` to see all options.
 
-To run a particular test, for example `tests/test_dice_loss.py`:
+To run a particular test, for example `tests/losses/test_dice_loss.py`:
 ```
-python -m tests.test_dice_loss
+python -m tests.losses.test_dice_loss
 ```
 
 Before submitting a pull request, we recommend that all linting and unit tests

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Its ambitions are as follows:
 - customizable design for varying user expertise;
 - multi-GPU multi-node data parallelism support.
 
+## Requirements
+
+MONAI works with the [currently supported versions of Python](https://devguide.python.org/versions), and depends directly on NumPy and PyTorch with many optional dependencies. 
+
+* Major releases of MONAI will have dependency versions stated for them. The current state of the `dev` branch in this repository is the unreleased development version of MONAI which typically will support current versions of dependencies and include updates and bug fixes to do so.
+* PyTorch support covers [the current version](https://github.com/pytorch/pytorch/releases) plus three previous minor versions. If compatibility issues with a PyTorch version and other dependencies arise, support for a version may be delayed until a major release. 
+* Our support policy for other dependencies adheres for the most part to [SPEC0](https://scientific-python.org/specs/spec-0000), where dependency versions are supported where possible for up to two years. Discovered vulnerabilities or defects may require certain versions to be explicitly not supported.
+* See the `requirements*.txt` files for dependency version information.
+
 ## Installation
 
 To install [the current release](https://pypi.org/project/monai/), you can simply run:

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Its ambitions are as follows:
 
 ## Requirements
 
-MONAI works with the [currently supported versions of Python](https://devguide.python.org/versions), and depends directly on NumPy and PyTorch with many optional dependencies. 
+MONAI works with the [currently supported versions of Python](https://devguide.python.org/versions), and depends directly on NumPy and PyTorch with many optional dependencies.
 
 * Major releases of MONAI will have dependency versions stated for them. The current state of the `dev` branch in this repository is the unreleased development version of MONAI which typically will support current versions of dependencies and include updates and bug fixes to do so.
-* PyTorch support covers [the current version](https://github.com/pytorch/pytorch/releases) plus three previous minor versions. If compatibility issues with a PyTorch version and other dependencies arise, support for a version may be delayed until a major release. 
+* PyTorch support covers [the current version](https://github.com/pytorch/pytorch/releases) plus three previous minor versions. If compatibility issues with a PyTorch version and other dependencies arise, support for a version may be delayed until a major release.
 * Our support policy for other dependencies adheres for the most part to [SPEC0](https://scientific-python.org/specs/spec-0000), where dependency versions are supported where possible for up to two years. Discovered vulnerabilities or defects may require certain versions to be explicitly not supported.
 * See the `requirements*.txt` files for dependency version information.
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -58,10 +58,10 @@ pip install monai-weekly
 ```
 
 The weekly build is released to PyPI every Sunday with a pre-release build number `dev[%y%U]`.
-To report any issues on the weekly preview, please include the version and commit information:
+To report any issues on the weekly preview, please include the version information:
 
 ```bash
-python -c "import monai; print(monai.__version__); print(monai.__commit_id__)"
+python -c "import monai; print(monai.__version__)"
 ```
 
 Coexistence of package `monai` and `monai-weekly` in a system may cause namespace conflicts
@@ -101,20 +101,20 @@ for the latest features:
 ### Option 1 (as a part of your system-wide module):
 
 ```bash
-pip install git+https://github.com/Project-MONAI/MONAI#egg=monai
+pip install git+https://github.com/Project-MONAI/MONAI
 ```
 
 or, to build with MONAI C++/CUDA extensions:
 
 ```bash
-BUILD_MONAI=1 pip install git+https://github.com/Project-MONAI/MONAI#egg=monai
+BUILD_MONAI=1 pip install git+https://github.com/Project-MONAI/MONAI
 ```
 
 To build the extensions, if the system environment already has a version of Pytorch installed,
 `--no-build-isolation` might be preferred:
 
 ```bash
-BUILD_MONAI=1 pip install --no-build-isolation git+https://github.com/Project-MONAI/MONAI#egg=monai
+BUILD_MONAI=1 pip install --no-build-isolation git+https://github.com/Project-MONAI/MONAI
 ```
 
 this command will download and install the current `dev` branch of [MONAI from


### PR DESCRIPTION
Addresses #8303.

### Description

This adds language in the README.md file stating the support policy. There's a few things needing updating in documents that I've added as well. I've explicitly not mentioned versions of libraries in the README.md so that this doesn't go out of date, and just stated the update policy time window of support. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
