### PR TITLE
fix: return mu (not mu+std) in VarAutoEncoder reparameterize at eval time (Fixes #8413)

### DIFF
--- a/monai/networks/nets/fullyconnectednet.py
+++ b/monai/networks/nets/fullyconnectednet.py
@@ -172,12 +172,11 @@ class VarFullyConnectedNet(nn.Module):
         return x
 
     def reparameterize(self, mu: torch.Tensor, logvar: torch.Tensor) -> torch.Tensor:
-        std = torch.exp(0.5 * logvar)
+        if self.training:  # reparameterization trick only during training
+            std = torch.exp(0.5 * logvar)
+            return mu + torch.randn_like(std) * std
 
-        if self.training:  # multiply random noise with std only during training
-            std = torch.randn_like(std).mul(std)
-
-        return std.add_(mu)
+        return mu
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         mu, logvar = self.encode_forward(x)

--- a/monai/networks/nets/varautoencoder.py
+++ b/monai/networks/nets/varautoencoder.py
@@ -142,12 +142,11 @@ class VarAutoEncoder(AutoEncoder):
         return x
 
     def reparameterize(self, mu: torch.Tensor, logvar: torch.Tensor) -> torch.Tensor:
-        std = torch.exp(0.5 * logvar)
+        if self.training:  # reparameterization trick only during training
+            std = torch.exp(0.5 * logvar)
+            return mu + torch.randn_like(std) * std
 
-        if self.training:  # multiply random noise with std only during training
-            std = torch.randn_like(std).mul(std)
-
-        return std.add_(mu)
+        return mu
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         mu, logvar = self.encode_forward(x)


### PR DESCRIPTION
Fixes #8413

## Problem

In `VarAutoEncoder.reparameterize()` and `VarFullyConnectedNet.reparameterize()`, the method always returns `std + mu`:

```python
std = torch.exp(0.5 * logvar)
if self.training:
    std = torch.randn_like(std).mul(std)
return std.add_(mu)  # BUG: at eval time, this returns mu + σ instead of mu
```

At **training** time, `std` is correctly replaced with `ε · σ` (random noise scaled by standard deviation). But at **eval** time, the raw standard deviation `σ = exp(0.5 · logvar)` is still added to the mean, producing `μ + σ` instead of just `μ`.

The reparameterization trick (Kingma & Welling, 2014) specifies:
- **Training:** `z = μ + ε · σ` where `ε ~ N(0,1)`
- **Inference:** `z = μ` (no stochastic component)

Adding the standard deviation to the mean at inference time introduces systematic bias — the latent code is shifted away from the learned mean by an amount proportional to the variance.

## Solution

Restructured the `reparameterize` method to return `mu` directly when not in training mode, avoiding the unnecessary `exp(0.5 * logvar)` computation:

```python
def reparameterize(self, mu, logvar):
    if self.training:
        std = torch.exp(0.5 * logvar)
        return mu + torch.randn_like(std) * std
    return mu
```

Applied to both:
- `monai/networks/nets/varautoencoder.py` — `VarAutoEncoder.reparameterize`
- `monai/networks/nets/fullyconnectednet.py` — `VarFullyConnectedNet.reparameterize`

Note: `spade_network.py` has a different implementation that always samples noise (intentional for GAN-style use), so it was left unchanged.

## Verification

**Manual verification:**
```
Eval mode: mu=tensor([[1., 2.]]), z=tensor([[1., 2.]])
PASS: In eval mode, reparameterize returns mu

Train mode: z1=tensor([[-0.6354,  2.5485]]), z2=tensor([[0.2493, 2.8168]])
PASS: In train mode, reparameterize returns mu + noise * std

Old buggy result would have been: tensor([[2.2840, 2.7788]])
```

**Existing tests pass (7/7 + 3/3):**
```
tests/networks/nets/test_varautoencoder.py::TestVarAutoEncoder::test_shape_0 PASSED
tests/networks/nets/test_varautoencoder.py::TestVarAutoEncoder::test_shape_1 PASSED
tests/networks/nets/test_varautoencoder.py::TestVarAutoEncoder::test_shape_2 PASSED
tests/networks/nets/test_varautoencoder.py::TestVarAutoEncoder::test_shape_3 PASSED
tests/networks/nets/test_varautoencoder.py::TestVarAutoEncoder::test_shape_4 PASSED
tests/networks/nets/test_varautoencoder.py::TestVarAutoEncoder::test_shape_5 PASSED
tests/networks/nets/test_varautoencoder.py::TestVarAutoEncoder::test_script PASSED

tests/networks/nets/test_fullyconnectednet.py::TestFullyConnectedNet::test_fc_shape_0 PASSED
tests/networks/nets/test_fullyconnectednet.py::TestFullyConnectedNet::test_fc_shape_1 PASSED
tests/networks/nets/test_fullyconnectednet.py::TestFullyConnectedNet::test_vfc_shape_0 PASSED
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.


## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-18 | Initial fix: return μ (not μ+std) in eval mode | rtmalikian |
| 2026-06-18 | Added DCO sign-off to commit | rtmalikian |
| 2026-06-18 | Updated PR documentation with changelog | rtmalikian |

### Files Changed
- `monai/networks/nets/varautoencoder.py` — Fixed `reparameterize()` to branch on `self.training` in both `VarAutoEncoder` and `VarFullyConnectedNet`

### Verification
- ✅ `VarAutoEncoder.reparameterize()` returns μ in eval mode, μ + ε·σ in train mode
- ✅ `VarFullyConnectedNet.reparameterize()` follows same pattern
- ✅ DCO sign-off present on all commits
