### PR TITLE
Adding pybind11 explicitly

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -82,7 +82,7 @@ jobs:
         find  /opt/hostedtoolcache/* -maxdepth 0 ! -name 'Python' -exec rm -rf {} \;
     - name: Install the dependencies
       run: |
-        python -m pip install --user --upgrade pip wheel
+        python -m pip install --user --upgrade pip wheel pybind11
         python -m pip install torch==2.5.1 torchvision==0.20.1
         cat "requirements-dev.txt"
         python -m pip install --no-build-isolation -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ black==25.1.0
 isort>=5.1, <6, !=6.0.0
 ruff>=0.14.11,<0.15
 pytype>=2020.6.1, <=2024.4.11; platform_system != "Windows"
+pybind11
 types-setuptools
 mypy>=1.5.0, <1.12.0
 ninja


### PR DESCRIPTION
Fixes #8813.

### Description

This fixes the missing `pybind11` requirement for `pytype`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
