### PR TITLE
 Fix channel-first indices buffer for distance_transform_edt (return_indices=True) #8656  

### DIFF
--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -2498,7 +2498,7 @@ def distance_transform_edt(
         if return_indices:
             dtype = torch.int32
             if indices is None:
-                indices = torch.zeros((img.shape[0],) + (img.dim()-1,) + img.shape[1:], dtype=dtype)  # type: ignore
+                indices = torch.zeros((img.shape[0],) + (img.dim() - 1,) + img.shape[1:], dtype=dtype)  # type: ignore
             else:
                 if not isinstance(indices, torch.Tensor) and indices.device != img.device:
                     raise TypeError("indices must be a torch.Tensor on the same device as img")
@@ -2532,7 +2532,7 @@ def distance_transform_edt(
                     raise TypeError("distances must be a numpy.ndarray of dtype float64")
         if return_indices:
             if indices is None:
-                indices = np.zeros((img_.shape[0],)+(img_.ndim-1,) + img_.shape[1:], dtype=np.int32)
+                indices = np.zeros((img_.shape[0],) + (img_.ndim - 1,) + img_.shape[1:], dtype=np.int32)
             else:
                 if not isinstance(indices, np.ndarray):
                     raise TypeError("indices must be a numpy.ndarray")

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -2498,7 +2498,7 @@ def distance_transform_edt(
         if return_indices:
             dtype = torch.int32
             if indices is None:
-                indices = torch.zeros((img.dim(),) + img.shape, dtype=dtype)  # type: ignore
+                indices = torch.zeros((img.shape[0],) + (img.dim()-1,) + img.shape[1:], dtype=dtype)  # type: ignore
             else:
                 if not isinstance(indices, torch.Tensor) and indices.device != img.device:
                     raise TypeError("indices must be a torch.Tensor on the same device as img")
@@ -2532,7 +2532,7 @@ def distance_transform_edt(
                     raise TypeError("distances must be a numpy.ndarray of dtype float64")
         if return_indices:
             if indices is None:
-                indices = np.zeros((img_.ndim,) + img_.shape, dtype=np.int32)
+                indices = np.zeros((img_.shape[0],)+(img_.ndim-1,) + img_.shape[1:], dtype=np.int32)
             else:
                 if not isinstance(indices, np.ndarray):
                     raise TypeError("indices must be a numpy.ndarray")


### PR DESCRIPTION

Fixes #8656  

Distance_transform_edt indices preallocation to use channel-first (C, spatial_dims, ...) layout for both torch/cuCIM and NumPy/SciPy paths, resolving “indices array has wrong shape” errors when return_indices=True.

### Description

```
  import torch
  from monai.transforms.utils import distance_transform_edt

  img = torch.tensor([[[0, 0, 1],
                       [0, 1, 1],
                       [1, 1, 1]]], dtype=torch.float32)  # shape (1, 3, 3)

  # Previously raised: RuntimeError: indices array has wrong shape
  indices = distance_transform_edt(img, return_distances=False, return_indices=True)
  print(indices.shape)  # now: (1, 2, 3, 3)

```

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
