### PR TITLE
Update the docstrings to match the actual code defaults

### DIFF
--- a/monai/losses/unified_focal_loss.py
+++ b/monai/losses/unified_focal_loss.py
@@ -45,7 +45,7 @@ class AsymmetricFocalTverskyLoss(_Loss):
             to_onehot_y: whether to convert `y` into the one-hot format. Defaults to False.
             delta : weight of the background. Defaults to 0.7.
             gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 0.75.
-            epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
+            epsilon : it defines a very small number each time. similarly smooth value. Defaults to 1e-7.
         """
         super().__init__(reduction=LossReduction(reduction).value)
         self.to_onehot_y = to_onehot_y
@@ -109,7 +109,7 @@ class AsymmetricFocalLoss(_Loss):
             to_onehot_y : whether to convert `y` into the one-hot format. Defaults to False.
             delta : weight of the background. Defaults to 0.7.
             gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 2.
-            epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
+            epsilon : it defines a very small number each time. similarly smooth value. Defaults to 1e-7.
         """
         super().__init__(reduction=LossReduction(reduction).value)
         self.to_onehot_y = to_onehot_y
@@ -158,18 +158,20 @@ class AsymmetricUnifiedFocalLoss(_Loss):
         self,
         to_onehot_y: bool = False,
         num_classes: int = 2,
-        delta: float = 0.7,
-        gamma: float = 0.5,
         weight: float = 0.5,
+        gamma: float = 0.5,
+        delta: float = 0.7,
         reduction: LossReduction | str = LossReduction.MEAN,
     ):
         """
         Args:
             to_onehot_y : whether to convert `y` into the one-hot format. Defaults to False.
             num_classes : number of classes, it only supports 2 now. Defaults to 2.
-            delta : weight of the background. Defaults to 0.7.
-            gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 0.5.
             weight : weight for each loss function. Defaults to 0.5.
+            gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 0.5.
+            delta : weight of the background. Defaults to 0.7.
+
+
 
         Example:
             >>> import torch

--- a/monai/losses/unified_focal_loss.py
+++ b/monai/losses/unified_focal_loss.py
@@ -44,7 +44,7 @@ class AsymmetricFocalTverskyLoss(_Loss):
         Args:
             to_onehot_y: whether to convert `y` into the one-hot format. Defaults to False.
             delta : weight of the background. Defaults to 0.7.
-            gamma : value of the exponent gamma in the definition of the Focal loss  . Defaults to 0.75.
+            gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 0.75.
             epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
         """
         super().__init__(reduction=LossReduction(reduction).value)
@@ -108,7 +108,7 @@ class AsymmetricFocalLoss(_Loss):
         Args:
             to_onehot_y : whether to convert `y` into the one-hot format. Defaults to False.
             delta : weight of the background. Defaults to 0.7.
-            gamma : value of the exponent gamma in the definition of the Focal loss  . Defaults to 2.
+            gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 2.
             epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
         """
         super().__init__(reduction=LossReduction(reduction).value)
@@ -158,9 +158,9 @@ class AsymmetricUnifiedFocalLoss(_Loss):
         self,
         to_onehot_y: bool = False,
         num_classes: int = 2,
-        weight: float = 0.5,
-        gamma: float = 0.5,
         delta: float = 0.7,
+        gamma: float = 0.5,
+        weight: float = 0.5,
         reduction: LossReduction | str = LossReduction.MEAN,
     ):
         """

--- a/monai/losses/unified_focal_loss.py
+++ b/monai/losses/unified_focal_loss.py
@@ -108,7 +108,7 @@ class AsymmetricFocalLoss(_Loss):
         Args:
             to_onehot_y : whether to convert `y` into the one-hot format. Defaults to False.
             delta : weight of the background. Defaults to 0.7.
-            gamma : value of the exponent gamma in the definition of the Focal loss  . Defaults to 0.75.
+            gamma : value of the exponent gamma in the definition of the Focal loss  . Defaults to 2.
             epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
         """
         super().__init__(reduction=LossReduction(reduction).value)
@@ -168,9 +168,8 @@ class AsymmetricUnifiedFocalLoss(_Loss):
             to_onehot_y : whether to convert `y` into the one-hot format. Defaults to False.
             num_classes : number of classes, it only supports 2 now. Defaults to 2.
             delta : weight of the background. Defaults to 0.7.
-            gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 0.75.
-            epsilon : it defines a very small number each time. simmily smooth value. Defaults to 1e-7.
-            weight : weight for each loss function, if it's none it's 0.5. Defaults to None.
+            gamma : value of the exponent gamma in the definition of the Focal loss. Defaults to 0.5.
+            weight : weight for each loss function. Defaults to 0.5.
 
         Example:
             >>> import torch


### PR DESCRIPTION
Fixes #8689

### Description

Update the docstrings to match the actual code defaults.

1. AsymmetricFocalLoss (line 103, 111): `gamma`
2. AsymmetricUnifiedFocalLoss (line 162, 171): `gamma`
3. AsymmetricUnifiedFocalLoss (line 172): `epsilon`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
