### PR TITLE
Fix make_gaussian_kernel truncated parameter for kernel_size > 3

### DIFF
--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -35,7 +35,9 @@ def make_triangular_kernel(kernel_size: int) -> torch.Tensor:
 
 def make_gaussian_kernel(kernel_size: int) -> torch.Tensor:
     sigma = torch.tensor(kernel_size / 3.0)
-    kernel = gaussian_1d(sigma=sigma, truncated=kernel_size // 2, approx="sampled", normalize=False) * (
+    # truncated is the number of std devs; set so that tail = kernel_size // 2
+    truncated = (kernel_size // 2) / float(sigma)
+    kernel = gaussian_1d(sigma=sigma, truncated=truncated, approx="sampled", normalize=False) * (
         2.5066282 * sigma
     )
     return kernel[:kernel_size]


### PR DESCRIPTION
Fixes #8780.

`make_gaussian_kernel` passed `kernel_size // 2` as the `truncated` parameter to `gaussian_1d`. But `gaussian_1d` interprets `truncated` as the number of standard deviations, not the half-width in samples. It computes `tail = int(sigma * truncated)`.

With `kernel_size=15`, `sigma=5.0`, `truncated=7`:
- `tail = 5.0 * 7 = 35` → kernel has 71 elements
- Slicing to `[:15]` keeps only the far-left tail where values are near zero
- LNCC of identical images returns ~0.0 instead of -1.0

Fix: set `truncated = (kernel_size // 2) / sigma` so that `tail` equals `kernel_size // 2`, producing a correctly-sized kernel.