### PR TITLE
Warn when PydicomReader falls back to an identity affine (#8468)

### DIFF
--- a/monai/data/image_reader.py
+++ b/monai/data/image_reader.py
@@ -738,6 +738,14 @@ class PydicomReader(ImageReader):
         """
         affine: np.ndarray = np.eye(4)
         if not ("00200037" in metadata and "00200032" in metadata):
+            warnings.warn(
+                "PydicomReader: ImageOrientationPatient (0020,0037) and/or "
+                "ImagePositionPatient (0020,0032) tags are missing, so the affine "
+                "matrix cannot be derived and defaults to the identity. The image "
+                "orientation and spacing may be incorrect (e.g. for multi-frame "
+                "Enhanced DICOM); consider using ITKReader for such files.",
+                stacklevel=2,
+            )
             return affine
         # "00200037" is the tag of `ImageOrientationPatient`
         rx, ry, rz, cx, cy, cz = metadata["00200037"]["Value"]

--- a/tests/data/test_pydicom_reader.py
+++ b/tests/data/test_pydicom_reader.py
@@ -1,0 +1,44 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from monai.data import PydicomReader
+from tests.test_utils import SkipIfNoModule
+
+
+@SkipIfNoModule("pydicom")
+class TestPydicomReaderAffine(unittest.TestCase):
+    def test_missing_orientation_tags_warns_and_returns_identity(self):
+        # Without ImageOrientationPatient (0020,0037) and ImagePositionPatient
+        # (0020,0032) the affine cannot be derived. The reader falls back to the
+        # identity matrix; regression test for #8468 ensures this is no longer
+        # silent so users know orientation/spacing may be wrong.
+        reader = PydicomReader()
+        with self.assertWarns(UserWarning):
+            affine = reader._get_affine({})
+        np.testing.assert_array_equal(affine, np.eye(4))
+
+    def test_partial_orientation_tags_warns(self):
+        # Only one of the two required tags present is still insufficient.
+        reader = PydicomReader()
+        metadata = {"00200037": {"Value": [1, 0, 0, 0, 1, 0]}}  # orientation only
+        with self.assertWarns(UserWarning):
+            affine = reader._get_affine(metadata)
+        np.testing.assert_array_equal(affine, np.eye(4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description
Fixes #8468. When `ImageOrientationPatient` (0020,0037) and `ImagePositionPatient` (0020,0032) are missing from the metadata (e.g. some multi-frame Enhanced DICOM), `PydicomReader._get_affine` returned `np.eye(4)` with no indication, so downstream orientation and spacing were silently wrong.

This adds a `UserWarning` that names the missing tags, states the affine defaults to identity, and suggests `ITKReader` for such files. The fallback behaviour itself is unchanged — this only surfaces it.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.

### Testing
Added `tests/data/test_pydicom_reader.py` asserting that `_get_affine` warns (`UserWarning`) and returns identity when the orientation/position tags are absent or only partially present.

```
python -m unittest tests.data.test_pydicom_reader
# Ran 2 tests ... OK
```
