### PR TITLE
Fix incorrect docstring defaults for DiffusionModelUNet

### DIFF
--- a/monai/networks/nets/diffusion_model_unet.py
+++ b/monai/networks/nets/diffusion_model_unet.py
@@ -1527,9 +1527,9 @@ class DiffusionModelUNet(nn.Module):
         upcast_attention: if True, upcast attention operations to full precision.
         dropout_cattn: if different from zero, this will be the dropout value for the cross-attention layers.
         include_fc: whether to include the final linear layer. Default to True.
-        use_combined_linear: whether to use a single linear layer for qkv projection, default to True.
+        use_combined_linear: whether to use a single linear layer for qkv projection, default to False.
         use_flash_attention: if True, use Pytorch's inbuilt flash attention for a memory efficient attention mechanism
-            (see https://pytorch.org/docs/2.2/generated/torch.nn.functional.scaled_dot_product_attention.html).
+            (see https://pytorch.org/docs/2.2/generated/torch.nn.functional.scaled_dot_product_attention.html), default to False.
     """
 
     def __init__(


### PR DESCRIPTION

Fixes #
Fix incorrect defaults for use_combined_linear and add default for use_flash_attention in docstring
### Description
The DiffusionModelUNet docstring listed use_combined_linear as default True, while the class signature sets it to False. It also omitted the default for use_flash_attention, which is False in the signature. This PR updates the Args section to match the actual defaults.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
