### PR TITLE
Remove dead and redundant code across monai/

### DIFF
--- a/monai/apps/nnunet/utils.py
+++ b/monai/apps/nnunet/utils.py
@@ -149,7 +149,6 @@ def create_new_dataset_json(
     """
     new_json_data: dict = {}
 
-    # modality = self.input_info.pop("modality")
     modality = ensure_tuple(modality)  # type: ignore
 
     new_json_data["channel_names"] = {}
@@ -161,18 +160,11 @@ def create_new_dataset_json(
     for _j in range(num_foreground_classes):
         new_json_data["labels"][f"class{_j + 1}"] = _j + 1
 
-    # new_json_data["numTraining"] = len(datalist_json["training"])
     new_json_data["numTraining"] = num_training_data
     new_json_data["file_ending"] = ".nii.gz"
 
     ConfigParser.export_config_file(
-        config=new_json_data,
-        # filepath=os.path.join(raw_data_foldername, "dataset.json"),
-        filepath=output_filepath,
-        fmt="json",
-        sort_keys=True,
-        indent=4,
-        ensure_ascii=False,
+        config=new_json_data, filepath=output_filepath, fmt="json", sort_keys=True, indent=4, ensure_ascii=False
     )
 
     return

--- a/monai/apps/vista3d/transforms.py
+++ b/monai/apps/vista3d/transforms.py
@@ -160,8 +160,6 @@ class VistaPostTransformd(MapTransform):
                     pred = pred.argmax(0).unsqueeze(0).float() + 1.0
                     pred[is_bk] = 0.0
                 else:
-                    # AsDiscrete will remove NaN
-                    # pred = monai.transforms.AsDiscrete(threshold=0.5)(pred)
                     pred[pred > 0] = 1.0
                 if "label_prompt" in data and data["label_prompt"] is not None:
                     pred += 0.5  # inplace mapping to avoid cloning pred

--- a/monai/data/ultrasound_confidence_map.py
+++ b/monai/data/ultrasound_confidence_map.py
@@ -244,6 +244,8 @@ class UltrasoundConfidenceMap:
 
             if iter_idx == 1:
                 vertical_end = s.shape[0]  # Vertical edges length
+            elif iter_idx == 5:
+                s.shape[0]  # Diagonal edges length
 
         # Normalize weights
         s = self.normalize(s)

--- a/monai/data/ultrasound_confidence_map.py
+++ b/monai/data/ultrasound_confidence_map.py
@@ -244,8 +244,6 @@ class UltrasoundConfidenceMap:
 
             if iter_idx == 1:
                 vertical_end = s.shape[0]  # Vertical edges length
-            elif iter_idx == 5:
-                s.shape[0]  # Diagonal edges length
 
         # Normalize weights
         s = self.normalize(s)

--- a/monai/inferers/merger.py
+++ b/monai/inferers/merger.py
@@ -309,9 +309,6 @@ class ZarrAvgMerger(Merger):
 
         self.chunks = chunks
 
-        # Handle compressor/codecs based on zarr version
-        is_zarr_v3 = version_geq(get_package_version("zarr"), "3.0.0")
-
         # Initialize codecs/compressor attributes with proper types
         self.codecs: list | None = None
         self.value_codecs: list | None = None

--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -232,7 +232,6 @@ class GlobalMutualInformationLoss(_Loss):
         sigma = torch.mean(bin_centers[1:] - bin_centers[:-1]) * sigma_ratio
         self.kernel_type = look_up_option(kernel_type, ["gaussian", "b-spline"])
         self.num_bins = num_bins
-        self.kernel_type = kernel_type
         # declared as buffers so they move with the module (e.g. ``.to(device)``); only populated for the
         # gaussian kernel, hence the ``Tensor`` annotation reflects the type at the use sites in that path.
         self.preterm: torch.Tensor | None

--- a/monai/losses/nacl_loss.py
+++ b/monai/losses/nacl_loss.py
@@ -138,7 +138,7 @@ class NACLLoss(_Loss):
         if self.distance_type == "l1":
             loss_conf = utargets.sub(inputs).abs_().mean()
         elif self.distance_type == "l2":
-            loss_conf = utargets.sub(inputs).pow_(2).abs_().mean()
+            loss_conf = utargets.sub(inputs).pow_(2).mean()
 
         loss: torch.Tensor = loss_ce + self.alpha * loss_conf
 

--- a/monai/metrics/generalized_dice.py
+++ b/monai/metrics/generalized_dice.py
@@ -181,7 +181,6 @@ def compute_generalized_dice(
     else:
         numer = 2.0 * (intersection * w)
         denom = denominator * w
-        y_pred_o = y_pred_o
 
     # Compute the score
     generalized_dice_score = numer / denom

--- a/monai/networks/blocks/text_embedding.py
+++ b/monai/networks/blocks/text_embedding.py
@@ -79,7 +79,6 @@ class TextEncoder(nn.Module):
             # text embedding as random initialized 'rand_embedding'
             text_embedding = self.text_embedding.weight
         else:
-            print(self.text_embedding)
             text_embedding = nn.functional.relu(self.text_to_vision(self.text_embedding))
 
         if self.spatial_dims == 3:

--- a/monai/networks/layers/filtering.py
+++ b/monai/networks/layers/filtering.py
@@ -96,9 +96,6 @@ class PHLFilter(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         raise NotImplementedError("PHLFilter does not currently support Backpropagation")
-        # scaled_features, = ctx.saved_variables
-        # grad_input = _C.phl_filter(grad_output, scaled_features)
-        # return grad_input
 
 
 class TrainableBilateralFilterFunction(torch.autograd.Function):

--- a/monai/networks/layers/simplelayers.py
+++ b/monai/networks/layers/simplelayers.py
@@ -671,7 +671,6 @@ class MeanFilter(ApplyFilter):
             size: edge length of the filter
         """
         filter = torch.ones([size] * spatial_dims)
-        filter = filter
         super().__init__(filter=filter)
 
 

--- a/monai/networks/nets/basic_unet.py
+++ b/monai/networks/nets/basic_unet.py
@@ -235,7 +235,6 @@ class BasicUNet(nn.Module):
         """
         super().__init__()
         fea = ensure_tuple_rep(features, 6)
-        print(f"BasicUNet features: {fea}.")
 
         self.conv_0 = TwoConv(spatial_dims, in_channels, features[0], act, norm, bias, dropout)
         self.down_1 = Down(spatial_dims, fea[0], fea[1], act, norm, bias, dropout)

--- a/monai/networks/nets/basic_unetplusplus.py
+++ b/monai/networks/nets/basic_unetplusplus.py
@@ -94,7 +94,6 @@ class BasicUNetPlusPlus(nn.Module):
         self.deep_supervision = deep_supervision
 
         fea = ensure_tuple_rep(features, 6)
-        print(f"BasicUNetPlusPlus features: {fea}.")
 
         self.conv_0_0 = TwoConv(spatial_dims, in_channels, fea[0], act, norm, bias, dropout)
         self.conv_1_0 = Down(spatial_dims, fea[0], fea[1], act, norm, bias, dropout)

--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1659,7 +1659,6 @@ def extreme_points_to_image(
         rescale_max: maximum value of output data.
     """
     # points to image
-    # points_image = torch.zeros(label.shape[1:], dtype=torch.float)
     points_image = torch.zeros_like(torch.as_tensor(label[0]), dtype=torch.float)
     for p in points:
         points_image[p] = 1.0

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 else:
     Events = optional_import("ignite.engine", name="Events")
 
+pd, has_pandas = optional_import("pandas")
+
 __all__ = [
     "torch_profiler_full",
     "torch_profiler_time_cpu_gpu",
@@ -375,8 +377,6 @@ class WorkflowProfiler:
 
     def get_times_summary_pd(self, times_in_s=True):
         """Returns the same information as `get_times_summary` but in a Pandas DataFrame."""
-        import pandas as pd
-
         summ = self.get_times_summary(times_in_s)
         suffix = "s" if times_in_s else "ns"
         columns = ["Count", f"Total Time ({suffix})", "Avg", "Std", "Min", "Max"]

--- a/monai/utils/profiling.py
+++ b/monai/utils/profiling.py
@@ -35,8 +35,6 @@ if TYPE_CHECKING:
 else:
     Events = optional_import("ignite.engine", name="Events")
 
-pd, has_pandas = optional_import("pandas")
-
 __all__ = [
     "torch_profiler_full",
     "torch_profiler_time_cpu_gpu",


### PR DESCRIPTION
### Description

Ran a code agent for dead code. Vetted them myself thereafter. 

Removes dead statements, no-ops, and leftover commented-out code. No runtime behavior changes.

| File | Dead/redundant code removed |
|---|---|
| `networks/nets/basic_unet.py` | Stray `print(f"BasicUNet features: ...")` debug call in constructor |
| `networks/nets/basic_unetplusplus.py` | Stray `print(f"BasicUNetPlusPlus features: ...")` debug call in constructor |
| `networks/blocks/text_embedding.py` | Stray `print(self.text_embedding)` debug call in `TextEncoder.forward` |
| `metrics/generalized_dice.py` | No-op self-assignment `y_pred_o = y_pred_o` |
| `networks/layers/simplelayers.py` | No-op self-assignment `filter = filter` in `MeanFilter` |
| `losses/nacl_loss.py` | Redundant `.abs_()` after `.pow_(2)` (operand already non-negative) in L2 branch |
| `losses/image_dissimilarity.py` | Overwrite discarding the `look_up_option`-validated `kernel_type` in `GlobalMutualInformationLoss` |
| `data/ultrasound_confidence_map.py` | Dead `elif` branch with discarded bare `s.shape[0]` expression |
| `inferers/merger.py` | Duplicated recomputation of `is_zarr_v3` in `ZarrAvgMerger` |
| `utils/profiling.py` | Unused module-level `pandas` optional-import (only consumer re-imports locally) |
| `apps/nnunet/utils.py` | Three blocks of commented-out code in `create_new_dataset_json` |
| `apps/vista3d/transforms.py` | Commented-out `AsDiscrete` alternative |
| `transforms/utils.py` | Commented-out `torch.zeros` alternative |
| `networks/layers/filtering.py` | Unreachable commented-out body after `raise` in `PHLFilter.backward` |

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).