### PR TITLE
Add input validation to ImageStats class

### DIFF
--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -230,11 +230,6 @@ class ImageStats(Analyzer):
             )
         if image.ndim < 3:
             raise ValueError(
-                f"Value for '{self.image_key}' must be a numpy array, torch.Tensor, or MetaTensor, "
-                f"but got {type(image).__name__}."
-            )
-        if image.ndim < 3:
-            raise ValueError(
                 f"Image data under '{self.image_key}' must have at least 3 dimensions, but got shape {image.shape}."
             )
             # --- End of validation ---

--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -235,7 +235,7 @@ class ImageStats(Analyzer):
             )
         if image.ndim < 3:
             raise ValueError(
-                f"Image data under '{self.image_key}' must have at least 3 dimensions, " f"but got shape {image.shape}."
+                f"Image data under '{self.image_key}' must have at least 3 dimensions, but got shape {image.shape}."
             )
             # --- End of validation ---
         """

--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -217,7 +217,7 @@ class ImageStats(Analyzer):
         self.update_ops(ImageStatsKeys.INTENSITY, SampleOperations())
 
     def __call__(self, data):
-        #Input Validation Addition
+        # Input Validation Addition
         if not isinstance(data, dict):
             raise TypeError(f"Input data must be a dict, but got {type(data).__name__}.")
         if self.image_key not in data:
@@ -235,8 +235,7 @@ class ImageStats(Analyzer):
             )
         if image.ndim < 3:
             raise ValueError(
-                f"Image data under '{self.image_key}' must have at least 3 dimensions, "
-                f"but got shape {image.shape}."
+                f"Image data under '{self.image_key}' must have at least 3 dimensions, " f"but got shape {image.shape}."
             )
             # --- End of validation ---
         """

--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -217,6 +217,28 @@ class ImageStats(Analyzer):
         self.update_ops(ImageStatsKeys.INTENSITY, SampleOperations())
 
     def __call__(self, data):
+        #Input Validation Addition
+        if not isinstance(data, dict):
+            raise TypeError(f"Input data must be a dict, but got {type(data).__name__}.")
+        if self.image_key not in data:
+            raise KeyError(f"Key '{self.image_key}' not found in input data.")
+        image = data[self.image_key]
+        if not isinstance(image, (np.ndarray, torch.Tensor, MetaTensor)):
+            raise TypeError(
+                f"Value for '{self.image_key}' must be a numpy array, torch.Tensor, or MetaTensor, "
+                f"but got {type(image).__name__}."
+            )
+        if image.ndim < 3:
+            raise ValueError(
+                f"Value for '{self.image_key}' must be a numpy array, torch.Tensor, or MetaTensor, "
+                f"but got {type(image).__name__}."
+            )
+        if image.ndim < 3:
+            raise ValueError(
+                f"Image data under '{self.image_key}' must have at least 3 dimensions, "
+                f"but got shape {image.shape}."
+            )
+            # --- End of validation ---
         """
         Callable to execute the pre-defined functions
 


### PR DESCRIPTION
Fixes # .

### Description

This pull request adds input validation to the ImageStats class in monai/auto3dseg/analyzer.py.
Specifically, it introduces type and value checks at the start of the __call__ method to ensure: The input is a dictionary. The specified image_key exists in the input data. The value for image_key is a NumPy array, torch.Tensor, or MetaTensor. The image array has at least 3 dimensions. If any of these checks fail, an informative error is raised.This enhancement improves robustness and user experience by providing clearer feedback when invalid data is passed to the analyzer.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for image statistics analysis to provide clearer error messages when inputs are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->