### PR TITLE
Fixing SSIM Test Method Names

### DIFF
--- a/tests/metrics/test_compute_multiscalessim_metric.py
+++ b/tests/metrics/test_compute_multiscalessim_metric.py
@@ -21,7 +21,7 @@ from monai.utils import set_determinism
 
 class TestMultiScaleSSIMMetric(unittest.TestCase):
 
-    def test2d_gaussian(self):
+    def test_2d_gaussian(self):
         set_determinism(0)
         preds = torch.abs(torch.randn(1, 1, 64, 64))
         target = torch.abs(torch.randn(1, 1, 64, 64))
@@ -34,7 +34,7 @@ class TestMultiScaleSSIMMetric(unittest.TestCase):
         expected_value = 0.023176
         self.assertAlmostEqual(expected_value, result.item(), 4)
 
-    def test2d_uniform(self):
+    def test_2d_uniform(self):
         set_determinism(0)
         preds = torch.abs(torch.randn(1, 1, 64, 64))
         target = torch.abs(torch.randn(1, 1, 64, 64))
@@ -47,7 +47,7 @@ class TestMultiScaleSSIMMetric(unittest.TestCase):
         expected_value = 0.022655
         self.assertAlmostEqual(expected_value, result.item(), 4)
 
-    def test3d_gaussian(self):
+    def test_3d_gaussian(self):
         set_determinism(0)
         preds = torch.abs(torch.randn(1, 1, 64, 64, 64))
         target = torch.abs(torch.randn(1, 1, 64, 64, 64))
@@ -60,19 +60,19 @@ class TestMultiScaleSSIMMetric(unittest.TestCase):
         expected_value = 0.061796
         self.assertAlmostEqual(expected_value, result.item(), 4)
 
-    def input_ill_input_shape2d(self):
+    def test_input_ill_input_shape2d(self):
         metric = MultiScaleSSIMMetric(spatial_dims=3, weights=[0.5, 0.5])
 
         with self.assertRaises(ValueError):
             metric(torch.randn(1, 1, 64, 64), torch.randn(1, 1, 64, 64))
 
-    def input_ill_input_shape3d(self):
+    def test_input_ill_input_shape3d(self):
         metric = MultiScaleSSIMMetric(spatial_dims=2, weights=[0.5, 0.5])
 
         with self.assertRaises(ValueError):
             metric(torch.randn(1, 1, 64, 64, 64), torch.randn(1, 1, 64, 64, 64))
 
-    def small_inputs(self):
+    def test_small_inputs(self):
         metric = MultiScaleSSIMMetric(spatial_dims=2)
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
### Description

This fixes erroneous test names flagged elsewhere by coderabbit.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
