### PR TITLE
Fix DiceFocalLoss to apply activation before removing background

### DIFF
--- a/monai/losses/dice.py
+++ b/monai/losses/dice.py
@@ -803,9 +803,9 @@ class DiceFocalLoss(_Loss):
         """
         super().__init__()
         self.dice = DiceLoss(
-            sigmoid=sigmoid,
-            softmax=softmax,
-            other_act=other_act,
+            sigmoid=False,
+            softmax=False,
+            other_act=None,
             squared_pred=squared_pred,
             jaccard=jaccard,
             reduction=reduction,
@@ -822,6 +822,9 @@ class DiceFocalLoss(_Loss):
         self.lambda_focal = lambda_focal
         self.to_onehot_y = to_onehot_y
         self.include_background = include_background
+        self.sigmoid = sigmoid
+        self.softmax = softmax
+        self.other_act = other_act
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """
@@ -845,6 +848,17 @@ class DiceFocalLoss(_Loss):
                 warnings.warn("single channel prediction, `to_onehot_y=True` ignored.")
             else:
                 target = one_hot(target, num_classes=n_pred_ch)
+
+        # Apply activation before removing background to ensure softmax/sigmoid works correctly
+        if self.sigmoid:
+            input = torch.sigmoid(input)
+        elif self.softmax:
+            if n_pred_ch == 1:
+                warnings.warn("single channel prediction, `softmax=True` ignored.")
+            else:
+                input = torch.softmax(input, 1)
+        elif self.other_act is not None:
+            input = self.other_act(input)
 
         if not self.include_background:
             if n_pred_ch == 1:


### PR DESCRIPTION
## Summary

This PR fixes a bug in `DiceFocalLoss` where using `include_background=False` with `softmax=True` or `sigmoid=True` for binary segmentation would cause the activation function to be ignored.

## Problem

When using `include_background=False` with `softmax=True` in `DiceFocalLoss` for binary segmentation, the Dice part would produce this warning and not apply softmax when calculating the Dice loss:

```
UserWarning: single channel prediction, `softmax=True` ignored.
```

This happened because the background channel was removed before the activation was applied, leaving only one channel for the Dice loss to process.

## Solution

The fix applies the activation (softmax/sigmoid/other_act) **before** removing the background channel, ensuring that the activation is applied to all channels as intended.

### Changes made:
1. Store `sigmoid`, `softmax`, and `other_act` as instance variables in `DiceFocalLoss.__init__()`
2. Apply activation in `forward()` before removing background
3. Disable activation in the internal `DiceLoss` instance to avoid double application

## Testing

- All existing tests pass
- Verified that the fix produces correct results by comparing with manual computation
- Verified that no warnings are produced when using `include_background=False` with `softmax=True` or `sigmoid=True`

## Related Issue

Fixes: https://github.com/Project-MONAI/MONAI/issues/5697