### PR TITLE
Fix compute_shape_offset non-tuple indexing for PyTorch >=2.9

### DIFF
--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -881,7 +881,7 @@ def compute_shape_offset(
             Default is False, using option 1 to compute the shape and offset.
 
     """
-    shape = np.array(spatial_shape, copy=True, dtype=float)
+    shape = np.array(tuple(spatial_shape), copy=True, dtype=float)
     sr = len(shape)
     in_affine_ = convert_data_type(to_affine_nd(sr, in_affine), np.ndarray)[0]
     out_affine_ = convert_data_type(to_affine_nd(sr, out_affine), np.ndarray)[0]

--- a/tests/data/utils/test_compute_shape_offset.py
+++ b/tests/data/utils/test_compute_shape_offset.py
@@ -1,3 +1,14 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import torch
 import unittest
 import numpy as np

--- a/tests/data/utils/test_compute_shape_offset.py
+++ b/tests/data/utils/test_compute_shape_offset.py
@@ -20,7 +20,17 @@ from monai.data.utils import compute_shape_offset
 
 
 class TestComputeShapeOffsetRegression(unittest.TestCase):
+    """Regression tests for `compute_shape_offset` input-shape handling."""
+
     def test_pytorch_size_input(self):
+        """Validate `torch.Size` input produces expected shape and offset.
+
+        Returns:
+            None.
+
+        Raises:
+            AssertionError: If computed shape/offset are not as expected.
+        """
         # 1. Create a PyTorch Size object (which triggered the original bug)
         spatial_shape = torch.Size([10, 10, 10])
         in_affine = np.eye(4)

--- a/tests/data/utils/test_compute_shape_offset.py
+++ b/tests/data/utils/test_compute_shape_offset.py
@@ -1,0 +1,20 @@
+import torch
+import unittest
+import numpy as np
+from monai.data.utils import compute_shape_offset
+
+class TestComputeShapeOffsetRegression(unittest.TestCase):
+    def test_pytorch_size_input(self):
+        # 1 Create a PyTorch Size object (which triggered the original bug)
+        spatial_shape = torch.Size([10, 10, 10])
+        in_affine = np.eye(4)
+        out_affine = np.eye(4)
+
+        # 2 Feed it into the function
+        shape, offset = compute_shape_offset(spatial_shape, in_affine, out_affine)
+
+        # 3 Prove it successfully processed the shape by checking its length
+        self.assertEqual(len(shape), 3)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/data/utils/test_compute_shape_offset.py
+++ b/tests/data/utils/test_compute_shape_offset.py
@@ -9,10 +9,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
 import unittest
+
 import numpy as np
+import torch
+
 from monai.data.utils import compute_shape_offset
+
 
 class TestComputeShapeOffsetRegression(unittest.TestCase):
     def test_pytorch_size_input(self):

--- a/tests/data/utils/test_compute_shape_offset.py
+++ b/tests/data/utils/test_compute_shape_offset.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest
 
 import numpy as np
@@ -19,16 +21,17 @@ from monai.data.utils import compute_shape_offset
 
 class TestComputeShapeOffsetRegression(unittest.TestCase):
     def test_pytorch_size_input(self):
-        # 1 Create a PyTorch Size object (which triggered the original bug)
+        # 1. Create a PyTorch Size object (which triggered the original bug)
         spatial_shape = torch.Size([10, 10, 10])
         in_affine = np.eye(4)
         out_affine = np.eye(4)
 
-        # 2 Feed it into the function
+        # 2. Feed it into the function
         shape, offset = compute_shape_offset(spatial_shape, in_affine, out_affine)
 
-        # 3 Prove it successfully processed the shape by checking its length
+        # 3. Prove it successfully processed the shape by checking its length
         self.assertEqual(len(shape), 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #8775  .

### Description

This PR resolves issue #8775 by casting spatial_shape to a tuple inside compute_shape_offset to prevent breaking changes in PyTorch >= 2.9.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
