### PR TITLE
Fix build failure by pinning pyamg to versions below 5.3.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -40,6 +40,6 @@ onnx>=1.13.0
 onnxruntime; python_version <= '3.10'
 zarr
 huggingface_hub
-pyamg>=5.0.0
+pyamg>=5.0.0, <5.3.0
 packaging
 polygraphy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -59,7 +59,7 @@ zarr
 lpips==0.1.4
 nvidia-ml-py
 huggingface_hub
-pyamg>=5.0.0
+pyamg>=5.0.0, <5.3.0
 git+https://github.com/facebookresearch/segment-anything.git@6fdee8f2727f4506cfbbe553e23b895e27956588
 onnx_graphsurgeon
 polygraphy

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ all =
     lpips==0.1.4
     nvidia-ml-py
     huggingface_hub
-    pyamg>=5.0.0
+    pyamg>=5.0.0, <5.3.0
 nibabel =
     nibabel
 ninja =
@@ -175,7 +175,7 @@ polygraphy =
 huggingface_hub =
     huggingface_hub
 pyamg =
-    pyamg>=5.0.0
+    pyamg>=5.0.0, <5.3.0
 # segment-anything =
 #     segment-anything @ git+https://github.com/facebookresearch/segment-anything@6fdee8f2727f4506cfbbe553e23b895e27956588#egg=segment-anything
 


### PR DESCRIPTION
Fixes #8547

### Description

Fix build failure by pinning pyamg to versions below 5.3.0

https://pypi.org/project/pyamg/5.3.0/#files

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
