### PR TITLE
Fix docstring typos across codebase

### DIFF
--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -223,7 +223,7 @@ class GlobalMutualInformationLoss(_Loss):
         """
         super().__init__(reduction=LossReduction(reduction).value)
         if num_bins <= 0:
-            raise ValueError("num_bins must > 0, got {num_bins}")
+            raise ValueError(f"num_bins must > 0, got {num_bins}")
         bin_centers = torch.linspace(0.0, 1.0, num_bins)  # (num_bins,)
         sigma = torch.mean(bin_centers[1:] - bin_centers[:-1]) * sigma_ratio
         self.kernel_type = look_up_option(kernel_type, ["gaussian", "b-spline"])

--- a/monai/losses/nacl_loss.py
+++ b/monai/losses/nacl_loss.py
@@ -84,7 +84,7 @@ class NACLLoss(_Loss):
 
     def get_constr_target(self, mask: torch.Tensor) -> torch.Tensor:
         """
-        Converts the mask to one hot represenation and is smoothened with the selected spatial filter.
+        Converts the mask to one hot representation and is smoothened with the selected spatial filter.
 
         Args:
             mask: the shape should be BH[WD].

--- a/monai/losses/unified_focal_loss.py
+++ b/monai/losses/unified_focal_loss.py
@@ -45,7 +45,7 @@ class AsymmetricFocalTverskyLoss(_Loss):
             to_onehot_y: whether to convert `y` into the one-hot format. Defaults to False.
             delta : weight of the background. Defaults to 0.7.
             gamma : value of the exponent gamma in the definition of the Focal loss  . Defaults to 0.75.
-            epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
+            epsilon : it defines a very small number each time. similarly smooth value. Defaults to 1e-7.
         """
         super().__init__(reduction=LossReduction(reduction).value)
         self.to_onehot_y = to_onehot_y
@@ -109,7 +109,7 @@ class AsymmetricFocalLoss(_Loss):
             to_onehot_y : whether to convert `y` into the one-hot format. Defaults to False.
             delta : weight of the background. Defaults to 0.7.
             gamma : value of the exponent gamma in the definition of the Focal loss  . Defaults to 0.75.
-            epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
+            epsilon : it defines a very small number each time. similarly smooth value. Defaults to 1e-7.
         """
         super().__init__(reduction=LossReduction(reduction).value)
         self.to_onehot_y = to_onehot_y
@@ -169,7 +169,7 @@ class AsymmetricUnifiedFocalLoss(_Loss):
             num_classes : number of classes, it only supports 2 now. Defaults to 2.
             delta : weight of the background. Defaults to 0.7.
             gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 0.75.
-            epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
+            epsilon : it defines a very small number each time. similarly smooth value. Defaults to 1e-7.
             weight : weight for each loss function, if it's none it's 0.5. Defaults to None.
 
         Example:

--- a/monai/networks/blocks/downsample.py
+++ b/monai/networks/blocks/downsample.py
@@ -232,7 +232,7 @@ class SubpixelDownsample(nn.Module):
     Example: (1, 1, 4, 4) with r=2 becomes (1, 4, 2, 2).
 
     See: Shi et al., 2016, "Real-Time Single Image and Video Super-Resolution
-    Using a nEfficient Sub-Pixel Convolutional Neural Network."
+    Using an Efficient Sub-Pixel Convolutional Neural Network."
 
     The pixel unshuffle mechanism is the inverse operation of:
     https://github.com/Project-MONAI/MONAI/blob/dev/monai/networks/blocks/upsample.py

--- a/monai/networks/blocks/upsample.py
+++ b/monai/networks/blocks/upsample.py
@@ -195,7 +195,7 @@ class SubpixelUpsample(nn.Module):
     default single layer.
 
     See: Shi et al., 2016, "Real-Time Single Image and Video Super-Resolution
-    Using a nEfficient Sub-Pixel Convolutional Neural Network."
+    Using an Efficient Sub-Pixel Convolutional Neural Network."
 
     See: Aitken et al., 2017, "Checkerboard artifact free sub-pixel convolution".
 

--- a/monai/networks/utils.py
+++ b/monai/networks/utils.py
@@ -372,7 +372,7 @@ def pixelshuffle(x: torch.Tensor, spatial_dims: int, scale_factor: int) -> torch
     Apply pixel shuffle to the tensor `x` with spatial dimensions `spatial_dims` and scaling factor `scale_factor`.
 
     See: Shi et al., 2016, "Real-Time Single Image and Video Super-Resolution
-    Using a nEfficient Sub-Pixel Convolutional Neural Network."
+    Using an Efficient Sub-Pixel Convolutional Neural Network."
 
     See: Aitken et al., 2017, "Checkerboard artifact free sub-pixel convolution".
 
@@ -1183,7 +1183,7 @@ def replace_modules_temp(
 
 def freeze_layers(model: nn.Module, freeze_vars=None, exclude_vars=None):
     """
-    A utilty function to help freeze specific layers.
+    A utility function to help freeze specific layers.
 
     Args:
         model: a source PyTorch model to freeze layer.
@@ -1272,7 +1272,7 @@ def cast_all(x, from_dtype=torch.float16, to_dtype=torch.float32):
 class CastToFloat(torch.nn.Module):
     """
     Class used to add autocast protection for ONNX export
-    for forward methods with single return vaue
+    for forward methods with single return value
     """
 
     def __init__(self, mod):


### PR DESCRIPTION
## Summary

I was doing reviews with AI code reviewers and it caught some docstring typos.

- Fix "nEfficient" to "an Efficient" in downsample.py, upsample.py, utils.py
- Fix "utilty" to "utility" in utils.py
- Fix "vaue" to "value" in utils.py
- Fix "simmily" to "similarly" in unified_focal_loss.py (3 occurrences)
- Fix "represenation" to "representation" in nacl_loss.py
- Add missing f-string prefix in image_dissimilarity.py error message

## Test plan
- [x] All modified files import successfully
- [x] `unified_focal_loss.py` tests pass (4 passed)
- [x] `nacl_loss.py` tests pass (7 passed)
- [x] Upsample/Downsample block tests pass (177 passed)
- [x] f-string fix verified - error message now correctly shows `num_bins` value

**Note:** These are all non-breaking docstring/comment fixes only.