### PR TITLE
Update the docstrings to match the actual code defaults

### DIFF
--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -168,7 +168,9 @@ class FocalLoss(_Loss):
         if self.use_softmax:
             if not self.include_background and self.alpha is not None:
                 if isinstance(self.alpha, (float, int)):
-                    warnings.warn("`include_background=False`, scalar `alpha` ignored when using softmax.")
+                    warnings.warn(
+                        "`include_background=False`, scalar `alpha` ignored when using softmax.", stacklevel=2
+                    )
             loss = softmax_focal_loss(input, target, self.gamma, self.alpha)
         else:
             loss = sigmoid_focal_loss(input, target, self.gamma, self.alpha)

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -112,12 +112,17 @@ class FocalLoss(_Loss):
         self.include_background = include_background
         self.to_onehot_y = to_onehot_y
         self.gamma = gamma
-        self.alpha = alpha
         self.weight = weight
         self.use_softmax = use_softmax
         weight = torch.as_tensor(weight) if weight is not None else None
         self.register_buffer("class_weight", weight)
         self.class_weight: None | torch.Tensor
+        self.alpha: float | torch.Tensor | None
+
+        if isinstance(alpha, (list, tuple)):
+            self.alpha = torch.tensor(alpha)
+        else:
+            self.alpha = alpha
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """
@@ -159,7 +164,10 @@ class FocalLoss(_Loss):
         input = input.float()
         target = target.float()
 
-        alpha_arg = self.alpha
+        alpha_arg: float | torch.Tensor | None = self.alpha
+        if isinstance(alpha_arg, torch.Tensor):
+            alpha_arg = alpha_arg.to(input.device)
+
         if self.use_softmax:
             if not self.include_background and self.alpha is not None:
                 if isinstance(self.alpha, (float, int)):
@@ -208,7 +216,7 @@ class FocalLoss(_Loss):
 
 
 def softmax_focal_loss(
-    input: torch.Tensor, target: torch.Tensor, gamma: float = 2.0, alpha: float | Sequence[float] | None = None
+    input: torch.Tensor, target: torch.Tensor, gamma: float = 2.0, alpha: float | torch.Tensor | None = None
 ) -> torch.Tensor:
     """
     FL(pt) = -alpha * (1 - pt)**gamma * log(pt)
@@ -241,7 +249,7 @@ def softmax_focal_loss(
 
 
 def sigmoid_focal_loss(
-    input: torch.Tensor, target: torch.Tensor, gamma: float = 2.0, alpha: float | Sequence[float] | None = None
+    input: torch.Tensor, target: torch.Tensor, gamma: float = 2.0, alpha: float | torch.Tensor | None = None
 ) -> torch.Tensor:
     """
     FL(pt) = -alpha * (1 - pt)**gamma * log(pt)

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -164,16 +164,17 @@ class FocalLoss(_Loss):
         loss: Optional[torch.Tensor] = None
         input = input.float()
         target = target.float()
-
+        alpha_arg = self.alpha
         if self.use_softmax:
             if not self.include_background and self.alpha is not None:
                 if isinstance(self.alpha, (float, int)):
+                    alpha_arg = None
                     warnings.warn(
                         "`include_background=False`, scalar `alpha` ignored when using softmax.", stacklevel=2
                     )
-            loss = softmax_focal_loss(input, target, self.gamma, self.alpha)
+            loss = softmax_focal_loss(input, target, self.gamma, alpha_arg)
         else:
-            loss = sigmoid_focal_loss(input, target, self.gamma, self.alpha)
+            loss = sigmoid_focal_loss(input, target, self.gamma, alpha_arg)
 
         num_of_classes = target.shape[1]
         if self.class_weight is not None and num_of_classes != 1:

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -115,11 +115,12 @@ class FocalLoss(_Loss):
         self.weight = weight
         self.use_softmax = use_softmax
         self.alpha: float | torch.Tensor | None
-
-        if isinstance(alpha, (list, tuple)):
-            self.alpha = torch.tensor(alpha)
+        if alpha is None:
+            self.alpha = None
+        elif isinstance(alpha, (float, int)):
+            self.alpha = float(alpha)
         else:
-            self.alpha = alpha
+            self.alpha = torch.as_tensor(alpha)
         weight = torch.as_tensor(weight) if weight is not None else None
         self.register_buffer("class_weight", weight)
         self.class_weight: None | torch.Tensor
@@ -165,6 +166,8 @@ class FocalLoss(_Loss):
         target = target.float()
 
         alpha_arg: float | torch.Tensor | None = self.alpha
+        if isinstance(alpha_arg, torch.Tensor):
+            alpha_arg = alpha_arg.to(input.device)
 
         if self.use_softmax:
             if not self.include_background and self.alpha is not None:

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -165,9 +165,9 @@ class FocalLoss(_Loss):
                 if isinstance(self.alpha, (float, int)):
                     alpha_arg = None
                     warnings.warn("`include_background=False`, scalar `alpha` ignored when using softmax.")
-            loss = softmax_focal_loss(input, target, self.gamma, self.alpha_arg)
+            loss = softmax_focal_loss(input, target, self.gamma, alpha_arg)
         else:
-            loss = sigmoid_focal_loss(input, target, self.gamma, self.alpha_arg)
+            loss = sigmoid_focal_loss(input, target, self.gamma, alpha_arg)
 
         num_of_classes = target.shape[1]
         if self.class_weight is not None and num_of_classes != 1:

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -70,7 +70,7 @@ class FocalLoss(_Loss):
         include_background: bool = True,
         to_onehot_y: bool = False,
         gamma: float = 2.0,
-        alpha: float | None = None,
+        alpha: float | Sequence[float] | None = None,
         weight: Sequence[float] | float | int | torch.Tensor | None = None,
         reduction: LossReduction | str = LossReduction.MEAN,
         use_softmax: bool = False,
@@ -78,11 +78,13 @@ class FocalLoss(_Loss):
         """
         Args:
             include_background: if False, channel index 0 (background category) is excluded from the loss calculation.
-                If False, `alpha` is invalid when using softmax.
+                If False, `alpha` is invalid when using softmax unless `alpha` is a sequence (explicit class weights).
             to_onehot_y: whether to convert the label `y` into the one-hot format. Defaults to False.
             gamma: value of the exponent gamma in the definition of the Focal loss. Defaults to 2.
             alpha: value of the alpha in the definition of the alpha-balanced Focal loss.
-                The value should be in [0, 1]. Defaults to None.
+                The value should be in [0, 1].
+                If a sequence is provided, it must match the number of classes (after excluding background if set).
+                Defaults to None.
             weight: weights to apply to the voxels of each class. If None no weights are applied.
                 The input can be a single value (same weight for all classes), a sequence of values (the length
                 of the sequence should be the same as the number of classes. If not ``include_background``,
@@ -156,13 +158,16 @@ class FocalLoss(_Loss):
         loss: Optional[torch.Tensor] = None
         input = input.float()
         target = target.float()
+
+        alpha_arg = self.alpha
         if self.use_softmax:
             if not self.include_background and self.alpha is not None:
-                self.alpha = None
-                warnings.warn("`include_background=False`, `alpha` ignored when using softmax.")
-            loss = softmax_focal_loss(input, target, self.gamma, self.alpha)
+                if isinstance(self.alpha, (float, int)):
+                    alpha_arg = None
+                    warnings.warn("`include_background=False`, scalar `alpha` ignored when using softmax.")
+            loss = softmax_focal_loss(input, target, self.gamma, self.alpha_arg)
         else:
-            loss = sigmoid_focal_loss(input, target, self.gamma, self.alpha)
+            loss = sigmoid_focal_loss(input, target, self.gamma, self.alpha_arg)
 
         num_of_classes = target.shape[1]
         if self.class_weight is not None and num_of_classes != 1:
@@ -203,7 +208,7 @@ class FocalLoss(_Loss):
 
 
 def softmax_focal_loss(
-    input: torch.Tensor, target: torch.Tensor, gamma: float = 2.0, alpha: Optional[float] = None
+    input: torch.Tensor, target: torch.Tensor, gamma: float = 2.0, alpha: float | Sequence[float] | None = None
 ) -> torch.Tensor:
     """
     FL(pt) = -alpha * (1 - pt)**gamma * log(pt)
@@ -215,8 +220,18 @@ def softmax_focal_loss(
     loss: torch.Tensor = -(1 - input_ls.exp()).pow(gamma) * input_ls * target
 
     if alpha is not None:
-        # (1-alpha) for the background class and alpha for the other classes
-        alpha_fac = torch.tensor([1 - alpha] + [alpha] * (target.shape[1] - 1)).to(loss)
+        alpha_t = torch.as_tensor(alpha, device=input.device, dtype=input.dtype)
+
+        if alpha_t.ndim == 0:  # scalar
+            # (1-alpha) for the background class and alpha for the other classes
+            alpha_fac = torch.tensor([1 - alpha] + [alpha] * (target.shape[1] - 1)).to(loss)
+        else:  # sequence
+            if alpha_t.shape[0] != target.shape[1]:
+                raise ValueError(
+                    f"The length of alpha ({alpha_t.shape[0]}) must match the number of classes ({target.shape[1]})."
+                )
+            alpha_fac = alpha_t
+
         broadcast_dims = [-1] + [1] * len(target.shape[2:])
         alpha_fac = alpha_fac.view(broadcast_dims)
         loss = alpha_fac * loss
@@ -225,7 +240,7 @@ def softmax_focal_loss(
 
 
 def sigmoid_focal_loss(
-    input: torch.Tensor, target: torch.Tensor, gamma: float = 2.0, alpha: Optional[float] = None
+    input: torch.Tensor, target: torch.Tensor, gamma: float = 2.0, alpha: float | Sequence[float] | None = None
 ) -> torch.Tensor:
     """
     FL(pt) = -alpha * (1 - pt)**gamma * log(pt)
@@ -248,8 +263,21 @@ def sigmoid_focal_loss(
     loss = (invprobs * gamma).exp() * loss
 
     if alpha is not None:
-        # alpha if t==1; (1-alpha) if t==0
-        alpha_factor = target * alpha + (1 - target) * (1 - alpha)
+        alpha_t = torch.as_tensor(alpha, device=input.device, dtype=input.dtype)
+        if alpha_t.ndim == 0:  # scalar
+            # alpha if t==1; (1-alpha) if t==0
+            alpha_factor = target * alpha_t + (1 - target) * (1 - alpha_t)
+        else:  # sequence / per-channel alpha
+            if alpha_t.shape[0] != target.shape[1]:
+                raise ValueError(
+                    f"The length of alpha ({alpha_t.shape[0]}) must match the number of classes ({target.shape[1]})."
+                )
+            # Reshape alpha for broadcasting: (1, C, 1, 1...)
+            broadcast_dims = [-1] + [1] * len(target.shape[2:])
+            alpha_t = alpha_t.view(broadcast_dims)
+            # Apply alpha_c if t==1, (1-alpha_c) if t==0 for channel c
+            alpha_factor = target * alpha_t + (1 - target) * (1 - alpha_t)
+
         loss = alpha_factor * loss
 
     return loss

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -165,18 +165,13 @@ class FocalLoss(_Loss):
         input = input.float()
         target = target.float()
 
-        alpha_arg: float | torch.Tensor | None = self.alpha
-        if isinstance(alpha_arg, torch.Tensor):
-            alpha_arg = alpha_arg.to(input.device)
-
         if self.use_softmax:
             if not self.include_background and self.alpha is not None:
                 if isinstance(self.alpha, (float, int)):
-                    alpha_arg = None
                     warnings.warn("`include_background=False`, scalar `alpha` ignored when using softmax.")
-            loss = softmax_focal_loss(input, target, self.gamma, alpha_arg)
+            loss = softmax_focal_loss(input, target, self.gamma, self.alpha)
         else:
-            loss = sigmoid_focal_loss(input, target, self.gamma, alpha_arg)
+            loss = sigmoid_focal_loss(input, target, self.gamma, self.alpha)
 
         num_of_classes = target.shape[1]
         if self.class_weight is not None and num_of_classes != 1:

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -223,8 +223,9 @@ def softmax_focal_loss(
         alpha_t = torch.as_tensor(alpha, device=input.device, dtype=input.dtype)
 
         if alpha_t.ndim == 0:  # scalar
+            alpha_val = alpha_t.item()
             # (1-alpha) for the background class and alpha for the other classes
-            alpha_fac = torch.tensor([1 - alpha] + [alpha] * (target.shape[1] - 1)).to(loss)
+            alpha_fac = torch.tensor([1 - alpha_val] + [alpha_val] * (target.shape[1] - 1)).to(loss)
         else:  # sequence
             if alpha_t.shape[0] != target.shape[1]:
                 raise ValueError(

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -114,15 +114,15 @@ class FocalLoss(_Loss):
         self.gamma = gamma
         self.weight = weight
         self.use_softmax = use_softmax
-        weight = torch.as_tensor(weight) if weight is not None else None
-        self.register_buffer("class_weight", weight)
-        self.class_weight: None | torch.Tensor
         self.alpha: float | torch.Tensor | None
 
         if isinstance(alpha, (list, tuple)):
             self.alpha = torch.tensor(alpha)
         else:
             self.alpha = alpha
+        weight = torch.as_tensor(weight) if weight is not None else None
+        self.register_buffer("class_weight", weight)
+        self.class_weight: None | torch.Tensor
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """
@@ -165,8 +165,6 @@ class FocalLoss(_Loss):
         target = target.float()
 
         alpha_arg: float | torch.Tensor | None = self.alpha
-        if isinstance(alpha_arg, torch.Tensor):
-            alpha_arg = alpha_arg.to(input.device)
 
         if self.use_softmax:
             if not self.include_background and self.alpha is not None:
@@ -228,13 +226,16 @@ def softmax_focal_loss(
     loss: torch.Tensor = -(1 - input_ls.exp()).pow(gamma) * input_ls * target
 
     if alpha is not None:
-        alpha_t = torch.as_tensor(alpha, device=input.device, dtype=input.dtype)
+        if isinstance(alpha, torch.Tensor):
+            alpha_t = alpha.to(device=input.device, dtype=input.dtype)
+        else:
+            alpha_t = torch.tensor(alpha, device=input.device, dtype=input.dtype)
 
         if alpha_t.ndim == 0:  # scalar
             alpha_val = alpha_t.item()
             # (1-alpha) for the background class and alpha for the other classes
             alpha_fac = torch.tensor([1 - alpha_val] + [alpha_val] * (target.shape[1] - 1)).to(loss)
-        else:  # sequence
+        else:  # tensor (sequence)
             if alpha_t.shape[0] != target.shape[1]:
                 raise ValueError(
                     f"The length of alpha ({alpha_t.shape[0]}) must match the number of classes ({target.shape[1]})."
@@ -272,11 +273,15 @@ def sigmoid_focal_loss(
     loss = (invprobs * gamma).exp() * loss
 
     if alpha is not None:
-        alpha_t = torch.as_tensor(alpha, device=input.device, dtype=input.dtype)
+        if isinstance(alpha, torch.Tensor):
+            alpha_t = alpha.to(device=input.device, dtype=input.dtype)
+        else:
+            alpha_t = torch.tensor(alpha, device=input.device, dtype=input.dtype)
+
         if alpha_t.ndim == 0:  # scalar
             # alpha if t==1; (1-alpha) if t==0
             alpha_factor = target * alpha_t + (1 - target) * (1 - alpha_t)
-        else:  # sequence / per-channel alpha
+        else:  # tensor (sequence)
             if alpha_t.shape[0] != target.shape[1]:
                 raise ValueError(
                     f"The length of alpha ({alpha_t.shape[0]}) must match the number of classes ({target.shape[1]})."

--- a/monai/losses/focal_loss.py
+++ b/monai/losses/focal_loss.py
@@ -82,7 +82,8 @@ class FocalLoss(_Loss):
             gamma: value of the exponent gamma in the definition of the Focal loss. Defaults to 2.
             alpha: value of the alpha in the definition of the alpha-balanced Focal loss.
                 The value should be in [0, 1].
-                If a sequence is provided, it must match the number of classes (after excluding background if set).
+                If a sequence is provided, its length must match the number of classes
+                (excluding the background class if `include_background=False`).
                 Defaults to None.
             weight: weights to apply to the voxels of each class. If None no weights are applied.
                 The input can be a single value (same weight for all classes), a sequence of values (the length
@@ -289,8 +290,10 @@ def sigmoid_focal_loss(
             # Reshape alpha for broadcasting: (1, C, 1, 1...)
             broadcast_dims = [-1] + [1] * len(target.shape[2:])
             alpha_t = alpha_t.view(broadcast_dims)
-            # Apply alpha_c if t==1, (1-alpha_c) if t==0 for channel c
-            alpha_factor = target * alpha_t + (1 - target) * (1 - alpha_t)
+            # Apply per-class weight only to positive samples
+            # For positive samples (target==1): multiply by alpha[c]
+            # For negative samples (target==0): keep weight as 1.0
+            alpha_factor = torch.where(target == 1, alpha_t, torch.ones_like(alpha_t))
 
         loss = alpha_factor * loss
 

--- a/monai/losses/unified_focal_loss.py
+++ b/monai/losses/unified_focal_loss.py
@@ -108,7 +108,7 @@ class AsymmetricFocalLoss(_Loss):
         Args:
             to_onehot_y : whether to convert `y` into the one-hot format. Defaults to False.
             delta : weight of the background. Defaults to 0.7.
-            gamma : value of the exponent gamma in the definition of the Focal loss  . Defaults to 0.75.
+            gamma : value of the exponent gamma in the definition of the Focal loss  . Defaults to 2.
             epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
         """
         super().__init__(reduction=LossReduction(reduction).value)
@@ -168,8 +168,7 @@ class AsymmetricUnifiedFocalLoss(_Loss):
             to_onehot_y : whether to convert `y` into the one-hot format. Defaults to False.
             num_classes : number of classes, it only supports 2 now. Defaults to 2.
             delta : weight of the background. Defaults to 0.7.
-            gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 0.75.
-            epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
+            gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 0.5.
             weight : weight for each loss function, if it's none it's 0.5. Defaults to None.
 
         Example:

--- a/tests/losses/test_focal_loss.py
+++ b/tests/losses/test_focal_loss.py
@@ -374,6 +374,47 @@ class TestFocalLoss(unittest.TestCase):
             test_input = torch.ones(2, 2, 8, 8)
             test_script_save(loss, test_input, test_input)
 
+    def test_alpha_sequence_broadcasting(self):
+        """
+        Test FocalLoss with alpha as a sequence for proper broadcasting.
+        """
+        num_classes = 3
+        alpha_seq = [0.1, 0.5, 2.0]
+        batch_size = 2
+        spatial_dims = (4, 4)
+
+        devices = ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+
+        for device in devices:
+            logits = torch.randn(batch_size, num_classes, *spatial_dims, device=device)
+            target = torch.randint(0, num_classes, (batch_size, 1, *spatial_dims), device=device)
+
+            # Case 1: Softmax + Alpha Sequence
+            loss_func_softmax = FocalLoss(
+                to_onehot_y=True, gamma=2.0, alpha=alpha_seq, use_softmax=True, reduction="mean"
+            )
+            loss_soft = loss_func_softmax(logits, target)
+
+            self.assertTrue(torch.is_tensor(loss_soft))
+            self.assertEqual(loss_soft.ndim, 0)
+            self.assertTrue(loss_soft > 0, f"Softmax loss on {device} should be positive")
+
+            # Case 2: Sigmoid + Alpha Sequence
+            loss_func_sigmoid = FocalLoss(
+                to_onehot_y=True, gamma=2.0, alpha=alpha_seq, use_softmax=False, reduction="mean"
+            )
+            loss_sig = loss_func_sigmoid(logits, target)
+
+            self.assertTrue(torch.is_tensor(loss_sig))
+            self.assertEqual(loss_sig.ndim, 0)
+            self.assertTrue(loss_sig > 0, f"Sigmoid loss on {device} should be positive")
+
+            # Case 3: Error Handling (Mismatched alpha length)
+            if device == devices[0]:
+                wrong_alpha = [0.1, 0.5]
+                with self.assertRaisesRegex(ValueError, "length of alpha"):
+                    FocalLoss(to_onehot_y=True, alpha=wrong_alpha, use_softmax=True)(logits, target)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/losses/test_focal_loss.py
+++ b/tests/losses/test_focal_loss.py
@@ -24,7 +24,8 @@ from monai.networks import one_hot
 from tests.test_utils import TEST_DEVICES, test_script_save
 
 TEST_CASES = []
-for device in ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]:
+for case in TEST_DEVICES:
+    device = case[0]
     input_data = {
         "input": torch.tensor(
             [[[[1.0, 1.0], [0.5, 0.0]], [[1.0, 1.0], [0.5, 0.0]], [[1.0, 1.0], [0.5, 0.0]]]], device=device
@@ -79,10 +80,10 @@ for device in ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]:
 
 TEST_ALPHA_BROADCASTING = []
 for case in TEST_DEVICES:
-    dev = case[0]
+    device = case[0]
     for include_background in [True, False]:
         for use_softmax in [True, False]:
-            TEST_ALPHA_BROADCASTING.append([dev, include_background, use_softmax])
+            TEST_ALPHA_BROADCASTING.append([device, include_background, use_softmax])
 
 
 class TestFocalLoss(unittest.TestCase):

--- a/tests/losses/test_focal_loss.py
+++ b/tests/losses/test_focal_loss.py
@@ -79,10 +79,10 @@ for device in ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]:
 
 TEST_ALPHA_BROADCASTING = []
 for case in TEST_DEVICES:
-    device = case[0]
+    dev = case[0]
     for include_background in [True, False]:
         for use_softmax in [True, False]:
-            TEST_ALPHA_BROADCASTING.append([device, include_background, use_softmax])
+            TEST_ALPHA_BROADCASTING.append([dev, include_background, use_softmax])
 
 
 class TestFocalLoss(unittest.TestCase):

--- a/tests/losses/test_focal_loss.py
+++ b/tests/losses/test_focal_loss.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 
 from monai.losses import FocalLoss
 from monai.networks import one_hot
-from tests.test_utils import test_script_save
+from tests.test_utils import TEST_DEVICES, test_script_save
 
 TEST_CASES = []
 for device in ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]:
@@ -76,6 +76,13 @@ for device in ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]:
     )
     TEST_CASES.append([{"to_onehot_y": True, "use_softmax": True}, input_data, 0.16276])
     TEST_CASES.append([{"to_onehot_y": True, "alpha": 0.8, "use_softmax": True}, input_data, 0.08138])
+
+TEST_ALPHA_BROADCASTING = []
+for case in TEST_DEVICES:
+    device = case[0]
+    for include_background in [True, False]:
+        for use_softmax in [True, False]:
+            TEST_ALPHA_BROADCASTING.append([device, include_background, use_softmax])
 
 
 class TestFocalLoss(unittest.TestCase):
@@ -374,46 +381,39 @@ class TestFocalLoss(unittest.TestCase):
             test_input = torch.ones(2, 2, 8, 8)
             test_script_save(loss, test_input, test_input)
 
-    def test_alpha_sequence_broadcasting(self):
+    @parameterized.expand(TEST_ALPHA_BROADCASTING)
+    def test_alpha_sequence_broadcasting(self, device, include_background, use_softmax):
         """
         Test FocalLoss with alpha as a sequence for proper broadcasting.
         """
         num_classes = 3
-        alpha_seq = [0.1, 0.5, 2.0]
         batch_size = 2
         spatial_dims = (4, 4)
 
-        devices = ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+        logits = torch.randn(batch_size, num_classes, *spatial_dims, device=device)
+        target = torch.randint(0, num_classes, (batch_size, 1, *spatial_dims), device=device)
 
-        for device in devices:
-            logits = torch.randn(batch_size, num_classes, *spatial_dims, device=device)
-            target = torch.randint(0, num_classes, (batch_size, 1, *spatial_dims), device=device)
+        if include_background:
+            alpha_seq = [0.1, 0.5, 2.0]
+        else:
+            alpha_seq = [0.5, 2.0]
 
-            # Case 1: Softmax + Alpha Sequence
-            loss_func_softmax = FocalLoss(
-                to_onehot_y=True, gamma=2.0, alpha=alpha_seq, use_softmax=True, reduction="mean"
-            )
-            loss_soft = loss_func_softmax(logits, target)
+        loss_func = FocalLoss(
+            to_onehot_y=True,
+            gamma=2.0,
+            alpha=alpha_seq,
+            include_background=include_background,
+            use_softmax=use_softmax,
+            reduction="mean",
+        )
 
-            self.assertTrue(torch.is_tensor(loss_soft))
-            self.assertEqual(loss_soft.ndim, 0)
-            self.assertTrue(loss_soft > 0, f"Softmax loss on {device} should be positive")
+        result = loss_func(logits, target)
 
-            # Case 2: Sigmoid + Alpha Sequence
-            loss_func_sigmoid = FocalLoss(
-                to_onehot_y=True, gamma=2.0, alpha=alpha_seq, use_softmax=False, reduction="mean"
-            )
-            loss_sig = loss_func_sigmoid(logits, target)
-
-            self.assertTrue(torch.is_tensor(loss_sig))
-            self.assertEqual(loss_sig.ndim, 0)
-            self.assertTrue(loss_sig > 0, f"Sigmoid loss on {device} should be positive")
-
-            # Case 3: Error Handling (Mismatched alpha length)
-            if device == devices[0]:
-                wrong_alpha = [0.1, 0.5]
-                with self.assertRaisesRegex(ValueError, "length of alpha"):
-                    FocalLoss(to_onehot_y=True, alpha=wrong_alpha, use_softmax=True)(logits, target)
+        self.assertTrue(torch.is_tensor(result))
+        self.assertEqual(result.ndim, 0)
+        self.assertTrue(
+            result > 0, f"Loss should be positive. params: dev={device}, bg={include_background}, softmax={use_softmax}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #8689 .

### Description

Update the docstrings to match the actual code defaults.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
