### PR TITLE
docs: clarify RandWeightedCrop(d) does not crop the weight map (#7851)

### DIFF
--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -965,6 +965,7 @@ class RandWeightedCrop(Randomizable, TraceableTransform, LazyTransform, MultiSam
         weight_map: weight map used to generate patch samples. The weights must be non-negative.
             Each element denotes a sampling weight of the spatial location. 0 indicates no sampling.
             It should be a single-channel array in shape, for example, `(1, spatial_dim_0, spatial_dim_1, ...)`.
+            The weight map is only used to compute the patch sample locations; it is not cropped itself.
         lazy: a flag to indicate whether this transform should execute lazily or not. Defaults to False.
     """
 

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -943,7 +943,7 @@ class RandWeightedCropd(Randomizable, MapTransform, LazyTransform, MultiSampleTr
         keys: keys of the corresponding items to be transformed.
             See also: :py:class:`monai.transforms.compose.MapTransform`
         w_key: key for the weight map. The corresponding value will be used as the sampling weights,
-            it should be a single-channel array in size, for example, `(1, spatial_dim_0, spatial_dim_1, ...)`.
+            it should be a single-channel array with shape, for example, `(1, spatial_dim_0, spatial_dim_1, ...)`.
             The weight map is only used to compute the patch sample locations; it is not cropped itself.
             To obtain the cropped weight map (e.g. to batch it alongside the image), include ``w_key`` in
             ``keys`` so it is cropped with the same sample centers; otherwise it is passed through unchanged

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -943,7 +943,11 @@ class RandWeightedCropd(Randomizable, MapTransform, LazyTransform, MultiSampleTr
         keys: keys of the corresponding items to be transformed.
             See also: :py:class:`monai.transforms.compose.MapTransform`
         w_key: key for the weight map. The corresponding value will be used as the sampling weights,
-            it should be a single-channel array in size, for example, `(1, spatial_dim_0, spatial_dim_1, ...)`
+            it should be a single-channel array in size, for example, `(1, spatial_dim_0, spatial_dim_1, ...)`.
+            The weight map is only used to compute the patch sample locations; it is not cropped itself.
+            To obtain the cropped weight map (e.g. to batch it alongside the image), include ``w_key`` in
+            ``keys`` so it is cropped with the same sample centers; otherwise it is passed through unchanged
+            at its original spatial size.
         spatial_size: the spatial size of the image patch e.g. [224, 224, 128].
             If its components have non-positive values, the corresponding size of `img` will be used.
         num_samples: number of samples (image patches) to take in the returned list.


### PR DESCRIPTION
Addresses #7851 .

### Description

`RandWeightedCrop(d)` uses `w_key`/`weight_map` only to pick patch locations; the map itself is passed through uncropped at its original size. Per #7851, this breaks `DataLoader` collation when the weight map is a separate key and images differ in shape. This documents the behavior on both the array and dict transforms, and notes that `w_key` should be added to `keys` to get a cropped weight map.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] In-line docstrings updated.
