### PR TITLE
Fft cleanup/update

### DIFF
--- a/monai/networks/blocks/fft_utils_t.py
+++ b/monai/networks/blocks/fft_utils_t.py
@@ -28,9 +28,6 @@ def roll_1d(x: Tensor, shift: int, shift_dim: int) -> Tensor:
 
     Returns:
         1d-shifted version of x
-
-    Note:
-        This function is called when fftshift and ifftshift are not available in the running pytorch version
     """
     shift = shift % x.size(shift_dim)
     if shift == 0:
@@ -55,9 +52,6 @@ def roll(x: Tensor, shift: list[int], shift_dims: list[int]) -> Tensor:
 
     Returns:
         shifted version of x
-
-    Note:
-        This function is called when fftshift and ifftshift are not available in the running pytorch version
     """
     if len(shift) != len(shift_dims):
         raise ValueError(f"len(shift) != len(shift_dims), got f{len(shift)} and f{len(shift_dims)}.")
@@ -78,9 +72,6 @@ def fftshift(x: Tensor, shift_dims: list[int]) -> Tensor:
 
     Returns:
         fft-shifted version of x
-
-    Note:
-        This function is called when fftshift is not available in the running pytorch version
     """
     shift = [0] * len(shift_dims)
     for i, dim_num in enumerate(shift_dims):
@@ -100,9 +91,6 @@ def ifftshift(x: Tensor, shift_dims: list[int]) -> Tensor:
 
     Returns:
         ifft-shifted version of x
-
-    Note:
-        This function is called when ifftshift is not available in the running pytorch version
     """
     shift = [0] * len(shift_dims)
     for i, dim_num in enumerate(shift_dims):

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1878,11 +1878,7 @@ class Fourier:
         dims = tuple(range(-spatial_dims, 0))
         k: NdarrayOrTensor
         if isinstance(x, torch.Tensor):
-            if hasattr(torch.fft, "fftshift"):  # `fftshift` is new in torch 1.8.0
-                k = torch.fft.fftshift(torch.fft.fftn(x, dim=dims), dim=dims)
-            else:
-                # if using old PyTorch, will convert to numpy array and return
-                k = np.fft.fftshift(np.fft.fftn(x.cpu().numpy(), axes=dims), axes=dims)
+            k = torch.fft.fftshift(torch.fft.fftn(x, dim=dims), dim=dims)
         else:
             k = np.fft.fftshift(np.fft.fftn(x, axes=dims), axes=dims)
         return ascontiguousarray(k) if as_contiguous else k
@@ -1906,11 +1902,7 @@ class Fourier:
         dims = tuple(range(-spatial_dims, 0))
         out: NdarrayOrTensor
         if isinstance(k, torch.Tensor):
-            if hasattr(torch.fft, "ifftshift"):  # `ifftshift` is new in torch 1.8.0
-                out = torch.fft.ifftn(torch.fft.ifftshift(k, dim=dims), dim=dims, norm="backward").real
-            else:
-                # if using old PyTorch, will convert to numpy array and return
-                out = np.fft.ifftn(np.fft.ifftshift(k.cpu().numpy(), axes=dims), axes=dims).real
+            out = torch.fft.ifftn(torch.fft.ifftshift(k, dim=dims), dim=dims, norm="backward").real
         else:
             out = np.fft.ifftn(np.fft.ifftshift(k, axes=dims), axes=dims).real
         return ascontiguousarray(out) if as_contiguous else out


### PR DESCRIPTION
Remove legacy PyTorch 1.8.0 compatibility code from FFT utilities. MONAI now requires PyTorch ≥ 2.4.1, so the version checks and NumPy fallbacks are no longer needed.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).