### PR TITLE
fix: HistogramNormalized doc

### DIFF
--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -1836,7 +1836,7 @@ class HistogramNormalized(MapTransform):
             See also: :py:class:`monai.transforms.compose.MapTransform`
         num_bins: number of the bins to use in histogram, default to `256`. for more details:
             https://numpy.org/doc/stable/reference/generated/numpy.histogram.html.
-        min: the min value to normalize input image, default to `255`.
+        min: the min value to normalize input image, default to `0`.
         max: the max value to normalize input image, default to `255`.
         mask: if provided, must be ndarray of bools or 0s and 1s, and same shape as `image`.
             only points at which `mask==True` are used for the equalization.


### PR DESCRIPTION
### Description

The docstring for `min` parameter for `HistogramNormalized` wrongly shows the default value to be 255 when the correct default value is 0. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
