### PR TITLE
fix(losses): add missing docstring entries for default parameters

### DIFF
--- a/monai/losses/cldice.py
+++ b/monai/losses/cldice.py
@@ -126,8 +126,8 @@ class SoftclDiceLoss(_Loss):
     def __init__(self, iter_: int = 3, smooth: float = 1.0) -> None:
         """
         Args:
-            iter_: Number of iterations for skeletonization
-            smooth: Smoothing parameter
+            iter_: Number of iterations for skeletonization. Defaults to 3.
+            smooth: Smoothing parameter. Defaults to 1.0.
         """
         super().__init__()
         self.iter = iter_
@@ -160,9 +160,9 @@ class SoftDiceclDiceLoss(_Loss):
     def __init__(self, iter_: int = 3, alpha: float = 0.5, smooth: float = 1.0) -> None:
         """
         Args:
-            iter_: Number of iterations for skeletonization
-            smooth: Smoothing parameter
-            alpha: Weighing factor for cldice
+            iter_: Number of iterations for skeletonization. Defaults to 3.
+            smooth: Smoothing parameter. Defaults to 1.0.
+            alpha: Weighing factor for cldice. Defaults to 0.5.
         """
         super().__init__()
         self.iter = iter_

--- a/monai/losses/cldice.py
+++ b/monai/losses/cldice.py
@@ -161,8 +161,8 @@ class SoftDiceclDiceLoss(_Loss):
         """
         Args:
             iter_: Number of iterations for skeletonization. Defaults to 3.
-            smooth: Smoothing parameter. Defaults to 1.0.
             alpha: Weighing factor for cldice. Defaults to 0.5.
+            smooth: Smoothing parameter. Defaults to 1.0.
         """
         super().__init__()
         self.iter = iter_

--- a/monai/losses/hausdorff_loss.py
+++ b/monai/losses/hausdorff_loss.py
@@ -54,6 +54,7 @@ class HausdorffDTLoss(_Loss):
     ) -> None:
         """
         Args:
+            alpha: the exponent to transform the distance when computing the loss. Defaults to 2.0.
             include_background: if False, channel index 0 (background category) is excluded from the calculation.
                 if the non-background segmentations are small compared to the total image size they can get overwhelmed
                 by the signal from the background so excluding it in such cases helps convergence.


### PR DESCRIPTION
## Description

Fixes missing and incomplete docstring parameter documentation in two loss files, consistent with the pattern established in #8701.

### Changes

**`monai/losses/hausdorff_loss.py`**
- `HausdorffDTLoss.__init__`: Added missing `alpha` parameter (default `2.0`) to the `Args` section. The parameter was present in the function signature but completely absent from the docstring.

**`monai/losses/cldice.py`**
- `SoftclDiceLoss.__init__`: Added `Defaults to X.` to `iter_` and `smooth` parameter descriptions.
- `SoftDiceclDiceLoss.__init__`: Added `Defaults to X.` to `iter_`, `smooth`, and `alpha` parameter descriptions.

### Motivation

These are pure docstring fixes — no code logic was changed. The missing `alpha` documentation in `HausdorffDTLoss` is the primary fix, and the `cldice.py` changes follow the same "document defaults" pattern from #8701.

## Checklist
- [x] Docstring-only change (no logic modified)
- [x] No new tests required
- [x] DCO sign-off included