### PR TITLE
Remove deprecated `net_name` in test file

### DIFF
--- a/tests/bundle/test_bundle_download.py
+++ b/tests/bundle/test_bundle_download.py
@@ -322,7 +322,6 @@ class TestLoad(unittest.TestCase):
                     bundle_dir=tempdir,
                     progress=False,
                     device=device,
-                    # net_name=model_name,
                     source="github",
                     **net_args,
                 )

--- a/tests/bundle/test_bundle_download.py
+++ b/tests/bundle/test_bundle_download.py
@@ -322,7 +322,7 @@ class TestLoad(unittest.TestCase):
                     bundle_dir=tempdir,
                     progress=False,
                     device=device,
-                    net_name=model_name,
+                    # net_name=model_name,
                     source="github",
                     **net_args,
                 )


### PR DESCRIPTION
Fixes #8453


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
