### PR TITLE
Update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -27,9 +27,9 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.14.11
     hooks:
-    -   id: ruff
+    -   id: ruff-check
         args: ["--fix"]
         exclude: |
           (?x)(
@@ -55,7 +55,7 @@ repos:
           )$
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.5.0
+    rev: v2.6.0
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]


### PR DESCRIPTION
This pull request updates the `.pre-commit-config.yaml` file to use newer versions of several pre-commit hooks, ensuring the codebase benefits from the latest features and bug fixes. It also switches the Ruff hook to a newer recommended id.

Pre-commit hook version upgrades:

* Upgraded `pre-commit-hooks` from `v5.0.0` to `v6.0.0` for improved linting and formatting checks.
* Upgraded `ruff-pre-commit` from `v0.7.0` to `v0.14.11` and changed the hook id from `ruff` to `ruff-check` to align with the latest configuration recommendations.
* Upgraded `pycln` from `v2.5.0` to `v2.6.0` for more robust import cleaning.

cc: @ericspod 