### PR TITLE
Fix division by zero in Warp for singleton spatial dimensions

### DIFF
--- a/monai/networks/blocks/warp.py
+++ b/monai/networks/blocks/warp.py
@@ -155,7 +155,10 @@ class Warp(nn.Module):
 
         if not _use_compiled:  # pytorch native grid_sample
             for i, dim in enumerate(grid.shape[1:-1]):
-                grid[..., i] = grid[..., i] * 2 / (dim - 1) - 1
+                # guard against a singleton spatial dim (e.g. a single-slice volume), where
+                # ``dim - 1 == 0`` would divide by zero; clamp the denominator to 1 so the lone
+                # voxel maps to -1, matching ``monai.networks.utils.normalize_transform``.
+                grid[..., i] = grid[..., i] * 2 / max(dim - 1, 1) - 1
             index_ordering: list[int] = list(range(spatial_dims - 1, -1, -1))
             grid = grid[..., index_ordering]  # z, y, x -> x, y, z
             return F.grid_sample(

--- a/tests/networks/blocks/warp/test_warp.py
+++ b/tests/networks/blocks/warp/test_warp.py
@@ -138,6 +138,20 @@ class TestWarp(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, ""):
             warp_layer(image=torch.arange(4).reshape((1, 1, 2, 2)).to(dtype=torch.float), ddf=torch.zeros(1, 2, 3, 3))
 
+    def test_singleton_spatial_dim(self):
+        # a single-slice volume / single-row image has a spatial dim of size 1; the grid
+        # normalization must not divide by zero (regression for native grid_sample path).
+        # "zeros" padding maps an out-of-range (here NaN, pre-fix) coordinate to 0, so it exposes
+        # the bug; "border"/"reflection" would clamp onto the lone voxel and mask it.
+        for shape, ndim in [((1, 1, 1, 4, 4), 3), ((1, 1, 1, 5), 2), ((1, 1, 5, 1), 2)]:
+            image = torch.rand(*shape)
+            ddf = torch.zeros(shape[0], ndim, *shape[2:])
+            warp_layer = Warp(mode="bilinear", padding_mode="zeros")
+            result = warp_layer(image, ddf)
+            self.assertFalse(torch.isnan(result).any(), f"NaN in warp output for shape {shape}")
+            # a zero displacement field must reproduce the input image
+            np.testing.assert_allclose(result.cpu().numpy(), image.cpu().numpy(), rtol=1e-4, atol=1e-4)
+
     def test_grad(self):
         for b in GridSampleMode:
             for p in GridSamplePadMode:

--- a/tests/networks/blocks/warp/test_warp.py
+++ b/tests/networks/blocks/warp/test_warp.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 import torch
@@ -138,18 +139,26 @@ class TestWarp(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, ""):
             warp_layer(image=torch.arange(4).reshape((1, 1, 2, 2)).to(dtype=torch.float), ddf=torch.zeros(1, 2, 3, 3))
 
+    @mock.patch("monai.networks.blocks.warp.USE_COMPILED", False)
     def test_singleton_spatial_dim(self):
-        # a single-slice volume / single-row image has a spatial dim of size 1; the grid
-        # normalization must not divide by zero (regression for native grid_sample path).
-        # "zeros" padding maps an out-of-range (here NaN, pre-fix) coordinate to 0, so it exposes
-        # the bug; "border"/"reflection" would clamp onto the lone voxel and mask it.
+        """
+        Regression test for a singleton spatial dimension (a single-slice volume or a
+        single-row/column image), where the grid normalization ``* 2 / (dim - 1)`` previously
+        divided by zero.
+
+        The native ``grid_sample`` path is forced via ``USE_COMPILED=False`` because only that
+        branch normalizes the grid; the csrc ``grid_pull`` path is unaffected. ``padding_mode``
+        is ``"zeros"`` so an out-of-range (pre-fix ``nan``) coordinate maps to 0 and exposes the
+        bug, whereas ``"border"``/``"reflection"`` would clamp onto the lone voxel and mask it.
+        For a zero displacement field the warped output must contain no ``nan`` and must equal
+        the input image.
+        """
         for shape, ndim in [((1, 1, 1, 4, 4), 3), ((1, 1, 1, 5), 2), ((1, 1, 5, 1), 2)]:
             image = torch.rand(*shape)
             ddf = torch.zeros(shape[0], ndim, *shape[2:])
             warp_layer = Warp(mode="bilinear", padding_mode="zeros")
             result = warp_layer(image, ddf)
             self.assertFalse(torch.isnan(result).any(), f"NaN in warp output for shape {shape}")
-            # a zero displacement field must reproduce the input image
             np.testing.assert_allclose(result.cpu().numpy(), image.cpu().numpy(), rtol=1e-4, atol=1e-4)
 
     def test_grad(self):


### PR DESCRIPTION
### Description

`Warp.forward` (native `grid_sample` path) normalizes grid coordinates with:

```python
grid[..., i] = grid[..., i] * 2 / (dim - 1) - 1
```

When a spatial dimension has size 1 — a **single-slice volume** `(B, C, 1, H, W)` or a single-row/column image `(B, C, 1, W)` / `(B, C, H, 1)` — `dim - 1 == 0`, so the normalization divides by zero and produces `inf`/`nan` coordinates. With `padding_mode="zeros"`, even a **zero displacement field** then yields:

- `nan` output for 2D single-row/column inputs, and
- all-zeros output for 3D single-slice inputs,

instead of returning the input image unchanged.

#### Fix

Clamp the denominator to 1 so the lone voxel maps to `-1`. This mirrors the guard MONAI already applies in `monai.networks.utils.normalize_transform`, which performs the identical `align_corners=True` normalization and clamps the size with `norm[norm <= 1.0] = 2.0` to avoid exactly this division by zero. Non-singleton dimensions are numerically unchanged.

```python
grid[..., i] = grid[..., i] * 2 / max(dim - 1, 1) - 1
```

#### Verification

Added `test_singleton_spatial_dim` (2D single-row, 2D single-column, 3D single-slice). With a zero displacement field the warped output now equals the input and contains no `nan`. The test fails on the current code and passes with the fix; the existing `Warp` tests are unaffected.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests --disttests`.
- [x] In-line docstrings updated.
