### PR TITLE
fix(RandGridDistortiond): only convert transform keys when skipping transform

### DIFF
--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -2305,12 +2305,13 @@ class RandGridDistortiond(RandomizableTransform, MapTransform):
         d = dict(data)
         self.randomize(None)
         if not self._do_transform:
-            out: dict[Hashable, torch.Tensor] = convert_to_tensor(d, track_meta=get_track_meta())
-            return out
+            for key in self.key_iterator(d):
+                d[key] = convert_to_tensor(d[key], track_meta=get_track_meta())
+            return d
 
         first_key: Hashable = self.first_key(d)
         if first_key == ():
-            out = convert_to_tensor(d, track_meta=get_track_meta())
+            out: dict[Hashable, torch.Tensor] = convert_to_tensor(d, track_meta=get_track_meta())
             return out
         if isinstance(d[first_key], MetaTensor) and d[first_key].pending_operations:  # type: ignore
             warnings.warn(f"data['{first_key}'] has pending operations, transform may return incorrect results.")

--- a/tests/transforms/test_rand_grid_distortiond.py
+++ b/tests/transforms/test_rand_grid_distortiond.py
@@ -85,6 +85,15 @@ class TestRandGridDistortiond(unittest.TestCase):
         assert_allclose(result["img"], expected_val_img, type_test=False, rtol=1e-4, atol=1e-4)
         assert_allclose(result["mask"], expected_val_mask, type_test=False, rtol=1e-4, atol=1e-4)
 
+    def test_no_transform_preserves_non_image_keys(self):
+        """Non-image dict entries must not be coerced to tensors when the transform is skipped."""
+        img = np.indices([6, 6]).astype(np.float32)
+        data = {"img": img, "label": 42, "filename": "scan.nii"}
+        g = RandGridDistortiond(keys=["img"], prob=0.0)
+        result = g(data)
+        self.assertIsInstance(result["label"], int)
+        self.assertIsInstance(result["filename"], str)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Fixes #8604

### Root Cause

`RandGridDistortiond.__call__` uses `convert_to_tensor(d, track_meta=...)` on the **entire** input dict when the transform is skipped (`_do_transform=False`). `convert_to_tensor` recursively converts **every** value in the dict — including non-image entries such as scalars and integers — into PyTorch tensors.

When the DataLoader collates a batch of these dicts, MONAI's `collate_meta_tensor_fn` is invoked for entries that now appear as tensors. That collate path expects non-image keys to retain their original Python types; receiving 0-d tensors instead triggers:

```
AttributeError: 'int' object has no attribute 'numel'
```

### Fix

Replace the whole-dict conversion with a per-key loop using `self.key_iterator(d)`, so only the keys this transform is responsible for are converted. This matches the pattern already used in the `for key, mode, padding_mode in self.key_iterator(...)` loop further down in the same method, and mirrors the approach in sibling transforms such as `RandAffined`.

### Changes

- `monai/transforms/spatial/dictionary.py`: use `key_iterator` in the no-op branch of `RandGridDistortiond.__call__`
- `tests/transforms/test_rand_grid_distortiond.py`: add regression test asserting that non-image dict entries (integer, string) are preserved when the transform is skipped

## Test plan

- [x] New test `test_no_transform_preserves_non_image_keys` confirms integer and string dict entries survive a skipped transform
- [x] Existing parameterized tests (`test_rand_grid_distortiond_0/1/2`) still pass
- [x] Manually verified that a `DataLoader` with `RandGridDistortiond(prob=0.0)` no longer raises `AttributeError` when the batch contains integer metadata fields alongside image tensors