### PR TITLE
Fixes #8697 GPU memory leak by checking both image and label tensors for CUDA device

### DIFF
--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -471,9 +471,9 @@ class LabelStats(Analyzer):
         image_tensor = d[self.image_key]
         label_tensor = d[self.label_key]
         using_cuda = (
-            isinstance(image_tensor, MetaTensor) and image_tensor.device.type == "cuda"
+            isinstance(image_tensor, torch.Tensor) and image_tensor.device.type == "cuda"
         ) or (
-            isinstance(label_tensor, MetaTensor) and label_tensor.device.type == "cuda"
+            isinstance(label_tensor, torch.Tensor) and label_tensor.device.type == "cuda"
         )
         restore_grad_state = torch.is_grad_enabled()
         torch.set_grad_enabled(False)

--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -468,10 +468,13 @@ class LabelStats(Analyzer):
         """
         d: dict[Hashable, MetaTensor] = dict(data)
         start = time.time()
-        if isinstance(d[self.image_key], (torch.Tensor, MetaTensor)) and d[self.image_key].device.type == "cuda":
-            using_cuda = True
-        else:
-            using_cuda = False
+        image_tensor = d[self.image_key]
+        label_tensor = d[self.label_key]
+        using_cuda = (
+            isinstance(image_tensor, (torch.Tensor, MetaTensor)) and image_tensor.device.type == "cuda"
+        ) or (
+            isinstance(label_tensor, (torch.Tensor, MetaTensor)) and label_tensor.device.type == "cuda"
+        )
         restore_grad_state = torch.is_grad_enabled()
         torch.set_grad_enabled(False)
 

--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -471,9 +471,9 @@ class LabelStats(Analyzer):
         image_tensor = d[self.image_key]
         label_tensor = d[self.label_key]
         using_cuda = (
-            isinstance(image_tensor, (torch.Tensor, MetaTensor)) and image_tensor.device.type == "cuda"
+            isinstance(image_tensor, MetaTensor) and image_tensor.device.type == "cuda"
         ) or (
-            isinstance(label_tensor, (torch.Tensor, MetaTensor)) and label_tensor.device.type == "cuda"
+            isinstance(label_tensor, MetaTensor) and label_tensor.device.type == "cuda"
         )
         restore_grad_state = torch.is_grad_enabled()
         torch.set_grad_enabled(False)

--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -485,7 +485,7 @@ class LabelStats(Analyzer):
             raise ValueError(f"Label shape {ndas_label.shape} is different from image shape {ndas[0].shape}")
 
         nda_foregrounds: list[torch.Tensor] = [get_foreground_label(nda, ndas_label) for nda in ndas]
-        nda_foregrounds = [nda if nda.numel() > 0 else torch.Tensor([0]) for nda in nda_foregrounds]
+        nda_foregrounds = [nda if nda.numel() > 0 else MetaTensor([0.0]) for nda in nda_foregrounds]
 
         unique_label = unique(ndas_label)
         if isinstance(ndas_label, (MetaTensor, torch.Tensor)):

--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -478,7 +478,7 @@ class LabelStats(Analyzer):
         restore_grad_state = torch.is_grad_enabled()
         torch.set_grad_enabled(False)
 
-        ndas: list[MetaTensor] = [image_tensor[i] for i in range(d[self.image_key].shape[0])]  # type: ignore
+        ndas: list[MetaTensor] = [image_tensor[i] for i in range(image_tensor.shape[0])]  # type: ignore
         ndas_label: MetaTensor = label_tensor.astype(torch.int16)  # (H,W,D)
 
         if ndas_label.shape != ndas[0].shape:

--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -478,8 +478,8 @@ class LabelStats(Analyzer):
         restore_grad_state = torch.is_grad_enabled()
         torch.set_grad_enabled(False)
 
-        ndas: list[MetaTensor] = [d[self.image_key][i] for i in range(d[self.image_key].shape[0])]  # type: ignore
-        ndas_label: MetaTensor = d[self.label_key].astype(torch.int16)  # (H,W,D)
+        ndas: list[MetaTensor] = [image_tensor[i] for i in range(d[self.image_key].shape[0])]  # type: ignore
+        ndas_label: MetaTensor = label_tensor.astype(torch.int16)  # (H,W,D)
 
         if ndas_label.shape != ndas[0].shape:
             raise ValueError(f"Label shape {ndas_label.shape} is different from image shape {ndas[0].shape}")


### PR DESCRIPTION
Modified device detection to check BOTH image and label tensors

torch.cuda.empty_cache() now called if EITHER tensor is on GPU

Prevents GPU memory leaks in mixed device scenarios