### PR TITLE
add kwargs in array and functional file

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -1108,6 +1108,7 @@ class Zoom(InvertibleTransform, LazyTransform):
             _dtype,
             lazy=lazy_,
             transform_info=self.get_transform_info(),
+            **self.kwargs,
         )
 
     def inverse(self, data: torch.Tensor) -> torch.Tensor:

--- a/monai/transforms/spatial/functional.py
+++ b/monai/transforms/spatial/functional.py
@@ -411,7 +411,7 @@ def rotate(img, angle, output_shape, mode, padding_mode, align_corners, dtype, l
     return out.copy_meta_from(meta_info) if isinstance(out, MetaTensor) else out
 
 
-def zoom(img, scale_factor, keep_size, mode, padding_mode, align_corners, dtype, lazy, transform_info):
+def zoom(img, scale_factor, keep_size, mode, padding_mode, align_corners, dtype, lazy, transform_info, **kwargs):
     """
     Functional implementation of zoom.
     This function operates eagerly or lazily according to
@@ -450,7 +450,7 @@ def zoom(img, scale_factor, keep_size, mode, padding_mode, align_corners, dtype,
     if keep_size:
         do_pad_crop = not np.allclose(output_size, im_shape)
         if do_pad_crop and lazy:  # update for lazy evaluation
-            _pad_crop = ResizeWithPadOrCrop(spatial_size=im_shape, mode=padding_mode)
+            _pad_crop = ResizeWithPadOrCrop(spatial_size=im_shape, mode=padding_mode, **kwargs)
             _pad_crop.lazy = True
             _tmp_img = MetaTensor([], affine=torch.eye(len(output_size) + 1))
             _tmp_img.push_pending_operation({LazyAttr.SHAPE: list(output_size), LazyAttr.AFFINE: xform})
@@ -486,7 +486,7 @@ def zoom(img, scale_factor, keep_size, mode, padding_mode, align_corners, dtype,
         out = out.copy_meta_from(meta_info)
     do_pad_crop = not np.allclose(output_size, zoomed.shape[1:])
     if do_pad_crop:
-        _pad_crop = ResizeWithPadOrCrop(spatial_size=img_t.shape[1:], mode=padding_mode)
+        _pad_crop = ResizeWithPadOrCrop(spatial_size=img_t.shape[1:], mode=padding_mode, **kwargs)
         out = _pad_crop(out)
     if get_track_meta() and do_pad_crop:
         padcrop_xform = out.applied_operations.pop()


### PR DESCRIPTION
Fixes #8492 

### Description

This PR adds support for `**kwargs` in the `ResizeWithPadOrCrop` transform to fix the issue where extra keyword arguments were ignored, causing errors in some workflows. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced zoom functionality to support additional parameters, allowing for greater flexibility in image transformation operations. 

* **Refactor**
  * Improved handling of optional arguments in zoom-related transformations for more customizable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->