### PR TITLE
Replace deprecated `cuda.cudart` with `cuda.bindings.runtime`.

### DIFF
--- a/monai/networks/trt_compiler.py
+++ b/monai/networks/trt_compiler.py
@@ -39,9 +39,9 @@ if polygraphy_imported:
 
 trt, trt_imported = optional_import("tensorrt")
 torch_tensorrt, _ = optional_import("torch_tensorrt", "1.4.0")
-cudart, cudart_imported = optional_import("cuda.bindings.runtime")
-if not cudart_imported:
-    cudart, cudart_imported = optional_import("cuda.cudart")
+cudart, _cudart_imported = optional_import("cuda.bindings.runtime")
+if not _cudart_imported:
+    cudart, _cudart_imported = optional_import("cuda.cudart")
 
 
 lock_sm = threading.Lock()

--- a/monai/networks/trt_compiler.py
+++ b/monai/networks/trt_compiler.py
@@ -40,6 +40,8 @@ if polygraphy_imported:
 trt, trt_imported = optional_import("tensorrt")
 torch_tensorrt, _ = optional_import("torch_tensorrt", "1.4.0")
 cudart, cudart_imported = optional_import("cuda.bindings.runtime")
+if not cudart_imported:
+    cudart, cudart_imported = optional_import("cuda.cudart")
 
 
 lock_sm = threading.Lock()
@@ -83,7 +85,11 @@ def cuassert(cuda_ret):
     """
     Error reporting method for CUDA calls.
     Args:
-     cuda_ret: CUDA return code.
+        cuda_ret: Tuple returned by CUDA runtime calls, where the first element
+            is a cudaError_t enum and subsequent elements are return values.
+
+    Raises:
+        RuntimeError: If the CUDA call returned an error.
     """
     err = cuda_ret[0]
     if err.value != 0:
@@ -92,8 +98,8 @@ def cuassert(cuda_ret):
             _, err_name = cudart.cudaGetErrorName(err)
             _, err_str = cudart.cudaGetErrorString(err)
             err_msg = f"CUDA ERROR {err.value}: {err_name} — {err_str}"
-        except Exception:
-            pass
+        except Exception as e:
+            get_logger("monai.networks.trt_compiler").debug(f"Failed to retrieve CUDA error details: {e}")
         raise RuntimeError(err_msg)
     if len(cuda_ret) > 1:
         return cuda_ret[1]

--- a/monai/networks/trt_compiler.py
+++ b/monai/networks/trt_compiler.py
@@ -39,9 +39,7 @@ if polygraphy_imported:
 
 trt, trt_imported = optional_import("tensorrt")
 torch_tensorrt, _ = optional_import("torch_tensorrt", "1.4.0")
-cudart, _cudart_imported = optional_import("cuda.bindings.runtime")
-if not _cudart_imported:
-    cudart, _cudart_imported = optional_import("cuda.cudart")
+cudart, cudart_imported = optional_import("cuda.bindings.runtime")
 
 
 lock_sm = threading.Lock()
@@ -88,8 +86,15 @@ def cuassert(cuda_ret):
      cuda_ret: CUDA return code.
     """
     err = cuda_ret[0]
-    if err != 0:
-        raise RuntimeError(f"CUDA ERROR: {err}")
+    if err.value != 0:
+        err_msg = f"CUDA ERROR: {err.value}"
+        try:
+            _, err_name = cudart.cudaGetErrorName(err)
+            _, err_str = cudart.cudaGetErrorString(err)
+            err_msg = f"CUDA ERROR {err.value}: {err_name} — {err_str}"
+        except Exception:
+            pass
+        raise RuntimeError(err_msg)
     if len(cuda_ret) > 1:
         return cuda_ret[1]
     return None


### PR DESCRIPTION
Fixes #8789 

### Description

Replaces the deprecated `cuda.cudart` import in `trt_compiler.py` with `cuda.bindings.runtime`, which is the current API introduced in `cuda-bindings` >= 12.6 (pulled in by PyTorch 2.10+).

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
