### PR TITLE
Fix Zip Slip vulnerability in NGC private bundle download

### DIFF
--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -29,7 +29,7 @@ import torch
 from torch.cuda import is_available
 
 from monai._version import get_versions
-from monai.apps.utils import _basename, download_url, extractall, get_logger, _extract_zip
+from monai.apps.utils import _basename, _extract_zip, download_url, extractall, get_logger
 from monai.bundle.config_parser import ConfigParser
 from monai.bundle.utils import DEFAULT_INFERENCE, DEFAULT_METADATA, merge_kv
 from monai.bundle.workflows import BundleWorkflow, ConfigWorkflow
@@ -289,6 +289,7 @@ def _download_from_ngc_private(
     extract_path = download_path / f"{filename}"
     _extract_zip(zip_path, extract_path)
     logger.info(f"Writing into directory: {extract_path}.")
+
 
 def _get_ngc_token(api_key, retry=0):
     """Try to connect to NGC."""

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -30,7 +30,7 @@ import torch
 from torch.cuda import is_available
 
 from monai._version import get_versions
-from monai.apps.utils import _basename, download_url, extractall, get_logger
+from monai.apps.utils import _basename, download_url, extractall, get_logger, _extract_zip
 from monai.bundle.config_parser import ConfigParser
 from monai.bundle.utils import DEFAULT_INFERENCE, DEFAULT_METADATA, merge_kv
 from monai.bundle.workflows import BundleWorkflow, ConfigWorkflow
@@ -288,10 +288,8 @@ def _download_from_ngc_private(
     if remove_prefix:
         filename = _remove_ngc_prefix(filename, prefix=remove_prefix)
     extract_path = download_path / f"{filename}"
-    with zipfile.ZipFile(zip_path, "r") as z:
-        z.extractall(extract_path)
-        logger.info(f"Writing into directory: {extract_path}.")
-
+    _extract_zip(zip_path, extract_path)
+    logger.info(f"Writing into directory: {extract_path}.")
 
 def _get_ngc_token(api_key, retry=0):
     """Try to connect to NGC."""

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -17,7 +17,6 @@ import os
 import re
 import urllib
 import warnings
-import zipfile
 from collections.abc import Mapping, Sequence
 from functools import partial
 from pathlib import Path


### PR DESCRIPTION
Replaced the unsafe `zipfile.extractall()` in `_download_from_ngc_private` with MONAI's safe extraction utility. Prevents path traversal via crafted zip member paths (CWE-22).

### Description

This changes _download_from_ngc_private() to use the same safe zip extraction path as the other bundle download sources. The previous code used ZipFile.extractall() directly, which could allow Zip Slip path traversal if a malicious archive is downloaded. Now extraction validates member paths and keeps writes within the target directory.