### PR TITLE
resolves CI's drive-out-of-space by prune caching and use torch fro CPU

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -33,16 +33,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.9'
-    - name: cache weekly timestamp
-      id: pip-cache
-      run: |
-        echo "datew=$(date '+%Y-%V')" >> $GITHUB_OUTPUT
-    - name: cache for pip
-      uses: actions/cache@v4
-      id: cache
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
@@ -75,22 +66,11 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.9'
+        cache: 'pip'
     - name: Prepare pip wheel
       run: |
         which python
         python -m pip install --upgrade pip wheel
-    - name: cache weekly timestamp
-      id: pip-cache
-      run: |
-        echo "datew=$(date '+%Y-%V')" >> $GITHUB_OUTPUT
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: cache for pip
-      uses: actions/cache@v4
-      id: cache
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ matrix.os }}-latest-pip-${{ steps.pip-cache.outputs.datew }}
     - if: runner.os == 'windows'
       name: Install torch cpu from pytorch.org (Windows only)
       run: |
@@ -136,18 +116,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.9'
-    - name: cache weekly timestamp
-      id: pip-cache
-      run: |
-        echo "datew=$(date '+%Y-%V')" >> $GITHUB_OUTPUT
-    - name: cache for pip
-      uses: actions/cache@v4
-      id: cache
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.cache/torch
-        key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
@@ -155,7 +124,7 @@ jobs:
         # install the latest pytorch for testing
         # however, "pip install monai*.tar.gz" will build cpp/cuda with an isolated
         # fresh torch installation according to pyproject.toml
-        python -m pip install torch>=2.5.1 torchvision
+        python -m pip install torch>=2.5.1 torchvision --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Check packages
       run: |
         pip uninstall monai
@@ -184,7 +153,7 @@ jobs:
       working-directory: ${{ steps.mktemp.outputs.tmp_dir }}
       run: |
         # install from wheel
-        python -m pip install monai*.whl
+        python -m pip install monai*.whl --extra-index-url https://download.pytorch.org/whl/cpu
         python -c 'import monai; monai.config.print_config()' 2>&1 | grep -iv "unknown"
         python -c 'import monai; print(monai.__file__)'
         python -m pip uninstall -y monai
@@ -195,7 +164,7 @@ jobs:
         # install from tar.gz
         name=$(ls *.tar.gz | head -n1)
         echo $name
-        python -m pip install $name[all]
+        python -m pip install $name[all] --extra-index-url https://download.pytorch.org/whl/cpu
         python -c 'import monai; monai.config.print_config()' 2>&1 | grep -iv "unknown"
         python -c 'import monai; print(monai.__file__)'
     - name: Quick test
@@ -205,7 +174,7 @@ jobs:
         cp ${{ steps.root.outputs.pwd }}/requirements*.txt .
         cp -r ${{ steps.root.outputs.pwd }}/tests .
         ls -al
-        python -m pip install -r requirements-dev.txt
+        python -m pip install -r requirements-dev.txt --extra-index-url https://download.pytorch.org/whl/cpu
         python -m unittest -v
       env:
         PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python  # https://github.com/Project-MONAI/MONAI/issues/4354
@@ -218,22 +187,11 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.9'
-    - name: cache weekly timestamp
-      id: pip-cache
-      run: |
-        echo "datew=$(date '+%Y-%V')" >> $GITHUB_OUTPUT
-    - name: cache for pip
-      uses: actions/cache@v4
-      id: cache
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.cache/torch
-        key: ${{ runner.os }}-pip-${{ steps.pip-cache.outputs.datew }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        python -m pip install -r docs/requirements.txt
+        python -m pip install -r docs/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
     - name: Make html
       run: |
         cd docs/

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,6 @@ setup(
     cmdclass=get_cmds(),
     packages=find_packages(exclude=("docs", "examples", "tests")),
     zip_safe=False,
-    package_data={"monai": ["py.typed", *jit_extension_source]}, # type: ignore
+    package_data={"monai": ["py.typed", *jit_extension_source]},  # type: ignore[arg-type]
     ext_modules=get_extensions(),
 )

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,6 @@ setup(
     cmdclass=get_cmds(),
     packages=find_packages(exclude=("docs", "examples", "tests")),
     zip_safe=False,
-    package_data={"monai": ["py.typed", *jit_extension_source]}, # type: ignore[arg-type]
+    package_data={"monai": ["py.typed", *jit_extension_source]}, # type: ignore
     ext_modules=get_extensions(),
 )

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,6 @@ setup(
     cmdclass=get_cmds(),
     packages=find_packages(exclude=("docs", "examples", "tests")),
     zip_safe=False,
-    package_data={"monai": ["py.typed", *jit_extension_source]},
+    package_data={"monai": ["py.typed", *jit_extension_source]}, # type: ignore[arg-type]
     ext_modules=get_extensions(),
 )


### PR DESCRIPTION
This pull request simplifies the caching setup for pip dependencies in the GitHub Actions workflow and ensures that all pip installs use the PyTorch CPU wheel index. The main changes involve replacing custom cache steps with the built-in `cache: 'pip'` option in `actions/setup-python`, and adding the `--extra-index-url` flag to all relevant pip install commands for consistent dependency resolution.

**Workflow caching improvements:**
* Replaced custom pip cache steps (using `actions/cache` and manual timestamp keys) with the built-in `cache: 'pip'` option in `actions/setup-python`, streamlining cache management across all jobs. [[1]](diffhunk://#diff-cbf97851bdfebccf2fcdd8848c6a93adb8d8affd5c6b1faf00238d528c3ef6cbL36-R36) [[2]](diffhunk://#diff-cbf97851bdfebccf2fcdd8848c6a93adb8d8affd5c6b1faf00238d528c3ef6cbR69-L93) [[3]](diffhunk://#diff-cbf97851bdfebccf2fcdd8848c6a93adb8d8affd5c6b1faf00238d528c3ef6cbL139-R127) [[4]](diffhunk://#diff-cbf97851bdfebccf2fcdd8848c6a93adb8d8affd5c6b1faf00238d528c3ef6cbL221-R194)

**Dependency installation updates:**
* Updated all `pip install` commands to include `--extra-index-url https://download.pytorch.org/whl/cpu`, ensuring that PyTorch and related packages are consistently installed from the CPU wheel index. This affects installation from wheels, tarballs, requirements files, and direct package installs. [[1]](diffhunk://#diff-cbf97851bdfebccf2fcdd8848c6a93adb8d8affd5c6b1faf00238d528c3ef6cbL139-R127) [[2]](diffhunk://#diff-cbf97851bdfebccf2fcdd8848c6a93adb8d8affd5c6b1faf00238d528c3ef6cbL187-R156) [[3]](diffhunk://#diff-cbf97851bdfebccf2fcdd8848c6a93adb8d8affd5c6b1faf00238d528c3ef6cbL198-R167) [[4]](diffhunk://#diff-cbf97851bdfebccf2fcdd8848c6a93adb8d8affd5c6b1faf00238d528c3ef6cbL208-R177) [[5]](diffhunk://#diff-cbf97851bdfebccf2fcdd8848c6a93adb8d8affd5c6b1faf00238d528c3ef6cbL221-R194)