### PR TITLE
fix: emit nnUNet store_true flags as bare CLI args in nnUNetV2Runner

### DIFF
--- a/monai/apps/nnunet/nnunetv2_runner.py
+++ b/monai/apps/nnunet/nnunetv2_runner.py
@@ -598,7 +598,11 @@ class nnUNetV2Runner:  # noqa: N801
 
         for _key, _value in kwargs.items():
             prefix = "-" if _key in {"p", "pretrained_weights"} else "--"
-            cmd += [f"{prefix}{_key}", str(_value)]
+            if isinstance(_value, bool):
+                if _value:
+                    cmd.append(f"{prefix}{_key}")
+            else:
+                cmd += [f"{prefix}{_key}", str(_value)]
 
         cmd_str: list[str] = [str(c) for c in cmd]
 

--- a/monai/apps/nnunet/nnunetv2_runner.py
+++ b/monai/apps/nnunet/nnunetv2_runner.py
@@ -596,7 +596,6 @@ class nnUNetV2Runner:  # noqa: N801
         if self.export_validation_probabilities:
             cmd.append("--npz")
 
-        store_true_flags = {"c", "val", "use_compressed", "disable_checkpointing"}
         for _key, _value in kwargs.items():
             prefix = "-" if _key in {"p", "pretrained_weights"} else "--"
             if isinstance(_value, bool):


### PR DESCRIPTION
Fixes #8237 .

### Description
The runner passed boolean flags like `--c` through as `--c True`, but nnU-Net treats these as `store_true` flags that take no value, so it errored out with `unrecognized arguments: True`. Now we emit just the bare flag when it's set, drop it when it isn't, and leave the other args alone.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how command-line options are passed for training and validation, so boolean settings now behave as expected.
  * Validation now runs through the standard training workflow with validation enabled, helping ensure more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->