### PR TITLE
Update coverage configuration to use `monai` as source

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -278,7 +278,7 @@ disallow_incomplete_defs = True
 
 [coverage:run]
 concurrency = multiprocessing
-source = .
+source = monai
 data_file = .coverage/.coverage
 omit = setup.py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -280,7 +280,6 @@ disallow_incomplete_defs = True
 concurrency = multiprocessing
 source = monai
 data_file = .coverage/.coverage
-omit = setup.py
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
### Description

This pull request makes a minor configuration update to the test coverage settings. The change restricts coverage measurement to only the `monai` package, rather than the entire source tree.

- Coverage configuration: Changed the `source` setting in `setup.cfg` from `.` (current directory) to `monai`, so coverage reports now only include files within the `monai` package.

This addresses misleading information about coverage since it combines the package and tests, see: https://app.codecov.io/gh/Project-MONAI/MONAI

<img width="3180" height="528" alt="image" src="https://github.com/user-attachments/assets/39e740d6-1ea8-45ce-bf05-07d2368601f5" />


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
