### PR TITLE
Register GlobalMutualInformationLoss bin_centers as buffer

### DIFF
--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -233,9 +233,11 @@ class GlobalMutualInformationLoss(_Loss):
         self.kernel_type = look_up_option(kernel_type, ["gaussian", "b-spline"])
         self.num_bins = num_bins
         self.kernel_type = kernel_type
+        self.bin_centers: torch.Tensor | None
+        self.register_buffer("bin_centers", None, persistent=False)
         if self.kernel_type == "gaussian":
             self.preterm = 1 / (2 * sigma**2)
-            self.bin_centers = bin_centers[None, None, ...]
+            self.register_buffer("bin_centers", bin_centers[None, None, ...], persistent=False)
         self.smooth_nr = float(smooth_nr)
         self.smooth_dr = float(smooth_dr)
 
@@ -314,6 +316,8 @@ class GlobalMutualInformationLoss(_Loss):
         """
         img = torch.clamp(img, 0, 1)
         img = img.reshape(img.shape[0], -1, 1)  # (batch, num_sample, 1)
+        if self.bin_centers is None:
+            raise ValueError("bin_centers must be defined for gaussian parzen windowing.")
         weight = torch.exp(
             -self.preterm.to(img) * (img - self.bin_centers.to(img)) ** 2
         )  # (batch, num_sample, num_bin)

--- a/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
+++ b/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
@@ -116,6 +116,25 @@ class TestGlobalMutualInformationLoss(unittest.TestCase):
 
 
 class TestGlobalMutualInformationLossIll(unittest.TestCase):
+    def test_gaussian_bin_centers_registered_buffer(self):
+        loss = GlobalMutualInformationLoss(kernel_type="gaussian", num_bins=16)
+
+        self.assertIn("bin_centers", dict(loss.named_buffers()))
+        self.assertIsNotNone(loss.bin_centers)
+        self.assertFalse(loss.bin_centers.requires_grad)
+
+        loss = loss.to(dtype=torch.float64)
+        self.assertEqual(loss.bin_centers.dtype, torch.float64)
+
+        if torch.cuda.is_available():
+            loss = loss.to(device="cuda:0")
+            self.assertEqual(loss.bin_centers.device, torch.device("cuda:0"))
+
+    def test_b_spline_bin_centers_exists_as_none(self):
+        loss = GlobalMutualInformationLoss(kernel_type="b-spline")
+
+        self.assertIsNone(loss.bin_centers)
+
     @parameterized.expand(
         [
             (torch.ones((1, 2), dtype=torch.float), torch.ones((1, 3), dtype=torch.float)),  # mismatched_simple_dims


### PR DESCRIPTION
Fixes #8866.

### Description

This PR fixes a device placement bug in `GlobalMutualInformationLoss.__init__` where `bin_centers` was assigned as a plain Python attribute instead of being registered as a buffer. 

- Registered `bin_centers` as a non-persistent buffer in `image_dissimilarity.py`, ensuring that `GlobalMutualInformationLoss` now follows normal `nn.Module` buffer semantics for `.to(device)` / `dtype` moves and avoids silent gradient tracking.
- Added a regression test in `test_global_mutual_information_loss.py` to verify that `bin_centers` is properly exposed through `named_buffers()`, does not require gradients, and successfully changes dtype when the module is moved.

*Verification:* Passed `python -m pytest tests/losses/image_dissimilarity/test_global_mutual_information_loss.py -q -k gaussian_bin_centers_registered_buffer` and `-k ill_opts`. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.