### PR TITLE
Fix AutoencoderKlMaisi forcing CUDA transfer on CPU inputs

### DIFF
--- a/monai/apps/generation/maisi/networks/autoencoderkl_maisi.py
+++ b/monai/apps/generation/maisi/networks/autoencoderkl_maisi.py
@@ -215,7 +215,7 @@ class MaisiConvolution(nn.Module):
             x = torch.cat(outputs, dim=self.dim_split + 2)
         else:
             target_device = outputs[0].device
-            
+
             x = outputs[0].clone().to("cpu", non_blocking=True)
             outputs[0] = torch.Tensor(0)
             _empty_cuda_cache(self.save_mem)
@@ -229,7 +229,7 @@ class MaisiConvolution(nn.Module):
 
             if target_device.type != "cpu":
                 x = x.to(target_device, non_blocking=True)
-                
+
         return x
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/monai/apps/generation/maisi/networks/autoencoderkl_maisi.py
+++ b/monai/apps/generation/maisi/networks/autoencoderkl_maisi.py
@@ -214,6 +214,8 @@ class MaisiConvolution(nn.Module):
         if max(outputs[0].size()) < 500:
             x = torch.cat(outputs, dim=self.dim_split + 2)
         else:
+            target_device = outputs[0].device
+            
             x = outputs[0].clone().to("cpu", non_blocking=True)
             outputs[0] = torch.Tensor(0)
             _empty_cuda_cache(self.save_mem)
@@ -225,7 +227,9 @@ class MaisiConvolution(nn.Module):
                 if self.print_info:
                     logger.info(f"MaisiConvolution concat progress: {k + 1}/{len(outputs) - 1}.")
 
-            x = x.to("cuda", non_blocking=True)
+            if target_device.type != "cpu":
+                x = x.to(target_device, non_blocking=True)
+                
         return x
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Fixes #8735 

### Description

This PR fixes a bug in `AutoencoderKlMaisi` where the model would force a transfer to `cuda` even if the input tensors and the model were placed on the `CPU`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
