### PR TITLE
feat: add activation checkpointing to unet

### DIFF
--- a/monai/networks/blocks/activation_checkpointing.py
+++ b/monai/networks/blocks/activation_checkpointing.py
@@ -1,0 +1,41 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import cast
+
+import torch
+import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
+
+
+class ActivationCheckpointWrapper(nn.Module):
+    """Wrapper applying activation checkpointing to a module during training.
+
+    Args:
+        module: The module to wrap with activation checkpointing.
+    """
+
+    def __init__(self, module: nn.Module) -> None:
+        super().__init__()
+        self.module = module
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass with optional activation checkpointing.
+
+        Args:
+            x: Input tensor.
+
+        Returns:
+            Output tensor from the wrapped module.
+        """
+        return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -13,28 +13,16 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Sequence
-from typing import cast
 
 import torch
 import torch.nn as nn
-from torch.utils.checkpoint import checkpoint
 
+from monai.networks.blocks.activation_checkpointing import ActivationCheckpointWrapper
 from monai.networks.blocks.convolutions import Convolution, ResidualUnit
 from monai.networks.layers.factories import Act, Norm
 from monai.networks.layers.simplelayers import SkipConnection
 
 __all__ = ["UNet", "Unet"]
-
-
-class _ActivationCheckpointWrapper(nn.Module):
-    """Apply activation checkpointing to the wrapped module during training."""
-
-    def __init__(self, module: nn.Module) -> None:
-        super().__init__()
-        self.module = module
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))
 
 
 class UNet(nn.Module):
@@ -313,9 +301,9 @@ class UNet(nn.Module):
 
 class CheckpointUNet(UNet):
     def _get_connection_block(self, down_path: nn.Module, up_path: nn.Module, subblock: nn.Module) -> nn.Module:
-        subblock = _ActivationCheckpointWrapper(subblock)
-        down_path = _ActivationCheckpointWrapper(down_path)
-        up_path = _ActivationCheckpointWrapper(up_path)
+        subblock = ActivationCheckpointWrapper(subblock)
+        down_path = ActivationCheckpointWrapper(down_path)
+        up_path = ActivationCheckpointWrapper(up_path)
         return super()._get_connection_block(down_path, up_path, subblock)
 
 

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -303,11 +303,21 @@ class CheckpointUNet(UNet):
     """UNet variant that wraps internal connection blocks with activation checkpointing.
 
     See `UNet` for constructor arguments. During training with gradients enabled,
-    intermediate activations inside encoder–decoder connections are recomputed in
+    intermediate activations inside encoder-decoder connections are recomputed in
     the backward pass to reduce peak memory usage at the cost of extra compute.
     """
 
     def _get_connection_block(self, down_path: nn.Module, up_path: nn.Module, subblock: nn.Module) -> nn.Module:
+        """Returns connection block with activation checkpointing applied to all components.
+
+        Args:
+            down_path: encoding half of the layer (will be wrapped with checkpointing).
+            up_path: decoding half of the layer (will be wrapped with checkpointing).
+            subblock: block defining the next layer (will be wrapped with checkpointing).
+
+        Returns:
+            Connection block with all components wrapped for activation checkpointing.
+        """
         subblock = ActivationCheckpointWrapper(subblock)
         down_path = ActivationCheckpointWrapper(down_path)
         up_path = ActivationCheckpointWrapper(up_path)

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -22,7 +22,7 @@ from monai.networks.blocks.convolutions import Convolution, ResidualUnit
 from monai.networks.layers.factories import Act, Norm
 from monai.networks.layers.simplelayers import SkipConnection
 
-__all__ = ["UNet", "Unet"]
+__all__ = ["UNet", "Unet", "CheckpointUNet"]
 
 
 class UNet(nn.Module):
@@ -300,6 +300,13 @@ class UNet(nn.Module):
 
 
 class CheckpointUNet(UNet):
+    """UNet variant that wraps internal connection blocks with activation checkpointing.
+
+    See `UNet` for constructor arguments. During training with gradients enabled,
+    intermediate activations inside encoder–decoder connections are recomputed in
+    the backward pass to reduce peak memory usage at the cost of extra compute.
+    """
+
     def _get_connection_block(self, down_path: nn.Module, up_path: nn.Module, subblock: nn.Module) -> nn.Module:
         subblock = ActivationCheckpointWrapper(subblock)
         down_path = ActivationCheckpointWrapper(down_path)

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -30,10 +30,19 @@ class _ActivationCheckpointWrapper(nn.Module):
     """Apply activation checkpointing to the wrapped module during training."""
     def __init__(self, module: nn.Module) -> None:
         super().__init__()
+        # Pre-detect BatchNorm presence for fast path
+        self._has_bn = any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in module.modules())
         self.module = module
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.training and torch.is_grad_enabled() and x.requires_grad:
+            if self._has_bn:
+                warnings.warn(
+                    "Activation checkpointing skipped for a subblock containing BatchNorm to avoid double-updating "
+                    "running statistics during recomputation.",
+                    RuntimeWarning,
+                )
+                return cast(torch.Tensor, self.module(x))
             try:
                 return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))
             except TypeError:

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -25,6 +25,7 @@ from monai.networks.layers.simplelayers import SkipConnection
 
 __all__ = ["UNet", "Unet"]
 
+
 class _ActivationCheckpointWrapper(nn.Module):
     def __init__(self, module: nn.Module) -> None:
         super().__init__()
@@ -34,6 +35,7 @@ class _ActivationCheckpointWrapper(nn.Module):
         if self.training:
             return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))
         return cast(torch.Tensor, self.module(x))
+
 
 class UNet(nn.Module):
     """

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -32,8 +32,12 @@ class _ActivationCheckpointWrapper(nn.Module):
         self.module = module
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if self.training:
-            return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))
+        if self.training and torch.is_grad_enabled() and x.requires_grad:
+            try:
+                return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))
+            except TypeError:
+                # Fallback for older PyTorch without `use_reentrant`
+                return cast(torch.Tensor, checkpoint(self.module, x))
         return cast(torch.Tensor, self.module(x))
 
 

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -33,13 +33,7 @@ class _ActivationCheckpointWrapper(nn.Module):
         self.module = module
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if self.training and torch.is_grad_enabled() and x.requires_grad:
-            try:
-                return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))
-            except TypeError:
-                # Fallback for older PyTorch without `use_reentrant`
-                return cast(torch.Tensor, checkpoint(self.module, x))
-        return cast(torch.Tensor, self.module(x))
+        return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))
 
 
 class UNet(nn.Module):
@@ -138,7 +132,6 @@ class UNet(nn.Module):
         dropout: float = 0.0,
         bias: bool = True,
         adn_ordering: str = "NDA",
-        use_checkpointing: bool = False,
     ) -> None:
         super().__init__()
 
@@ -167,7 +160,6 @@ class UNet(nn.Module):
         self.dropout = dropout
         self.bias = bias
         self.adn_ordering = adn_ordering
-        self.use_checkpointing = use_checkpointing
 
         def _create_block(
             inc: int, outc: int, channels: Sequence[int], strides: Sequence[int], is_top: bool
@@ -214,8 +206,6 @@ class UNet(nn.Module):
             subblock: block defining the next layer in the network.
         Returns: block for this layer: `nn.Sequential(down_path, SkipConnection(subblock), up_path)`
         """
-        if self.use_checkpointing:
-            subblock = _ActivationCheckpointWrapper(subblock)
         return nn.Sequential(down_path, SkipConnection(subblock), up_path)
 
     def _get_down_layer(self, in_channels: int, out_channels: int, strides: int, is_top: bool) -> nn.Module:
@@ -321,5 +311,9 @@ class UNet(nn.Module):
         x = self.model(x)
         return x
 
+class CheckpointUNet(UNet):
+    def _get_connection_block(self, down_path: nn.Module, up_path: nn.Module, subblock: nn.Module) -> nn.Module:
+        subblock = _ActivationCheckpointWrapper(subblock)
+        return super()._get_connection_block(down_path, up_path, subblock)
 
 Unet = UNet

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -30,19 +30,10 @@ class _ActivationCheckpointWrapper(nn.Module):
     """Apply activation checkpointing to the wrapped module during training."""
     def __init__(self, module: nn.Module) -> None:
         super().__init__()
-        # Pre-detect BatchNorm presence for fast path
-        self._has_bn = any(isinstance(m, nn.modules.batchnorm._BatchNorm) for m in module.modules())
         self.module = module
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.training and torch.is_grad_enabled() and x.requires_grad:
-            if self._has_bn:
-                warnings.warn(
-                    "Activation checkpointing skipped for a subblock containing BatchNorm to avoid double-updating "
-                    "running statistics during recomputation.",
-                    RuntimeWarning,
-                )
-                return cast(torch.Tensor, self.module(x))
             try:
                 return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))
             except TypeError:

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -81,8 +81,6 @@ class UNet(nn.Module):
             if a conv layer is directly followed by a batch norm layer, bias should be False.
         adn_ordering: a string representing the ordering of activation (A), normalization (N), and dropout (D).
             Defaults to "NDA". See also: :py:class:`monai.networks.blocks.ADN`.
-        use_checkpointing: if True, apply activation checkpointing to internal sub-blocks during training to reduce memory
-        at the cost of extra compute. Checkpointing is bypassed in eval and when gradients are disabled. Defaults to False.
 
     Examples::
 

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -28,6 +28,7 @@ __all__ = ["UNet", "Unet"]
 
 class _ActivationCheckpointWrapper(nn.Module):
     """Apply activation checkpointing to the wrapped module during training."""
+
     def __init__(self, module: nn.Module) -> None:
         super().__init__()
         self.module = module
@@ -309,9 +310,11 @@ class UNet(nn.Module):
         x = self.model(x)
         return x
 
+
 class CheckpointUNet(UNet):
     def _get_connection_block(self, down_path: nn.Module, up_path: nn.Module, subblock: nn.Module) -> nn.Module:
         subblock = _ActivationCheckpointWrapper(subblock)
         return super()._get_connection_block(down_path, up_path, subblock)
+
 
 Unet = UNet

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -87,7 +87,7 @@ class UNet(nn.Module):
             if a conv layer is directly followed by a batch norm layer, bias should be False.
         adn_ordering: a string representing the ordering of activation (A), normalization (N), and dropout (D).
             Defaults to "NDA". See also: :py:class:`monai.networks.blocks.ADN`.
-        use_checkpointing: if True, apply activation checkpointing to internal sub-blocks during training to reduce memory 
+        use_checkpointing: if True, apply activation checkpointing to internal sub-blocks during training to reduce memory
         at the cost of extra compute. Checkpointing is bypassed in eval and when gradients are disabled. Defaults to False.
 
     Examples::

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -27,6 +27,7 @@ __all__ = ["UNet", "Unet"]
 
 
 class _ActivationCheckpointWrapper(nn.Module):
+    """Apply activation checkpointing to the wrapped module during training."""
     def __init__(self, module: nn.Module) -> None:
         super().__init__()
         self.module = module
@@ -86,6 +87,8 @@ class UNet(nn.Module):
             if a conv layer is directly followed by a batch norm layer, bias should be False.
         adn_ordering: a string representing the ordering of activation (A), normalization (N), and dropout (D).
             Defaults to "NDA". See also: :py:class:`monai.networks.blocks.ADN`.
+        use_checkpointing: if True, apply activation checkpointing to internal sub-blocks during training to reduce memory 
+        at the cost of extra compute. Checkpointing is bypassed in eval and when gradients are disabled. Defaults to False.
 
     Examples::
 

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Sequence
+from typing import cast
 
 import torch
 import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
 
 from monai.networks.blocks.convolutions import Convolution, ResidualUnit
 from monai.networks.layers.factories import Act, Norm
@@ -23,6 +25,15 @@ from monai.networks.layers.simplelayers import SkipConnection
 
 __all__ = ["UNet", "Unet"]
 
+class _ActivationCheckpointWrapper(nn.Module):
+    def __init__(self, module: nn.Module) -> None:
+        super().__init__()
+        self.module = module
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.training:
+            return cast(torch.Tensor, checkpoint(self.module, x, use_reentrant=False))
+        return cast(torch.Tensor, self.module(x))
 
 class UNet(nn.Module):
     """
@@ -118,6 +129,7 @@ class UNet(nn.Module):
         dropout: float = 0.0,
         bias: bool = True,
         adn_ordering: str = "NDA",
+        use_checkpointing: bool = False,
     ) -> None:
         super().__init__()
 
@@ -146,6 +158,7 @@ class UNet(nn.Module):
         self.dropout = dropout
         self.bias = bias
         self.adn_ordering = adn_ordering
+        self.use_checkpointing = use_checkpointing
 
         def _create_block(
             inc: int, outc: int, channels: Sequence[int], strides: Sequence[int], is_top: bool
@@ -192,6 +205,8 @@ class UNet(nn.Module):
             subblock: block defining the next layer in the network.
         Returns: block for this layer: `nn.Sequential(down_path, SkipConnection(subblock), up_path)`
         """
+        if self.use_checkpointing:
+            subblock = _ActivationCheckpointWrapper(subblock)
         return nn.Sequential(down_path, SkipConnection(subblock), up_path)
 
     def _get_down_layer(self, in_channels: int, out_channels: int, strides: int, is_top: bool) -> nn.Module:

--- a/monai/networks/nets/unet.py
+++ b/monai/networks/nets/unet.py
@@ -314,6 +314,8 @@ class UNet(nn.Module):
 class CheckpointUNet(UNet):
     def _get_connection_block(self, down_path: nn.Module, up_path: nn.Module, subblock: nn.Module) -> nn.Module:
         subblock = _ActivationCheckpointWrapper(subblock)
+        down_path = _ActivationCheckpointWrapper(down_path)
+        up_path = _ActivationCheckpointWrapper(up_path)
         return super()._get_connection_block(down_path, up_path, subblock)
 
 

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -104,10 +104,12 @@ class TestCheckpointUNet(unittest.TestCase):
             spatial_dims=2, in_channels=1, out_channels=2, channels=(8, 16, 32), strides=(2, 2), num_res_units=1
         )
 
+        torch.manual_seed(0)
         x = torch.randn(2, 1, 32, 32, device=device)
 
-        net_ckpt = CheckpointUNet(**params).to(device)
         net_plain = UNet(**params).to(device)
+        net_ckpt = CheckpointUNet(**params).to(device)
+        net_ckpt.load_state_dict(net_plain.state_dict())
 
         with eval_mode(net_ckpt), eval_mode(net_plain):
             y_ckpt = net_ckpt(x)

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -124,17 +124,20 @@ CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_C
 class TestCheckpointUNet(unittest.TestCase):
     @parameterized.expand(CASES)
     def test_shape(self, input_param, input_shape, expected_shape):
+        """Validate CheckpointUNet output shapes across configurations.
+
+        Args:
+            input_param: Mapping of constructor kwargs for the network under test.
+            input_shape: Shape tuple for the synthetic input tensor.
+            expected_shape: Expected output tensor shape.
+        """
         net = CheckpointUNet(**input_param).to(device)
         with eval_mode(net):
             result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
 
     def test_script(self):
-        """
-        TorchScript doesn't support activation-checkpointing (torch.utils.checkpoint) calls inside the module.
-        To keep the test suite validating TorchScript compatibility, script the plain UNet (which is scriptable),
-        rather than the CheckpointUNet wrapper that uses checkpointing internals.
-        """
+        """Script the baseline UNet to maintain TorchScript coverage."""
         net = UNet(
             spatial_dims=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2), num_res_units=0
         )
@@ -142,7 +145,7 @@ class TestCheckpointUNet(unittest.TestCase):
         test_script_save(net, test_data)
 
     def test_checkpointing_equivalence_eval(self):
-        """Ensure that CheckpointUNet matches standard UNet in eval mode (checkpointing inactive)."""
+        """Confirm eval parity when checkpointing is inactive."""
         params = dict(
             spatial_dims=2, in_channels=1, out_channels=2, channels=(8, 16, 32), strides=(2, 2), num_res_units=1
         )
@@ -168,7 +171,7 @@ class TestCheckpointUNet(unittest.TestCase):
         self.assertLess(diff, 1e-3, f"Eval-mode outputs differ more than expected (mean abs diff={diff:.6f})")
 
     def test_checkpointing_activates_training(self):
-        """Ensure checkpointing triggers recomputation under training and gradients propagate."""
+        """Verify checkpointing recomputes activations during training."""
         params = dict(
             spatial_dims=2, in_channels=1, out_channels=1, channels=(8, 16, 32), strides=(2, 2), num_res_units=1
         )

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -164,7 +164,7 @@ ILL_CASES = [
 ]
 
 
-class TestUNET(unittest.TestCase):
+class TestCheckpointUNet(unittest.TestCase):
     @parameterized.expand(CASES)
     def test_shape(self, input_param, input_shape, expected_shape):
         net = CheckpointUNet(**input_param).to(device)

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -1,0 +1,208 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+from parameterized import parameterized
+
+from monai.networks import eval_mode
+from monai.networks.layers import Act, Norm
+from monai.networks.nets.unet import CheckpointUNet
+from tests.test_utils import test_script_save
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+TEST_CASE_0 = [  # single channel 2D, batch 16, no residual
+    {
+        "spatial_dims": 2,
+        "in_channels": 1,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 0,
+    },
+    (16, 1, 32, 32),
+    (16, 3, 32, 32),
+]
+
+TEST_CASE_1 = [  # single channel 2D, batch 16
+    {
+        "spatial_dims": 2,
+        "in_channels": 1,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 1,
+    },
+    (16, 1, 32, 32),
+    (16, 3, 32, 32),
+]
+
+TEST_CASE_2 = [  # single channel 3D, batch 16
+    {
+        "spatial_dims": 3,
+        "in_channels": 1,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 1,
+    },
+    (16, 1, 32, 24, 48),
+    (16, 3, 32, 24, 48),
+]
+
+TEST_CASE_3 = [  # 4-channel 3D, batch 16
+    {
+        "spatial_dims": 3,
+        "in_channels": 4,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 1,
+    },
+    (16, 4, 32, 64, 48),
+    (16, 3, 32, 64, 48),
+]
+
+TEST_CASE_4 = [  # 4-channel 3D, batch 16, batch normalization
+    {
+        "spatial_dims": 3,
+        "in_channels": 4,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 1,
+        "norm": Norm.BATCH,
+    },
+    (16, 4, 32, 64, 48),
+    (16, 3, 32, 64, 48),
+]
+
+TEST_CASE_5 = [  # 4-channel 3D, batch 16, LeakyReLU activation
+    {
+        "spatial_dims": 3,
+        "in_channels": 4,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 1,
+        "act": (Act.LEAKYRELU, {"negative_slope": 0.2}),
+        "adn_ordering": "NA",
+    },
+    (16, 4, 32, 64, 48),
+    (16, 3, 32, 64, 48),
+]
+
+TEST_CASE_6 = [  # 4-channel 3D, batch 16, LeakyReLU activation explicit
+    {
+        "spatial_dims": 3,
+        "in_channels": 4,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 1,
+        "act": (torch.nn.LeakyReLU, {"negative_slope": 0.2}),
+    },
+    (16, 4, 32, 64, 48),
+    (16, 3, 32, 64, 48),
+]
+
+CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5, TEST_CASE_6]
+
+ILL_CASES = [
+    [
+        {  # len(channels) < 2
+            "spatial_dims": 2,
+            "in_channels": 1,
+            "out_channels": 3,
+            "channels": (16,),
+            "strides": (2, 2),
+            "num_res_units": 0,
+        }
+    ],
+    [
+        {  # len(strides) < len(channels) - 1
+            "spatial_dims": 2,
+            "in_channels": 1,
+            "out_channels": 3,
+            "channels": (8, 8, 8),
+            "strides": (2,),
+            "num_res_units": 0,
+        }
+    ],
+    [
+        {  # len(kernel_size) = 3, spatial_dims = 2
+            "spatial_dims": 2,
+            "in_channels": 1,
+            "out_channels": 3,
+            "channels": (8, 8, 8),
+            "strides": (2, 2),
+            "kernel_size": (3, 3, 3),
+        }
+    ],
+    [
+        {  # len(up_kernel_size) = 2, spatial_dims = 3
+            "spatial_dims": 3,
+            "in_channels": 1,
+            "out_channels": 3,
+            "channels": (8, 8, 8),
+            "strides": (2, 2),
+            "up_kernel_size": (3, 3),
+        }
+    ],
+]
+
+
+class TestUNET(unittest.TestCase):
+    @parameterized.expand(CASES)
+    def test_shape(self, input_param, input_shape, expected_shape):
+        net = CheckpointUNet(**input_param).to(device)
+        with eval_mode(net):
+            result = net.forward(torch.randn(input_shape).to(device))
+            self.assertEqual(result.shape, expected_shape)
+
+    def test_script(self):
+        net = CheckpointUNet(
+            spatial_dims=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2), num_res_units=0
+        )
+        test_data = torch.randn(16, 1, 32, 32)
+        test_script_save(net, test_data)
+
+    def test_script_without_running_stats(self):
+        net = CheckpointUNet(
+            spatial_dims=2,
+            in_channels=1,
+            out_channels=3,
+            channels=(16, 32, 64),
+            strides=(2, 2),
+            num_res_units=0,
+            norm=("batch", {"track_running_stats": False}),
+        )
+        test_data = torch.randn(16, 1, 16, 4)
+        test_script_save(net, test_data)
+
+    def test_ill_input_shape(self):
+        net = CheckpointUNet(spatial_dims=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2))
+        with eval_mode(net):
+            with self.assertRaisesRegex(RuntimeError, "Sizes of tensors must match"):
+                net.forward(torch.randn(2, 1, 16, 5))
+
+    @parameterized.expand(ILL_CASES)
+    def test_ill_input_hyper_params(self, input_param):
+        with self.assertRaises(ValueError):
+            _ = CheckpointUNet(**input_param)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -11,7 +11,6 @@
 
 from __future__ import annotations
 
-import re
 import unittest
 
 import torch

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -123,7 +123,13 @@ CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_C
 class TestCheckpointUNet(unittest.TestCase):
     @parameterized.expand(CASES)
     def test_shape(self, input_param, input_shape, expected_shape):
-        """Validate CheckpointUNet output shapes across configurations."""
+        """Validate CheckpointUNet output shapes across configurations.
+
+        Args:
+            input_param: Dictionary of UNet constructor arguments.
+            input_shape: Tuple specifying input tensor dimensions.
+            expected_shape: Tuple specifying expected output tensor dimensions.
+        """
         net = CheckpointUNet(**input_param).to(device)
         with eval_mode(net):
             result = net.forward(torch.randn(input_shape).to(device))

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -19,7 +19,6 @@ from parameterized import parameterized
 from monai.networks import eval_mode
 from monai.networks.layers import Act, Norm
 from monai.networks.nets.unet import CheckpointUNet, UNet
-from tests.test_utils import test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -129,14 +128,6 @@ class TestCheckpointUNet(unittest.TestCase):
         with eval_mode(net):
             result = net.forward(torch.randn(input_shape).to(device))
             self.assertEqual(result.shape, expected_shape)
-
-    def test_script(self):
-        """Script the baseline UNet to maintain TorchScript coverage."""
-        net = UNet(
-            spatial_dims=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2), num_res_units=0
-        )
-        test_data = torch.randn(16, 1, 32, 32)
-        test_script_save(net, test_data)
 
     def test_checkpointing_equivalence_eval(self):
         """Confirm eval parity when checkpointing is inactive."""

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -151,9 +151,11 @@ class TestCheckpointUNet(unittest.TestCase):
         # Check shape equality
         self.assertEqual(y_ckpt.shape, y_plain.shape)
 
-        # Check numerical similarity
-        diff = torch.mean(torch.abs(y_ckpt - y_plain)).item()
-        self.assertLess(diff, 1e-3, f"Eval-mode outputs differ more than expected (mean abs diff={diff:.6f})")
+        # Check numerical equivalence
+        self.assertTrue(
+            torch.allclose(y_ckpt, y_plain, atol=1e-6, rtol=1e-5),
+            f"Eval-mode outputs differ: max abs diff={torch.max(torch.abs(y_ckpt - y_plain)).item():.2e}",
+        )
 
     def test_checkpointing_activates_training(self):
         """Verify checkpointing recomputes activations during training."""

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -1,6 +1,6 @@
 # Copyright (c) MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #     http://www.apache.org/licenses/LICENSE-2.0
 # Unless required by applicable law or agreed to in writing, software
@@ -17,13 +17,12 @@ import torch
 from parameterized import parameterized
 
 from monai.networks import eval_mode
-from monai.networks.layers import Act, Norm
-from monai.networks.nets.unet import CheckpointUNet
+from monai.networks.nets.unet import CheckpointUNet, UNet
 from tests.test_utils import test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-TEST_CASE_0 = [  # single channel 2D, batch 16, no residual
+TEST_CASE_0 = [
     {
         "spatial_dims": 2,
         "in_channels": 1,
@@ -36,7 +35,7 @@ TEST_CASE_0 = [  # single channel 2D, batch 16, no residual
     (16, 3, 32, 32),
 ]
 
-TEST_CASE_1 = [  # single channel 2D, batch 16
+TEST_CASE_1 = [
     {
         "spatial_dims": 2,
         "in_channels": 1,
@@ -49,7 +48,7 @@ TEST_CASE_1 = [  # single channel 2D, batch 16
     (16, 3, 32, 32),
 ]
 
-TEST_CASE_2 = [  # single channel 3D, batch 16
+TEST_CASE_2 = [
     {
         "spatial_dims": 3,
         "in_channels": 1,
@@ -62,7 +61,7 @@ TEST_CASE_2 = [  # single channel 3D, batch 16
     (16, 3, 32, 24, 48),
 ]
 
-TEST_CASE_3 = [  # 4-channel 3D, batch 16
+TEST_CASE_3 = [
     {
         "spatial_dims": 3,
         "in_channels": 4,
@@ -75,93 +74,7 @@ TEST_CASE_3 = [  # 4-channel 3D, batch 16
     (16, 3, 32, 64, 48),
 ]
 
-TEST_CASE_4 = [  # 4-channel 3D, batch 16, batch normalization
-    {
-        "spatial_dims": 3,
-        "in_channels": 4,
-        "out_channels": 3,
-        "channels": (16, 32, 64),
-        "strides": (2, 2),
-        "num_res_units": 1,
-        "norm": Norm.BATCH,
-    },
-    (16, 4, 32, 64, 48),
-    (16, 3, 32, 64, 48),
-]
-
-TEST_CASE_5 = [  # 4-channel 3D, batch 16, LeakyReLU activation
-    {
-        "spatial_dims": 3,
-        "in_channels": 4,
-        "out_channels": 3,
-        "channels": (16, 32, 64),
-        "strides": (2, 2),
-        "num_res_units": 1,
-        "act": (Act.LEAKYRELU, {"negative_slope": 0.2}),
-        "adn_ordering": "NA",
-    },
-    (16, 4, 32, 64, 48),
-    (16, 3, 32, 64, 48),
-]
-
-TEST_CASE_6 = [  # 4-channel 3D, batch 16, LeakyReLU activation explicit
-    {
-        "spatial_dims": 3,
-        "in_channels": 4,
-        "out_channels": 3,
-        "channels": (16, 32, 64),
-        "strides": (2, 2),
-        "num_res_units": 1,
-        "act": (torch.nn.LeakyReLU, {"negative_slope": 0.2}),
-    },
-    (16, 4, 32, 64, 48),
-    (16, 3, 32, 64, 48),
-]
-
-CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5, TEST_CASE_6]
-
-ILL_CASES = [
-    [
-        {  # len(channels) < 2
-            "spatial_dims": 2,
-            "in_channels": 1,
-            "out_channels": 3,
-            "channels": (16,),
-            "strides": (2, 2),
-            "num_res_units": 0,
-        }
-    ],
-    [
-        {  # len(strides) < len(channels) - 1
-            "spatial_dims": 2,
-            "in_channels": 1,
-            "out_channels": 3,
-            "channels": (8, 8, 8),
-            "strides": (2,),
-            "num_res_units": 0,
-        }
-    ],
-    [
-        {  # len(kernel_size) = 3, spatial_dims = 2
-            "spatial_dims": 2,
-            "in_channels": 1,
-            "out_channels": 3,
-            "channels": (8, 8, 8),
-            "strides": (2, 2),
-            "kernel_size": (3, 3, 3),
-        }
-    ],
-    [
-        {  # len(up_kernel_size) = 2, spatial_dims = 3
-            "spatial_dims": 3,
-            "in_channels": 1,
-            "out_channels": 3,
-            "channels": (8, 8, 8),
-            "strides": (2, 2),
-            "up_kernel_size": (3, 3),
-        }
-    ],
-]
+CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3]
 
 
 class TestCheckpointUNet(unittest.TestCase):
@@ -179,29 +92,51 @@ class TestCheckpointUNet(unittest.TestCase):
         test_data = torch.randn(16, 1, 32, 32)
         test_script_save(net, test_data)
 
-    def test_script_without_running_stats(self):
-        net = CheckpointUNet(
-            spatial_dims=2,
-            in_channels=1,
-            out_channels=3,
-            channels=(16, 32, 64),
-            strides=(2, 2),
-            num_res_units=0,
-            norm=("batch", {"track_running_stats": False}),
-        )
-        test_data = torch.randn(16, 1, 16, 4)
-        test_script_save(net, test_data)
-
     def test_ill_input_shape(self):
         net = CheckpointUNet(spatial_dims=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2))
         with eval_mode(net):
             with self.assertRaisesRegex(RuntimeError, "Sizes of tensors must match"):
                 net.forward(torch.randn(2, 1, 16, 5))
 
-    @parameterized.expand(ILL_CASES)
-    def test_ill_input_hyper_params(self, input_param):
-        with self.assertRaises(ValueError):
-            _ = CheckpointUNet(**input_param)
+    def test_checkpointing_equivalence_eval(self):
+        """Ensure that CheckpointUNet matches standard UNet in eval mode (checkpointing inactive)."""
+        params = dict(
+            spatial_dims=2, in_channels=1, out_channels=2, channels=(8, 16, 32), strides=(2, 2), num_res_units=1
+        )
+
+        x = torch.randn(2, 1, 32, 32, device=device)
+
+        net_ckpt = CheckpointUNet(**params).to(device)
+        net_plain = UNet(**params).to(device)
+
+        with eval_mode(net_ckpt), eval_mode(net_plain):
+            y_ckpt = net_ckpt(x)
+            y_plain = net_plain(x)
+
+        # checkpointing should not change outputs in eval mode
+        self.assertTrue(torch.allclose(y_ckpt, y_plain, atol=1e-6, rtol=1e-5))
+
+    def test_checkpointing_activates_training(self):
+        """Ensure checkpointing triggers recomputation under training and gradients propagate."""
+        params = dict(
+            spatial_dims=2, in_channels=1, out_channels=1, channels=(8, 16, 32), strides=(2, 2), num_res_units=1
+        )
+
+        net = CheckpointUNet(**params).to(device)
+        net.train()
+
+        x = torch.randn(2, 1, 32, 32, device=device, requires_grad=True)
+        y = net(x)
+        loss = y.mean()
+        loss.backward()
+
+        # gradient flow check
+        grad_norm = sum(p.grad.abs().sum() for p in net.parameters() if p.grad is not None)
+        self.assertGreater(grad_norm.item(), 0.0)
+
+        # checkpointing should reduce activation memory use; we can't directly assert memory savings
+        # but we can confirm no runtime errors and gradients propagate correctly
+        self.assertIsNotNone(grad_norm)
 
 
 if __name__ == "__main__":

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -1,6 +1,6 @@
 # Copyright (c) MONAI Consortium
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #     http://www.apache.org/licenses/LICENSE-2.0
 # Unless required by applicable law or agreed to in writing, software
@@ -11,18 +11,20 @@
 
 from __future__ import annotations
 
+import re
 import unittest
 
 import torch
 from parameterized import parameterized
 
 from monai.networks import eval_mode
+from monai.networks.layers import Act, Norm
 from monai.networks.nets.unet import CheckpointUNet, UNet
 from tests.test_utils import test_script_save
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-TEST_CASE_0 = [
+TEST_CASE_0 = [  # single channel 2D, batch 16, no residual
     {
         "spatial_dims": 2,
         "in_channels": 1,
@@ -35,7 +37,7 @@ TEST_CASE_0 = [
     (16, 3, 32, 32),
 ]
 
-TEST_CASE_1 = [
+TEST_CASE_1 = [  # single channel 2D, batch 16
     {
         "spatial_dims": 2,
         "in_channels": 1,
@@ -48,7 +50,7 @@ TEST_CASE_1 = [
     (16, 3, 32, 32),
 ]
 
-TEST_CASE_2 = [
+TEST_CASE_2 = [  # single channel 3D, batch 16
     {
         "spatial_dims": 3,
         "in_channels": 1,
@@ -61,7 +63,7 @@ TEST_CASE_2 = [
     (16, 3, 32, 24, 48),
 ]
 
-TEST_CASE_3 = [
+TEST_CASE_3 = [  # 4-channel 3D, batch 16
     {
         "spatial_dims": 3,
         "in_channels": 4,
@@ -74,7 +76,50 @@ TEST_CASE_3 = [
     (16, 3, 32, 64, 48),
 ]
 
-CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3]
+TEST_CASE_4 = [  # 4-channel 3D, batch 16, batch normalization
+    {
+        "spatial_dims": 3,
+        "in_channels": 4,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 1,
+        "norm": Norm.BATCH,
+    },
+    (16, 4, 32, 64, 48),
+    (16, 3, 32, 64, 48),
+]
+
+TEST_CASE_5 = [  # 4-channel 3D, batch 16, LeakyReLU activation
+    {
+        "spatial_dims": 3,
+        "in_channels": 4,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 1,
+        "act": (Act.LEAKYRELU, {"negative_slope": 0.2}),
+        "adn_ordering": "NA",
+    },
+    (16, 4, 32, 64, 48),
+    (16, 3, 32, 64, 48),
+]
+
+TEST_CASE_6 = [  # 4-channel 3D, batch 16, LeakyReLU activation explicit
+    {
+        "spatial_dims": 3,
+        "in_channels": 4,
+        "out_channels": 3,
+        "channels": (16, 32, 64),
+        "strides": (2, 2),
+        "num_res_units": 1,
+        "act": (torch.nn.LeakyReLU, {"negative_slope": 0.2}),
+    },
+    (16, 4, 32, 64, 48),
+    (16, 3, 32, 64, 48),
+]
+
+CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_CASE_5, TEST_CASE_6]
 
 
 class TestCheckpointUNet(unittest.TestCase):
@@ -86,17 +131,16 @@ class TestCheckpointUNet(unittest.TestCase):
             self.assertEqual(result.shape, expected_shape)
 
     def test_script(self):
-        net = CheckpointUNet(
+        """
+        TorchScript doesn't support activation-checkpointing (torch.utils.checkpoint) calls inside the module.
+        To keep the test suite validating TorchScript compatibility, script the plain UNet (which is scriptable),
+        rather than the CheckpointUNet wrapper that uses checkpointing internals.
+        """
+        net = UNet(
             spatial_dims=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2), num_res_units=0
         )
         test_data = torch.randn(16, 1, 32, 32)
         test_script_save(net, test_data)
-
-    def test_ill_input_shape(self):
-        net = CheckpointUNet(spatial_dims=2, in_channels=1, out_channels=3, channels=(16, 32, 64), strides=(2, 2))
-        with eval_mode(net):
-            with self.assertRaisesRegex(RuntimeError, "Sizes of tensors must match"):
-                net.forward(torch.randn(2, 1, 16, 5))
 
     def test_checkpointing_equivalence_eval(self):
         """Ensure that CheckpointUNet matches standard UNet in eval mode (checkpointing inactive)."""
@@ -104,19 +148,25 @@ class TestCheckpointUNet(unittest.TestCase):
             spatial_dims=2, in_channels=1, out_channels=2, channels=(8, 16, 32), strides=(2, 2), num_res_units=1
         )
 
-        torch.manual_seed(0)
         x = torch.randn(2, 1, 32, 32, device=device)
 
+        torch.manual_seed(42)
         net_plain = UNet(**params).to(device)
-        net_ckpt = CheckpointUNet(**params).to(device)
-        net_ckpt.load_state_dict(net_plain.state_dict())
 
+        torch.manual_seed(42)
+        net_ckpt = CheckpointUNet(**params).to(device)
+
+        # Both in eval mode disables checkpointing logic
         with eval_mode(net_ckpt), eval_mode(net_plain):
             y_ckpt = net_ckpt(x)
             y_plain = net_plain(x)
 
-        # checkpointing should not change outputs in eval mode
-        self.assertTrue(torch.allclose(y_ckpt, y_plain, atol=1e-6, rtol=1e-5))
+        # Check shape equality
+        self.assertEqual(y_ckpt.shape, y_plain.shape)
+
+        # Check numerical similarity
+        diff = torch.mean(torch.abs(y_ckpt - y_plain)).item()
+        self.assertLess(diff, 1e-3, f"Eval-mode outputs differ more than expected (mean abs diff={diff:.6f})")
 
     def test_checkpointing_activates_training(self):
         """Ensure checkpointing triggers recomputation under training and gradients propagate."""
@@ -135,10 +185,6 @@ class TestCheckpointUNet(unittest.TestCase):
         # gradient flow check
         grad_norm = sum(p.grad.abs().sum() for p in net.parameters() if p.grad is not None)
         self.assertGreater(grad_norm.item(), 0.0)
-
-        # checkpointing should reduce activation memory use; we can't directly assert memory savings
-        # but we can confirm no runtime errors and gradients propagate correctly
-        self.assertIsNotNone(grad_norm)
 
 
 if __name__ == "__main__":

--- a/tests/networks/nets/test_checkpointunet.py
+++ b/tests/networks/nets/test_checkpointunet.py
@@ -124,13 +124,7 @@ CASES = [TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_4, TEST_C
 class TestCheckpointUNet(unittest.TestCase):
     @parameterized.expand(CASES)
     def test_shape(self, input_param, input_shape, expected_shape):
-        """Validate CheckpointUNet output shapes across configurations.
-
-        Args:
-            input_param: Mapping of constructor kwargs for the network under test.
-            input_shape: Shape tuple for the synthetic input tensor.
-            expected_shape: Expected output tensor shape.
-        """
+        """Validate CheckpointUNet output shapes across configurations."""
         net = CheckpointUNet(**input_param).to(device)
         with eval_mode(net):
             result = net.forward(torch.randn(input_shape).to(device))


### PR DESCRIPTION
### Description
Introduces an optional `use_checkpointing` flag in the `UNet` implementation. When enabled, intermediate activations in the encoder–decoder blocks are recomputed during the backward pass instead of being stored in memory. 
 - Implemented via a lightweight `_ActivationCheckpointWrapper` wrapper around sub-blocks.
 - Checkpointing is only applied during training to avoid overhead at inference.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
