### PR TITLE
Fix SSIMLoss docstring examples: remove redundant 1- prefix

### DIFF
--- a/monai/losses/ssim_loss.py
+++ b/monai/losses/ssim_loss.py
@@ -111,17 +111,17 @@ class SSIMLoss(_Loss):
                 # 2D data
                 x = torch.ones([1,1,10,10])/2
                 y = torch.ones([1,1,10,10])/2
-                print(1-SSIMLoss(spatial_dims=2)(x,y))
+                print(SSIMLoss(spatial_dims=2)(x,y))
 
                 # pseudo-3D data
                 x = torch.ones([1,5,10,10])/2  # 5 could represent number of slices
                 y = torch.ones([1,5,10,10])/2
-                print(1-SSIMLoss(spatial_dims=2)(x,y))
+                print(SSIMLoss(spatial_dims=2)(x,y))
 
                 # 3D data
                 x = torch.ones([1,1,10,10,10])/2
                 y = torch.ones([1,1,10,10,10])/2
-                print(1-SSIMLoss(spatial_dims=3)(x,y))
+                print(SSIMLoss(spatial_dims=3)(x,y))
         """
         ssim_value = self.ssim_metric._compute_tensor(input, target).view(-1, 1)
         loss: torch.Tensor = 1 - ssim_value


### PR DESCRIPTION
Fixes #8822.

### Description

\`SSIMLoss.forward()\` already returns \`1 - ssim_value\` (see \`monai/losses/ssim_loss.py\` line 127):

\`\`\`python
ssim_value = self.ssim_metric._compute_tensor(input, target).view(-1, 1)
loss: torch.Tensor = 1 - ssim_value
\`\`\`

…yet the three docstring examples call \`print(1-SSIMLoss(...)(x,y))\`, which computes \`1 - (1 - ssim) = ssim\` — the structural similarity value, not the loss. A user copying the example would build a "loss" that **increases** as images grow more similar and train in the wrong direction.

Removing the \`1-\` prefix in the three \`print(...)\` calls makes the examples print the actual loss, consistent with the \`Returns\` docstring that already says *"1 minus the ssim index (recall this is meant to be a loss function)"*.

Verified locally:

\`\`\`
>>> SSIMLoss(spatial_dims=2)(x, x)  # identical inputs
tensor(0.)   # correct loss behavior
\`\`\`

Before the fix the docstring would have printed \`1.0\` (the similarity), after the fix it prints \`0.0\` (the loss).

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] In-line docstrings updated.

### Checks
- [x] I've read the [contribution guidelines](https://github.com/Project-MONAI/MONAI/blob/dev/CONTRIBUTING.md).
- [x] DCO \`Signed-off-by\` included.