### PR TITLE
Docs: add spatial shape constraints to SegResNetDS docstring

### DIFF
--- a/monai/networks/nets/segresnet_ds.py
+++ b/monai/networks/nets/segresnet_ds.py
@@ -254,6 +254,21 @@ class SegResNetDS(nn.Module):
                     image spacing into an approximately isotropic space.
                     Otherwise, by default, the kernel size and downsampling is always isotropic.
 
+                    Spatial shape constraints:
+    The input spatial dimensions must be divisible by ``2 ** (len(blocks_down) - 1)``.
+    With the default ``blocks_down=(1, 2, 2, 4)`` (4 levels), each spatial dimension
+    must be divisible by 8.
+
+    Use :py:meth:`shape_factor` to query the required divisors for a given configuration,
+    and :py:meth:`is_valid_shape` to check whether a specific input tensor satisfies them.
+
+    Example::
+
+        model = SegResNetDS(spatial_dims=3, blocks_down=(1, 2, 2, 4))
+        print(model.shape_factor())  # [8, 8, 8]
+        # Valid input: shape (1, 1, 128, 128, 128) -- all dims divisible by 8
+        # Invalid input: shape (1, 1, 100, 100, 100) -- 100 is not divisible by 8
+
     """
 
     def __init__(

--- a/monai/networks/nets/segresnet_ds.py
+++ b/monai/networks/nets/segresnet_ds.py
@@ -255,19 +255,20 @@ class SegResNetDS(nn.Module):
                     Otherwise, by default, the kernel size and downsampling is always isotropic.
 
                     .. note::
-        **Spatial shape constraints**: If ``resolution`` is ``None`` (isotropic mode),
-        each spatial dimension must be divisible by ``2 ** (len(blocks_down) - 1)``.
-        With the default ``blocks_down=(1, 2, 2, 4)``, each dimension must be
-        divisible by 8. If ``resolution`` is provided (anisotropic mode),
-        divisibility can differ per dimension; use :py:meth:`shape_factor` for
-        the exact required factors and :py:meth:`is_valid_shape` to verify a shape.
 
-        Example::
+                    **Spatial shape constraints**: If ``resolution`` is ``None`` (isotropic mode),
+                    each spatial dimension must be divisible by ``2 ** (len(blocks_down) - 1)``.
+                    With the default ``blocks_down=(1, 2, 2, 4)``, each dimension must be
+                    divisible by 8. If ``resolution`` is provided (anisotropic mode),
+                    divisibility can differ per dimension; use :py:meth:`shape_factor` for
+                    the exact required factors and :py:meth:`is_valid_shape` to verify a shape.
 
-            model = SegResNetDS(spatial_dims=3, blocks_down=(1, 2, 2, 4))
-            print(model.shape_factor())  # [8, 8, 8]
-            print(model.is_valid_shape((1, 1, 128, 128, 128)))  # True
-            print(model.is_valid_shape((1, 1, 100, 100, 100)))  # False
+                    Example::
+
+                        model = SegResNetDS(spatial_dims=3, blocks_down=(1, 2, 2, 4))
+                        print(model.shape_factor())  # [8, 8, 8]
+                        print(model.is_valid_shape((1, 1, 128, 128, 128)))  # True
+                        print(model.is_valid_shape((1, 1, 100, 100, 100)))  # False
 
     """
 

--- a/monai/networks/nets/segresnet_ds.py
+++ b/monai/networks/nets/segresnet_ds.py
@@ -254,8 +254,6 @@ class SegResNetDS(nn.Module):
                     image spacing into an approximately isotropic space.
                     Otherwise, by default, the kernel size and downsampling is always isotropic.
 
-                    .. note::
-
                     **Spatial shape constraints**: If ``resolution`` is ``None`` (isotropic mode),
                     each spatial dimension must be divisible by ``2 ** (len(blocks_down) - 1)``.
                     With the default ``blocks_down=(1, 2, 2, 4)``, each dimension must be

--- a/monai/networks/nets/segresnet_ds.py
+++ b/monai/networks/nets/segresnet_ds.py
@@ -255,19 +255,23 @@ class SegResNetDS(nn.Module):
                     Otherwise, by default, the kernel size and downsampling is always isotropic.
 
                     Spatial shape constraints:
-    The input spatial dimensions must be divisible by ``2 ** (len(blocks_down) - 1)``.
-    With the default ``blocks_down=(1, 2, 2, 4)`` (4 levels), each spatial dimension
-    must be divisible by 8.
+        If ``resolution is None`` (isotropic downsampling), each input spatial dimension
+        must be divisible by ``2 ** (len(blocks_down) - 1)``.
+        With the default ``blocks_down=(1, 2, 2, 4)`` (4 levels), each spatial dimension
+        must be divisible by 8.
 
-    Use :py:meth:`shape_factor` to query the required divisors for a given configuration,
-    and :py:meth:`is_valid_shape` to check whether a specific input tensor satisfies them.
+        If ``resolution`` is provided, divisibility can differ by dimension based on
+        anisotropic scales; use :py:meth:`shape_factor` for the exact required factors.
 
-    Example::
+        Use :py:meth:`shape_factor` to query the required divisors for a given configuration,
+        and :py:meth:`is_valid_shape` to check whether a specific input tensor satisfies them.
 
-        model = SegResNetDS(spatial_dims=3, blocks_down=(1, 2, 2, 4))
-        print(model.shape_factor())  # [8, 8, 8]
-        # Valid input: shape (1, 1, 128, 128, 128) -- all dims divisible by 8
-        # Invalid input: shape (1, 1, 100, 100, 100) -- 100 is not divisible by 8
+        Example::
+
+            model = SegResNetDS(spatial_dims=3, blocks_down=(1, 2, 2, 4))
+            print(model.shape_factor())  # [8, 8, 8]
+            # Valid input: shape (1, 1, 128, 128, 128) -- all dims divisible by 8
+            # Invalid input: shape (1, 1, 100, 100, 100) -- 100 is not divisible by 8
 
     """
 

--- a/monai/networks/nets/segresnet_ds.py
+++ b/monai/networks/nets/segresnet_ds.py
@@ -254,24 +254,20 @@ class SegResNetDS(nn.Module):
                     image spacing into an approximately isotropic space.
                     Otherwise, by default, the kernel size and downsampling is always isotropic.
 
-                    Spatial shape constraints:
-        If ``resolution is None`` (isotropic downsampling), each input spatial dimension
-        must be divisible by ``2 ** (len(blocks_down) - 1)``.
-        With the default ``blocks_down=(1, 2, 2, 4)`` (4 levels), each spatial dimension
-        must be divisible by 8.
-
-        If ``resolution`` is provided, divisibility can differ by dimension based on
-        anisotropic scales; use :py:meth:`shape_factor` for the exact required factors.
-
-        Use :py:meth:`shape_factor` to query the required divisors for a given configuration,
-        and :py:meth:`is_valid_shape` to check whether a specific input tensor satisfies them.
+                    .. note::
+        **Spatial shape constraints**: If ``resolution`` is ``None`` (isotropic mode),
+        each spatial dimension must be divisible by ``2 ** (len(blocks_down) - 1)``.
+        With the default ``blocks_down=(1, 2, 2, 4)``, each dimension must be
+        divisible by 8. If ``resolution`` is provided (anisotropic mode),
+        divisibility can differ per dimension; use :py:meth:`shape_factor` for
+        the exact required factors and :py:meth:`is_valid_shape` to verify a shape.
 
         Example::
 
             model = SegResNetDS(spatial_dims=3, blocks_down=(1, 2, 2, 4))
             print(model.shape_factor())  # [8, 8, 8]
-            # Valid input: shape (1, 1, 128, 128, 128) -- all dims divisible by 8
-            # Invalid input: shape (1, 1, 100, 100, 100) -- 100 is not divisible by 8
+            print(model.is_valid_shape((1, 1, 128, 128, 128)))  # True
+            print(model.is_valid_shape((1, 1, 100, 100, 100)))  # False
 
     """
 


### PR DESCRIPTION
Fixes #6771

### Description

Adds spatial shape constraint documentation to the SegResNetDS class docstring.
Documents that input spatial dimensions must be divisible by 2 ** (len(blocks_down) - 1),
with a worked example and pointers to the existing shape_factor() and is_valid_shape() methods.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.