### PR TITLE
Fix incorrect `truncated` parameter in `make_gaussian_kernel` causing corrupted `LocalNormalizedCrossCorrelationLoss`

### DIFF
--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -35,7 +35,7 @@ def make_triangular_kernel(kernel_size: int) -> torch.Tensor:
 
 def make_gaussian_kernel(kernel_size: int) -> torch.Tensor:
     sigma = torch.tensor(kernel_size / 3.0)
-    kernel = gaussian_1d(sigma=sigma, truncated=kernel_size // 2, approx="sampled", normalize=False) * (
+    kernel = gaussian_1d(sigma=sigma, truncated=(kernel_size // 2) / sigma, approx="sampled", normalize=False) * (
         2.5066282 * sigma
     )
     return kernel[:kernel_size]

--- a/tests/integration/test_reg_loss_integration.py
+++ b/tests/integration/test_reg_loss_integration.py
@@ -117,5 +117,6 @@ class TestRegLossIntegration(unittest.TestCase):
                     f"LNCC of identical images should be -1.0, got {loss.item():.6f} (kernel_size={kernel_size})",
                 )
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration/test_reg_loss_integration.py
+++ b/tests/integration/test_reg_loss_integration.py
@@ -26,6 +26,7 @@ TEST_CASES = [
     [LocalNormalizedCrossCorrelationLoss, {"kernel_size": 7, "kernel_type": "rectangular"}, ["pred", "target"]],
     [LocalNormalizedCrossCorrelationLoss, {"kernel_size": 5, "kernel_type": "triangular"}, ["pred", "target"]],
     [LocalNormalizedCrossCorrelationLoss, {"kernel_size": 3, "kernel_type": "gaussian"}, ["pred", "target"]],
+    [LocalNormalizedCrossCorrelationLoss, {"kernel_size": 7, "kernel_type": "gaussian"}, ["pred", "target"]],
     [GlobalMutualInformationLoss, {"num_bins": 10}, ["pred", "target"]],
     [GlobalMutualInformationLoss, {"kernel_type": "b-spline", "num_bins": 10}, ["pred", "target"]],
 ]
@@ -98,6 +99,23 @@ class TestRegLossIntegration(unittest.TestCase):
             optimizer.step()
         self.assertGreater(init_loss, loss_val, "loss did not decrease")
 
+def test_lncc_gaussian_kernel_gt3_identical_images(self):
+        """
+        Regression test for make_gaussian_kernel truncated parameter bug.
+        LNCC on identical inputs must be close to -1.0 for gaussian kernel_size > 3.
+        """
+        for kernel_size in [5, 7]:
+            with self.subTest(kernel_size=kernel_size):
+                loss_fn = LocalNormalizedCrossCorrelationLoss(
+                    spatial_dims=2, kernel_size=kernel_size, kernel_type="gaussian"
+                ).to(self.device)
+                x = torch.rand(2, 1, 32, 32, device=self.device)
+                y = x.clone()
+                loss = loss_fn(x, y)
+                self.assertTrue(
+                    torch.allclose(loss, torch.tensor(-1.0, device=self.device, dtype=loss.dtype), atol=1e-3),
+                    f"LNCC of identical images should be -1.0, got {loss.item():.6f} (kernel_size={kernel_size})",
+                )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration/test_reg_loss_integration.py
+++ b/tests/integration/test_reg_loss_integration.py
@@ -99,7 +99,7 @@ class TestRegLossIntegration(unittest.TestCase):
             optimizer.step()
         self.assertGreater(init_loss, loss_val, "loss did not decrease")
 
-def test_lncc_gaussian_kernel_gt3_identical_images(self):
+    def test_lncc_gaussian_kernel_gt3_identical_images(self):
         """
         Regression test for make_gaussian_kernel truncated parameter bug.
         LNCC on identical inputs must be close to -1.0 for gaussian kernel_size > 3.


### PR DESCRIPTION
Fixes #8780 

### Description

Divide the pixel radius by `sigma` to convert it into the correct sigma-unit ratio.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
