### PR TITLE
fix(NrrdReader): handle non-spatial axes in 4-D NRRD files

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -1549,10 +1549,22 @@ class NrrdReader(ImageReader):
             header[MetaKeys.SPATIAL_SHAPE] = header["sizes"].copy()
             [header.pop(k) for k in ("sizes", "space origin", "space directions")]  # rm duplicated data in header
 
-            if self.channel_dim is None:  # default to "no_channel" or -1
-                header[MetaKeys.ORIGINAL_CHANNEL_DIM] = (
-                    float("nan") if len(data.shape) == len(header[MetaKeys.SPATIAL_SHAPE]) else 0
-                )
+            if self.channel_dim is None:  # default to "no_channel" or 0
+                # Use the NRRD 'kinds' field to detect non-spatial (channel) axes.
+                # Spatial kinds are 'domain' and 'space'; anything else (e.g. 'list',
+                # 'vector') marks a channel axis.
+                _SPATIAL_KINDS = {"domain", "space"}
+                ch_axes = [idx for idx, k in enumerate(header.get("kinds", [])) if k.lower() not in _SPATIAL_KINDS]
+                if ch_axes:
+                    ch_ax = ch_axes[0]
+                    header[MetaKeys.ORIGINAL_CHANNEL_DIM] = ch_ax
+                    sp_shape = list(header[MetaKeys.SPATIAL_SHAPE])
+                    sp_shape.pop(ch_ax)
+                    header[MetaKeys.SPATIAL_SHAPE] = np.array(sp_shape)
+                else:
+                    header[MetaKeys.ORIGINAL_CHANNEL_DIM] = (
+                        float("nan") if len(data.shape) == len(header[MetaKeys.SPATIAL_SHAPE]) else 0
+                    )
             else:
                 header[MetaKeys.ORIGINAL_CHANNEL_DIM] = self.channel_dim
             _copy_compatible_dict(header, compatible_meta)
@@ -1570,6 +1582,11 @@ class NrrdReader(ImageReader):
         """
         direction = header["space directions"]
         origin = header["space origin"]
+
+        # pynrrd represents non-spatial axes (e.g. 'list' kind in 4-D NRRD files) as rows
+        # where every element is NaN.  Filter them out so the affine only encodes spatial axes.
+        valid = ~np.all(np.isnan(direction.astype(float)), axis=1)
+        direction = direction[valid]
 
         x, y = direction.shape
         affine_diam = min(x, y) + 1
@@ -1609,4 +1626,6 @@ class NrrdReader(ImageReader):
         header["space directions"] = np.rot90(np.flip(header["space directions"], 0))
         header["space origin"] = header["space origin"][::-1]
         header["sizes"] = header["sizes"][::-1]
+        if "kinds" in header:
+            header["kinds"] = header["kinds"][::-1]
         return header

--- a/tests/data/test_nrrd_reader.py
+++ b/tests/data/test_nrrd_reader.py
@@ -44,6 +44,21 @@ TEST_CASE_8 = [
         "space origin": [1.0, 5.0, 20.0],
     },
 ]
+# 4-D NRRD with an explicit 'list' channel axis (kinds: list domain domain domain).
+# pynrrd stores the 'none' space direction for the channel axis as a row of NaN values.
+TEST_CASE_4D_CHANNEL = [
+    (3, 4, 5, 6),  # (channel, H, W, D)
+    "test_4d_channel.nrrd",
+    np.float32,
+    {
+        "dimension": 4,
+        "space": "left-posterior-superior",
+        "kinds": ["list", "domain", "domain", "domain"],
+        "sizes": [3, 4, 5, 6],
+        "space directions": np.array([[np.nan, np.nan, np.nan], [1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]]),
+        "space origin": np.array([10.0, 20.0, 30.0]),
+    },
+]
 
 
 @skipUnless(has_nrrd, "nrrd required")
@@ -127,6 +142,30 @@ class TestNrrdReader(unittest.TestCase):
         self.assertEqual(image_array.dtype, dtype)
         self.assertTupleEqual(image_array.shape, expected_shape[::-1])
         self.assertTupleEqual(image_array.shape, tuple(image_header["spatial_shape"]))
+
+    @parameterized.expand([TEST_CASE_4D_CHANNEL])
+    def test_read_4d_channel(self, data_shape, filename, dtype, reference_header):
+        """4-D NRRD with a 'list' channel axis must not crash in _get_affine and must
+        set ORIGINAL_CHANNEL_DIM / spatial_shape correctly."""
+        test_image = np.random.rand(*data_shape).astype(dtype)
+        with tempfile.TemporaryDirectory() as tempdir:
+            filepath = os.path.join(tempdir, filename)
+            nrrd.write(filepath, test_image, header=reference_header)
+            reader = NrrdReader()
+            image_array, image_header = reader.get_data(reader.read(filepath))
+        self.assertIsInstance(image_array, np.ndarray)
+        self.assertEqual(image_array.dtype, dtype)
+        self.assertTupleEqual(image_array.shape, data_shape)
+        # spatial_shape must exclude the channel axis
+        self.assertTupleEqual(tuple(image_header["spatial_shape"]), data_shape[1:])
+        # channel dim 0 must be identified
+        self.assertEqual(image_header["original_channel_dim"], 0)
+        # affine must be a valid 4×4 matrix (3 spatial dims → 4×4)
+        self.assertTupleEqual(image_header["affine"].shape, (4, 4))
+        np.testing.assert_allclose(
+            image_header["affine"],
+            np.array([[-1.0, 0.0, 0.0, -10.0], [0.0, -2.0, 0.0, -20.0], [0.0, 0.0, 3.0, 30.0], [0.0, 0.0, 0.0, 1.0]]),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #8653 — `NrrdReader` crashes with a `ValueError` when loading 4-D NRRD files that carry a non-spatial (channel) axis, e.g. files produced by 3D Slicer with `kinds: list domain domain domain`.

**Root cause:** pynrrd represents a `(none)` space direction (for non-spatial axes) as a row of `NaN` values in the `space directions` array. The previous `_get_affine` implementation assumed every row is spatial, so it received a `(4, 3)` direction matrix and tried to assign its `(3, 4)` transpose into a `(4, 3)` slice — causing a shape mismatch `ValueError`.

**Changes:**
- `NrrdReader._get_affine`: filter all-NaN rows (non-spatial axes) before constructing the affine matrix so only genuine spatial directions are used.
- `NrrdReader.get_data`: use the `kinds` header field to auto-detect the channel axis (any kind that is not `domain` or `space`), set `ORIGINAL_CHANNEL_DIM` accordingly, and exclude the channel axis from `SPATIAL_SHAPE` — consistent with `NibabelReader` behaviour.
- `NrrdReader._convert_f_to_c_order`: also reverse `kinds` (when present) so the detected channel index stays correct after F→C reordering.
- `tests/data/test_nrrd_reader.py`: add `TEST_CASE_4D_CHANNEL` / `test_read_4d_channel` covering the corrected behaviour (no crash, correct affine, correct channel dim, correct spatial shape).

## Test plan

- [x] All 11 existing `TestNrrdReader` tests pass.
- [x] New `test_read_4d_channel_0` exercises a `(3, 4, 5, 6)` NRRD file with `kinds: list domain domain domain` and verifies:
  - No `ValueError` from `_get_affine`
  - `affine` is a valid `(4, 4)` matrix encoding only the 3 spatial axes
  - `original_channel_dim == 0`
  - `spatial_shape == (4, 5, 6)` (channel excluded)