### PR TITLE
Clean unused constructors in pushpull C++/CUDA implementation

### DIFF
--- a/monai/csrc/resample/pushpull.h
+++ b/monai/csrc/resample/pushpull.h
@@ -22,25 +22,25 @@ limitations under the License.
 
 #define MONAI_PUSHPULL_DECLARE(space)                                            \
   namespace space {                                                              \
-  template <typename BoundType, typename InterpolationType, typename SourceType> \
+  template <typename SourceType>                                                 \
   std::deque<at::Tensor> pushpull(                                               \
       const SourceType& source,                                                  \
       const at::Tensor& grid,                                                    \
-      BoundType bound,                                                           \
-      InterpolationType interpolation,                                           \
+      monai::BoundVectorRef bound,                                               \
+      monai::InterpolationVectorRef interpolation,                               \
       bool extrapolate,                                                          \
       bool do_pull,                                                              \
       bool do_push,                                                              \
       bool do_count,                                                             \
       bool do_grad,                                                              \
       bool do_sgrad);                                                            \
-  template <typename BoundType, typename InterpolationType, typename SourceType> \
+  template <typename SourceType>                                                 \
   std::deque<at::Tensor> pushpull(                                               \
       const SourceType& source,                                                  \
       const at::Tensor& grid,                                                    \
       const at::Tensor& target,                                                  \
-      BoundType bound,                                                           \
-      InterpolationType interpolation,                                           \
+      monai::BoundVectorRef bound,                                               \
+      monai::InterpolationVectorRef interpolation,                               \
       bool extrapolate,                                                          \
       bool do_pull,                                                              \
       bool do_push,                                                              \

--- a/monai/csrc/resample/pushpull_cpu.cpp
+++ b/monai/csrc/resample/pushpull_cpu.cpp
@@ -35,7 +35,7 @@ limitations under the License.
 // . [DONE] spatial gradient mode (without multiplication with output gradient)
 // . [DONE] second order gradients (backward pass for spatial gradients)
 // . performance tests
-// . input bound/inter are always vectors -> clean unused constructors
+// . [DONE] input bound/inter are always vectors -> clean unused constructors
 
 #include <ATen/ATen.h>
 #include <limits>
@@ -2187,39 +2187,42 @@ MONAI_NAMESPACE_DEVICE { // cpu
   //                    FUNCTIONAL FORM WITH DISPATCH
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#define PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, SourceType0) \
-  template std::deque<Tensor> pushpull(                                    \
-      const SourceType0&,                                                  \
-      const Tensor&,                                                       \
-      const Tensor&,                                                       \
-      BoundType0,                                                          \
-      InterpolationType0,                                                  \
-      bool,                                                                \
-      bool,                                                                \
-      bool,                                                                \
-      bool,                                                                \
-      bool,                                                                \
-      bool);                                                               \
-  template std::deque<Tensor> pushpull(                                    \
-      const SourceType0&, const Tensor&, BoundType0, InterpolationType0, bool, bool, bool, bool, bool, bool)
-#define PUSHPULL_INSTANTIATE2(BoundType0, InterpolationType0)         \
-  PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, IntArrayRef); \
-  PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, Tensor)
-#define PUSHPULL_INSTANTIATE1(BoundType0)               \
-  PUSHPULL_INSTANTIATE2(BoundType0, InterpolationType); \
-  PUSHPULL_INSTANTIATE2(BoundType0, InterpolationVectorRef)
-#define PUSHPULL_INSTANTIATE        \
-  PUSHPULL_INSTANTIATE1(BoundType); \
-  PUSHPULL_INSTANTIATE1(BoundVectorRef)
+#define PUSHPULL_INSTANTIATE_SOURCE(SourceType) \
+  template std::deque<Tensor> pushpull(         \
+      const SourceType&,                        \
+      const Tensor&,                            \
+      const Tensor&,                            \
+      BoundVectorRef,                           \
+      InterpolationVectorRef,                   \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool);                                    \
+  template std::deque<Tensor> pushpull(         \
+      const SourceType&,                        \
+      const Tensor&,                            \
+      BoundVectorRef,                           \
+      InterpolationVectorRef,                   \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool)
+
+#define PUSHPULL_INSTANTIATE              \
+  PUSHPULL_INSTANTIATE_SOURCE(IntArrayRef); \
+  PUSHPULL_INSTANTIATE_SOURCE(Tensor)
 
   // Two arguments (source, grid)
-  // > `bound` and `interpolation` can be single arguments or vectors.
-  template <typename BoundType, typename InterpolationType, typename SourceType>
+  // > bound and interpolation are strictly VectorRef.
+  template <typename SourceType>
   MONAI_HOST std::deque<Tensor> pushpull(
       const SourceType& source,
       const Tensor& grid,
-      BoundType bound,
-      InterpolationType interpolation,
+      BoundVectorRef bound,
+      InterpolationVectorRef interpolation,
       bool extrapolate,
       bool do_pull,
       bool do_push,
@@ -2238,15 +2241,14 @@ MONAI_NAMESPACE_DEVICE { // cpu
   }
 
   // Three arguments (source, grid, target)
-  // > `bound` and `interpolation` can be single arguments or vectors.
-  // > `source` can be a tensor or a vector of dimensions.
-  template <typename BoundType, typename InterpolationType, typename SourceType>
+  // > bound and interpolation are strictly VectorRef.
+  template <typename SourceType>
   MONAI_HOST std::deque<Tensor> pushpull(
       const SourceType& source,
       const Tensor& grid,
       const Tensor& target,
-      BoundType bound,
-      InterpolationType interpolation,
+      BoundVectorRef bound,
+      InterpolationVectorRef interpolation,
       bool extrapolate,
       bool do_pull,
       bool do_push,

--- a/monai/csrc/resample/pushpull_cpu.cpp
+++ b/monai/csrc/resample/pushpull_cpu.cpp
@@ -2198,6 +2198,7 @@ MONAI_NAMESPACE_DEVICE { // cpu
       bool,                                     \
       bool,                                     \
       bool,                                     \
+      bool,                                     \
       bool);                                    \
   template std::deque<Tensor> pushpull(         \
       const SourceType&,                        \

--- a/monai/csrc/resample/pushpull_cuda.cu
+++ b/monai/csrc/resample/pushpull_cuda.cu
@@ -2160,6 +2160,7 @@ MONAI_NAMESPACE_DEVICE { // cuda
       bool,                                     \
       bool,                                     \
       bool,                                     \
+      bool,                                     \
       bool);                                    \
   template std::deque<Tensor> pushpull(         \
       const SourceType&,                        \

--- a/monai/csrc/resample/pushpull_cuda.cu
+++ b/monai/csrc/resample/pushpull_cuda.cu
@@ -35,7 +35,7 @@ limitations under the License.
 // . [DONE] spatial gradient mode (without multiplication with output gradient)
 // . [DONE] second order gradients (backward pass for spatial gradients)
 // . performance tests
-// . input bound/inter are always vectors -> clean unused constructors
+// . [DONE] input bound/inter are always vectors -> clean unused constructors
 
 #include <ATen/ATen.h>
 #include <limits>
@@ -2149,39 +2149,42 @@ MONAI_NAMESPACE_DEVICE { // cuda
   //                    FUNCTIONAL FORM WITH DISPATCH
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#define PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, SourceType0) \
-  template std::deque<Tensor> pushpull(                                    \
-      const SourceType0&,                                                  \
-      const Tensor&,                                                       \
-      const Tensor&,                                                       \
-      BoundType0,                                                          \
-      InterpolationType0,                                                  \
-      bool,                                                                \
-      bool,                                                                \
-      bool,                                                                \
-      bool,                                                                \
-      bool,                                                                \
-      bool);                                                               \
-  template std::deque<Tensor> pushpull(                                    \
-      const SourceType0&, const Tensor&, BoundType0, InterpolationType0, bool, bool, bool, bool, bool, bool)
-#define PUSHPULL_INSTANTIATE2(BoundType0, InterpolationType0)         \
-  PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, IntArrayRef); \
-  PUSHPULL_INSTANTIATE3(BoundType0, InterpolationType0, Tensor)
-#define PUSHPULL_INSTANTIATE1(BoundType0)               \
-  PUSHPULL_INSTANTIATE2(BoundType0, InterpolationType); \
-  PUSHPULL_INSTANTIATE2(BoundType0, InterpolationVectorRef)
-#define PUSHPULL_INSTANTIATE        \
-  PUSHPULL_INSTANTIATE1(BoundType); \
-  PUSHPULL_INSTANTIATE1(BoundVectorRef)
+#define PUSHPULL_INSTANTIATE_SOURCE(SourceType) \
+  template std::deque<Tensor> pushpull(         \
+      const SourceType&,                        \
+      const Tensor&,                            \
+      const Tensor&,                            \
+      BoundVectorRef,                           \
+      InterpolationVectorRef,                   \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool);                                    \
+  template std::deque<Tensor> pushpull(         \
+      const SourceType&,                        \
+      const Tensor&,                            \
+      BoundVectorRef,                           \
+      InterpolationVectorRef,                   \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool,                                     \
+      bool)
+
+#define PUSHPULL_INSTANTIATE              \
+  PUSHPULL_INSTANTIATE_SOURCE(IntArrayRef); \
+  PUSHPULL_INSTANTIATE_SOURCE(Tensor)
 
   // Two arguments (source, grid)
-  // > `bound` and `interpolation` can be single arguments or vectors.
-  template <typename BoundType, typename InterpolationType, typename SourceType>
+  // > bound and interpolation are strictly VectorRef.
+  template <typename SourceType>
   MONAI_HOST std::deque<Tensor> pushpull(
       const SourceType& source,
       const Tensor& grid,
-      BoundType bound,
-      InterpolationType interpolation,
+      BoundVectorRef bound,
+      InterpolationVectorRef interpolation,
       bool extrapolate,
       bool do_pull,
       bool do_push,
@@ -2206,15 +2209,14 @@ MONAI_NAMESPACE_DEVICE { // cuda
   }
 
   // Three arguments (source, grid, target)
-  // > `bound` and `interpolation` can be single arguments or vectors.
-  // > `source` can be a tensor or a vector of dimensions.
-  template <typename BoundType, typename InterpolationType, typename SourceType>
+  // > bound and interpolation are strictly VectorRef.
+  template <typename SourceType>
   MONAI_HOST std::deque<Tensor> pushpull(
       const SourceType& source,
       const Tensor& grid,
       const Tensor& target,
-      BoundType bound,
-      InterpolationType interpolation,
+      BoundVectorRef bound,
+      InterpolationVectorRef interpolation,
       bool extrapolate,
       bool do_pull,
       bool do_push,


### PR DESCRIPTION
### Description

- Modified `pushpull_cpu.cpp` and `pushpull_cuda.cu`.
- Removed template instantiations for Scalar types (`BoundType`, `InterpolationType`).
- Enforced `BoundVectorRef` and `InterpolationVectorRef` as the only supported input types for `bound` and `interpolation` parameters.
- Simplified the `PUSHPULL_INSTANTIATE` macros.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
