### PR TITLE
Fix index using tuple for image cropping operation

### DIFF
--- a/monai/transforms/croppad/functional.py
+++ b/monai/transforms/croppad/functional.py
@@ -144,7 +144,7 @@ def crop_or_pad_nd(img: torch.Tensor, translation_mat, spatial_size: tuple[int, 
         _mode = _convert_pt_pad_mode(mode)
         img = pad_nd(img, to_pad, mode=_mode, **kwargs)
     if do_crop:
-        img = img[to_crop]
+        img = img[tuple(to_crop)]
     return img
 
 


### PR DESCRIPTION
I'm getting a warning at this line:
"Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x instead of x. In pytorch 2.9 this will be interpreted as     _tensor.py:1654
tensor index, x, which will result either in an error or a different result".

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
