### PR TITLE
Adding What's New Page for 1.5.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-01-28
+
+## What's Changed
+### Fixed
+* Fix Zip Slip vulnerability in NGC private bundle download (#8682)
+
 ## [1.5.1] - 2025-09-22
 
 ## What's Changed
@@ -1261,7 +1267,8 @@ the postprocessing steps should be used before calling the metrics methods
 
 [highlights]: https://github.com/Project-MONAI/MONAI/blob/master/docs/source/highlights.md
 
-[Unreleased]: https://github.com/Project-MONAI/MONAI/compare/1.5.1...HEAD
+[Unreleased]: https://github.com/Project-MONAI/MONAI/compare/1.5.2...HEAD
+[1.5.2]: https://github.com/Project-MONAI/MONAI/compare/1.5.1...1.5.2
 [1.5.1]: https://github.com/Project-MONAI/MONAI/compare/1.5.0...1.5.1
 [1.5.0]: https://github.com/Project-MONAI/MONAI/compare/1.4.0...1.5.0
 [1.4.0]: https://github.com/Project-MONAI/MONAI/compare/1.3.2...1.4.0

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 .. toctree::
    :maxdepth: 1
 
+   whatsnew_1_5_2.md
    whatsnew_1_5_1.md
    whatsnew_1_5.md
    whatsnew_1_4.md

--- a/docs/source/whatsnew_1_5_1.md
+++ b/docs/source/whatsnew_1_5_1.md
@@ -1,5 +1,5 @@
 
-# What's new in 1.5.1 🎉🎉
+# What's new in 1.5.1
 
 This is a minor update for MONAI to address security concerns and improve compatibility with the newest PyTorch release.
 

--- a/docs/source/whatsnew_1_5_2.md
+++ b/docs/source/whatsnew_1_5_2.md
@@ -1,0 +1,8 @@
+
+# What's new in 1.5.2 🎉🎉
+
+This is a minor update for MONAI to address a security concern.
+
+With the upgrade support for PyTorch 2.8, MONAI now directly support NVIDIA GeForce RTX 50 series GPUs and other Blackwell-based GPUs!
+
+- Security fix to address advisory [GHSA-9rg3-9pvr-6p27](https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-9rg3-9pvr-6p27).

--- a/docs/source/whatsnew_1_5_2.md
+++ b/docs/source/whatsnew_1_5_2.md
@@ -3,6 +3,4 @@
 
 This is a minor update for MONAI to address a security concern.
 
-With the upgrade support for PyTorch 2.8, MONAI now directly support NVIDIA GeForce RTX 50 series GPUs and other Blackwell-based GPUs!
-
 - Security fix to address advisory [GHSA-9rg3-9pvr-6p27](https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-9rg3-9pvr-6p27).


### PR DESCRIPTION
### Description

This adds the "what's new" page for the minor 1.5.2 release. This commit should probably just be cherry-picked for the release. Branch rules will have to be temporarily broken to allow the PR past blossom as well, since no code is modified here this is safe and it's only the documentation generation that should be checked.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
