### PR TITLE
Fix CheckpointLoader bug with strict_shape=False and multiple objects

### DIFF
--- a/monai/handlers/checkpoint_loader.py
+++ b/monai/handlers/checkpoint_loader.py
@@ -99,8 +99,14 @@ class CheckpointLoader:
                 checkpoint = {k: checkpoint}
 
             # skip items that don't match data shape
+            # only apply copy_model_state for torch.nn.Module objects
+            # this is needed to handle shape mismatches for models
             for k, obj in self.load_dict.items():
-                checkpoint[k] = copy_model_state(obj, checkpoint, inplace=False)[0]
+                if isinstance(obj, torch.nn.Module) and k in checkpoint:
+                    _, _, _ = copy_model_state(obj, checkpoint[k], inplace=True)
+                    # after copy_model_state, the model's state_dict has been updated
+                    # with matching shapes, so we need to update the checkpoint
+                    checkpoint[k] = obj.state_dict()
 
         # save current max epochs setting in the engine, don't overwrite it if larger than max_epochs in checkpoint
         prior_max_epochs = engine.state.max_epochs


### PR DESCRIPTION
## Summary

This PR fixes a potential bug in `CheckpointLoader` when using `strict_shape=False` with multiple objects in `load_dict` (e.g., both `model` and `optimizer`).

## Problem

When `strict_shape=False` and `load_dict` contains multiple objects (like `{'model': model, 'optimizer': optimizer}`), the `copy_model_state` function was being called on all objects, including non-`torch.nn.Module` objects like optimizers. This caused errors because:

1. `copy_model_state` expects the source to be iterable (like a state_dict), but optimizers are not iterable
2. Even for models, the state_dict from the checkpoint was never loaded because the key matching logic was incorrect

## Solution

The fix ensures that:
1. `copy_model_state` is only applied to `torch.nn.Module` objects
2. After `copy_model_state` updates the model, the checkpoint is updated with the model's new state_dict
3. Other objects (like optimizers) are loaded directly by `Checkpoint.load_objects` without going through `copy_model_state`

## Testing

- All existing tests pass, including `test_strict_shape` which specifically tests the `strict_shape=False` behavior
- The fix has been verified with the test case provided in the issue