### PR TITLE
Replace BaseException with Exception across codebase

### DIFF
--- a/monai/__init__.py
+++ b/monai/__init__.py
@@ -131,7 +131,7 @@ try:
     # workaround related to https://github.com/Project-MONAI/MONAI/issues/7575
     if hasattr(torch.cuda.device_count, "cache_clear"):
         torch.cuda.device_count.cache_clear()
-except BaseException:
+except Exception:
     from .utils.misc import MONAIEnvVars
 
     if MONAIEnvVars.debug():

--- a/monai/apps/auto3dseg/data_analyzer.py
+++ b/monai/apps/auto3dseg/data_analyzer.py
@@ -341,7 +341,7 @@ class DataAnalyzer:
                     _label_argmax = True  # track if label is argmaxed
                     batch_data[self.label_key] = label.to(device)
                 d = summarizer(batch_data)
-            except BaseException as err:
+            except Exception as err:
                 if "image_meta_dict" in batch_data.keys():
                     filename = batch_data["image_meta_dict"][ImageMetaKey.FILENAME_OR_OBJ]
                 else:
@@ -357,7 +357,7 @@ class DataAnalyzer:
                                 label = torch.argmax(label, dim=0) if label.shape[0] > 1 else label[0]
                             batch_data[self.label_key] = label.to("cpu")
                         d = summarizer(batch_data)
-                    except BaseException as err:
+                    except Exception as err:
                         logger.info(f"Unable to process data {filename} on {device}. {err}")
                         continue
                 else:

--- a/monai/apps/auto3dseg/ensemble_builder.py
+++ b/monai/apps/auto3dseg/ensemble_builder.py
@@ -216,7 +216,7 @@ class AlgoEnsemble(ABC):
             if "image_save_func" in param:
                 try:
                     ensemble_preds = self.ensemble_pred(preds, sigmoid=sigmoid)
-                except BaseException:
+                except Exception:
                     ensemble_preds = self.ensemble_pred([_.to("cpu") for _ in preds], sigmoid=sigmoid)
                 res = img_saver(ensemble_preds)
                 # res is the path to the saved results

--- a/monai/apps/auto3dseg/utils.py
+++ b/monai/apps/auto3dseg/utils.py
@@ -59,7 +59,7 @@ def import_bundle_algo_history(
         if best_metric is None:
             try:
                 best_metric = algo.get_score()
-            except BaseException:
+            except Exception:
                 pass
 
         is_trained = best_metric is not None

--- a/monai/apps/detection/metrics/coco.py
+++ b/monai/apps/detection/metrics/coco.py
@@ -541,7 +541,7 @@ def _compute_stats_single_threshold(
         for save_idx, array_index in enumerate(inds):
             precision[save_idx] = pr[array_index]
             th_scores[save_idx] = dt_scores_sorted[array_index]
-    except BaseException:
+    except Exception:
         pass
 
     return recall, np.array(precision), np.array(th_scores)

--- a/monai/apps/nnunet/nnunetv2_runner.py
+++ b/monai/apps/nnunet/nnunetv2_runner.py
@@ -200,7 +200,7 @@ class nnUNetV2Runner:  # noqa: N801
             from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
 
             self.dataset_name = maybe_convert_to_dataset_name(int(self.dataset_name_or_id))
-        except BaseException:
+        except Exception:
             logger.warning(
                 f"Dataset with name/ID: {self.dataset_name_or_id} cannot be found in the record. "
                 "Please ignore the message above if you are running the pipeline from a fresh start. "
@@ -278,7 +278,7 @@ class nnUNetV2Runner:  # noqa: N801
                 num_input_channels=num_input_channels,
                 output_datafolder=raw_data_foldername,
             )
-        except BaseException as err:
+        except Exception as err:
             logger.warning(f"Input config may be incorrect. Detail info: error/exception message is:\n {err}")
             return
 

--- a/monai/config/deviceconfig.py
+++ b/monai/config/deviceconfig.py
@@ -120,7 +120,7 @@ def print_config(file=sys.stdout):
 def _dict_append(in_dict, key, fn):
     try:
         in_dict[key] = fn() if callable(fn) else fn
-    except BaseException:
+    except Exception:
         in_dict[key] = "UNKNOWN for given OS"
 
 

--- a/monai/data/__init__.py
+++ b/monai/data/__init__.py
@@ -118,7 +118,7 @@ from .utils import (
 from .wsi_datasets import MaskedPatchWSIDataset, PatchWSIDataset, SlidingPatchWSIDataset
 from .wsi_reader import BaseWSIReader, CuCIMWSIReader, OpenSlideWSIReader, TiffFileWSIReader, WSIReader
 
-with contextlib.suppress(BaseException):
+with contextlib.suppress(Exception):
     from multiprocessing.reduction import ForkingPickler
 
     def _rebuild_meta(cls, storage, dtype, metadata):

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -545,7 +545,7 @@ class SlidingWindowInferer(Inferer):
                 )
             if cache_roi_weight_map and self.roi_weight_map is None:
                 warnings.warn("cache_roi_weight_map=True, but cache is not created. (dynamic roi_size?)")
-        except BaseException as e:
+        except Exception as e:
             raise RuntimeError(
                 f"roi size {self.roi_size}, mode={mode}, sigma_scale={sigma_scale}, device={device}\n"
                 "Seems to be OOM. Please try smaller patch size or mode='constant' instead of mode='gaussian'."

--- a/monai/utils/tf32.py
+++ b/monai/utils/tf32.py
@@ -41,7 +41,7 @@ def has_ampere_or_later() -> bool:
             major, _ = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
             if major >= 8:
                 return True
-    except BaseException:
+    except Exception:
         pass
     finally:
         pynvml.nvmlShutdown()
@@ -71,7 +71,7 @@ def detect_default_tf32() -> bool:
                 may_enable_tf32 = True
 
         return may_enable_tf32
-    except BaseException:
+    except Exception:
         from monai.utils.misc import MONAIEnvVars
 
         if MONAIEnvVars.debug():

--- a/tests/apps/detection/networks/test_retinanet.py
+++ b/tests/apps/detection/networks/test_retinanet.py
@@ -140,7 +140,7 @@ class TestRetinaNet(unittest.TestCase):
     def test_script(self, model, input_param, input_shape):
         try:
             idx = int(self.id().split("test_script_")[-1])
-        except BaseException:
+        except Exception:
             idx = 0
         idx %= 3
         # test whether support torchscript
@@ -174,7 +174,7 @@ class TestRetinaNet(unittest.TestCase):
     def test_onnx(self, model, input_param, input_shape):
         try:
             idx = int(self.id().split("test_onnx_")[-1])
-        except BaseException:
+        except Exception:
             idx = 0
         idx %= 3
         # test whether support torchscript

--- a/tests/networks/nets/test_resnet.py
+++ b/tests/networks/nets/test_resnet.py
@@ -249,7 +249,7 @@ class TestResNet(unittest.TestCase):
         if os.path.exists(self.tmp_ckpt_filename):
             try:
                 os.remove(self.tmp_ckpt_filename)
-            except BaseException:
+            except Exception:
                 pass
 
     @parameterized.expand(TEST_CASES)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -241,7 +241,7 @@ def is_tf32_env():
                 a_full = torch.randn(1024, 1024, dtype=torch.double, device="cuda", generator=g_gpu)
                 b_full = torch.randn(1024, 1024, dtype=torch.double, device="cuda", generator=g_gpu)
                 _tf32_enabled = (a_full.float() @ b_full.float() - a_full @ b_full).abs().max().item() > 0.001  # 0.1713
-            except BaseException:
+            except Exception:
                 pass
         print(f"tf32 enabled: {_tf32_enabled}")
     return _tf32_enabled


### PR DESCRIPTION
## Summary
Fixes #7401

- Replaced all 17 occurrences of `except BaseException` with `except Exception` across 13 files in `monai/` and `tests/`
- Catching `BaseException` inadvertently suppresses `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`, which should nearly always propagate
- `Exception` is the appropriate base class for catchable errors in all these contexts

## Files changed
- `monai/__init__.py`
- `monai/config/deviceconfig.py`
- `monai/utils/tf32.py`
- `monai/inferers/inferer.py`
- `monai/data/__init__.py`
- `monai/apps/auto3dseg/utils.py`
- `monai/apps/auto3dseg/ensemble_builder.py`
- `monai/apps/auto3dseg/data_analyzer.py`
- `monai/apps/detection/metrics/coco.py`
- `monai/apps/nnunet/nnunetv2_runner.py`
- `tests/test_utils.py`
- `tests/networks/nets/test_resnet.py`
- `tests/apps/detection/networks/test_retinanet.py`

## Test plan
- [x] All existing unit tests should pass without modification (this is a strict narrowing of catch scope)
- [ ] Verify `KeyboardInterrupt` (Ctrl+C) is no longer silently swallowed during long-running operations

Signed-off-by: Oleksandr Sanin <alexaaander.sanin@gmail.com>