### PR TITLE
[ADD] soft_label argument in DiceCELoss 

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -674,6 +674,7 @@ class DiceCELoss(_Loss):
         lambda_dice: float = 1.0,
         lambda_ce: float = 1.0,
         label_smoothing: float = 0.0,
+        soft_label: bool = False,
     ) -> None:
         """
         Args:
@@ -737,6 +738,7 @@ class DiceCELoss(_Loss):
             smooth_dr=smooth_dr,
             batch=batch,
             weight=dice_weight,
+            soft_label=soft_label,
         )
         self.cross_entropy = nn.CrossEntropyLoss(weight=weight, reduction=reduction, label_smoothing=label_smoothing)
         self.binary_cross_entropy = nn.BCEWithLogitsLoss(pos_weight=weight, reduction=reduction)

--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -716,6 +716,8 @@ class DiceCELoss(_Loss):
             label_smoothing: a value in [0, 1] range. If > 0, the labels are smoothed
                 by the given factor to reduce overfitting.
                 Defaults to 0.0.
+            soft_label: whether the target contains non-binary values (soft labels) or not.
+                If True a soft label formulation of the DiceLoss will be used.
 
         """
         super().__init__()


### PR DESCRIPTION
Fixes # .

### Description

MONAI's DiceLoss supports soft_label in case the segmentation mask (i.e., the target) contains non-binary values. This functionality is already implemented. However, when using DiceCELoss it is not possible to specify the argument 'soft_label' for the DiceLoss part. 
This simple fix adds 'soft_label' as an argument of the DiceCELoss to be able to control whether the DiceLoss part should use the soft or hard label formulation.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).