### PR TITLE
docs: fix docstring parameter name, add missing Args and Raises secti…

### DIFF
--- a/monai/losses/barlow_twins.py
+++ b/monai/losses/barlow_twins.py
@@ -36,7 +36,7 @@ class BarlowTwinsLoss(_Loss):
     def __init__(self, lambd: float = 5e-3) -> None:
         """
         Args:
-            lamb: Can be any float to handle the informativeness and invariance trade-off. Ideally set to 5e-3.
+            lambd: Can be any float to handle the informativeness and invariance trade-off. Ideally set to 5e-3.
 
         Raises:
             ValueError: When an input of dimension length > 2 is passed

--- a/monai/losses/ds_loss.py
+++ b/monai/losses/ds_loss.py
@@ -69,6 +69,17 @@ class DeepSupervisionLoss(_Loss):
         return self.loss(input, target)  # type: ignore[no-any-return]
 
     def forward(self, input: None | torch.Tensor | list[torch.Tensor], target: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            input: a single tensor or a list of tensors from deeply supervised network outputs.
+            target: the target tensor.
+
+        Returns:
+            torch.Tensor: the computed deep supervision loss.
+
+        Raises:
+            ValueError: if ``input`` is None.
+        """
         if isinstance(input, (list, tuple)):
             weights = self.get_weights(levels=len(input))
             loss = torch.tensor(0, dtype=torch.float, device=target.device)

--- a/monai/losses/multi_scale.py
+++ b/monai/losses/multi_scale.py
@@ -55,9 +55,15 @@ class MultiScaleLoss(_Loss):
     ) -> None:
         """
         Args:
-            loss: loss function to be wrapped
+            loss: loss function to be wrapped.
             scales: list of scalars or None, if None, do not apply any scaling.
-            kernel: gaussian or cauchy.
+            kernel: type of smoothing kernel, either ``"gaussian"`` or ``"cauchy"``. Defaults to ``"gaussian"``.
+            reduction: specifies the reduction to apply to the output:
+                ``"none"`` | ``"mean"`` | ``"sum"``. Defaults to ``"mean"``.
+
+        Raises:
+            ValueError: if ``kernel`` is not ``"gaussian"`` or ``"cauchy"``.
+            ValueError: if ``reduction`` is not ``"mean"``, ``"sum"``, or ``"none"``.
         """
         super().__init__(reduction=LossReduction(reduction).value)
         if kernel not in kernel_fn_dict:

--- a/monai/losses/nacl_loss.py
+++ b/monai/losses/nacl_loss.py
@@ -52,9 +52,15 @@ class NACLLoss(_Loss):
             classes: number of classes
             dim: dimension of data (supports 2d and 3d)
             kernel_size: size of the spatial kernel
-            distance_type: l1/l2 distance between spatial kernel and predicted logits
-            alpha: weightage between cross entropy and logit constraint
-            sigma: sigma of gaussian
+            kernel_ops: type of spatial kernel, either ``"mean"`` or ``"gaussian"``. Defaults to ``"mean"``.
+            distance_type: l1/l2 distance between spatial kernel and predicted logits. Defaults to ``"l1"``.
+            alpha: weightage between cross entropy and logit constraint. Defaults to 0.1.
+            sigma: sigma of gaussian filter, used when ``kernel_ops="gaussian"``. Defaults to 1.0.
+
+        Raises:
+            ValueError: if ``kernel_ops`` is not ``"mean"`` or ``"gaussian"``.
+            ValueError: if ``dim`` is not 2 or 3.
+            ValueError: if ``distance_type`` is not ``"l1"`` or ``"l2"``.
         """
 
         super().__init__()

--- a/monai/losses/perceptual.py
+++ b/monai/losses/perceptual.py
@@ -70,6 +70,12 @@ class PerceptualLoss(nn.Module):
             Defaults to `None`.
         channel_wise: if True, the loss is returned per channel. Otherwise the loss is averaged over the channels.
             Defaults to ``False``.
+
+    Raises:
+        NotImplementedError: if ``spatial_dims`` is not 2 or 3.
+        ValueError: if a MedicalNet network is used with ``spatial_dims=2`` or ``is_fake_3d=True``.
+        ValueError: if ``channel_wise=True`` is used with a non-MedicalNet network.
+        ValueError: if ``network_type`` is not one of the supported options.
     """
 
     def __init__(


### PR DESCRIPTION
 ### Description

  Fix several docstring issues across loss functions in `monai/losses/`:

  - `barlow_twins.py`: fix parameter name typo (`lamb` → `lambd`) in Args section
  - `nacl_loss.py`: add missing `kernel_ops` arg, update `distance_type`/`alpha` with defaults, add `Raises` section
  - `multi_scale.py`: add missing `reduction` arg, add `Raises` section
  - `ds_loss.py`: add `forward` docstring with Args and `Raises` section
  - `perceptual.py`: add `Raises` section to class docstring

  No functional changes.

  ### Types of changes
  - [x] Non-breaking change (fix or new feature that would not break existing functionality).