### PR TITLE
fix(data): avoid divide-by-zero in pydicom affine for single-slice volumes

### DIFF
--- a/tests/data/test_init_reader.py
+++ b/tests/data/test_init_reader.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from monai.data import ITKReader, NibabelReader, NrrdReader, NumpyReader, PILReader, PydicomReader
 from monai.transforms import LoadImage, LoadImaged
+from monai.utils import MetaKeys
 from tests.test_utils import SkipIfNoModule
 
 
@@ -99,6 +100,40 @@ class TestInitLoadImage(unittest.TestCase):
                     # The reader must not force an eager C-order copy; the native
                     # (F-order) layout from nibabel should be preserved here.
                     self.assertFalse(data.flags.c_contiguous)
+
+    @SkipIfNoModule("Pydicom")
+    def test_pydicom_reader_get_affine_single_slice_with_last_position(self):
+        reader = PydicomReader()
+        metadata = {
+            "00200037": {"Value": [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]},
+            "00200032": {"Value": [10.0, 20.0, 30.0]},
+            "00280030": {"Value": [0.5, 0.25]},
+            "lastImagePositionPatient": np.array([10.0, 20.0, 30.0]),
+            MetaKeys.SPATIAL_SHAPE: np.array([64, 64, 1]),
+        }
+
+        affine = reader._get_affine(metadata, lps_to_ras=False)
+
+        np.testing.assert_allclose(affine[0, 2], 0.0)
+        np.testing.assert_allclose(affine[1, 2], 0.0)
+        np.testing.assert_allclose(affine[2, 2], 1.0)
+
+    @SkipIfNoModule("Pydicom")
+    def test_pydicom_reader_get_affine_multi_slice_uses_last_position(self):
+        reader = PydicomReader()
+        metadata = {
+            "00200037": {"Value": [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]},
+            "00200032": {"Value": [0.0, 0.0, 0.0]},
+            "00280030": {"Value": [1.0, 1.0]},
+            "lastImagePositionPatient": np.array([0.0, 0.0, 4.0]),
+            MetaKeys.SPATIAL_SHAPE: np.array([8, 8, 5]),
+        }
+
+        affine = reader._get_affine(metadata, lps_to_ras=False)
+
+        np.testing.assert_allclose(affine[0, 2], 0.0)
+        np.testing.assert_allclose(affine[1, 2], 0.0)
+        np.testing.assert_allclose(affine[2, 2], 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/data/test_init_reader.py
+++ b/tests/data/test_init_reader.py
@@ -49,7 +49,7 @@ class TestInitLoadImage(unittest.TestCase):
     @SkipIfNoModule("nibabel")
     @SkipIfNoModule("PIL")
     @SkipIfNoModule("nrrd")
-    @SkipIfNoModule("Pydicom")
+    @SkipIfNoModule("pydicom")
     def test_readers(self):
         inst = ITKReader()
         self.assertIsInstance(inst, ITKReader)
@@ -101,7 +101,7 @@ class TestInitLoadImage(unittest.TestCase):
                     # (F-order) layout from nibabel should be preserved here.
                     self.assertFalse(data.flags.c_contiguous)
 
-    @SkipIfNoModule("Pydicom")
+    @SkipIfNoModule("pydicom")
     def test_pydicom_reader_get_affine_single_slice_with_last_position(self):
         reader = PydicomReader()
         metadata = {
@@ -118,7 +118,7 @@ class TestInitLoadImage(unittest.TestCase):
         np.testing.assert_allclose(affine[1, 2], 0.0)
         np.testing.assert_allclose(affine[2, 2], 1.0)
 
-    @SkipIfNoModule("Pydicom")
+    @SkipIfNoModule("pydicom")
     def test_pydicom_reader_get_affine_multi_slice_uses_last_position(self):
         reader = PydicomReader()
         metadata = {

--- a/tests/data/test_init_reader.py
+++ b/tests/data/test_init_reader.py
@@ -125,7 +125,7 @@ class TestInitLoadImage(unittest.TestCase):
             "00200037": {"Value": [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]},
             "00200032": {"Value": [0.0, 0.0, 0.0]},
             "00280030": {"Value": [1.0, 1.0]},
-            "lastImagePositionPatient": np.array([0.0, 0.0, 4.0]),
+            "lastImagePositionPatient": np.array([0.0, 0.0, 8.0]),
             MetaKeys.SPATIAL_SHAPE: np.array([8, 8, 5]),
         }
 
@@ -133,7 +133,7 @@ class TestInitLoadImage(unittest.TestCase):
 
         np.testing.assert_allclose(affine[0, 2], 0.0)
         np.testing.assert_allclose(affine[1, 2], 0.0)
-        np.testing.assert_allclose(affine[2, 2], 1.0)
+        np.testing.assert_allclose(affine[2, 2], 2.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- fix PydicomReader._get_affine to skip lastImagePositionPatient z-step derivation when there is only one slice
- add regression tests for single-slice and multi-slice metadata paths

Why:
For single-slice 3D DICOM segmentation metadata, n == 1 caused division by zero in affine z-step computation.

Validation:
- python -m pytest tests/data/test_init_reader.py -k pydicom_reader_get_affine -q
- python -m pre_commit run --files monai/data/image_reader.py tests/data/test_init_reader.py

Closes #8925