### PR TITLE
Fix network_type docstring formatting in PerceptualLoss

### DIFF
--- a/monai/losses/perceptual.py
+++ b/monai/losses/perceptual.py
@@ -49,14 +49,19 @@ class PerceptualLoss(nn.Module):
 
     Args:
         spatial_dims: number of spatial dimensions.
-        network_type: {``"alex"``, ``"vgg"``, ``"squeeze"``, ``"radimagenet_resnet50"``,
-        ``"medicalnet_resnet10_23datasets"``, ``"medicalnet_resnet50_23datasets"``, ``"resnet50"``}
-            Specifies the network architecture to use. Defaults to ``"alex"``.
+        network_type: type of network for perceptual loss. One of:
+            - "alex"
+            - "vgg"
+            - "squeeze"
+            - "radimagenet_resnet50"
+            - "medicalnet_resnet10_23datasets"
+            - "medicalnet_resnet50_23datasets"
+            - "resnet50"
         is_fake_3d: if True use 2.5D approach for a 3D perceptual loss.
         fake_3d_ratio: ratio of how many slices per axis are used in the 2.5D approach.
         cache_dir: path to cache directory to save the pretrained network weights.
         pretrained: whether to load pretrained weights. This argument only works when using networks from
-            LIPIS or Torchvision. Defaults to ``"True"``.
+            LIPIS or Torchvision. Defaults to ``True``.
         pretrained_path: if `pretrained` is `True`, users can specify a weights file to be loaded
             via using this argument. This argument only works when ``"network_type"`` is "resnet50".
             Defaults to `None`.
@@ -64,7 +69,7 @@ class PerceptualLoss(nn.Module):
             extract the expected state dict. This argument only works when ``"network_type"`` is "resnet50".
             Defaults to `None`.
         channel_wise: if True, the loss is returned per channel. Otherwise the loss is averaged over the channels.
-                Defaults to ``False``.
+            Defaults to ``False``.
     """
 
     def __init__(


### PR DESCRIPTION
Fixes #8592

### Description

This pull request fixes incorrect formatting and clarifies the documentation
for the `network_type` argument in `PerceptualLoss`.

The docstring now correctly reflects the supported network options
and matches the actual implementation.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

No functional behavior is changed.
