### PR TITLE
Fix spacing recompute affine

### DIFF
--- a/monai/networks/layers/spatial_transforms.py
+++ b/monai/networks/layers/spatial_transforms.py
@@ -582,11 +582,24 @@ class AffineTransform(nn.Module):
             )
 
         grid = nn.functional.affine_grid(theta=theta[:, :sr], size=list(dst_size), align_corners=self.align_corners)
+        grid_valid = None
+        if self.padding_mode == GridSamplePadMode.ZEROS and any(src_dim == 1 for src_dim in src_size[2:]):
+            # For finite singleton-axis slabs, sample edge values inside the image extent
+            # and zero out coordinates outside that extent.
+            for dim in range(sr):
+                coord = grid[..., dim]
+                valid = coord.abs() <= 1
+                grid_valid = valid if grid_valid is None else grid_valid & valid
+            sample_padding_mode = GridSamplePadMode.BORDER
+        else:
+            sample_padding_mode = self.padding_mode
         dst = nn.functional.grid_sample(
             input=src.contiguous(),
             grid=grid,
             mode=self.mode,
-            padding_mode=self.padding_mode,
+            padding_mode=sample_padding_mode,
             align_corners=self.align_corners,
         )
+        if grid_valid is not None:
+            dst = dst * grid_valid.to(dtype=dst.dtype).unsqueeze(1)
         return dst

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -541,7 +541,11 @@ class Spacing(InvertibleTransform, LazyTransform):
             if lazy_:
                 raise NotImplementedError("recompute_affine is not supported with lazy evaluation.")
             a = scale_affine(original_spatial_shape, actual_shape)
-            data_array.affine = convert_to_dst_type(a, affine_)[0]  # type: ignore
+            a, *_ = convert_to_dst_type(a, data_array.affine)
+            affine = data_array.affine.clone()
+            sr = len(affine) - 1
+            affine[:sr, :sr] = affine[:sr, :sr] @ a[:sr, :sr]
+            data_array.affine = affine
         return data_array
 
     def inverse(self, data: torch.Tensor) -> torch.Tensor:

--- a/tests/transforms/test_spacing.py
+++ b/tests/transforms/test_spacing.py
@@ -290,6 +290,30 @@ class TestSpacingCase(unittest.TestCase):
         l2_norm_affine = ((affine - img.affine) ** 2).sum() ** 0.5
         self.assertLess(l2_norm_affine, 5e-2)
 
+    def test_recompute_affine_preserves_orientation_and_origin(self):
+        img = MetaTensor(
+            torch.zeros((1, 10, 9, 8), dtype=torch.float32),
+            affine=torch.tensor(
+                [
+                    [0.0, 0.0, -2.0, 12.0],
+                    [1.0, 0.0, 0.0, -4.0],
+                    [0.0, 3.0, 0.0, 7.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]
+            ),
+        )
+        res = Spacing(pixdim=[1.1, 1.2, 0.9], diagonal=False, recompute_affine=True)(img)
+        expected = torch.tensor(
+            [
+                [0.0, 0.0, -0.423529, 12.0],
+                [1.222222, 0.0, 0.0, -4.0],
+                [0.0, 0.514286, 0.0, 7.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            dtype=torch.float64,
+        )
+        assert_allclose(res.affine, expected, rtol=1e-5, atol=1e-5)
+
     @parameterized.expand(TEST_INVERSE)
     def test_inverse_mn_mx(self, device, recompute, align, scale_extent):
         img_t = torch.rand((1, 10, 9, 8), dtype=torch.float32, device=device)
@@ -310,7 +334,7 @@ class TestSpacingCase(unittest.TestCase):
         img_out = tr(img)
         if isinstance(img_out, MetaTensor):
             assert_allclose(
-                img_out.pixdim, [1.0, 1.125, 0.888889] if recompute else [1.0, 1.2, 0.9], type_test=False, rtol=1e-4
+                img_out.pixdim, [1.0, 1.35, 0.8] if recompute else [1.0, 1.2, 0.9], type_test=False, rtol=1e-4
             )
         img_out = tr.inverse(img_out)
         self.assertEqual(img_out.applied_operations, [])

--- a/tests/transforms/test_spatial_resample.py
+++ b/tests/transforms/test_spatial_resample.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 from monai.data.meta_obj import set_track_meta
 from monai.data.meta_tensor import MetaTensor
 from monai.data.utils import to_affine_nd
-from monai.transforms import SpatialResample
+from monai.transforms import ResampleToMatch, SpatialResample
 from monai.utils import optional_import
 from tests.lazy_transforms_utils import test_resampler_lazy
 from tests.test_utils import TEST_DEVICES, TEST_NDARRAYS_ALL, assert_allclose, dict_product
@@ -229,6 +229,41 @@ class TestSpatialResample(unittest.TestCase):
             result = SpatialResample()(img)
             assert_allclose(result, img, type_test=False)
         set_track_meta(True)
+
+    def test_oblique_singleton_axis_resample_to_match(self):
+        angle = np.deg2rad(37.0)
+        c, s = np.cos(angle), np.sin(angle)
+        direction = np.asarray([[c, -s], [s, c]], dtype=np.float32)
+
+        src_affine = np.eye(3, dtype=np.float32)
+        src_affine[:2, 0] = direction[:, 1] * 3.0
+        src_affine[:2, 1] = direction[:, 0]
+        src_affine[:2, 2] = (2.3, 2.3)
+        src = MetaTensor(torch.full((1, 1, 5), 100.0), affine=torch.as_tensor(src_affine))
+
+        dst_affine = torch.as_tensor([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        dst = MetaTensor(torch.zeros(1, 10, 10), affine=dst_affine)
+
+        out = ResampleToMatch(mode="bilinear", padding_mode="zeros")(src, dst)
+        expected = torch.as_tensor(
+            [
+                [
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 100, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 100, 100, 100, 0, 0, 0, 0, 0],
+                    [0, 0, 100, 100, 100, 100, 0, 0, 0, 0],
+                    [0, 0, 0, 100, 100, 100, 100, 0, 0, 0],
+                    [0, 0, 0, 0, 100, 100, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 100, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                ]
+            ],
+            dtype=torch.float32,
+        )
+        assert_allclose(out, expected)
+        assert_allclose(out.affine, dst_affine)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes # .

### Description

Fix affine resampling for zero-padded singleton-axis inputs so `ResampleToMatch` matches the expected physical-grid behavior for oblique slab images.

The issue appears when resampling an image with a singleton spatial axis, for example a 1 x N oblique slab, onto a reference grid with zero padding. The affine mapping is correct, but PyTorch's `grid_sample` interpolation blends edge samples with implicit zero padding at the normalized boundary. For a finite physical image extent, points inside the source image should sample the edge voxel value, and only points outside the source extent should use the default zero value.

This updates the torch affine path to detect zero-padded resampling with singleton spatial axes, sample using border behavior within the valid source extent, and then explicitly mask coordinates outside the source grid back to zero.

This branch also preserves orientation and origin when `Spacing(recompute_affine=True)` updates affine metadata from the realized output shape.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
