### PR TITLE
Fix #8442: pass meta_data to EnsureChannelFirst when track_meta is False

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -299,7 +299,10 @@ class LoadImage(Transform):
             img_array, meta_data, self.simple_keys, pattern=self.pattern, sep=self.sep
         )
         if self.ensure_channel_first:
-            img = EnsureChannelFirst()(img)
+            if not isinstance(img, MetaTensor):
+                img = EnsureChannelFirst()(img, meta_dict=meta_data)
+            else:
+                img = EnsureChannelFirst()(img)
         if self.image_only:
             return img
         return img, img.meta if isinstance(img, MetaTensor) else meta_data

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -299,10 +299,7 @@ class LoadImage(Transform):
             img_array, meta_data, self.simple_keys, pattern=self.pattern, sep=self.sep
         )
         if self.ensure_channel_first:
-            if not isinstance(img, MetaTensor):
-                img = EnsureChannelFirst()(img, meta_dict=meta_data)
-            else:
-                img = EnsureChannelFirst()(img)
+            img = EnsureChannelFirst()(img, meta_dict=meta_data)
         if self.image_only:
             return img
         return img, img.meta if isinstance(img, MetaTensor) else meta_data

--- a/tests/transforms/test_load_image.py
+++ b/tests/transforms/test_load_image.py
@@ -497,6 +497,16 @@ class TestLoadImageMeta(unittest.TestCase):
             self.assertNotIsInstance(r, MetaTensor)
             self.assertFalse(hasattr(r, "affine"))
 
+    def test_track_meta_false_ensure_channel_first(self):
+        try:
+            set_track_meta(False)
+            r = LoadImage(image_only=True, ensure_channel_first=True)(self.test_data)
+            self.assertTupleEqual(r.shape, (1, 128, 128, 128))
+            self.assertIsInstance(r, torch.Tensor)
+            self.assertNotIsInstance(r, MetaTensor)
+        finally:
+            set_track_meta(True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/transforms/test_load_image.py
+++ b/tests/transforms/test_load_image.py
@@ -25,7 +25,7 @@ from PIL import Image
 
 from monai.apps import download_and_extract
 from monai.data import NibabelReader, PydicomReader
-from monai.data.meta_obj import set_track_meta
+from monai.data.meta_obj import get_track_meta, set_track_meta
 from monai.data.meta_tensor import MetaTensor
 from monai.transforms import LoadImage
 from monai.utils import optional_import
@@ -498,6 +498,7 @@ class TestLoadImageMeta(unittest.TestCase):
             self.assertFalse(hasattr(r, "affine"))
 
     def test_track_meta_false_ensure_channel_first(self):
+        _previous_meta = get_track_meta()
         try:
             set_track_meta(False)
             r = LoadImage(image_only=True, ensure_channel_first=True)(self.test_data)
@@ -505,7 +506,7 @@ class TestLoadImageMeta(unittest.TestCase):
             self.assertIsInstance(r, torch.Tensor)
             self.assertNotIsInstance(r, MetaTensor)
         finally:
-            set_track_meta(True)
+            set_track_meta(_previous_meta)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #8442

### Description

`LoadImage` with `ensure_channel_first=True` raises `ValueError` when `set_track_meta(False)` is active.

**Root cause chain:**
1. `set_track_meta(False)` causes `MetaTensor.ensure_torch_and_prune_meta()` to return a plain tensor instead of a `MetaTensor`
2. `EnsureChannelFirst()(img)` then has no metadata source (img is not a MetaTensor and no `meta_dict` is passed)
3. This hits the `ValueError` branch in `EnsureChannelFirst.__call__` at line 205 of `utility/array.py`

**Fix:** pass `meta_data` explicitly to `EnsureChannelFirst` when `img` is not a `MetaTensor`. `EnsureChannelFirst.__call__` already accepts a `meta_dict` parameter; `meta_data` is always a validated dict at this point in `LoadImage.__call__`.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.