### PR TITLE
Diffusion Model Encoder has an output layer set in forward method and this leads to problems

### DIFF
--- a/monai/networks/nets/diffusion_model_unet.py
+++ b/monai/networks/nets/diffusion_model_unet.py
@@ -1904,7 +1904,7 @@ class DiffusionModelEncoder(nn.Module):
         spatial_dims: int,
         in_channels: int,
         out_channels: int,
-        input_shape: Sequence[int],
+        input_shape: Sequence[int] = (64, 64),
         num_res_blocks: Sequence[int] | int = (2, 2, 2, 2),
         channels: Sequence[int] = (32, 64, 64, 64),
         attention_levels: Sequence[bool] = (False, False, True, True),

--- a/monai/networks/nets/diffusion_model_unet.py
+++ b/monai/networks/nets/diffusion_model_unet.py
@@ -2063,10 +2063,9 @@ class DiffusionModelEncoder(nn.Module):
         h = h.reshape(h.shape[0], -1)
 
         # 5. out
-        if self.out is None:
-            self.out = nn.Sequential(
-                nn.Linear(h.shape[1], 512), nn.ReLU(), nn.Dropout(0.1), nn.Linear(512, self.out_channels)
-            )
+        self.out = nn.Sequential(
+            nn.Linear(h.shape[1], 512), nn.ReLU(), nn.Dropout(0.1), nn.Linear(512, self.out_channels)
+        )
         output: torch.Tensor = self.out(h)
 
         return output

--- a/monai/networks/nets/diffusion_model_unet.py
+++ b/monai/networks/nets/diffusion_model_unet.py
@@ -1894,7 +1894,7 @@ class DiffusionModelEncoder(nn.Module):
         num_head_channels: number of channels in each attention head.
         with_conditioning: if True add spatial transformers to perform conditioning.
         transformer_num_layers: number of layers of Transformer blocks to use.
-        cross_attention_dim: number of context dimensions to use.
+        cross_attention_dim: number of context dimensions to use. 
         num_class_embeds: if specified (as an int), then this model will be class-conditional with `num_class_embeds` classes.
         upcast_attention: if True, upcast attention operations to full precision.
     """

--- a/monai/networks/nets/diffusion_model_unet.py
+++ b/monai/networks/nets/diffusion_model_unet.py
@@ -1891,7 +1891,7 @@ class DiffusionModelEncoder(nn.Module):
         norm_num_groups: number of groups for the normalization.
         norm_eps: epsilon for the normalization.
         resblock_updown: if True use residual blocks for downsampling.
-        num_head_channels: number of channels in each attention head.
+        num_head_channels: number of channels in each attention head. 
         with_conditioning: if True add spatial transformers to perform conditioning.
         transformer_num_layers: number of layers of Transformer blocks to use.
         cross_attention_dim: number of context dimensions to use.

--- a/monai/networks/nets/diffusion_model_unet.py
+++ b/monai/networks/nets/diffusion_model_unet.py
@@ -1891,7 +1891,7 @@ class DiffusionModelEncoder(nn.Module):
         norm_num_groups: number of groups for the normalization.
         norm_eps: epsilon for the normalization.
         resblock_updown: if True use residual blocks for downsampling.
-        num_head_channels: number of channels in each attention head. 
+        num_head_channels: number of channels in each attention head.
         with_conditioning: if True add spatial transformers to perform conditioning.
         transformer_num_layers: number of layers of Transformer blocks to use.
         cross_attention_dim: number of context dimensions to use.

--- a/monai/networks/nets/diffusion_model_unet.py
+++ b/monai/networks/nets/diffusion_model_unet.py
@@ -33,16 +33,16 @@ from __future__ import annotations
 
 import math
 from collections.abc import Sequence
+from functools import reduce
 from typing import Optional
 
+import numpy as np
 import torch
 from torch import nn
-import numpy as np
 
 from monai.networks.blocks import Convolution, CrossAttentionBlock, MLPBlock, SABlock, SpatialAttentionBlock, Upsample
 from monai.networks.layers.factories import Pool
 from monai.utils import ensure_tuple_rep, optional_import
-from functools import reduce
 
 Rearrange, _ = optional_import("einops.layers.torch", name="Rearrange")
 
@@ -1904,7 +1904,7 @@ class DiffusionModelEncoder(nn.Module):
         spatial_dims: int,
         in_channels: int,
         out_channels: int,
-        input_shape: Sequence[int], 
+        input_shape: Sequence[int],
         num_res_blocks: Sequence[int] | int = (2, 2, 2, 2),
         channels: Sequence[int] = (32, 64, 64, 64),
         attention_levels: Sequence[bool] = (False, False, True, True),
@@ -2012,14 +2012,13 @@ class DiffusionModelEncoder(nn.Module):
             self.down_blocks.append(down_block)
 
         for _ in channels:
-            input_shape = [int(np.ceil(i_/2)) for i_ in input_shape]
+            input_shape = [int(np.ceil(i_ / 2)) for i_ in input_shape]
 
-        last_dim_flattened = reduce(lambda x, y: x*y, input_shape) * self.down_blocks[-1].downsampler.op.conv.out_channels
+        last_dim_flattened = int(reduce(lambda x, y: x * y, input_shape) * channels[-1])
+
         self.out: Optional[nn.Module] = nn.Sequential(
-            nn.Linear(last_dim_flattened, 512),
-            nn.ReLU(), nn.Dropout(0.1),
-            nn.Linear(512, self.out_channels)
-            )
+            nn.Linear(last_dim_flattened, 512), nn.ReLU(), nn.Dropout(0.1), nn.Linear(512, self.out_channels)
+        )
 
     def forward(
         self,

--- a/monai/networks/nets/diffusion_model_unet.py
+++ b/monai/networks/nets/diffusion_model_unet.py
@@ -1894,7 +1894,7 @@ class DiffusionModelEncoder(nn.Module):
         num_head_channels: number of channels in each attention head.
         with_conditioning: if True add spatial transformers to perform conditioning.
         transformer_num_layers: number of layers of Transformer blocks to use.
-        cross_attention_dim: number of context dimensions to use. 
+        cross_attention_dim: number of context dimensions to use.
         num_class_embeds: if specified (as an int), then this model will be class-conditional with `num_class_embeds` classes.
         upcast_attention: if True, upcast attention operations to full precision.
     """

--- a/monai/networks/nets/diffusion_model_unet.py
+++ b/monai/networks/nets/diffusion_model_unet.py
@@ -37,10 +37,12 @@ from typing import Optional
 
 import torch
 from torch import nn
+import numpy as np
 
 from monai.networks.blocks import Convolution, CrossAttentionBlock, MLPBlock, SABlock, SpatialAttentionBlock, Upsample
 from monai.networks.layers.factories import Pool
 from monai.utils import ensure_tuple_rep, optional_import
+from functools import reduce
 
 Rearrange, _ = optional_import("einops.layers.torch", name="Rearrange")
 
@@ -1882,6 +1884,7 @@ class DiffusionModelEncoder(nn.Module):
         spatial_dims: number of spatial dimensions.
         in_channels: number of input channels.
         out_channels: number of output channels.
+        input_shape: spatial shape of the input (without batch and channel dims).
         num_res_blocks: number of residual blocks (see _ResnetBlock) per level.
         channels: tuple of block output channels.
         attention_levels: list of levels to add attention.
@@ -1901,6 +1904,7 @@ class DiffusionModelEncoder(nn.Module):
         spatial_dims: int,
         in_channels: int,
         out_channels: int,
+        input_shape: Sequence[int], 
         num_res_blocks: Sequence[int] | int = (2, 2, 2, 2),
         channels: Sequence[int] = (32, 64, 64, 64),
         attention_levels: Sequence[bool] = (False, False, True, True),
@@ -2007,7 +2011,15 @@ class DiffusionModelEncoder(nn.Module):
 
             self.down_blocks.append(down_block)
 
-        self.out: Optional[nn.Module] = None
+        for _ in channels:
+            input_shape = [int(np.ceil(i_/2)) for i_ in input_shape]
+
+        last_dim_flattened = reduce(lambda x, y: x*y, input_shape) * self.down_blocks[-1].downsampler.op.conv.out_channels
+        self.out: Optional[nn.Module] = nn.Sequential(
+            nn.Linear(last_dim_flattened, 512),
+            nn.ReLU(), nn.Dropout(0.1),
+            nn.Linear(512, self.out_channels)
+            )
 
     def forward(
         self,


### PR DESCRIPTION
Fixes #8577 .

### Description

This pull request sets the out layer of DiffusionModelEncoder in the init method. This requires the inclusion of input_shape parameter in the init method to calculate the input dimension to the last linear layer.

The output spatial shape derivation is a bit baroque, but allows for the otherwise not very pleasant odd spatial dimensions at input. 


### Types of changes
- [x] Non breaking change (fix or new feature that would cause existing functionality to change). **The tutorial that was failing will need to provide this input parameter, but input_shape is now defaulted to the notebook dims.**
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
