### PR TITLE
Add docstring note that Transpose/Transposed do not update the affine matrix

### DIFF
--- a/monai/transforms/utility/array.py
+++ b/monai/transforms/utility/array.py
@@ -571,6 +571,13 @@ class ToPIL(Transform):
 class Transpose(Transform):
     """
     Transposes the input image based on the given `indices` dimension ordering.
+
+    .. note::
+        This transform does not update the affine matrix in the metadata. As a result,
+        affine-dependent transforms applied after (e.g. :py:class:`monai.transforms.Spacing`)
+        may produce unexpected results, because the affine no longer corresponds to the
+        transposed data. To reorient medical images in an affine-aware way, use
+        :py:class:`monai.transforms.Orientation` instead.
     """
 
     backend = [TransformBackends.TORCH]

--- a/monai/transforms/utility/dictionary.py
+++ b/monai/transforms/utility/dictionary.py
@@ -636,6 +636,13 @@ class ToPILd(MapTransform):
 class Transposed(MapTransform, InvertibleTransform):
     """
     Dictionary-based wrapper of :py:class:`monai.transforms.Transpose`.
+
+    .. note::
+        This transform does not update the affine matrix in the metadata. As a result,
+        affine-dependent transforms applied after (e.g. :py:class:`monai.transforms.Spacingd`)
+        may produce unexpected results, because the affine no longer corresponds to the
+        transposed data. To reorient medical images in an affine-aware way, use
+        :py:class:`monai.transforms.Orientationd` instead.
     """
 
     backend = Transpose.backend


### PR DESCRIPTION
Closes #6711.

### Description

This PR adds a documentation note to the `Transpose` and `Transposed`
transforms clarifying that they do not update the affine matrix in the
image metadata. As established in #5975, this is intended behavior:
applying an affine-dependent transform such as `Spacing`/`Spacingd`
after `Transpose`/`Transposed` can therefore produce unexpected results.
The note points users to `Orientation`/`Orientationd` for affine-aware
reorientation.

This is a documentation-only change; no functional code is modified.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
