### PR TITLE
Honor per-transform mode and padding_mode in lazy resampling

### DIFF
--- a/monai/transforms/lazy/utils.py
+++ b/monai/transforms/lazy/utils.py
@@ -20,7 +20,10 @@ import monai
 from monai.config import NdarrayOrTensor
 from monai.data.utils import AFFINE_TOL
 from monai.transforms.utils_pytorch_numpy_unification import allclose
-from monai.utils import LazyAttr, TraceKeys, convert_to_numpy, convert_to_tensor, look_up_option
+from monai.utils import InterpolateMode, LazyAttr, TraceKeys, convert_to_numpy, convert_to_tensor, look_up_option
+
+# interp modes with no grid_sample equivalent; the lazy resample backend keeps its default for these
+_INTERP_ONLY_MODES = frozenset({InterpolateMode.AREA.value, InterpolateMode.NEAREST_EXACT.value})
 
 __all__ = ["resample", "combine_transforms"]
 
@@ -92,25 +95,26 @@ def affine_from_pending(pending_item):
 def kwargs_from_pending(pending_item):
     """Extract kwargs from a pending transform item.
 
-    When ``pending_item`` is a dict, ``align_corners`` is also extracted from its ``extra_info`` entry
-    (if present and boolean) so the lazy pipeline preserves the original transform's alignment.
+    When ``pending_item`` is a dict, ``mode``, ``padding_mode`` and ``align_corners`` are read from
+    its ``extra_info`` entry so the lazy pipeline preserves the resampling settings recorded by the
+    originating transform (see issue #6850).
     """
     if not isinstance(pending_item, dict):
         return {}
+    extra_info = pending_item.get(TraceKeys.EXTRA_INFO)
+    extra_info = extra_info if isinstance(extra_info, dict) else {}
+    interp_mode = pending_item.get(LazyAttr.INTERP_MODE, extra_info.get("mode"))
     ret = {
-        LazyAttr.INTERP_MODE: pending_item.get(LazyAttr.INTERP_MODE, None),  # interpolation mode
-        LazyAttr.PADDING_MODE: pending_item.get(LazyAttr.PADDING_MODE, None),  # padding mode
+        LazyAttr.INTERP_MODE: None if str(interp_mode) in _INTERP_ONLY_MODES else interp_mode,
+        LazyAttr.PADDING_MODE: pending_item.get(LazyAttr.PADDING_MODE, extra_info.get("padding_mode")),
     }
     if LazyAttr.SHAPE in pending_item:
         ret[LazyAttr.SHAPE] = pending_item[LazyAttr.SHAPE]
     if LazyAttr.DTYPE in pending_item:
         ret[LazyAttr.DTYPE] = pending_item[LazyAttr.DTYPE]
-    # Extract align_corners from extra_info if available
-    extra_info = pending_item.get(TraceKeys.EXTRA_INFO)
-    if isinstance(extra_info, dict) and "align_corners" in extra_info:
-        align_corners_val = extra_info["align_corners"]
-        if isinstance(align_corners_val, bool):
-            ret[LazyAttr.ALIGN_CORNERS] = align_corners_val
+    align_corners = extra_info.get("align_corners")
+    if isinstance(align_corners, bool):
+        ret[LazyAttr.ALIGN_CORNERS] = align_corners
     return ret
 
 

--- a/tests/transforms/test_lazy_resample_mode.py
+++ b/tests/transforms/test_lazy_resample_mode.py
@@ -1,0 +1,59 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+from parameterized import parameterized
+
+import monai.transforms as mt
+from monai.data import MetaTensor, set_track_meta
+from monai.transforms.lazy.functional import apply_pending
+from monai.transforms.lazy.utils import kwargs_from_pending
+from monai.utils import LazyAttr, TraceKeys
+
+LABEL_MODE_CASES = [
+    ["spacing", mt.Spacing, {"pixdim": (1.5, 1.5, 1.5), "mode": "nearest", "padding_mode": "zeros"}],
+    ["rotate", mt.Rotate, {"angle": (0.0, 0.0, 0.3), "mode": "nearest", "keep_size": True}],
+]
+
+
+class TestLazyResampleMode(unittest.TestCase):
+    def setUp(self):
+        set_track_meta(True)
+
+    @parameterized.expand(LABEL_MODE_CASES)
+    def test_lazy_preserves_nearest_labels(self, _, xform_cls, xform_kwargs):
+        labels = torch.zeros(1, 20, 20, 20)
+        labels[0, 4:16, 4:16, 4:16] = 1
+        labels[0, 8:12, 8:12, 8:12] = 2
+        xform = xform_cls(**xform_kwargs)
+        xform.lazy = True
+        out, _ = apply_pending(xform(MetaTensor(labels)))
+        self.assertEqual(set(out.unique().tolist()), {0.0, 1.0, 2.0})
+
+    def test_kwargs_from_pending_reads_extra_info(self):
+        pending = {TraceKeys.EXTRA_INFO: {"mode": "nearest", "padding_mode": "border", "align_corners": True}}
+        kwargs = kwargs_from_pending(pending)
+        self.assertEqual(kwargs[LazyAttr.INTERP_MODE], "nearest")
+        self.assertEqual(kwargs[LazyAttr.PADDING_MODE], "border")
+        self.assertTrue(kwargs[LazyAttr.ALIGN_CORNERS])
+
+    def test_kwargs_from_pending_drops_interpolate_only_modes(self):
+        for mode in ("area", "nearest-exact"):
+            kwargs = kwargs_from_pending({TraceKeys.EXTRA_INFO: {"mode": mode}})
+            self.assertIsNone(kwargs[LazyAttr.INTERP_MODE])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #6850 .

### Description

Lazy resampling dropped each transform's interpolation and padding mode. `kwargs_from_pending` read `mode` and `padding_mode` from top-level `LazyAttr` keys that transforms never set on a pending item, whereas transforms record them in `extra_info` (the same place `align_corners` was already read from). Every lazily executed spatial transform therefore resampled with the backend default, so a nearest-mode label map came out interpolated. This reads `mode` and `padding_mode` from `extra_info`, mirroring the existing `align_corners` handling. Interpolation modes that only `torch.interpolate` supports (`area`, `nearest-exact`), for which the lazy `grid_sample` backend has no equivalent, keep the resampler default rather than raising.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.