### PR TITLE
Fix: add package install hint to ImageWriter backend error message

### DIFF
--- a/monai/data/image_writer.py
+++ b/monai/data/image_writer.py
@@ -116,7 +116,12 @@ def resolve_writer(ext_name, error_if_not_found=True) -> Sequence:
         except Exception:  # other writer init errors indicating it exists
             avail_writers.append(_writer)
     if not avail_writers and error_if_not_found:
-        raise OptionalImportError(f"No ImageWriter backend found for {fmt}. Please install a suitable package: 'nibabel' (for .nii/.nii.gz), 'itk' (for .nrrd/.mha), or 'Pillow' (for .png/.jpg).")
+        _supported = ", ".join(sorted(SUPPORTED_WRITERS.keys()))
+        raise OptionalImportError(
+            f"No ImageWriter backend found for {fmt}. "
+            f"Supported formats: {_supported}. "
+            f"Please install a suitable package such as 'nibabel', 'itk', or 'Pillow'."
+        )
     writer_tuple = ensure_tuple(avail_writers)
     SUPPORTED_WRITERS[fmt] = writer_tuple
     return writer_tuple

--- a/monai/data/image_writer.py
+++ b/monai/data/image_writer.py
@@ -116,7 +116,7 @@ def resolve_writer(ext_name, error_if_not_found=True) -> Sequence:
         except Exception:  # other writer init errors indicating it exists
             avail_writers.append(_writer)
     if not avail_writers and error_if_not_found:
-        raise OptionalImportError(f"No ImageWriter backend found for {fmt}.")
+        raise OptionalImportError(f"No ImageWriter backend found for {fmt}. Please install a suitable package: 'nibabel' (for .nii/.nii.gz), 'itk' (for .nrrd/.mha), or 'Pillow' (for .png/.jpg).")
     writer_tuple = ensure_tuple(avail_writers)
     SUPPORTED_WRITERS[fmt] = writer_tuple
     return writer_tuple

--- a/monai/data/image_writer.py
+++ b/monai/data/image_writer.py
@@ -116,7 +116,7 @@ def resolve_writer(ext_name, error_if_not_found=True) -> Sequence:
         except Exception:  # other writer init errors indicating it exists
             avail_writers.append(_writer)
     if not avail_writers and error_if_not_found:
-        _supported = ", ".join(sorted(SUPPORTED_WRITERS.keys()))
+        _supported = ", ".join(sorted(k for k in SUPPORTED_WRITERS.keys() if k != "*"))
         raise OptionalImportError(
             f"No ImageWriter backend found for {fmt}. "
             f"Supported formats: {_supported}. "


### PR DESCRIPTION
Fixes #7980

### Description
When no suitable ImageWriter backend is found, the error message previously 
only said "No ImageWriter backend found for {fmt}." which gives the user 
no actionable information.

This change adds a clear install hint to the error message, telling the 
user which package to install depending on their file format.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.