### PR TITLE
WIP: Orientation transform checks for space of a metatensor

### DIFF
--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -550,7 +550,7 @@ class Orientationd(MapTransform, InvertibleTransform, LazyTransform):
         keys: KeysCollection,
         axcodes: str | None = None,
         as_closest_canonical: bool = False,
-        labels: Sequence[tuple[str, str]] | None = (("L", "R"), ("P", "A"), ("I", "S")),
+        labels: Sequence[tuple[str, str]] | None = None,
         allow_missing_keys: bool = False,
         lazy: bool = False,
     ) -> None:
@@ -564,7 +564,9 @@ class Orientationd(MapTransform, InvertibleTransform, LazyTransform):
             as_closest_canonical: if True, load the image as closest to canonical axis format.
             labels: optional, None or sequence of (2,) sequences
                 (2,) sequences are labels for (beginning, end) of output axis.
-                Defaults to ``(('L', 'R'), ('P', 'A'), ('I', 'S'))``.
+                Defaults to using the ``"space"`` attribute of a metatensor,
+                where appliable, or (('L', 'R'), ('P', 'A'), ('I', 'S'))``
+                otherwise (i.e. for plain tensors).
             allow_missing_keys: don't raise exception if key is missing.
             lazy: a flag to indicate whether this transform should execute lazily or not.
                 Defaults to False


### PR DESCRIPTION
Draft fix for #8467 

### Description

The `Orientation` transform now checks whether the input tensor is a metatensor with its affine defined in LPS space. If so, it adjusts the `labels` passed to `nibabel.orientations.axcodes2ornt` to give the expected behaviour.

The default value of the `label` parameter of the `Orientation` transform (and `OrientationD`) has changed from `(('L', 'R'), ('P', 'A'), ('I', 'S'))` to `None`. However, since the behaviour of `nibabel.orientations.axcodes2ornt` when passed `labels=None` is equivalent to when passing `labels=(('L', 'R'), ('P', 'A'), ('I', 'S'))`, I would not consider this a breaking change.

This is a draft awaiting implementation of tests. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
