### PR TITLE
Excluded from MANIFEST.in and setup.py tests folder and subfolders.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include versioneer.py
 include monai/_version.py
-
+exclude tests/*
 include README.md
 include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include versioneer.py
 include monai/_version.py
-exclude tests/*
+
 include README.md
 include LICENSE
+
+prune tests

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ jit_extension_source = [os.path.join("..", path) for path in jit_extension_sourc
 setup(
     version=versioneer.get_version(),
     cmdclass=get_cmds(),
-    packages=find_packages(exclude=("docs", "examples", "tests")),
+    packages=find_packages(exclude=("docs", "examples", "tests", "tests.*")),
     zip_safe=False,
     package_data={"monai": ["py.typed", *jit_extension_source]},  # type: ignore[arg-type]
     ext_modules=get_extensions(),


### PR DESCRIPTION
Fixes Tests are installed as a package

### Description

This pull request resolves an issue introduced in commit `af9e8f96d704a1b4bbce5b5ca52e0e2b7ea076dc`, where the `tests` directory was inadvertently included as an installable package starting from MONAI 1.5.0, due to the refactor on tests that created multiple subfolders with ` __init__.py ` files on them.

This caused import conflicts in downstream projects with their own local `tests` folder, as Python could mistakenly resolve imports to MONAI’s packaged `tests` module.

To correct this behavior, the following adjustments are made:

- `MANIFEST.in` updated to exclude the `tests` directory:
  ```txt
  exclude tests/*
  ```
- `setup.py` updated to prevent inclusion of `tests` and its subpackages:
  ```python
  packages = find_packages(exclude=("docs", "examples", "tests", "tests.*"))
  ```

These changes ensure that the MONAI test suite is not installed as part of the distributed package, restoring expected import resolution for downstream users.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
