### PR TITLE
fix: improve error message when no ImageWriter backend found

### DIFF
--- a/monai/data/image_writer.py
+++ b/monai/data/image_writer.py
@@ -116,7 +116,18 @@ def resolve_writer(ext_name, error_if_not_found=True) -> Sequence:
         except Exception:  # other writer init errors indicating it exists
             avail_writers.append(_writer)
     if not avail_writers and error_if_not_found:
-        raise OptionalImportError(f"No ImageWriter backend found for {fmt}. Please install pillow (`pip install pillow`)")
+        hints = {
+            "png": "pip install pillow",
+            "jpg": "pip install pillow",
+            "jpeg": "pip install pillow",
+            "nii": "pip install nibabel",
+            "nii.gz": "pip install nibabel",
+            "dcm": "pip install itk",
+        }
+        hint = hints.get(fmt.lstrip(".").lower(), "pip install pillow or pip install nibabel")
+        raise OptionalImportError(
+        f"No ImageWriter backend found for {fmt}. Try: {hint}."
+            )
     writer_tuple = ensure_tuple(avail_writers)
     SUPPORTED_WRITERS[fmt] = writer_tuple
     return writer_tuple

--- a/monai/data/image_writer.py
+++ b/monai/data/image_writer.py
@@ -116,7 +116,7 @@ def resolve_writer(ext_name, error_if_not_found=True) -> Sequence:
         except Exception:  # other writer init errors indicating it exists
             avail_writers.append(_writer)
     if not avail_writers and error_if_not_found:
-        raise OptionalImportError(f"No ImageWriter backend found for {fmt}.")
+        raise OptionalImportError(f"No ImageWriter backend found for {fmt}. Please install pillow (`pip install pillow`)")
     writer_tuple = ensure_tuple(avail_writers)
     SUPPORTED_WRITERS[fmt] = writer_tuple
     return writer_tuple


### PR DESCRIPTION
Fixes # .

### Description
Improved the error message when no ImageWriter backend is found to suggest 
the correct package based on file format.

Before:
`No ImageWriter backend found for png.`

After (format-aware):
- `.png/.jpg` → `No ImageWriter backend found for png. Try: pip install pillow.`
- `.nii` → `No ImageWriter backend found for nii. Try: pip install nibabel.`
- `.dcm` → `No ImageWriter backend found for dcm. Try: pip install itk.`

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
