### PR TITLE
Torch and Pickle Safe Load Fixes

### DIFF
--- a/monai/apps/nnunet/nnunet_bundle.py
+++ b/monai/apps/nnunet/nnunet_bundle.py
@@ -182,7 +182,9 @@ class ModelnnUNetWrapper(torch.nn.Module):
         parameters = []
 
         checkpoint = torch.load(
-            join(Path(model_training_output_dir).parent, "nnunet_checkpoint.pth"), map_location=torch.device("cpu"), weights_only=True
+            join(Path(model_training_output_dir).parent, "nnunet_checkpoint.pth"),
+            map_location=torch.device("cpu"),
+            weights_only=True,
         )
         trainer_name = checkpoint["trainer_name"]
         configuration_name = checkpoint["init_args"]["configuration"]
@@ -192,7 +194,9 @@ class ModelnnUNetWrapper(torch.nn.Module):
             else None
         )
         if Path(model_training_output_dir).joinpath(model_name).is_file():
-            monai_checkpoint = torch.load(join(model_training_output_dir, model_name), map_location=torch.device("cpu"), weights_only=True)
+            monai_checkpoint = torch.load(
+                join(model_training_output_dir, model_name), map_location=torch.device("cpu"), weights_only=True
+            )
             if "network_weights" in monai_checkpoint.keys():
                 parameters.append(monai_checkpoint["network_weights"])
             else:
@@ -383,8 +387,12 @@ def convert_nnunet_to_monai_bundle(nnunet_config: dict, bundle_root_folder: str,
         dataset_name, f"{nnunet_trainer}__{nnunet_plans}__{nnunet_configuration}"
     )
 
-    nnunet_checkpoint_final = torch.load(Path(nnunet_model_folder).joinpath(f"fold_{fold}", "checkpoint_final.pth"), weights_only=True)
-    nnunet_checkpoint_best = torch.load(Path(nnunet_model_folder).joinpath(f"fold_{fold}", "checkpoint_best.pth"), weights_only=True)
+    nnunet_checkpoint_final = torch.load(
+        Path(nnunet_model_folder).joinpath(f"fold_{fold}", "checkpoint_final.pth"), weights_only=True
+    )
+    nnunet_checkpoint_best = torch.load(
+        Path(nnunet_model_folder).joinpath(f"fold_{fold}", "checkpoint_best.pth"), weights_only=True
+    )
 
     nnunet_checkpoint = {}
     nnunet_checkpoint["inference_allowed_mirroring_axes"] = nnunet_checkpoint_final["inference_allowed_mirroring_axes"]

--- a/monai/apps/nnunet/nnunet_bundle.py
+++ b/monai/apps/nnunet/nnunet_bundle.py
@@ -133,7 +133,7 @@ def get_nnunet_trainer(
         cudnn.benchmark = True
 
     if pretrained_model is not None:
-        state_dict = torch.load(pretrained_model)
+        state_dict = torch.load(pretrained_model, weights_only=True)
         if "network_weights" in state_dict:
             nnunet_trainer.network._orig_mod.load_state_dict(state_dict["network_weights"])
     return nnunet_trainer
@@ -182,7 +182,7 @@ class ModelnnUNetWrapper(torch.nn.Module):
         parameters = []
 
         checkpoint = torch.load(
-            join(Path(model_training_output_dir).parent, "nnunet_checkpoint.pth"), map_location=torch.device("cpu")
+            join(Path(model_training_output_dir).parent, "nnunet_checkpoint.pth"), map_location=torch.device("cpu"), weights_only=True
         )
         trainer_name = checkpoint["trainer_name"]
         configuration_name = checkpoint["init_args"]["configuration"]
@@ -192,7 +192,7 @@ class ModelnnUNetWrapper(torch.nn.Module):
             else None
         )
         if Path(model_training_output_dir).joinpath(model_name).is_file():
-            monai_checkpoint = torch.load(join(model_training_output_dir, model_name), map_location=torch.device("cpu"))
+            monai_checkpoint = torch.load(join(model_training_output_dir, model_name), map_location=torch.device("cpu"), weights_only=True)
             if "network_weights" in monai_checkpoint.keys():
                 parameters.append(monai_checkpoint["network_weights"])
             else:
@@ -383,8 +383,8 @@ def convert_nnunet_to_monai_bundle(nnunet_config: dict, bundle_root_folder: str,
         dataset_name, f"{nnunet_trainer}__{nnunet_plans}__{nnunet_configuration}"
     )
 
-    nnunet_checkpoint_final = torch.load(Path(nnunet_model_folder).joinpath(f"fold_{fold}", "checkpoint_final.pth"))
-    nnunet_checkpoint_best = torch.load(Path(nnunet_model_folder).joinpath(f"fold_{fold}", "checkpoint_best.pth"))
+    nnunet_checkpoint_final = torch.load(Path(nnunet_model_folder).joinpath(f"fold_{fold}", "checkpoint_final.pth"), weights_only=True)
+    nnunet_checkpoint_best = torch.load(Path(nnunet_model_folder).joinpath(f"fold_{fold}", "checkpoint_best.pth"), weights_only=True)
 
     nnunet_checkpoint = {}
     nnunet_checkpoint["inference_allowed_mirroring_axes"] = nnunet_checkpoint_final["inference_allowed_mirroring_axes"]
@@ -470,7 +470,7 @@ def get_network_from_nnunet_plans(
     if model_ckpt is None:
         return network
     else:
-        state_dict = torch.load(model_ckpt)
+        state_dict = torch.load(model_ckpt, weights_only=True)
         network.load_state_dict(state_dict[model_key_in_ckpt])
         return network
 
@@ -534,7 +534,7 @@ def convert_monai_bundle_to_nnunet(nnunet_config: dict, bundle_root_folder: str,
 
     Path(nnunet_model_folder).joinpath(f"fold_{fold}").mkdir(parents=True, exist_ok=True)
 
-    nnunet_checkpoint: dict = torch.load(f"{bundle_root_folder}/models/nnunet_checkpoint.pth")
+    nnunet_checkpoint: dict = torch.load(f"{bundle_root_folder}/models/nnunet_checkpoint.pth", weights_only=True)
     latest_checkpoints: list[str] = subfiles(
         Path(bundle_root_folder).joinpath("models", f"fold_{fold}"), prefix="checkpoint_epoch", sort=True
     )
@@ -545,7 +545,7 @@ def convert_monai_bundle_to_nnunet(nnunet_config: dict, bundle_root_folder: str,
     epochs.sort()
     final_epoch: int = epochs[-1]
     monai_last_checkpoint: dict = torch.load(
-        f"{bundle_root_folder}/models/fold_{fold}/checkpoint_epoch={final_epoch}.pt"
+        f"{bundle_root_folder}/models/fold_{fold}/checkpoint_epoch={final_epoch}.pt", weights_only=True
     )
 
     best_checkpoints: list[str] = subfiles(
@@ -558,7 +558,7 @@ def convert_monai_bundle_to_nnunet(nnunet_config: dict, bundle_root_folder: str,
     key_metrics.sort()
     best_key_metric: str = key_metrics[-1]
     monai_best_checkpoint: dict = torch.load(
-        f"{bundle_root_folder}/models/fold_{fold}/checkpoint_key_metric={best_key_metric}.pt"
+        f"{bundle_root_folder}/models/fold_{fold}/checkpoint_key_metric={best_key_metric}.pt", weights_only=True
     )
 
     nnunet_checkpoint["optimizer_state"] = monai_last_checkpoint["optimizer_state"]

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -78,7 +78,7 @@ from .test_time_augmentation import TestTimeAugmentation
 from .thread_buffer import ThreadBuffer, ThreadDataLoader
 from .torchscript_utils import load_net_with_metadata, save_net_with_metadata
 from .utils import (
-    PICKLE_KEY_SUFFIX,
+    # PICKLE_KEY_SUFFIX,
     affine_to_spacing,
     compute_importance_map,
     compute_shape_offset,

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -77,7 +77,7 @@ from .synthetic import create_test_image_2d, create_test_image_3d
 from .test_time_augmentation import TestTimeAugmentation
 from .thread_buffer import ThreadBuffer, ThreadDataLoader
 from .torchscript_utils import load_net_with_metadata, save_net_with_metadata
-from .utils import (  # PICKLE_KEY_SUFFIX,
+from .utils import (
     affine_to_spacing,
     compute_importance_map,
     compute_shape_offset,

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -77,8 +77,7 @@ from .synthetic import create_test_image_2d, create_test_image_3d
 from .test_time_augmentation import TestTimeAugmentation
 from .thread_buffer import ThreadBuffer, ThreadDataLoader
 from .torchscript_utils import load_net_with_metadata, save_net_with_metadata
-from .utils import (
-    # PICKLE_KEY_SUFFIX,
+from .utils import (  # PICKLE_KEY_SUFFIX,
     affine_to_spacing,
     compute_importance_map,
     compute_shape_offset,

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -208,7 +208,7 @@ class PersistentDataset(Dataset):
         errors. If in doubt, it is advisable to clear the cache directory.
 
         Loading is done using `torch.load` with `weights_only=False`, thus the user must ensure the data
-        being loaded is safe. Typically this will be cached data the user created themselves, if data 
+        being loaded is safe. Typically this will be cached data the user created themselves, if data
         from external sources is used this should be validated for safely independently.
 
     Lazy Resampling:

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -254,7 +254,7 @@ class PersistentDataset(Dataset):
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save,
                 and ``monai.data.utils.SUPPORTED_PICKLE_MOD``.
-            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`.
                 Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             hash_transform: a callable to compute hash from the transform information when caching.
@@ -461,7 +461,7 @@ class CacheNTransDataset(PersistentDataset):
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save,
                 and ``monai.data.utils.SUPPORTED_PICKLE_MOD``.
-            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`.
                 Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             hash_transform: a callable to compute hash from the transform information when caching.
@@ -557,7 +557,7 @@ class LMDBDataset(PersistentDataset):
                 defaults to `monai.data.utils.pickle_hashing`.
             db_name: lmdb database file name. Defaults to "monai_cache".
             progress: whether to display a progress bar.
-            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`.
                 Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             hash_transform: a callable to compute hash from the transform information when caching.

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -397,7 +397,7 @@ class PersistentDataset(Dataset):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 temp_hash_file = Path(tmpdirname) / hashfile.name
                 torch.save(
-                    obj=convert_to_tensor(_item_transformed),
+                    obj=convert_to_tensor(_item_transformed, convert_numeric=False),
                     f=temp_hash_file,
                     pickle_module=look_up_option(self.pickle_module, SUPPORTED_PICKLE_MOD),
                     pickle_protocol=self.pickle_protocol,
@@ -1655,7 +1655,7 @@ class GDSDataset(PersistentDataset):
                 meta_hash_file = self.cache_dir / meta_hash_file_name
                 temp_hash_file = Path(tmpdirname) / meta_hash_file_name
                 torch.save(
-                    obj=convert_to_tensor(self._meta_cache[meta_hash_file_name]),
+                    obj=convert_to_tensor(self._meta_cache[meta_hash_file_name], convert_numeric=False),
                     f=temp_hash_file,
                     pickle_module=look_up_option(self.pickle_module, SUPPORTED_PICKLE_MOD),
                     pickle_protocol=self.pickle_protocol,

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -210,6 +210,7 @@ class PersistentDataset(Dataset):
         Cached data is expected to be tensors, primitives, or dictionaries keying to these values. Numpy arrays will
         be converted to tensors, however any other object type returned by transforms will not be loadable since
         `torch.load` will be used with `weights_only=True` to prevent loading of potentially malicious objects.
+        Legacy cache files may not be loadable and may need to be recomputed.
 
     Lazy Resampling:
         If you make use of the lazy resampling feature of `monai.transforms.Compose`, please refer to
@@ -375,13 +376,12 @@ class PersistentDataset(Dataset):
 
         if hashfile is not None and hashfile.is_file():  # cache hit
             try:
-                # Loading with weights_only=False is expected to be safe as these should be the user's own cached data
                 return torch.load(hashfile, weights_only=True)
             except PermissionError as e:
                 if sys.platform != "win32":
                     raise e
-            except RuntimeError as e:
-                if "Invalid magic number; corrupt file" in str(e):
+            except (pickle.UnpicklingError, RuntimeError) as e:  # corrupt or unloadable cached files are recomputed
+                if "Invalid magic number; corrupt file" in str(e) or isinstance(e, pickle.UnpicklingError):
                     warnings.warn(f"Corrupt cache file detected: {hashfile}. Deleting and recomputing.")
                     hashfile.unlink()
                 else:

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import collections.abc
+from io import BytesIO
 import math
 import pickle
 import shutil
@@ -599,6 +600,16 @@ class LMDBDataset(PersistentDataset):
         super().set_data(data=data)
         self._read_env = self._fill_cache_start_reader(show_progress=self.progress)
 
+    def _safe_serialize(self,val):
+        out=BytesIO()
+        torch.save(convert_to_tensor(val), out, protocol=self.pickle_protocol)
+        out.seek(0)
+        return out.read()
+    
+    def _safe_deserialize(self,val):
+        out=BytesIO(val)
+        return torch.load(out,weights_only=True)    
+
     def _fill_cache_start_reader(self, show_progress=True):
         """
         Check the LMDB cache and write the cache if needed. py-lmdb doesn't have a good support for concurrent write.
@@ -624,7 +635,8 @@ class LMDBDataset(PersistentDataset):
                             continue
                         if val is None:
                             val = self._pre_transform(deepcopy(item))  # keep the original hashed
-                            val = pickle.dumps(val, protocol=self.pickle_protocol)
+                            # val = pickle.dumps(val, protocol=self.pickle_protocol)
+                            val=self._safe_serialize(val)
                         with env.begin(write=True) as txn:
                             txn.put(key, val)
                         done = True
@@ -669,7 +681,8 @@ class LMDBDataset(PersistentDataset):
             warnings.warn("LMDBDataset: cache key not found, running fallback caching.")
             return super()._cachecheck(item_transformed)
         try:
-            return pickle.loads(data)
+            # return pickle.loads(data)
+            return self._safe_deserialize(data)
         except Exception as err:
             raise RuntimeError("Invalid cache value, corrupted lmdb file?") from err
 

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -207,6 +207,10 @@ class PersistentDataset(Dataset):
         not guaranteed, so caution should be used when modifying transforms to avoid unexpected
         errors. If in doubt, it is advisable to clear the cache directory.
 
+        Loading is done using `torch.load` with `weights_only=False`, thus the user must ensure the data
+        being loaded is safe. Typically this will be cached data the user has created themselves but if
+        data from external sources is used this should be validated for safetly independently.
+
     Lazy Resampling:
         If you make use of the lazy resampling feature of `monai.transforms.Compose`, please refer to
         its documentation to familiarize yourself with the interaction between `PersistentDataset` and
@@ -371,6 +375,7 @@ class PersistentDataset(Dataset):
 
         if hashfile is not None and hashfile.is_file():  # cache hit
             try:
+                # Loading with weights_only=False is expected to be safe as these should be the user's own cached data
                 return torch.load(hashfile, weights_only=False)
             except PermissionError as e:
                 if sys.platform != "win32":

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -208,8 +208,8 @@ class PersistentDataset(Dataset):
         errors. If in doubt, it is advisable to clear the cache directory.
 
         Loading is done using `torch.load` with `weights_only=False`, thus the user must ensure the data
-        being loaded is safe. Typically this will be cached data the user has created themselves but if
-        data from external sources is used this should be validated for safetly independently.
+        being loaded is safe. Typically this will be cached data the user created themselves, if data 
+        from external sources is used this should be validated for safely independently.
 
     Lazy Resampling:
         If you make use of the lazy resampling feature of `monai.transforms.Compose`, please refer to

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -207,9 +207,9 @@ class PersistentDataset(Dataset):
         not guaranteed, so caution should be used when modifying transforms to avoid unexpected
         errors. If in doubt, it is advisable to clear the cache directory.
 
-        Loading is done using `torch.load` with `weights_only=False`, thus the user must ensure the data
-        being loaded is safe. Typically this will be cached data the user created themselves, if data
-        from external sources is used this should be validated for safely independently.
+        Cached data is expected to be tensors, primitives, or dictionaries keying to these values. Numpy arrays will
+        be converted to tensors, however any other object type returned by transforms will not be loadable since
+        `torch.load` will be used with `weights_only=True` to prevent loading of potentially malicious objects.
 
     Lazy Resampling:
         If you make use of the lazy resampling feature of `monai.transforms.Compose`, please refer to
@@ -376,7 +376,7 @@ class PersistentDataset(Dataset):
         if hashfile is not None and hashfile.is_file():  # cache hit
             try:
                 # Loading with weights_only=False is expected to be safe as these should be the user's own cached data
-                return torch.load(hashfile, weights_only=False)
+                return torch.load(hashfile, weights_only=True)
             except PermissionError as e:
                 if sys.platform != "win32":
                     raise e
@@ -397,7 +397,7 @@ class PersistentDataset(Dataset):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 temp_hash_file = Path(tmpdirname) / hashfile.name
                 torch.save(
-                    obj=_item_transformed,
+                    obj=convert_to_tensor(_item_transformed),
                     f=temp_hash_file,
                     pickle_module=look_up_option(self.pickle_module, SUPPORTED_PICKLE_MOD),
                     pickle_protocol=self.pickle_protocol,
@@ -1655,7 +1655,7 @@ class GDSDataset(PersistentDataset):
                 meta_hash_file = self.cache_dir / meta_hash_file_name
                 temp_hash_file = Path(tmpdirname) / meta_hash_file_name
                 torch.save(
-                    obj=self._meta_cache[meta_hash_file_name],
+                    obj=convert_to_tensor(self._meta_cache[meta_hash_file_name]),
                     f=temp_hash_file,
                     pickle_module=look_up_option(self.pickle_module, SUPPORTED_PICKLE_MOD),
                     pickle_protocol=self.pickle_protocol,
@@ -1675,4 +1675,4 @@ class GDSDataset(PersistentDataset):
         if meta_hash_file_name in self._meta_cache:
             return self._meta_cache[meta_hash_file_name]
         else:
-            return torch.load(self.cache_dir / meta_hash_file_name, weights_only=False)
+            return torch.load(self.cache_dir / meta_hash_file_name, weights_only=True)

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -605,10 +605,10 @@ class LMDBDataset(PersistentDataset):
         torch.save(convert_to_tensor(val), out, protocol=self.pickle_protocol)
         out.seek(0)
         return out.read()
-    
+
     def _safe_deserialize(self,val):
         out=BytesIO(val)
-        return torch.load(out,weights_only=True)    
+        return torch.load(out,weights_only=True)
 
     def _fill_cache_start_reader(self, show_progress=True):
         """

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -12,9 +12,7 @@
 from __future__ import annotations
 
 import collections.abc
-from io import BytesIO
 import math
-from pickle import UnpicklingError
 import shutil
 import sys
 import tempfile
@@ -23,9 +21,11 @@ import time
 import warnings
 from collections.abc import Callable, Sequence
 from copy import copy, deepcopy
+from io import BytesIO
 from multiprocessing.managers import ListProxy
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
+from pickle import UnpicklingError
 from typing import IO, TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -254,7 +254,7 @@ class PersistentDataset(Dataset):
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save,
                 and ``monai.data.utils.SUPPORTED_PICKLE_MOD``.
-            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`.
                 Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             hash_transform: a callable to compute hash from the transform information when caching.
@@ -461,7 +461,7 @@ class CacheNTransDataset(PersistentDataset):
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save,
                 and ``monai.data.utils.SUPPORTED_PICKLE_MOD``.
-            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`.
                 Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             hash_transform: a callable to compute hash from the transform information when caching.
@@ -557,7 +557,7 @@ class LMDBDataset(PersistentDataset):
                 defaults to `monai.data.utils.pickle_hashing`.
             db_name: lmdb database file name. Defaults to "monai_cache".
             progress: whether to display a progress bar.
-            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`.
                 Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             hash_transform: a callable to compute hash from the transform information when caching.
@@ -601,15 +601,14 @@ class LMDBDataset(PersistentDataset):
         super().set_data(data=data)
         self._read_env = self._fill_cache_start_reader(show_progress=self.progress)
 
-    def _safe_serialize(self,val):
-        out=BytesIO()
-        torch.save(convert_to_tensor(val), out, pickle_protocol =self.pickle_protocol)
+    def _safe_serialize(self, val):
+        out = BytesIO()
+        torch.save(convert_to_tensor(val), out, pickle_protocol=self.pickle_protocol)
         out.seek(0)
         return out.read()
 
-    def _safe_deserialize(self,val):
-        out=BytesIO(val)
-        return torch.load(out,weights_only=True)
+    def _safe_deserialize(self, val):
+        return torch.load(BytesIO(val), map_location="cpu", weights_only=True)
 
     def _fill_cache_start_reader(self, show_progress=True):
         """
@@ -637,7 +636,7 @@ class LMDBDataset(PersistentDataset):
                         if val is None:
                             val = self._pre_transform(deepcopy(item))  # keep the original hashed
                             # val = pickle.dumps(val, protocol=self.pickle_protocol)
-                            val=self._safe_serialize(val)
+                            val = self._safe_serialize(val)
                         with env.begin(write=True) as txn:
                             txn.put(key, val)
                         done = True

--- a/monai/data/dataset.py
+++ b/monai/data/dataset.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import collections.abc
 from io import BytesIO
 import math
-import pickle
+from pickle import UnpicklingError
 import shutil
 import sys
 import tempfile
@@ -254,8 +254,8 @@ class PersistentDataset(Dataset):
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save,
                 and ``monai.data.utils.SUPPORTED_PICKLE_MOD``.
-            pickle_protocol: can be specified to override the default protocol, default to `2`.
-                this arg is used by `torch.save`, for more details, please check:
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+                Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             hash_transform: a callable to compute hash from the transform information when caching.
                 This may reduce errors due to transforms changing during experiments. Default to None (no hash).
@@ -381,8 +381,8 @@ class PersistentDataset(Dataset):
             except PermissionError as e:
                 if sys.platform != "win32":
                     raise e
-            except (pickle.UnpicklingError, RuntimeError) as e:  # corrupt or unloadable cached files are recomputed
-                if "Invalid magic number; corrupt file" in str(e) or isinstance(e, pickle.UnpicklingError):
+            except (UnpicklingError, RuntimeError) as e:  # corrupt or unloadable cached files are recomputed
+                if "Invalid magic number; corrupt file" in str(e) or isinstance(e, UnpicklingError):
                     warnings.warn(f"Corrupt cache file detected: {hashfile}. Deleting and recomputing.")
                     hashfile.unlink()
                 else:
@@ -461,8 +461,8 @@ class CacheNTransDataset(PersistentDataset):
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save,
                 and ``monai.data.utils.SUPPORTED_PICKLE_MOD``.
-            pickle_protocol: can be specified to override the default protocol, default to `2`.
-                this arg is used by `torch.save`, for more details, please check:
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+                Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             hash_transform: a callable to compute hash from the transform information when caching.
                 This may reduce errors due to transforms changing during experiments. Default to None (no hash).
@@ -537,7 +537,7 @@ class LMDBDataset(PersistentDataset):
         hash_func: Callable[..., bytes] = pickle_hashing,
         db_name: str = "monai_cache",
         progress: bool = True,
-        pickle_protocol=pickle.HIGHEST_PROTOCOL,
+        pickle_protocol=DEFAULT_PROTOCOL,
         hash_transform: Callable[..., bytes] | None = None,
         reset_ops_id: bool = True,
         lmdb_kwargs: dict | None = None,
@@ -557,8 +557,9 @@ class LMDBDataset(PersistentDataset):
                 defaults to `monai.data.utils.pickle_hashing`.
             db_name: lmdb database file name. Defaults to "monai_cache".
             progress: whether to display a progress bar.
-            pickle_protocol: pickle protocol version. Defaults to pickle.HIGHEST_PROTOCOL.
-                https://docs.python.org/3/library/pickle.html#pickle-protocols
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+                Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
+                https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
             hash_transform: a callable to compute hash from the transform information when caching.
                 This may reduce errors due to transforms changing during experiments. Default to None (no hash).
                 Other options are `pickle_hashing` and `json_hashing` functions from `monai.data.utils`.
@@ -602,7 +603,7 @@ class LMDBDataset(PersistentDataset):
 
     def _safe_serialize(self,val):
         out=BytesIO()
-        torch.save(convert_to_tensor(val), out, protocol=self.pickle_protocol)
+        torch.save(convert_to_tensor(val), out, pickle_protocol =self.pickle_protocol)
         out.seek(0)
         return out.read()
     

--- a/monai/data/meta_tensor.py
+++ b/monai/data/meta_tensor.py
@@ -611,4 +611,4 @@ class MetaTensor(MetaObj, torch.Tensor):
 
 # needed in later versions of Pytorch to indicate the class is safe for serialisation
 if hasattr(torch.serialization, "add_safe_globals"):
-    torch.serialization.add_safe_globals([MetaTensor])
+    torch.serialization.add_safe_globals([MetaObj, MetaTensor, MetaKeys, SpaceKeys])

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -500,7 +500,7 @@ def list_data_collate(batch: Sequence):
     collate_fn = default_collate
     try:
         # if config.USE_META_DICT:
-            # data = pickle_operations(data)  # bc 0.9.0
+        # data = pickle_operations(data)  # bc 0.9.0
         if isinstance(elem, Mapping):
             ret = {}
             for k in elem:
@@ -654,14 +654,14 @@ def decollate_batch(batch, detach: bool = True, pad=True, fill_value=None):
         _gen = zip_longest(*deco.values(), fillvalue=fill_value) if pad else zip(*deco.values())
         ret = [dict(zip(deco, item)) for item in _gen]
         # if not config.USE_META_DICT:
-            # return ret
+        # return ret
         # return pickle_operations(ret, is_encode=False)  # bc 0.9.0
         return ret
     if isinstance(deco, Iterable):
         _gen = zip_longest(*deco, fillvalue=fill_value) if pad else zip(*deco)
         ret_list = [list(item) for item in _gen]
         # if not config.USE_META_DICT:
-            # return ret_list
+        # return ret_list
         # return pickle_operations(ret_list, is_encode=False)  # bc 0.9.0
         return ret_list
     raise NotImplementedError(f"Unable to de-collate: {batch}, type: {type(batch)}.")

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -93,7 +93,7 @@ __all__ = [
     "remove_keys",
     "remove_extra_metadata",
     "get_extra_metadata_keys",
-    "PICKLE_KEY_SUFFIX",
+    # "PICKLE_KEY_SUFFIX",
     "is_no_channel",
 ]
 
@@ -418,7 +418,7 @@ def dev_collate(batch, level: int = 1, logger_name: str = "dev_collate"):
     return
 
 
-PICKLE_KEY_SUFFIX = TraceKeys.KEY_SUFFIX
+# PICKLE_KEY_SUFFIX = TraceKeys.KEY_SUFFIX
 
 
 # def pickle_operations(data, key=PICKLE_KEY_SUFFIX, is_encode: bool = True):

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -92,7 +92,6 @@ __all__ = [
     "remove_keys",
     "remove_extra_metadata",
     "get_extra_metadata_keys",
-    # "PICKLE_KEY_SUFFIX",
     "is_no_channel",
 ]
 
@@ -415,32 +414,6 @@ def dev_collate(batch, level: int = 1, logger_name: str = "dev_collate"):
         return [dev_collate(samples, level=level + 1, logger_name=logger_name) for samples in transposed]
     logging.getLogger(logger_name).critical(f"{l_str} E: unsupported type in collate {batch_str}.")
     return
-
-
-# PICKLE_KEY_SUFFIX = TraceKeys.KEY_SUFFIX
-
-
-# def pickle_operations(data, key=PICKLE_KEY_SUFFIX, is_encode: bool = True):
-#     """
-#     Applied_operations are dictionaries with varying sizes, this method converts them to bytes so that we can (de-)collate.
-
-#     Args:
-#         data: a list or dictionary with substructures to be pickled/unpickled.
-#         key: the key suffix for the target substructures, defaults to "_transforms" (`data.utils.PICKLE_KEY_SUFFIX`).
-#         is_encode: whether it's encoding using pickle.dumps (True) or decoding using pickle.loads (False).
-#     """
-#     if isinstance(data, Mapping):
-#         data = dict(data)
-#         for k in data:
-#             if f"{k}".endswith(key):
-#                 if is_encode and not isinstance(data[k], bytes):
-#                     data[k] = pickle.dumps(data[k], 0)
-#                 if not is_encode and isinstance(data[k], bytes):
-#                     data[k] = pickle.loads(data[k])
-#         return {k: pickle_operations(v, key=key, is_encode=is_encode) for k, v in data.items()}
-#     elif isinstance(data, (list, tuple)):
-#         return [pickle_operations(item, key=key, is_encode=is_encode) for item in data]
-#     return data
 
 
 def collate_meta_tensor_fn(batch, *, collate_fn_map=None):

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -421,27 +421,27 @@ def dev_collate(batch, level: int = 1, logger_name: str = "dev_collate"):
 PICKLE_KEY_SUFFIX = TraceKeys.KEY_SUFFIX
 
 
-def pickle_operations(data, key=PICKLE_KEY_SUFFIX, is_encode: bool = True):
-    """
-    Applied_operations are dictionaries with varying sizes, this method converts them to bytes so that we can (de-)collate.
+# def pickle_operations(data, key=PICKLE_KEY_SUFFIX, is_encode: bool = True):
+#     """
+#     Applied_operations are dictionaries with varying sizes, this method converts them to bytes so that we can (de-)collate.
 
-    Args:
-        data: a list or dictionary with substructures to be pickled/unpickled.
-        key: the key suffix for the target substructures, defaults to "_transforms" (`data.utils.PICKLE_KEY_SUFFIX`).
-        is_encode: whether it's encoding using pickle.dumps (True) or decoding using pickle.loads (False).
-    """
-    if isinstance(data, Mapping):
-        data = dict(data)
-        for k in data:
-            if f"{k}".endswith(key):
-                if is_encode and not isinstance(data[k], bytes):
-                    data[k] = pickle.dumps(data[k], 0)
-                if not is_encode and isinstance(data[k], bytes):
-                    data[k] = pickle.loads(data[k])
-        return {k: pickle_operations(v, key=key, is_encode=is_encode) for k, v in data.items()}
-    elif isinstance(data, (list, tuple)):
-        return [pickle_operations(item, key=key, is_encode=is_encode) for item in data]
-    return data
+#     Args:
+#         data: a list or dictionary with substructures to be pickled/unpickled.
+#         key: the key suffix for the target substructures, defaults to "_transforms" (`data.utils.PICKLE_KEY_SUFFIX`).
+#         is_encode: whether it's encoding using pickle.dumps (True) or decoding using pickle.loads (False).
+#     """
+#     if isinstance(data, Mapping):
+#         data = dict(data)
+#         for k in data:
+#             if f"{k}".endswith(key):
+#                 if is_encode and not isinstance(data[k], bytes):
+#                     data[k] = pickle.dumps(data[k], 0)
+#                 if not is_encode and isinstance(data[k], bytes):
+#                     data[k] = pickle.loads(data[k])
+#         return {k: pickle_operations(v, key=key, is_encode=is_encode) for k, v in data.items()}
+#     elif isinstance(data, (list, tuple)):
+#         return [pickle_operations(item, key=key, is_encode=is_encode) for item in data]
+#     return data
 
 
 def collate_meta_tensor_fn(batch, *, collate_fn_map=None):
@@ -500,8 +500,8 @@ def list_data_collate(batch: Sequence):
     key = None
     collate_fn = default_collate
     try:
-        if config.USE_META_DICT:
-            data = pickle_operations(data)  # bc 0.9.0
+        # if config.USE_META_DICT:
+            # data = pickle_operations(data)  # bc 0.9.0
         if isinstance(elem, Mapping):
             ret = {}
             for k in elem:
@@ -654,15 +654,17 @@ def decollate_batch(batch, detach: bool = True, pad=True, fill_value=None):
     if isinstance(deco, Mapping):
         _gen = zip_longest(*deco.values(), fillvalue=fill_value) if pad else zip(*deco.values())
         ret = [dict(zip(deco, item)) for item in _gen]
-        if not config.USE_META_DICT:
-            return ret
-        return pickle_operations(ret, is_encode=False)  # bc 0.9.0
+        # if not config.USE_META_DICT:
+            # return ret
+        # return pickle_operations(ret, is_encode=False)  # bc 0.9.0
+        return ret
     if isinstance(deco, Iterable):
         _gen = zip_longest(*deco, fillvalue=fill_value) if pad else zip(*deco)
         ret_list = [list(item) for item in _gen]
-        if not config.USE_META_DICT:
-            return ret_list
-        return pickle_operations(ret_list, is_encode=False)  # bc 0.9.0
+        # if not config.USE_META_DICT:
+            # return ret_list
+        # return pickle_operations(ret_list, is_encode=False)  # bc 0.9.0
+        return ret_list
     raise NotImplementedError(f"Unable to de-collate: {batch}, type: {type(batch)}.")
 
 

--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -30,7 +30,6 @@ import numpy as np
 import torch
 from torch.utils.data._utils.collate import default_collate
 
-from monai import config
 from monai.config.type_definitions import NdarrayOrTensor, NdarrayTensor, PathLike
 from monai.data.meta_obj import MetaObj
 from monai.utils import (

--- a/monai/handlers/checkpoint_loader.py
+++ b/monai/handlers/checkpoint_loader.py
@@ -122,7 +122,7 @@ class CheckpointLoader:
         Args:
             engine: Ignite Engine, it can be a trainer, validator or evaluator.
         """
-        checkpoint = torch.load(self.load_path, map_location=self.map_location, weights_only=False)
+        checkpoint = torch.load(self.load_path, map_location=self.map_location, weights_only=True)
 
         k, _ = list(self.load_dict.items())[0]
         # single object and checkpoint is directly a state_dict

--- a/monai/utils/state_cacher.py
+++ b/monai/utils/state_cacher.py
@@ -124,7 +124,7 @@ class StateCacher:
         fn = self.cached[key]["obj"]  # pytype: disable=attribute-error
         if not os.path.exists(fn):  # pytype: disable=wrong-arg-types
             raise RuntimeError(f"Failed to load state in {fn}. File doesn't exist anymore.")
-        data_obj = torch.load(fn, map_location=lambda storage, location: storage, weights_only=False)
+        data_obj = torch.load(fn, map_location=lambda storage, location: storage, weights_only=True)
         # copy back to device if necessary
         if "device" in self.cached[key]:
             data_obj = data_obj.to(self.cached[key]["device"])

--- a/monai/utils/state_cacher.py
+++ b/monai/utils/state_cacher.py
@@ -64,7 +64,7 @@ class StateCacher:
             pickle_module: module used for pickling metadata and objects, default to `pickle`.
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
-            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`.
                 Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
 

--- a/monai/utils/state_cacher.py
+++ b/monai/utils/state_cacher.py
@@ -64,8 +64,8 @@ class StateCacher:
             pickle_module: module used for pickling metadata and objects, default to `pickle`.
                 this arg is used by `torch.save`, for more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
-            pickle_protocol: can be specified to override the default protocol, default to `2`.
-                this arg is used by `torch.save`, for more details, please check:
+            pickle_protocol: specifies pickle protocol when saving, with `torch.save`. 
+                Defaults to torch.serialization.DEFAULT_PROTOCOL. For more details, please check:
                 https://pytorch.org/docs/stable/generated/torch.save.html#torch.save.
 
         """

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -117,7 +117,7 @@ def convert_to_tensor(
     wrap_sequence: bool = False,
     track_meta: bool = False,
     safe: bool = False,
-    convert_numeric: bool = True
+    convert_numeric: bool = True,
 ) -> Any:
     """
     Utility to convert the input data to a PyTorch Tensor, if `track_meta` is True, the output will be a `MetaTensor`,

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -158,6 +158,10 @@ def convert_to_tensor(
     if safe:
         data = safe_dtype_range(data, dtype)
     dtype = get_equivalent_dtype(dtype, torch.Tensor)
+
+    # common keyword arguments for recursive calls
+    conv_kwargs = dict(dtype=dtype, device=device, track_meta=track_meta, convert_numeric=convert_numeric)
+
     if isinstance(data, torch.Tensor):
         return _convert_tensor(data).to(dtype=dtype, device=device, memory_format=torch.contiguous_format)
     if isinstance(data, np.ndarray):
@@ -172,13 +176,13 @@ def convert_to_tensor(
     elif (has_cp and isinstance(data, cp_ndarray)) or (convert_numeric and isinstance(data, (float, int, bool))):
         return _convert_tensor(data, dtype=dtype, device=device)
     elif isinstance(data, list):
-        list_ret = [convert_to_tensor(i, dtype=dtype, device=device, track_meta=track_meta) for i in data]
+        list_ret = [convert_to_tensor(i, **conv_kwargs) for i in data]
         return _convert_tensor(list_ret, dtype=dtype, device=device) if wrap_sequence else list_ret
     elif isinstance(data, tuple):
-        tuple_ret = tuple(convert_to_tensor(i, dtype=dtype, device=device, track_meta=track_meta) for i in data)
+        tuple_ret = tuple(convert_to_tensor(i, **conv_kwargs) for i in data)
         return _convert_tensor(tuple_ret, dtype=dtype, device=device) if wrap_sequence else tuple_ret
     elif isinstance(data, dict):
-        return {k: convert_to_tensor(v, dtype=dtype, device=device, track_meta=track_meta) for k, v in data.items()}
+        return {k: convert_to_tensor(v, **conv_kwargs) for k, v in data.items()}
 
     return data
 

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -159,9 +159,6 @@ def convert_to_tensor(
         data = safe_dtype_range(data, dtype)
     dtype = get_equivalent_dtype(dtype, torch.Tensor)
 
-    # common keyword arguments for recursive calls
-    conv_kwargs = dict(dtype=dtype, device=device, track_meta=track_meta, convert_numeric=convert_numeric)
-
     if isinstance(data, torch.Tensor):
         return _convert_tensor(data).to(dtype=dtype, device=device, memory_format=torch.contiguous_format)
     if isinstance(data, np.ndarray):
@@ -176,13 +173,22 @@ def convert_to_tensor(
     elif (has_cp and isinstance(data, cp_ndarray)) or (convert_numeric and isinstance(data, (float, int, bool))):
         return _convert_tensor(data, dtype=dtype, device=device)
     elif isinstance(data, list):
-        list_ret = [convert_to_tensor(i, **conv_kwargs) for i in data]
+        list_ret = [
+            convert_to_tensor(i, dtype=dtype, device=device, track_meta=track_meta, convert_numeric=convert_numeric)
+            for i in data
+        ]
         return _convert_tensor(list_ret, dtype=dtype, device=device) if wrap_sequence else list_ret
     elif isinstance(data, tuple):
-        tuple_ret = tuple(convert_to_tensor(i, **conv_kwargs) for i in data)
+        tuple_ret = tuple(
+            convert_to_tensor(i, dtype=dtype, device=device, track_meta=track_meta, convert_numeric=convert_numeric)
+            for i in data
+        )
         return _convert_tensor(tuple_ret, dtype=dtype, device=device) if wrap_sequence else tuple_ret
     elif isinstance(data, dict):
-        return {k: convert_to_tensor(v, **conv_kwargs) for k, v in data.items()}
+        return {
+            k: convert_to_tensor(v, dtype=dtype, device=device, track_meta=track_meta, convert_numeric=convert_numeric)
+            for k, v in data.items()
+        }
 
     return data
 

--- a/monai/utils/type_conversion.py
+++ b/monai/utils/type_conversion.py
@@ -117,6 +117,7 @@ def convert_to_tensor(
     wrap_sequence: bool = False,
     track_meta: bool = False,
     safe: bool = False,
+    convert_numeric: bool = True
 ) -> Any:
     """
     Utility to convert the input data to a PyTorch Tensor, if `track_meta` is True, the output will be a `MetaTensor`,
@@ -136,6 +137,7 @@ def convert_to_tensor(
         safe: if `True`, then do safe dtype convert when intensity overflow. default to `False`.
             E.g., `[256, -12]` -> `[tensor(0), tensor(244)]`.
             If `True`, then `[256, -12]` -> `[tensor(255), tensor(0)]`.
+        convert_numeric: if `True`, convert numeric Python values to tensors.
 
     """
 
@@ -167,7 +169,7 @@ def convert_to_tensor(
             if data.ndim > 0:
                 data = np.ascontiguousarray(data)
             return _convert_tensor(data, dtype=dtype, device=device)
-    elif (has_cp and isinstance(data, cp_ndarray)) or isinstance(data, (float, int, bool)):
+    elif (has_cp and isinstance(data, cp_ndarray)) or (convert_numeric and isinstance(data, (float, int, bool))):
         return _convert_tensor(data, dtype=dtype, device=device)
     elif isinstance(data, list):
         list_ret = [convert_to_tensor(i, dtype=dtype, device=device, track_meta=track_meta) for i in data]

--- a/tests/data/meta_tensor/test_meta_tensor.py
+++ b/tests/data/meta_tensor/test_meta_tensor.py
@@ -245,7 +245,7 @@ class TestMetaTensor(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             fname = os.path.join(tmp_dir, "im.pt")
             torch.save(m, fname)
-            m2 = torch.load(fname, weights_only=False)
+            m2 = torch.load(fname, weights_only=True) 
         self.check(m2, m, ids=False)
 
     @skip_if_no_cuda

--- a/tests/data/meta_tensor/test_meta_tensor.py
+++ b/tests/data/meta_tensor/test_meta_tensor.py
@@ -245,7 +245,7 @@ class TestMetaTensor(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             fname = os.path.join(tmp_dir, "im.pt")
             torch.save(m, fname)
-            m2 = torch.load(fname, weights_only=True) 
+            m2 = torch.load(fname, weights_only=True)
         self.check(m2, m, ids=False)
 
     @skip_if_no_cuda

--- a/tests/data/test_gdsdataset.py
+++ b/tests/data/test_gdsdataset.py
@@ -86,7 +86,8 @@ class TestDataset(unittest.TestCase):
                     cache_dir=tempdir,
                     device=0,
                     pickle_module="pickle",
-                    pickle_protocol=pickle.HIGHEST_PROTOCOL,
+                    # TODO: was pickle.HIGHEST_PROTOCOL but this wasn't compatible with torch.load, need to improve compatibility
+                    pickle_protocol=torch.serialization.DEFAULT_PROTOCOL,
                 )
                 assert_allclose(items[0], p(np.arange(0, np.prod(shape)).reshape(shape)))
                 ds1 = GDSDataset(items, transform=_InplaceXform(), cache_dir=tempdir, device=0)

--- a/tests/data/test_gdsdataset.py
+++ b/tests/data/test_gdsdataset.py
@@ -12,7 +12,6 @@
 from __future__ import annotations
 
 import os
-import pickle
 import tempfile
 import unittest
 

--- a/tests/data/test_persistentdataset.py
+++ b/tests/data/test_persistentdataset.py
@@ -12,12 +12,12 @@
 from __future__ import annotations
 
 import os
-import pickle
 import tempfile
 import unittest
 
 import nibabel as nib
 import numpy as np
+import torch
 from parameterized import parameterized
 
 from monai.data import PersistentDataset, json_hashing
@@ -66,7 +66,8 @@ class TestDataset(unittest.TestCase):
                 transform=_InplaceXform(),
                 cache_dir=tempdir,
                 pickle_module="pickle",
-                pickle_protocol=pickle.HIGHEST_PROTOCOL,
+                # TODO: was pickle.HIGHEST_PROTOCOL but this wasn't compatible with torch.load, need to improve compatibility
+                pickle_protocol=torch.serialization.DEFAULT_PROTOCOL,
             )
             self.assertEqual(items, [[[]], [[0]], [[0, 1]], [[0, 1, 2]], [[0, 1, 2, 3]]])
             ds1 = PersistentDataset(items, transform=_InplaceXform(), cache_dir=tempdir)

--- a/tests/utils/test_state_cacher.py
+++ b/tests/utils/test_state_cacher.py
@@ -27,7 +27,13 @@ DEVICE = "cuda:0" if torch.cuda.is_available() else "cpu"
 TEST_CASE_0 = [torch.Tensor([1]).to(DEVICE), {"in_memory": True}]
 TEST_CASE_1 = [
     torch.Tensor([1]).to(DEVICE),
-    {"in_memory": False, "cache_dir": gettempdir(), "pickle_module": None, "pickle_protocol": pickle.HIGHEST_PROTOCOL},
+    {
+        "in_memory": False,
+        "cache_dir": gettempdir(),
+        "pickle_module": None,
+        # TODO: was pickle.HIGHEST_PROTOCOL but this wasn't compatible with torch.load, need to improve compatibility
+        "pickle_protocol": torch.serialization.DEFAULT_PROTOCOL,
+    },
 ]
 TEST_CASE_2 = [torch.Tensor([1]).to(DEVICE), {"in_memory": False, "allow_overwrite": False}]
 TEST_CASE_3 = [torch.Tensor([1]).to(DEVICE), {"in_memory": False, "cache_dir": Path(gettempdir())}]


### PR DESCRIPTION
Fixes #8355.

### Description

This modifies the use of `torch.load` to load weights-only everywhere. This will change some behaviour in that data needs to be converted to tensors where possible, ie. converting Numpy arrays to tensors. 

This issue was reported by @h3rrr in https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-6vm5-6jv9-rjpj.

This will also replace uses of `pickle` for saving and loading with `torch.save/load`. This also requires that Numpy arrays be converted but otherwise uses the restriction of weights-only to enforce safe loading.

This issue was reported by @h3rrr in https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-p8cm-mm2v-gwjm.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
