### PR TITLE
timestep scheduling with np.linspace

### DIFF
--- a/monai/networks/schedulers/ddim.py
+++ b/monai/networks/schedulers/ddim.py
@@ -125,9 +125,7 @@ class DDIMScheduler(Scheduler):
                 f" the max train timestep."
             )
 
-        # creates integer timesteps by multiplying by ratio
-        # casting to int to avoid issues when num_inference_step is power of 3
-        timesteps = np.linspace(num_train_timesteps - 1 - steps_offset, 0, num_inference_steps).round().astype(np.int64)
+        timesteps = np.linspace((self.num_train_timesteps - 1) - self.steps_offset, 0, num_inference_steps).round().astype(np.int64)
         self.timesteps = torch.from_numpy(timesteps).to(device)
         self.timesteps += self.steps_offset
 

--- a/monai/networks/schedulers/ddim.py
+++ b/monai/networks/schedulers/ddim.py
@@ -117,15 +117,14 @@ class DDIMScheduler(Scheduler):
             )
 
         self.num_inference_steps = num_inference_steps
-        step_ratio = self.num_train_timesteps // self.num_inference_steps
-        if self.steps_offset >= step_ratio:
-            raise ValueError(
-                f"`steps_offset`: {self.steps_offset} cannot be greater than or equal to "
-                f"`num_train_timesteps // num_inference_steps : {step_ratio}` as this will cause timesteps to exceed"
-                f" the max train timestep."
-            )
+        if self.steps_offset < 0 or self.steps_offset >= self.num_train_timesteps:
+            raise ValueError(f"`steps_offset`: {self.steps_offset} must be in range [0, {self.num_train_timesteps}).")
 
-        timesteps = np.linspace((self.num_train_timesteps - 1) - self.steps_offset, 0, num_inference_steps).round().astype(np.int64)
+        timesteps = (
+            np.linspace((self.num_train_timesteps - 1) - self.steps_offset, 0, num_inference_steps)
+            .round()
+            .astype(np.int64)
+        )
         self.timesteps = torch.from_numpy(timesteps).to(device)
         self.timesteps += self.steps_offset
 

--- a/monai/networks/schedulers/ddim.py
+++ b/monai/networks/schedulers/ddim.py
@@ -127,7 +127,7 @@ class DDIMScheduler(Scheduler):
 
         # creates integer timesteps by multiplying by ratio
         # casting to int to avoid issues when num_inference_step is power of 3
-        timesteps = np.linspace(self.num_train_timesteps - 1, 0, num_inference_steps).round().astype(np.int64)
+        timesteps = np.linspace(num_train_timesteps - 1 - steps_offset, 0, num_inference_steps).round().astype(np.int64)
         self.timesteps = torch.from_numpy(timesteps).to(device)
         self.timesteps += self.steps_offset
 

--- a/monai/networks/schedulers/ddim.py
+++ b/monai/networks/schedulers/ddim.py
@@ -127,7 +127,7 @@ class DDIMScheduler(Scheduler):
 
         # creates integer timesteps by multiplying by ratio
         # casting to int to avoid issues when num_inference_step is power of 3
-        timesteps = (np.arange(0, num_inference_steps) * step_ratio).round()[::-1].copy().astype(np.int64)
+        timesteps = np.linspace(self.num_train_timesteps - 1, 0, num_inference_steps).round().astype(np.int64)
         self.timesteps = torch.from_numpy(timesteps).to(device)
         self.timesteps += self.steps_offset
 

--- a/monai/networks/schedulers/ddim.py
+++ b/monai/networks/schedulers/ddim.py
@@ -120,7 +120,11 @@ class DDIMScheduler(Scheduler):
         if self.steps_offset < 0 or self.steps_offset >= self.num_train_timesteps:
             raise ValueError(f"`steps_offset`: {self.steps_offset} must be in range [0, {self.num_train_timesteps}).")
 
-        self.timesteps = torch.linspace((self.num_train_timesteps - 1) - self.steps_offset, 0, num_inference_steps, device=device).round().long()
+        self.timesteps = (
+            torch.linspace((self.num_train_timesteps - 1) - self.steps_offset, 0, num_inference_steps, device=device)
+            .round()
+            .long()
+        )
         self.timesteps += self.steps_offset
 
     def _get_variance(self, timestep: int, prev_timestep: int) -> torch.Tensor:

--- a/monai/networks/schedulers/ddim.py
+++ b/monai/networks/schedulers/ddim.py
@@ -120,12 +120,7 @@ class DDIMScheduler(Scheduler):
         if self.steps_offset < 0 or self.steps_offset >= self.num_train_timesteps:
             raise ValueError(f"`steps_offset`: {self.steps_offset} must be in range [0, {self.num_train_timesteps}).")
 
-        timesteps = (
-            np.linspace((self.num_train_timesteps - 1) - self.steps_offset, 0, num_inference_steps)
-            .round()
-            .astype(np.int64)
-        )
-        self.timesteps = torch.from_numpy(timesteps).to(device)
+        self.timesteps = torch.linspace((self.num_train_timesteps - 1) - self.steps_offset, 0, num_inference_steps, device=device).round().long()
         self.timesteps += self.steps_offset
 
     def _get_variance(self, timestep: int, prev_timestep: int) -> torch.Tensor:

--- a/monai/networks/schedulers/ddpm.py
+++ b/monai/networks/schedulers/ddpm.py
@@ -125,7 +125,7 @@ class DDPMScheduler(Scheduler):
         step_ratio = self.num_train_timesteps // self.num_inference_steps
         # creates integer timesteps by multiplying by ratio
         # casting to int to avoid issues when num_inference_step is power of 3
-        timesteps = (np.arange(0, num_inference_steps) * step_ratio).round()[::-1].astype(np.int64)
+        timesteps = np.linspace(self.num_train_timesteps - 1, 0, num_inference_steps).round().astype(np.int64)
         self.timesteps = torch.from_numpy(timesteps).to(device)
 
     def _get_mean(self, timestep: int, x_0: torch.Tensor, x_t: torch.Tensor) -> torch.Tensor:

--- a/monai/networks/schedulers/ddpm.py
+++ b/monai/networks/schedulers/ddpm.py
@@ -122,9 +122,7 @@ class DDPMScheduler(Scheduler):
             )
 
         self.num_inference_steps = num_inference_steps
-        # creates integer timesteps by multiplying by ratio
-        # casting to int to avoid issues when num_inference_step is power of 3
-        timesteps = np.linspace(self.num_train_timesteps - 1, 0, num_inference_steps).round().astype(np.int64)
+        timesteps = np.linspace(self.num_train_timesteps - 1, 0, self.num_inference_steps).round().astype(np.int64)
         self.timesteps = torch.from_numpy(timesteps).to(device)
 
     def _get_mean(self, timestep: int, x_0: torch.Tensor, x_t: torch.Tensor) -> torch.Tensor:

--- a/monai/networks/schedulers/ddpm.py
+++ b/monai/networks/schedulers/ddpm.py
@@ -122,8 +122,8 @@ class DDPMScheduler(Scheduler):
             )
 
         self.num_inference_steps = num_inference_steps
-        timesteps = np.linspace(self.num_train_timesteps - 1, 0, self.num_inference_steps).round().astype(np.int64)
-        self.timesteps = torch.from_numpy(timesteps).to(device)
+        self.timesteps = torch.linspace(self.num_train_timesteps - 1, 0, self.num_inference_steps, device=device).round().long()
+        
 
     def _get_mean(self, timestep: int, x_0: torch.Tensor, x_t: torch.Tensor) -> torch.Tensor:
         """

--- a/monai/networks/schedulers/ddpm.py
+++ b/monai/networks/schedulers/ddpm.py
@@ -31,7 +31,6 @@
 
 from __future__ import annotations
 
-import numpy as np
 import torch
 
 from monai.utils import StrEnum
@@ -123,7 +122,7 @@ class DDPMScheduler(Scheduler):
 
         self.num_inference_steps = num_inference_steps
         self.timesteps = torch.linspace(self.num_train_timesteps - 1, 0, self.num_inference_steps, device=device).round().long()
-        
+
 
     def _get_mean(self, timestep: int, x_0: torch.Tensor, x_t: torch.Tensor) -> torch.Tensor:
         """

--- a/monai/networks/schedulers/ddpm.py
+++ b/monai/networks/schedulers/ddpm.py
@@ -122,8 +122,9 @@ class DDPMScheduler(Scheduler):
             )
 
         self.num_inference_steps = num_inference_steps
-        self.timesteps = torch.linspace(self.num_train_timesteps - 1, 0, self.num_inference_steps, device=device).round().long()
-        
+        self.timesteps = (
+            torch.linspace(self.num_train_timesteps - 1, 0, self.num_inference_steps, device=device).round().long()
+        )
 
     def _get_mean(self, timestep: int, x_0: torch.Tensor, x_t: torch.Tensor) -> torch.Tensor:
         """

--- a/monai/networks/schedulers/ddpm.py
+++ b/monai/networks/schedulers/ddpm.py
@@ -122,7 +122,6 @@ class DDPMScheduler(Scheduler):
             )
 
         self.num_inference_steps = num_inference_steps
-        step_ratio = self.num_train_timesteps // self.num_inference_steps
         # creates integer timesteps by multiplying by ratio
         # casting to int to avoid issues when num_inference_step is power of 3
         timesteps = np.linspace(self.num_train_timesteps - 1, 0, num_inference_steps).round().astype(np.int64)


### PR DESCRIPTION
Fixes #8600 

### Description

The `np.linspace` approach generates a descending array that starts exactly at 999 and ends exactly at 0 (after rounding), ensuring the scheduler samples the entire intended trajectory.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
