### PR TITLE
8564 fourier positional encoding

### DIFF
--- a/monai/networks/blocks/patchembedding.py
+++ b/monai/networks/blocks/patchembedding.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Optional
 
 import numpy as np
 import torch
@@ -53,7 +54,7 @@ class PatchEmbeddingBlock(nn.Module):
         pos_embed_type: str = "learnable",
         dropout_rate: float = 0.0,
         spatial_dims: int = 3,
-        pos_embed_kwargs: dict = {},
+        pos_embed_kwargs: Optional[dict] = None,
     ) -> None:
         """
         Args:
@@ -107,6 +108,8 @@ class PatchEmbeddingBlock(nn.Module):
             )
         self.position_embeddings = nn.Parameter(torch.zeros(1, self.n_patches, hidden_size))
         self.dropout = nn.Dropout(dropout_rate)
+
+        pos_embed_kwargs = {} if pos_embed_kwargs is None else pos_embed_kwargs
 
         if self.pos_embed_type == "none":
             pass

--- a/monai/networks/blocks/patchembedding.py
+++ b/monai/networks/blocks/patchembedding.py
@@ -19,14 +19,14 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn import LayerNorm
 
-from monai.networks.blocks.pos_embed_utils import build_sincos_position_embedding
+from monai.networks.blocks.pos_embed_utils import build_fourier_position_embedding, build_sincos_position_embedding
 from monai.networks.layers import Conv, trunc_normal_
 from monai.utils import ensure_tuple_rep, optional_import
 from monai.utils.module import look_up_option
 
 Rearrange, _ = optional_import("einops.layers.torch", name="Rearrange")
 SUPPORTED_PATCH_EMBEDDING_TYPES = {"conv", "perceptron"}
-SUPPORTED_POS_EMBEDDING_TYPES = {"none", "learnable", "sincos"}
+SUPPORTED_POS_EMBEDDING_TYPES = {"none", "learnable", "sincos", "fourier"}
 
 
 class PatchEmbeddingBlock(nn.Module):
@@ -53,6 +53,7 @@ class PatchEmbeddingBlock(nn.Module):
         pos_embed_type: str = "learnable",
         dropout_rate: float = 0.0,
         spatial_dims: int = 3,
+        pos_embed_kwargs: dict = {},
     ) -> None:
         """
         Args:
@@ -65,6 +66,8 @@ class PatchEmbeddingBlock(nn.Module):
             pos_embed_type: position embedding layer type.
             dropout_rate: fraction of the input units to drop.
             spatial_dims: number of spatial dimensions.
+            pos_embed_kwargs: additional arguments for position embedding. For `sincos`, it can contain
+                              `temperature` and for fourier it can contain `scales`.
         """
 
         super().__init__()
@@ -114,7 +117,17 @@ class PatchEmbeddingBlock(nn.Module):
             for in_size, pa_size in zip(img_size, patch_size):
                 grid_size.append(in_size // pa_size)
 
-            self.position_embeddings = build_sincos_position_embedding(grid_size, hidden_size, spatial_dims)
+            self.position_embeddings = build_sincos_position_embedding(
+                grid_size, hidden_size, spatial_dims, **pos_embed_kwargs
+            )
+        elif self.pos_embed_type == "fourier":
+            grid_size = []
+            for in_size, pa_size in zip(img_size, patch_size):
+                grid_size.append(in_size // pa_size)
+
+            self.position_embeddings = build_fourier_position_embedding(
+                grid_size, hidden_size, spatial_dims, **pos_embed_kwargs
+            )
         else:
             raise ValueError(f"pos_embed_type {self.pos_embed_type} not supported.")
 

--- a/monai/networks/blocks/pos_embed_utils.py
+++ b/monai/networks/blocks/pos_embed_utils.py
@@ -56,7 +56,7 @@ def build_fourier_position_embedding(
     grid_size_t = to_tuple(grid_size)
     if len(grid_size_t) != spatial_dims:
         raise ValueError(
-            f"Length of grid_size must be the same as spatial_dims. Got len(grid_size)={len(grid_size_t)}, should be {spatial_dims}."
+            f"Length of grid_size ({len(grid_size_t)}) must be the same as spatial_dims."
         )
 
     if embed_dim % (2 * spatial_dims) != 0:

--- a/monai/networks/blocks/pos_embed_utils.py
+++ b/monai/networks/blocks/pos_embed_utils.py
@@ -55,9 +55,7 @@ def build_fourier_position_embedding(
     to_tuple = _ntuple(spatial_dims)
     grid_size_t = to_tuple(grid_size)
     if len(grid_size_t) != spatial_dims:
-        raise ValueError(
-            f"Length of grid_size ({len(grid_size_t)}) must be the same as spatial_dims."
-        )
+        raise ValueError(f"Length of grid_size ({len(grid_size_t)}) must be the same as spatial_dims.")
 
     if embed_dim % (2 * spatial_dims) != 0:
         raise AssertionError(

--- a/monai/networks/blocks/pos_embed_utils.py
+++ b/monai/networks/blocks/pos_embed_utils.py
@@ -60,17 +60,23 @@ def build_fourier_position_embedding(
             f"Embed dimension must be divisible by {2 * spatial_dims} for {spatial_dims}D Fourier feature position embedding"
         )
 
-    scales: torch.Tensor = torch.as_tensor(scales, dtype=torch.float)
-    if scales.ndim > 1 and scales.ndim != spatial_dims:
-        raise ValueError("Scales must be either a float or a list of floats with length equal to spatial_dims")
-    if scales.ndim == 0:
-        scales = scales.repeat(spatial_dims)
+    # Ensure scales is a tensor of shape (spatial_dims,)
+    if isinstance(scales, float):
+        scales_tensor = torch.full((spatial_dims,), scales, dtype=torch.float)
+    elif isinstance(scales, (list, tuple)):
+        if len(scales) != spatial_dims:
+            raise ValueError(
+                f"Length of scales {len(scales)} does not match spatial_dims {spatial_dims}"
+            )
+        scales_tensor = torch.tensor(scales, dtype=torch.float)
+    else:
+        raise TypeError(f"scales must be float or list of floats, got {type(scales)}")
 
     gaussians = torch.normal(0.0, 1.0, (embed_dim // 2, spatial_dims))
-    gaussians = gaussians * scales
+    gaussians = gaussians * scales_tensor
 
-    positions = [torch.linspace(0, 1, x) for x in grid_size]
-    positions = torch.stack(torch.meshgrid(*positions, indexing="ij"), dim=-1)
+    position_indeces = [torch.linspace(0, 1, x) for x in grid_size]
+    positions = torch.stack(torch.meshgrid(*position_indeces, indexing="ij"), dim=-1)
     positions = positions.flatten(end_dim=-2)
 
     x_proj = (2.0 * torch.pi * positions) @ gaussians.T

--- a/monai/networks/blocks/pos_embed_utils.py
+++ b/monai/networks/blocks/pos_embed_utils.py
@@ -18,7 +18,7 @@ from typing import List, Union
 import torch
 import torch.nn as nn
 
-__all__ = ["build_sincos_position_embedding", "build_fourier_position_embedding"]
+__all__ = ["build_fourier_position_embedding", "build_sincos_position_embedding"]
 
 
 # From PyTorch internals
@@ -36,16 +36,17 @@ def build_fourier_position_embedding(
     grid_size: Union[int, List[int]], embed_dim: int, spatial_dims: int = 3, scales: Union[float, List[float]] = 1.0
 ) -> torch.nn.Parameter:
     """
-    Builds a (Anistropic) Fourier Feature based positional encoding based on the given grid size, embed dimension,
+    Builds a (Anistropic) Fourier feature position embedding based on the given grid size, embed dimension,
     spatial dimensions, and scales. The scales control the variance of the Fourier features, higher values make distant
     points more distinguishable.
+    Position embedding is made anistropic by allowing setting different scales for each spatial dimension.
         Reference: https://arxiv.org/abs/2509.02488
 
     Args:
-        grid_size (List[int]): The size of the grid in each spatial dimension.
+        grid_size (int | List[int]): The size of the grid in each spatial dimension.
         embed_dim (int): The dimension of the embedding.
         spatial_dims (int): The number of spatial dimensions (2 for 2D, 3 for 3D).
-        scales (List[float]): The scale for every spatial dimension. If a single float is provided,
+        scales (float | List[float]): The scale for every spatial dimension. If a single float is provided,
                               the same scale is used for all dimensions.
 
     Returns:
@@ -57,10 +58,8 @@ def build_fourier_position_embedding(
     if len(grid_size_t) != spatial_dims:
         raise ValueError(f"Length of grid_size ({len(grid_size_t)}) must be the same as spatial_dims.")
 
-    if embed_dim % (2 * spatial_dims) != 0:
-        raise AssertionError(
-            f"Embed dimension must be divisible by {2 * spatial_dims} for {spatial_dims}D Fourier feature position embedding"
-        )
+    if embed_dim % 2 != 0:
+        raise ValueError("embed_dim must be even for Fourier position embedding")
 
     # Ensure scales is a tensor of shape (spatial_dims,)
     if isinstance(scales, float):
@@ -72,11 +71,10 @@ def build_fourier_position_embedding(
     else:
         raise TypeError(f"scales must be float or list of floats, got {type(scales)}")
 
-    gaussians = torch.normal(0.0, 1.0, (embed_dim // 2, spatial_dims))
-    gaussians = gaussians * scales_tensor
+    gaussians = torch.randn(embed_dim // 2, spatial_dims, dtype=torch.float32) * scales_tensor
 
-    position_indeces = [torch.linspace(0, 1, x) for x in grid_size_t]
-    positions = torch.stack(torch.meshgrid(*position_indeces, indexing="ij"), dim=-1)
+    position_indices = [torch.linspace(0, 1, x, dtype=torch.float32) for x in grid_size_t]
+    positions = torch.stack(torch.meshgrid(*position_indices, indexing="ij"), dim=-1)
     positions = positions.flatten(end_dim=-2)
 
     x_proj = (2.0 * torch.pi * positions) @ gaussians.T

--- a/monai/networks/blocks/pos_embed_utils.py
+++ b/monai/networks/blocks/pos_embed_utils.py
@@ -34,7 +34,7 @@ def _ntuple(n):
 
 def build_fourier_position_embedding(
     grid_size: Union[int, List[int]], embed_dim: int, spatial_dims: int = 3, scales: Union[float, List[float]] = 1.0
-):
+) -> torch.nn.Parameter:
     """
     Builds a (Anistropic) Fourier Feature based positional encoding based on the given grid size, embed dimension,
     spatial dimensions, and scales. The scales control the variance of the Fourier features, higher values make distant
@@ -55,7 +55,12 @@ def build_fourier_position_embedding(
     to_tuple = _ntuple(spatial_dims)
     grid_size = to_tuple(grid_size)
 
-    scales = torch.tensor(scales)
+    if embed_dim % (2 * spatial_dims) != 0:
+        raise AssertionError(
+            f"Embed dimension must be divisible by {2 * spatial_dims} for {spatial_dims}D Fourier feature position embedding"
+        )
+
+    scales: torch.Tensor = torch.as_tensor(scales, dtype=torch.float)
     if scales.ndim > 1 and scales.ndim != spatial_dims:
         raise ValueError("Scales must be either a float or a list of floats with length equal to spatial_dims")
     if scales.ndim == 0:
@@ -65,15 +70,15 @@ def build_fourier_position_embedding(
     gaussians = gaussians * scales
 
     positions = [torch.linspace(0, 1, x) for x in grid_size]
-    positions = torch.stack(torch.meshgrid(*positions, indexing="ij"), axis=-1)
+    positions = torch.stack(torch.meshgrid(*positions, indexing="ij"), dim=-1)
     positions = positions.flatten(end_dim=-2)
 
     x_proj = (2.0 * torch.pi * positions) @ gaussians.T
 
-    pos_emb = torch.cat([torch.sin(x_proj), torch.cos(x_proj)], axis=-1)
-    pos_emb = pos_emb[None, :, :]
+    pos_emb = torch.cat([torch.sin(x_proj), torch.cos(x_proj)], dim=-1)
+    pos_emb = nn.Parameter(pos_emb[None, :, :], requires_grad=False)
 
-    return nn.Parameter(pos_emb, requires_grad=False)
+    return pos_emb
 
 
 def build_sincos_position_embedding(

--- a/monai/networks/blocks/pos_embed_utils.py
+++ b/monai/networks/blocks/pos_embed_utils.py
@@ -65,9 +65,7 @@ def build_fourier_position_embedding(
         scales_tensor = torch.full((spatial_dims,), scales, dtype=torch.float)
     elif isinstance(scales, (list, tuple)):
         if len(scales) != spatial_dims:
-            raise ValueError(
-                f"Length of scales {len(scales)} does not match spatial_dims {spatial_dims}"
-            )
+            raise ValueError(f"Length of scales {len(scales)} does not match spatial_dims {spatial_dims}")
         scales_tensor = torch.tensor(scales, dtype=torch.float)
     else:
         raise TypeError(f"scales must be float or list of floats, got {type(scales)}")

--- a/monai/networks/blocks/pos_embed_utils.py
+++ b/monai/networks/blocks/pos_embed_utils.py
@@ -18,7 +18,7 @@ from typing import List, Union
 import torch
 import torch.nn as nn
 
-__all__ = ["build_sincos_position_embedding"]
+__all__ = ["build_sincos_position_embedding", "build_fourier_position_embedding"]
 
 
 # From PyTorch internals
@@ -30,6 +30,50 @@ def _ntuple(n):
         return tuple(repeat(x, n))
 
     return parse
+
+
+def build_fourier_position_embedding(
+    grid_size: Union[int, List[int]], embed_dim: int, spatial_dims: int = 3, scales: Union[float, List[float]] = 1.0
+):
+    """
+    Builds a (Anistropic) Fourier Feature based positional encoding based on the given grid size, embed dimension,
+    spatial dimensions, and scales. The scales control the variance of the Fourier features, higher values make distant
+    points more distinguishable.
+        Reference: https://arxiv.org/abs/2509.02488
+
+    Args:
+        grid_size (List[int]): The size of the grid in each spatial dimension.
+        embed_dim (int): The dimension of the embedding.
+        spatial_dims (int): The number of spatial dimensions (2 for 2D, 3 for 3D).
+        scales (List[float]): The scale for every spatial dimension. If a single float is provided,
+                              the same scale is used for all dimensions.
+
+    Returns:
+        pos_embed (nn.Parameter): The Fourier feature position embedding as a fixed parameter.
+    """
+
+    to_tuple = _ntuple(spatial_dims)
+    grid_size = to_tuple(grid_size)
+
+    scales = torch.tensor(scales)
+    if scales.ndim > 1 and scales.ndim != spatial_dims:
+        raise ValueError("Scales must be either a float or a list of floats with length equal to spatial_dims")
+    if scales.ndim == 0:
+        scales = scales.repeat(spatial_dims)
+
+    gaussians = torch.normal(0.0, 1.0, (embed_dim // 2, spatial_dims))
+    gaussians = gaussians * scales
+
+    positions = [torch.linspace(0, 1, x) for x in grid_size]
+    positions = torch.stack(torch.meshgrid(*positions, indexing="ij"), axis=-1)
+    positions = positions.flatten(end_dim=-2)
+
+    x_proj = (2.0 * torch.pi * positions) @ gaussians.T
+
+    pos_emb = torch.cat([torch.sin(x_proj), torch.cos(x_proj)], axis=-1)
+    pos_emb = pos_emb[None, :, :]
+
+    return nn.Parameter(pos_emb, requires_grad=False)
 
 
 def build_sincos_position_embedding(

--- a/monai/networks/blocks/pos_embed_utils.py
+++ b/monai/networks/blocks/pos_embed_utils.py
@@ -53,7 +53,11 @@ def build_fourier_position_embedding(
     """
 
     to_tuple = _ntuple(spatial_dims)
-    grid_size = to_tuple(grid_size)
+    grid_size_t = to_tuple(grid_size)
+    if len(grid_size_t) != spatial_dims:
+        raise ValueError(
+            f"Length of grid_size must be the same as spatial_dims. Got len(grid_size)={len(grid_size_t)}, should be {spatial_dims}."
+        )
 
     if embed_dim % (2 * spatial_dims) != 0:
         raise AssertionError(
@@ -73,7 +77,7 @@ def build_fourier_position_embedding(
     gaussians = torch.normal(0.0, 1.0, (embed_dim // 2, spatial_dims))
     gaussians = gaussians * scales_tensor
 
-    position_indeces = [torch.linspace(0, 1, x) for x in grid_size]
+    position_indeces = [torch.linspace(0, 1, x) for x in grid_size_t]
     positions = torch.stack(torch.meshgrid(*position_indeces, indexing="ij"), dim=-1)
     positions = positions.flatten(end_dim=-2)
 

--- a/tests/networks/blocks/test_patchembedding.py
+++ b/tests/networks/blocks/test_patchembedding.py
@@ -87,6 +87,19 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
 
         self.assertEqual(net.position_embeddings.requires_grad, False)
 
+    def test_fourier_pos_embed(self):
+        net = PatchEmbeddingBlock(
+            in_channels=1,
+            img_size=(32, 32, 32),
+            patch_size=(8, 8, 8),
+            hidden_size=96,
+            num_heads=8,
+            pos_embed_type="fourier",
+            dropout_rate=0.5,
+        )
+
+        self.assertEqual(net.position_embeddings.requires_grad, False)
+
     def test_learnable_pos_embed(self):
         net = PatchEmbeddingBlock(
             in_channels=1,
@@ -101,6 +114,31 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
         self.assertEqual(net.position_embeddings.requires_grad, True)
 
     def test_ill_arg(self):
+        with self.assertRaises(ValueError):
+            PatchEmbeddingBlock(
+                in_channels=1,
+                img_size=(128, 128, 128),
+                patch_size=(16, 16, 16),
+                hidden_size=128,
+                num_heads=12,
+                proj_type="conv",
+                dropout_rate=5.0,
+                pos_embed_type="fourier",
+                pos_embed_kwargs=dict(scales=[1.0, 1.0]),
+            )
+
+            PatchEmbeddingBlock(
+                in_channels=1,
+                img_size=(128, 128),
+                patch_size=(16, 16),
+                hidden_size=128,
+                num_heads=12,
+                proj_type="conv",
+                dropout_rate=5.0,
+                pos_embed_type="fourier",
+                pos_embed_kwargs=dict(scales=[1.0, 1.0, 1.0]),
+            )
+
         with self.assertRaises(ValueError):
             PatchEmbeddingBlock(
                 in_channels=1,

--- a/tests/networks/blocks/test_patchembedding.py
+++ b/tests/networks/blocks/test_patchembedding.py
@@ -122,11 +122,12 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
                 hidden_size=128,
                 num_heads=12,
                 proj_type="conv",
-                dropout_rate=5.0,
+                dropout_rate=0.1,
                 pos_embed_type="fourier",
                 pos_embed_kwargs=dict(scales=[1.0, 1.0]),
             )
 
+        with self.assertRaises(ValueError):
             PatchEmbeddingBlock(
                 in_channels=1,
                 img_size=(128, 128),
@@ -134,7 +135,7 @@ class TestPatchEmbeddingBlock(unittest.TestCase):
                 hidden_size=128,
                 num_heads=12,
                 proj_type="conv",
-                dropout_rate=5.0,
+                dropout_rate=0.1,
                 pos_embed_type="fourier",
                 pos_embed_kwargs=dict(scales=[1.0, 1.0, 1.0]),
             )


### PR DESCRIPTION
Fixes #8564 .

### Description

Add Fourier feature positional encodings to `PatchEmbeddingBlock`. It has been shown, that Fourier feature positional encodings are better suited for Anistropic images and videos: https://arxiv.org/abs/2509.02488

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
