### PR TITLE
Slightly improve performance in engines/utils.py

### DIFF
--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -235,7 +235,7 @@ class PrepareBatchExtraInput(PrepareBatch):
                 args_.append(_get_data(k))
         elif isinstance(self.extra_keys, dict):
             for k, v in self.extra_keys.items():
-                kwargs_[k] = _get_data(v)
+                kwargs_.update({k: _get_data(v)})
 
         return cast(torch.Tensor, image), cast(torch.Tensor, label), tuple(args_), kwargs_
 

--- a/monai/engines/utils.py
+++ b/monai/engines/utils.py
@@ -219,8 +219,8 @@ class PrepareBatchExtraInput(PrepareBatch):
         `kwargs` supports other args for `Tensor.to()` API.
         """
         image, label = default_prepare_batch(batchdata, device, non_blocking, **kwargs)
-        args_ = list()
-        kwargs_ = dict()
+        args_ = []
+        kwargs_ = {}
 
         def _get_data(key: str) -> torch.Tensor:
             data = batchdata[key]
@@ -235,7 +235,7 @@ class PrepareBatchExtraInput(PrepareBatch):
                 args_.append(_get_data(k))
         elif isinstance(self.extra_keys, dict):
             for k, v in self.extra_keys.items():
-                kwargs_.update({k: _get_data(v)})
+                kwargs_[k] = _get_data(v)
 
         return cast(torch.Tensor, image), cast(torch.Tensor, label), tuple(args_), kwargs_
 


### PR DESCRIPTION
### Description
This change probably improves performance slightly (unforetunately, I don't have a local instance of MONAI installed in order to test this, but I'm pretty sure from looking at the code that using [], {} and kwargs_[k] = _get_data(v) should be semantically the same and probably slightly better in performance, see also #1423 (credits to @de-sh for the nice fix 👍 ) where at least [] and {} were changed as a refactoring and kwargs_[k] = _get_data(v) just seems better to me becuase I think that this saves some time due to dictionary lookups and temporary objects, but I'm not quite sure because it wasn't tested, so please correct me if I'm mistaken).

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
