### PR TITLE
Fix flake8 format in `PatchEmbeddingBlock`

### DIFF
--- a/monai/data/box_utils.py
+++ b/monai/data/box_utils.py
@@ -1128,7 +1128,8 @@ def non_max_suppression(
     scores_t, *_ = convert_to_dst_type(scores, boxes_t)
 
     # sort boxes in descending order according to the scores
-    sort_idxs = torch.argsort(scores_t, dim=0, descending=True)
+    # use stable=True to ensure deterministic ordering when scores are equal
+    sort_idxs = torch.argsort(scores_t, dim=0, descending=True, stable=True)
     boxes_sort = deepcopy(boxes_t)[sort_idxs, :]
 
     # initialize the list of picked indexes

--- a/monai/networks/blocks/patchembedding.py
+++ b/monai/networks/blocks/patchembedding.py
@@ -101,7 +101,7 @@ class PatchEmbeddingBlock(nn.Module):
             chars = (("h", "p1"), ("w", "p2"), ("d", "p3"))[:spatial_dims]
             from_chars = "b c " + " ".join(f"({k} {v})" for k, v in chars)
             to_chars = f"b ({' '.join([c[0] for c in chars])}) ({' '.join([c[1] for c in chars])} c)"
-            axes_len = {f"p{i+1}": p for i, p in enumerate(patch_size)}
+            axes_len = {f"p{i + 1}": p for i, p in enumerate(patch_size)}
             self.patch_embeddings = nn.Sequential(
                 Rearrange(f"{from_chars} -> {to_chars}", **axes_len), nn.Linear(self.patch_dim, hidden_size)
             )

--- a/runtests.sh
+++ b/runtests.sh
@@ -136,7 +136,7 @@ function print_version {
 
 function install_deps {
     echo "Pip installing MONAI development dependencies and compile MONAI cpp extensions..."
-    ${cmdPrefix}"${PY_EXE}" -m pip install -r requirements-dev.txt
+    ${cmdPrefix}"${PY_EXE}" -m pip install --no-build-isolation -r requirements-dev.txt
 }
 
 function compile_cpp {


### PR DESCRIPTION
### Description
Fix flake8 format in `PatchEmbeddingBlock`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
