### PR TITLE
Make get_norm_layer repr test tolerant of PyTorch bias= field

### DIFF
--- a/tests/networks/layers/test_get_layers.py
+++ b/tests/networks/layers/test_get_layers.py
@@ -11,11 +11,25 @@
 
 from __future__ import annotations
 
+import re
 import unittest
 
 from parameterized import parameterized
 
 from monai.networks.layers import get_act_layer, get_dropout_layer, get_norm_layer
+
+
+def _strip_bias_field(text: str) -> str:
+    """Strip the optional PyTorch >= 2.13 ``, bias=True|False`` repr fragment.
+
+    Args:
+        text: Layer string representation to normalize.
+
+    Returns:
+        The representation with any ``, bias=True|False`` removed.
+    """
+    return re.sub(r",\s*bias=(?:True|False)", "", text)
+
 
 TEST_CASE_NORM = [
     [{"name": ("group", {"num_groups": 1})}, "GroupNorm(1, 1, eps=1e-05, affine=True)"],
@@ -41,7 +55,7 @@ class TestGetLayers(unittest.TestCase):
     @parameterized.expand(TEST_CASE_NORM)
     def test_norm_layer(self, input_param, expected):
         layer = get_norm_layer(**input_param)
-        self.assertEqual(f"{layer}", expected)
+        self.assertEqual(_strip_bias_field(f"{layer}"), _strip_bias_field(expected))
 
     @parameterized.expand(TEST_CASE_ACT)
     def test_act_layer(self, input_param, expected):


### PR DESCRIPTION
PyTorch >= 2.13 adds an optional 'bias=' token to GroupNorm/InstanceNorm __repr__, breaking the exact-string match in test_norm_layer. Normalize the repr by stripping the bias= field so the test passes on PyTorch versions with or without it (backward- and forward-compatible).

###  Description

  test_norm_layer in tests/networks/layers/test_get_layers.py asserts that a norm layer's repr() exactly equals a hard-coded string. PyTorch >= 2.13 added an optional bias= token to GroupNorm /
  InstanceNorm __repr__, which breaks that exact-string match. This normalizes both the actual and expected repr by stripping the bias= field, so the test passes on PyTorch versions with or without
   it — backward- and forward-compatible, with no change to production code.
  
 ### Types of changes

  - [x] Non-breaking change (fix that would not break existing functionality).
  - [x] Quick tests passed locally (python -m tests.networks.layers.test_get_layers — 7/7).

  PyTorch < 2.13: GroupNorm(1, 1, eps=1e-05, affine=True)
  PyTorch >= 2.13: GroupNorm(1, 1, eps=1e-05, affine=True, bias=True)

The fix strips , bias=(True|False) from both sides before comparison. Local checks: targeted test 7/7 OK; black/isort/ruff clean; full pre-commit hooks pass.
