### PR TITLE
Add Fréchet Radiomics Distance (FRD) to MONAI metrics (#8643)

### DIFF
--- a/monai/metrics/__init__.py
+++ b/monai/metrics/__init__.py
@@ -19,6 +19,7 @@ from .cumulative_average import CumulativeAverage
 from .embedding_collapse import EmbeddingCollapseMetric, compute_embedding_collapse
 from .f_beta_score import FBetaScore
 from .fid import FIDMetric, compute_frechet_distance
+from .frd import FrechetRadiomicsDistance, get_frd_score
 from .froc import compute_fp_tp_probs, compute_fp_tp_probs_nd, compute_froc_curve_data, compute_froc_score
 from .generalized_dice import GeneralizedDiceScore, compute_generalized_dice
 from .hausdorff_distance import HausdorffDistanceMetric, compute_hausdorff_distance

--- a/monai/metrics/frd.py
+++ b/monai/metrics/frd.py
@@ -66,4 +66,6 @@ def get_frd_score(y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         ValueError: When either tensor has more than 2 dimensions. Inputs must have
             shape (number of samples, number of features).
     """
+    if y_pred.ndimension() > 2 or y.ndimension() > 2:
+        raise ValueError("Inputs should have (number images, number of features) shape.")
     return get_fid_score(y_pred, y)

--- a/monai/metrics/frd.py
+++ b/monai/metrics/frd.py
@@ -1,0 +1,65 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import torch
+
+from monai.metrics.fid import get_fid_score
+from monai.metrics.metric import Metric
+
+__all__ = ["FrechetRadiomicsDistance", "get_frd_score"]
+
+
+class FrechetRadiomicsDistance(Metric):
+    """
+    Fréchet Radiomics Distance (FRD). Computes the Fréchet distance between two
+    distributions of radiomic feature vectors, in the same way as the Fréchet
+    Inception Distance (FID) but for radiomics-based features.
+
+    Unlike FID, FRD uses interpretable, clinically relevant radiomic features
+    (e.g. from PyRadiomics) and works for both 2D and 3D images, with optional
+    conditioning by anatomical masks. See Konz et al. "Fréchet Radiomic Distance
+    (FRD): A Versatile Metric for Comparing Medical Imaging Datasets."
+    https://arxiv.org/abs/2412.01496
+
+    This metric accepts two groups of pre-extracted radiomic feature vectors with
+    shape (number of samples, number of features). The same Fréchet distance
+    formula as in FID is applied to the mean and covariance of these features.
+
+    Args:
+        y_pred: Radiomic feature vectors for the first distribution (e.g. from
+            generated or reconstructed images), shape (N, F).
+        y: Radiomic feature vectors for the second distribution (e.g. from real
+            images), shape (N, F).
+
+    Returns:
+        Scalar tensor containing the FRD value.
+    """
+
+    def __call__(self, y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return get_frd_score(y_pred, y)
+
+
+def get_frd_score(y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """Computes the FRD score from two batches of radiomic feature vectors.
+
+    The implementation reuses the same Fréchet distance as FID; only the
+    semantics (radiomic features vs. deep features) differ.
+
+    Args:
+        y_pred: Feature vectors for the first distribution, shape (N, F).
+        y: Feature vectors for the second distribution, shape (N, F).
+
+    Returns:
+        Scalar tensor containing the Fréchet Radiomics Distance.
+    """
+    return get_fid_score(y_pred, y)

--- a/monai/metrics/frd.py
+++ b/monai/metrics/frd.py
@@ -61,5 +61,9 @@ def get_frd_score(y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
     Returns:
         Scalar tensor containing the Fréchet Radiomics Distance.
+
+    Raises:
+        ValueError: When either tensor has more than 2 dimensions. Inputs must have
+            shape (number of samples, number of features).
     """
     return get_fid_score(y_pred, y)

--- a/monai/metrics/frd.py
+++ b/monai/metrics/frd.py
@@ -23,29 +23,37 @@ class FrechetRadiomicsDistance(Metric):
     """
     Fréchet Radiomics Distance (FRD). Computes the Fréchet distance between two
     distributions of radiomic feature vectors, in the same way as the Fréchet
-    Inception Distance (FID) but for radiomics-based features.
+    Inception Distance (FID) but applied to radiomics-based features instead of
+    deep-network embeddings.
 
     Unlike FID, FRD uses interpretable, clinically relevant radiomic features
-    (e.g. from PyRadiomics) and works for both 2D and 3D images, with optional
-    conditioning by anatomical masks. See Konz et al. "Fréchet Radiomic Distance
-    (FRD): A Versatile Metric for Comparing Medical Imaging Datasets."
-    https://arxiv.org/abs/2412.01496
+    (e.g. extracted via PyRadiomics), which makes it directly applicable to both
+    2D and 3D images and allows optional conditioning by anatomical masks —
+    all handled during upstream feature extraction, not by this class. See
+    Konz et al. "Fréchet Radiomic Distance (FRD): A Versatile Metric for
+    Comparing Medical Imaging Datasets." https://arxiv.org/abs/2412.01496
 
-    This metric accepts two groups of pre-extracted radiomic feature vectors with
-    shape (number of samples, number of features). The same Fréchet distance
-    formula as in FID is applied to the mean and covariance of these features.
-
-    Args:
-        y_pred: Radiomic feature vectors for the first distribution (e.g. from
-            generated or reconstructed images), shape (N, F).
-        y: Radiomic feature vectors for the second distribution (e.g. from real
-            images), shape (N, F).
-
-    Returns:
-        Scalar tensor containing the FRD value.
+    This class accepts pre-extracted radiomic feature tensors of shape (N, F)
+    and applies the same Fréchet distance formula as FID to the empirical means
+    and covariances of those features.
     """
 
     def __call__(self, y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """Compute FRD between two sets of pre-extracted radiomic feature vectors.
+
+        Args:
+            y_pred: Radiomic feature vectors for the first distribution (e.g. from
+                generated or reconstructed images), shape (N, F) with N >= 2.
+            y: Radiomic feature vectors for the second distribution (e.g. from real
+                images), shape (N, F) with N >= 2.
+
+        Returns:
+            Scalar tensor containing the FRD value.
+
+        Raises:
+            ValueError: When either tensor is not exactly 2-dimensional or has
+                fewer than 2 samples.
+        """
         return get_frd_score(y_pred, y)
 
 
@@ -53,19 +61,28 @@ def get_frd_score(y_pred: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Computes the FRD score from two batches of radiomic feature vectors.
 
     The implementation reuses the same Fréchet distance as FID; only the
-    semantics (radiomic features vs. deep features) differ.
+    semantics (radiomic features vs. deep network features) differ.
 
     Args:
-        y_pred: Feature vectors for the first distribution, shape (N, F).
-        y: Feature vectors for the second distribution, shape (N, F).
+        y_pred: Feature vectors for the first distribution, shape (N, F) with N >= 2.
+        y: Feature vectors for the second distribution, shape (N, F) with N >= 2.
 
     Returns:
         Scalar tensor containing the Fréchet Radiomics Distance.
 
     Raises:
-        ValueError: When either tensor has more than 2 dimensions. Inputs must have
-            shape (number of samples, number of features).
+        ValueError: When either tensor is not exactly 2-dimensional (i.e. not
+            shape (N, F)), or when either tensor has fewer than 2 samples
+            (required for covariance estimation).
     """
-    if y_pred.ndimension() > 2 or y.ndimension() > 2:
-        raise ValueError("Inputs should have (number images, number of features) shape.")
+    for name, t in (("y_pred", y_pred), ("y", y)):
+        if t.ndimension() != 2:
+            raise ValueError(
+                f"{name} must be a 2-D tensor of shape (N, F) — got shape {tuple(t.shape)}. "
+                "Pass pre-extracted radiomic feature vectors, not raw images."
+            )
+        if t.size(0) < 2:
+            raise ValueError(
+                f"{name} must contain at least 2 samples for covariance estimation — got {t.size(0)}."
+            )
     return get_fid_score(y_pred, y)

--- a/tests/metrics/test_compute_frd_metric.py
+++ b/tests/metrics/test_compute_frd_metric.py
@@ -38,9 +38,11 @@ class TestFrechetRadiomicsDistance(unittest.TestCase):
         fid_score = FIDMetric()(y_pred, y)
         np.testing.assert_allclose(frd_score.cpu().numpy(), fid_score.cpu().numpy(), atol=1e-6)
 
-    def test_input_dimensions(self):
+    def test_rejects_high_dimensional_input(self):
+        """FrechetRadiomicsDistance raises ValueError when inputs have ndimension() > 2."""
+        high_dim = torch.ones([3, 3, 144, 144])
         with self.assertRaises(ValueError):
-            FrechetRadiomicsDistance()(torch.ones([3, 3, 144, 144]), torch.ones([3, 3, 145, 145]))
+            FrechetRadiomicsDistance()(high_dim, high_dim)
 
 
 if __name__ == "__main__":

--- a/tests/metrics/test_compute_frd_metric.py
+++ b/tests/metrics/test_compute_frd_metric.py
@@ -39,7 +39,7 @@ class TestFrechetRadiomicsDistance(unittest.TestCase):
         np.testing.assert_allclose(frd_score.cpu().numpy(), fid_score.cpu().numpy(), atol=1e-6)
 
     def test_rejects_high_dimensional_input(self):
-        """Raises ValueError when inputs have more than 2 dimensions."""
+        """Raises ValueError when inputs have more than 2 dimensions. """
         high_dim = torch.ones([3, 3, 144, 144])
         with self.assertRaises(ValueError):
             FrechetRadiomicsDistance()(high_dim, high_dim)

--- a/tests/metrics/test_compute_frd_metric.py
+++ b/tests/metrics/test_compute_frd_metric.py
@@ -39,10 +39,24 @@ class TestFrechetRadiomicsDistance(unittest.TestCase):
         np.testing.assert_allclose(frd_score.cpu().numpy(), fid_score.cpu().numpy(), atol=1e-6)
 
     def test_rejects_high_dimensional_input(self):
-        """FrechetRadiomicsDistance raises ValueError when inputs have ndimension() > 2."""
+        """Raises ValueError when inputs have more than 2 dimensions."""
         high_dim = torch.ones([3, 3, 144, 144])
         with self.assertRaises(ValueError):
             FrechetRadiomicsDistance()(high_dim, high_dim)
+
+    def test_rejects_1d_input(self):
+        """Raises ValueError when inputs are 1-D (single feature vector, not a batch)."""
+        with self.assertRaises(ValueError):
+            FrechetRadiomicsDistance()(torch.ones([10]), torch.ones([10]))
+
+    def test_rejects_too_few_samples(self):
+        """Raises ValueError when either input has fewer than 2 samples."""
+        valid = torch.Tensor([[1.0, 2.0], [3.0, 4.0]])
+        single = torch.Tensor([[1.0, 2.0]])
+        with self.assertRaises(ValueError):
+            FrechetRadiomicsDistance()(single, valid)
+        with self.assertRaises(ValueError):
+            FrechetRadiomicsDistance()(valid, single)
 
 
 if __name__ == "__main__":

--- a/tests/metrics/test_compute_frd_metric.py
+++ b/tests/metrics/test_compute_frd_metric.py
@@ -1,0 +1,47 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import torch
+
+from monai.metrics import FIDMetric, FrechetRadiomicsDistance
+from monai.utils import optional_import
+
+_, has_scipy = optional_import("scipy")
+
+
+@unittest.skipUnless(has_scipy, "Requires scipy")
+class TestFrechetRadiomicsDistance(unittest.TestCase):
+    def test_results(self):
+        x = torch.Tensor([[1, 2], [1, 2], [1, 2]])
+        y = torch.Tensor([[2, 2], [1, 2], [1, 2]])
+        results = FrechetRadiomicsDistance()(x, y)
+        np.testing.assert_allclose(results.cpu().numpy(), 0.4444, atol=1e-4)
+
+    def test_frd_matches_fid_for_same_features(self):
+        """FRD uses the same Fréchet formula as FID; same inputs give same value."""
+        y_pred = torch.Tensor([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]])
+        y = torch.Tensor([[2.0, 2.0], [1.0, 2.0], [1.0, 2.0]])
+        frd_score = FrechetRadiomicsDistance()(y_pred, y)
+        fid_score = FIDMetric()(y_pred, y)
+        np.testing.assert_allclose(frd_score.cpu().numpy(), fid_score.cpu().numpy(), atol=1e-6)
+
+    def test_input_dimensions(self):
+        with self.assertRaises(ValueError):
+            FrechetRadiomicsDistance()(torch.ones([3, 3, 144, 144]), torch.ones([3, 3, 145, 145]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #8643

### Description
Implements FRD as in Konz et al. (arXiv:2412.01496): same Fréchet distance formula as FID, applied to pre-extracted radiomic features. 
Supports 2D/3D and optional mask conditioning via external feature extraction (e.g. PyRadiomics).

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
