### PR TITLE
Include more-itertools in build env

### DIFF
--- a/.github/workflows/pythonapp-min.yml
+++ b/.github/workflows/pythonapp-min.yml
@@ -136,6 +136,7 @@ jobs:
       run: |
         which python
         python -m pip install --user --upgrade pip setuptools wheel
+        python -m pip install --user more-itertools>=8.0
     - name: cache weekly timestamp
       id: pip-cache
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
   "wheel",
   "setuptools",
+  "more-itertools>=8.0",
   "torch>=2.4.1",
   "ninja",
   "packaging"


### PR DESCRIPTION
Fixes #8610.

### Description
setuptools’ import chain requires more-itertools, but it isn’t installed when setup.py runs.
Edit pyproject.toml to include it under [build-system].

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
