### PR TITLE
docs: add Windows BUILD_MONAI install instructions

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -117,6 +117,22 @@ To build the extensions, if the system environment already has a version of Pyto
 BUILD_MONAI=1 pip install --no-build-isolation git+https://github.com/Project-MONAI/MONAI
 ```
 
+On Windows the inline `BUILD_MONAI=1 pip install ...` form is not supported by
+`cmd.exe` or PowerShell. Set the environment variable first, then run either
+install command shown above:
+
+```bat
+:: cmd.exe
+set BUILD_MONAI=1
+pip install --no-build-isolation git+https://github.com/Project-MONAI/MONAI
+```
+
+```powershell
+# PowerShell
+$env:BUILD_MONAI="1"
+pip install --no-build-isolation git+https://github.com/Project-MONAI/MONAI
+```
+
 this command will download and install the current `dev` branch of [MONAI from
 GitHub](https://github.com/Project-MONAI/MONAI).
 
@@ -145,6 +161,22 @@ cd MONAI/
 BUILD_MONAI=1 pip install -e .
 # for MacOS
 BUILD_MONAI=1 CC=clang CXX=clang++ pip install -e .
+```
+
+On Windows set the environment variable before running `pip install -e .`:
+
+```bat
+:: cmd.exe
+cd MONAI/
+set BUILD_MONAI=1
+pip install -e .
+```
+
+```powershell
+# PowerShell
+cd MONAI/
+$env:BUILD_MONAI="1"
+pip install -e .
 ```
 
 To uninstall the package please run:


### PR DESCRIPTION
Fixes #6119 .

### Description

`docs/source/installation.md` only documents the POSIX inline form `BUILD_MONAI=1 pip install ...` for building the MONAI C++/CUDA extensions. This `VAR=value command` syntax is not supported by Windows `cmd.exe` or PowerShell, so the documented commands fail out of the box on Windows.

This adds short cmd.exe and PowerShell snippets to both install flows (Option 1 system-wide and Option 2 editable): set the environment variable first, then run the existing `pip install` command. The `set BUILD_MONAI=1` form is the one confirmed working on Windows 11 in the issue thread.

### Types of changes
- [x] Non-breaking change (documentation only).
- [x] Documentation updated.

### How tested
- Verified the new `bat`/`powershell` fenced blocks use valid Pygments lexers and lex without error tokens, so the strict docs build (`build_docs.yml`) emits no new warnings.
- pre-commit markdown hooks (end-of-file, trailing-whitespace, mixed-line-ending) pass on the changed file.
