### PR TITLE
fix(networks): only instantiate cross-attention layers when with_cross_attention=True

### DIFF
--- a/monai/networks/blocks/transformerblock.py
+++ b/monai/networks/blocks/transformerblock.py
@@ -78,15 +78,16 @@ class TransformerBlock(nn.Module):
         self.norm2 = nn.LayerNorm(hidden_size)
         self.with_cross_attention = with_cross_attention
 
-        self.norm_cross_attn = nn.LayerNorm(hidden_size)
-        self.cross_attn = CrossAttentionBlock(
-            hidden_size=hidden_size,
-            num_heads=num_heads,
-            dropout_rate=dropout_rate,
-            qkv_bias=qkv_bias,
-            causal=False,
-            use_flash_attention=use_flash_attention,
-        )
+        if with_cross_attention:
+            self.norm_cross_attn = nn.LayerNorm(hidden_size)
+            self.cross_attn = CrossAttentionBlock(
+                hidden_size=hidden_size,
+                num_heads=num_heads,
+                dropout_rate=dropout_rate,
+                qkv_bias=qkv_bias,
+                causal=False,
+                use_flash_attention=use_flash_attention,
+            )
 
     def forward(
         self, x: torch.Tensor, context: torch.Tensor | None = None, attn_mask: torch.Tensor | None = None

--- a/tests/networks/blocks/test_transformerblock.py
+++ b/tests/networks/blocks/test_transformerblock.py
@@ -54,6 +54,26 @@ class TestTransformerBlock(unittest.TestCase):
             TransformerBlock(hidden_size=622, num_heads=8, mlp_dim=3072, dropout_rate=0.4)
 
     @skipUnless(has_einops, "Requires einops")
+    def test_no_cross_attention_params_when_disabled(self):
+        """When with_cross_attention=False, no cross-attention parameters should be registered."""
+        block = TransformerBlock(hidden_size=128, mlp_dim=256, num_heads=4, with_cross_attention=False)
+        param_names = {n for n, _ in block.named_parameters()}
+        self.assertFalse(
+            any("cross_attn" in n or "norm_cross_attn" in n for n in param_names),
+            f"Unexpected cross-attention parameters found: {[n for n in param_names if 'cross' in n]}",
+        )
+
+    @skipUnless(has_einops, "Requires einops")
+    def test_cross_attention_params_when_enabled(self):
+        """When with_cross_attention=True, cross-attention parameters should be registered."""
+        block = TransformerBlock(hidden_size=128, mlp_dim=256, num_heads=4, with_cross_attention=True)
+        param_names = {n for n, _ in block.named_parameters()}
+        self.assertTrue(
+            any("cross_attn" in n for n in param_names),
+            "Expected cross-attention parameters not found when with_cross_attention=True",
+        )
+
+    @skipUnless(has_einops, "Requires einops")
     def test_access_attn_matrix(self):
         # input format
         hidden_size = 128

--- a/tests/networks/blocks/test_transformerblock.py
+++ b/tests/networks/blocks/test_transformerblock.py
@@ -55,7 +55,7 @@ class TestTransformerBlock(unittest.TestCase):
 
     @skipUnless(has_einops, "Requires einops")
     def test_no_cross_attention_params_when_disabled(self):
-        """When with_cross_attention=False, no cross-attention parameters should be registered."""
+        """Verify with_cross_attention=False registers no cross_attn or norm_cross_attn parameters."""
         block = TransformerBlock(hidden_size=128, mlp_dim=256, num_heads=4, with_cross_attention=False)
         param_names = {n for n, _ in block.named_parameters()}
         self.assertFalse(
@@ -65,12 +65,16 @@ class TestTransformerBlock(unittest.TestCase):
 
     @skipUnless(has_einops, "Requires einops")
     def test_cross_attention_params_when_enabled(self):
-        """When with_cross_attention=True, cross-attention parameters should be registered."""
+        """Verify with_cross_attention=True registers both cross_attn and norm_cross_attn parameters."""
         block = TransformerBlock(hidden_size=128, mlp_dim=256, num_heads=4, with_cross_attention=True)
         param_names = {n for n, _ in block.named_parameters()}
         self.assertTrue(
-            any("cross_attn" in n for n in param_names),
-            "Expected cross-attention parameters not found when with_cross_attention=True",
+            any(n.startswith("cross_attn.") for n in param_names),
+            "Expected cross_attn parameters not found when with_cross_attention=True",
+        )
+        self.assertTrue(
+            any(n.startswith("norm_cross_attn.") for n in param_names),
+            "Expected norm_cross_attn parameters not found when with_cross_attention=True",
         )
 
     @skipUnless(has_einops, "Requires einops")


### PR DESCRIPTION
## Summary

Fixes #8845

`TransformerBlock` was unconditionally creating `norm_cross_attn` and `cross_attn` in `__init__` regardless of the `with_cross_attention` flag. This caused unused parameters to appear in `model.parameters()` / `model.named_parameters()`, increasing model size and producing confusing "no gradient" warnings during training.

**Root cause** — two layers created unconditionally:
```python
# always ran, even when with_cross_attention=False
self.norm_cross_attn = nn.LayerNorm(hidden_size)
self.cross_attn = CrossAttentionBlock(...)
```

**Fix** — guard instantiation with the same flag already used in `forward`:
```python
if with_cross_attention:
    self.norm_cross_attn = nn.LayerNorm(hidden_size)
    self.cross_attn = CrossAttentionBlock(...)
```

## Changes

- `monai/networks/blocks/transformerblock.py`: wrap cross-attention layer init in `if with_cross_attention:`
- `tests/networks/blocks/test_transformerblock.py`: add two regression tests verifying parameter presence/absence

## Test plan

- [x] `test_no_cross_attention_params_when_disabled` — asserts no `cross_attn`/`norm_cross_attn` params when `with_cross_attention=False`
- [x] `test_cross_attention_params_when_enabled` — asserts cross-attn params exist when `with_cross_attention=True`
- [x] `test_ill_arg` — existing validation tests unchanged
- [x] Existing parameterized `test_shape` tests cover both `with_cross_attention=True/False` forward passes

https://claude.ai/code/session_01LV2dy8NFh3smu9f2RfgFvs