### PR TITLE
Change SupervisedTrainer decollation default.

### DIFF
--- a/monai/engines/trainer.py
+++ b/monai/engines/trainer.py
@@ -120,7 +120,7 @@ class SupervisedTrainer(Trainer):
             #ignite.engine.engine.Engine.register_events.
         decollate: whether to decollate the batch-first data to a list of data after model computation,
             recommend `decollate=True` when `postprocessing` uses components from `monai.transforms`.
-            default to `True`.
+            default to `False` as training slows due to tensor movement to CPU for decollation when enabled.
         optim_set_to_none: when calling `optimizer.zero_grad()`, instead of setting to zero, set the grads to None.
             more details: https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.zero_grad.html.
         to_kwargs: dict of other args for `prepare_batch` API when converting the input data, except for
@@ -154,7 +154,7 @@ class SupervisedTrainer(Trainer):
         amp: bool = False,
         event_names: list[str | EventEnum | type[EventEnum]] | None = None,
         event_to_attr: dict | None = None,
-        decollate: bool = True,
+        decollate: bool = False,
         optim_set_to_none: bool = False,
         to_kwargs: dict | None = None,
         amp_kwargs: dict | None = None,

--- a/tests/apps/deepgrow/transforms/test_deepgrow_interaction.py
+++ b/tests/apps/deepgrow/transforms/test_deepgrow_interaction.py
@@ -78,6 +78,7 @@ class TestInteractions(unittest.TestCase):
             optimizer=opt,
             loss_function=loss,
             iteration_update=i,
+            decollate=True,
         )
         engine.add_event_handler(IterationEvents.INNER_ITERATION_STARTED, add_one)
         engine.add_event_handler(IterationEvents.INNER_ITERATION_COMPLETED, add_one)

--- a/tests/integration/test_deepedit_interaction.py
+++ b/tests/integration/test_deepedit_interaction.py
@@ -103,6 +103,7 @@ class TestInteractions(unittest.TestCase):
             loss_function=loss,
             postprocessing=post_transforms,
             iteration_update=i,
+            decollate=True,
         )
         engine.add_event_handler(IterationEvents.INNER_ITERATION_STARTED, add_one)
         engine.add_event_handler(IterationEvents.INNER_ITERATION_COMPLETED, add_one)

--- a/tests/testing_data/config_fl_train.json
+++ b/tests/testing_data/config_fl_train.json
@@ -119,7 +119,8 @@
             "loss_function": "@loss",
             "optimizer": "@optimizer",
             "inferer": "@train#inferer",
-            "train_handlers": "@train#handlers"
+            "train_handlers": "@train#handlers",
+            "decollate": true
         }
     },
     "validate": {


### PR DESCRIPTION
Fixes #8541 .

### Description

By default, the SupervisedTrainer has `decollation` enabled by default. The decollation step moves the tensors to CPU for processing which significantly impacts the speed of each training step as described in issue #8541 

This pull request proposes to change the default of decollation to `False` and provide more information in the documentation as to the impact of the decollation option with regard to the training speed.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
