### PR TITLE
docs: clarify backward mapping logic for RandAffine and RandAffined

### DIFF
--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -2436,6 +2436,13 @@ class RandAffine(RandomizableTransform, InvertibleTransform, LazyTransform):
             - :py:class:`RandAffineGrid` for the random affine parameters configurations.
             - :py:class:`Affine` for the affine transformation parameters configurations.
 
+        Note:
+            The affine transformations in MONAI use a 'backward mapping' (image-to-grid) logic.
+            This can be counter-intuitive:
+            - Translation: A positive value shifts the image in the negative direction.
+            - Scaling: Positive scale_range values decrease the image size; values in [-1, 0) increase it.
+            - Rotation: The direction (CW/CCW) may vary depending on the axis.
+
         """
         RandomizableTransform.__init__(self, prob)
         LazyTransform.__init__(self, lazy=lazy)

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -1100,6 +1100,13 @@ class RandAffined(RandomizableTransform, MapTransform, InvertibleTransform, Lazy
             - :py:class:`monai.transforms.compose.MapTransform`
             - :py:class:`RandAffineGrid` for the random affine parameters configurations.
 
+        Note:
+            The affine transformations in MONAI use a 'backward mapping' (image-to-grid) logic.
+            This can be counter-intuitive:
+            - Translation: A positive value shifts the image in the negative direction.
+            - Scaling: Positive scale_range values decrease the image size; values in [-1, 0) increase it.
+            - Rotation: The direction (CW/CCW) may vary depending on the axis.
+
         """
         MapTransform.__init__(self, keys, allow_missing_keys)
         RandomizableTransform.__init__(self, prob)


### PR DESCRIPTION
Fixes #8726 

### Description

- Updated `monai/transforms/spatial/array.py`: Added a Note to `RandAffine `explaining the inverse relationship for translation and scaling.
- Updated `monai/transforms/spatial/dictionary.py`: Added a corresponding Note to `RandAffined `to ensure consistency for dictionary-based workflows.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
