### PR TITLE
fix: correct multiple typos in test files

### DIFF
--- a/tests/networks/utils/test_replace_module.py
+++ b/tests/networks/utils/test_replace_module.py
@@ -71,7 +71,7 @@ class TestReplaceModule(unittest.TestCase):
         # all replaced modules should be ReLU
         for r in replaced:
             self.assertIsInstance(r[1], torch.nn.ReLU)
-        # if a specfic module was named, check that the name matches exactly
+        # if a specific module was named, check that the name matches exactly
         if name == "features.denseblock1.denselayer1.layers.relu1":
             self.assertEqual(replaced[0][0], name)
 

--- a/tests/utils/test_look_up_option.py
+++ b/tests/utils/test_look_up_option.py
@@ -72,7 +72,7 @@ class TestLookUpOption(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "did you mean"):
             look_up_option(3, {1: "a", 2: "b", "c": 3})
         with self.assertRaisesRegex(ValueError, "did.*empty"):
-            look_up_option("empy", _CaseEnum)
+            look_up_option("empty", _CaseEnum)
         with self.assertRaisesRegex(ValueError, "Unsupported"):
             look_up_option(_CaseEnum1.EMPTY, _CaseEnum)
         with self.assertRaisesRegex(ValueError, "Unsupported"):

--- a/tests/utils/test_profiling.py
+++ b/tests/utils/test_profiling.py
@@ -72,7 +72,7 @@ class TestWorkflowProfiler(unittest.TestCase):
         self.assertIsInstance(dt, datetime.datetime)
 
     def test_profile_multithread(self):
-        """Test resulst are gathered from multiple threads using ThreadDataLoader."""
+        """Test results are gathered from multiple threads using ThreadDataLoader."""
         ds = Dataset([self.test_image] * 4, self.scale)
         dl = ThreadDataLoader(ds, batch_size=4, num_workers=4, use_thread_workers=True)
 


### PR DESCRIPTION
Fixes # .
Fixed the following typos in test files:
- `empy` → `empty` in `tests/utils/test_look_up_option.py`
- `resulst` → `results` in `tests/utils/test_profiling.py`
- `specfic` → `specific` in `tests/networks/utils/test_replace_module.py`
### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
