### PR TITLE
Remove unused test cases in bundle load

### DIFF
--- a/tests/bundle/test_bundle_download.py
+++ b/tests/bundle/test_bundle_download.py
@@ -316,19 +316,6 @@ class TestLoad(unittest.TestCase):
                 output_2 = model_2.forward(input_tensor)
                 assert_allclose(output_2, expected_output, atol=1e-4, rtol=1e-4, type_test=False)
 
-                model_3 = load(
-                    name=bundle_name,
-                    model_file=model_file,
-                    bundle_dir=tempdir,
-                    progress=False,
-                    device=device,
-                    source="github",
-                    **net_args,
-                )
-                model_3.eval()
-                output_3 = model_3.forward(input_tensor)
-                assert_allclose(output_3, expected_output, atol=1e-4, rtol=1e-4, type_test=False)
-
     @parameterized.expand([TEST_CASE_8])
     @skip_if_quick
     @skipUnless(has_huggingface_hub, "Requires `huggingface_hub`.")


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/8453

### Description

Remove unused test cases in bundle load.
https://github.com/Project-MONAI/MONAI/pull/8454/files#diff-5ad63db6f47bac69cb323c9d466ac0d8b86c9614cb7a96b9d69235feaa1c83d7

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
