### PR TITLE
Fix #8775: handle torch.Tensor input in compute_shape_offset

### DIFF
--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -881,7 +881,7 @@ def compute_shape_offset(
             Default is False, using option 1 to compute the shape and offset.
 
     """
-    shape = np.array(spatial_shape, copy=True, dtype=float)
+    shape = np.array(tuple(spatial_shape), copy=True, dtype=float)
     sr = len(shape)
     in_affine_ = convert_data_type(to_affine_nd(sr, in_affine), np.ndarray)[0]
     out_affine_ = convert_data_type(to_affine_nd(sr, out_affine), np.ndarray)[0]

--- a/tests/data/utils/test_compute_shape_offset.py
+++ b/tests/data/utils/test_compute_shape_offset.py
@@ -21,7 +21,7 @@ from monai.data.utils import compute_shape_offset
 
 class TestComputeShapeOffset(unittest.TestCase):
     """Unit tests for :func:`monai.data.utils.compute_shape_offset`."""
-    
+
     def test_pytorch_size_input(self):
         """Validate `torch.Size` input produces expected shape and offset.
 

--- a/tests/data/utils/test_compute_shape_offset.py
+++ b/tests/data/utils/test_compute_shape_offset.py
@@ -1,0 +1,49 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import torch
+
+from monai.data.utils import compute_shape_offset
+
+
+class TestComputeShapeOffset(unittest.TestCase):
+
+    def setUp(self):
+        self.affine = np.eye(4)
+
+    def test_numpy_array_input(self):
+        shape = np.array([64, 64, 64])
+        out_shape, offset = compute_shape_offset(shape, self.affine, self.affine)
+        self.assertEqual(len(out_shape), 3)
+
+    def test_list_input(self):
+        shape = [64, 64, 64]
+        out_shape, offset = compute_shape_offset(shape, self.affine, self.affine)
+        self.assertEqual(len(out_shape), 3)
+
+    def test_torch_tensor_input(self):
+        shape = torch.tensor([64, 64, 64])
+        out_shape, offset = compute_shape_offset(shape, self.affine, self.affine)
+        self.assertEqual(len(out_shape), 3)
+
+    def test_identity_affines_preserve_shape(self):
+        shape = torch.tensor([32, 48, 16])
+        out_shape, offset = compute_shape_offset(shape, self.affine, self.affine)
+        np.testing.assert_allclose(np.array(out_shape, dtype=float), shape.numpy().astype(float), atol=1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/data/utils/test_compute_shape_offset.py
+++ b/tests/data/utils/test_compute_shape_offset.py
@@ -20,28 +20,39 @@ from monai.data.utils import compute_shape_offset
 
 
 class TestComputeShapeOffset(unittest.TestCase):
+    """Unit tests for :func:`monai.data.utils.compute_shape_offset`."""
 
     def setUp(self):
+        """Set up a 4x4 identity affine used across all test cases."""
         self.affine = np.eye(4)
 
     def test_numpy_array_input(self):
+        """Verify compute_shape_offset accepts a numpy array as spatial_shape."""
         shape = np.array([64, 64, 64])
-        out_shape, offset = compute_shape_offset(shape, self.affine, self.affine)
+        out_shape, _ = compute_shape_offset(shape, self.affine, self.affine)
         self.assertEqual(len(out_shape), 3)
 
     def test_list_input(self):
+        """Verify compute_shape_offset accepts a plain list as spatial_shape."""
         shape = [64, 64, 64]
-        out_shape, offset = compute_shape_offset(shape, self.affine, self.affine)
+        out_shape, _ = compute_shape_offset(shape, self.affine, self.affine)
         self.assertEqual(len(out_shape), 3)
 
     def test_torch_tensor_input(self):
+        """Verify compute_shape_offset accepts a torch.Tensor as spatial_shape.
+
+        This path broke in PyTorch >= 2.9 because np.array() relied on the
+        non-tuple sequence indexing protocol that PyTorch removed. Wrapping with
+        tuple() fixes it.
+        """
         shape = torch.tensor([64, 64, 64])
-        out_shape, offset = compute_shape_offset(shape, self.affine, self.affine)
+        out_shape, _ = compute_shape_offset(shape, self.affine, self.affine)
         self.assertEqual(len(out_shape), 3)
 
     def test_identity_affines_preserve_shape(self):
+        """Verify that identity in/out affines produce an output shape matching the input."""
         shape = torch.tensor([32, 48, 16])
-        out_shape, offset = compute_shape_offset(shape, self.affine, self.affine)
+        out_shape, _ = compute_shape_offset(shape, self.affine, self.affine)
         np.testing.assert_allclose(np.array(out_shape, dtype=float), shape.numpy().astype(float), atol=1e-5)
 
 


### PR DESCRIPTION
## Description

`compute_shape_offset` in `monai/data/utils.py` passes `spatial_shape` directly to `np.array()`. When `spatial_shape` is a `torch.Tensor`, this relies on the non-tuple sequence indexing protocol, which PyTorch removed in version 2.9. The call raises a hard error on PyTorch ≥ 2.9.

The fix is to wrap `spatial_shape` in `tuple()` before passing it to `np.array()`. This routes through `__iter__`, which is stable across all PyTorch versions, and produces 0-d scalar tensors that NumPy consumes correctly.

## Root cause

The direct caller in `monai/transforms/spatial/functional.py` (line 115) constructs an `in_spatial_size` as a `torch.Tensor` and passes it straight to `compute_shape_offset`. This path has been broken since PyTorch 2.9.

## Changes

- `monai/data/utils.py` — one-character change: `np.array(spatial_shape, ...)` → `np.array(tuple(spatial_shape), ...)`
- `tests/data/utils/test_compute_shape_offset.py`: new unit tests covering `torch.Tensor`, `np.ndarray`, and plain list inputs

Fixes #8775