### PR TITLE
Enable macOS Install Test Only

### DIFF
--- a/.github/workflows/cicd_tests.yml
+++ b/.github/workflows/cicd_tests.yml
@@ -171,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]  # macOS-latest omitted for now for being very slow, see #8864
+        os: [windows-latest, ubuntu-latest, macOS-latest]  # macOS-latest is very slow (#8864), testing install only
     timeout-minutes: 120
     env:
       QUICKTEST: True
@@ -230,7 +230,8 @@ jobs:
         python -m pip uninstall -y monai
         BUILD_MONAI=1 python -m pip install -e .  # compile the cpp extensions
       shell: bash
-    - name: Run quick tests
+    - if: runner.os != 'darwin'
+      name: Run full tests
       run: |
         python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
         python -c "import monai; monai.config.print_config()"

--- a/.github/workflows/cicd_tests.yml
+++ b/.github/workflows/cicd_tests.yml
@@ -237,6 +237,14 @@ jobs:
         python -c "import monai; monai.config.print_config()"
         python -m unittest -v
       shell: bash
+    - if: runner.os == 'macOS'
+      name: Run min tests
+      run: |
+        python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
+        python -c "import monai; monai.config.print_config()"
+        # TODO: enable large range of macOS tests which don't take a very long time
+        ./runtests.sh --min
+      shell: bash
 
   packaging:  # Test package generation
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd_tests.yml
+++ b/.github/workflows/cicd_tests.yml
@@ -231,11 +231,11 @@ jobs:
         BUILD_MONAI=1 python -m pip install -e .  # compile the cpp extensions
       shell: bash
     - if: runner.os != 'macOS'
-      name: Run minimum tests
+      name: Run full tests
       run: |
         python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
         python -c "import monai; monai.config.print_config()"
-        ./runtests.sh --min
+        python -m unittest -v
       shell: bash
 
   packaging:  # Test package generation

--- a/.github/workflows/cicd_tests.yml
+++ b/.github/workflows/cicd_tests.yml
@@ -230,12 +230,12 @@ jobs:
         python -m pip uninstall -y monai
         BUILD_MONAI=1 python -m pip install -e .  # compile the cpp extensions
       shell: bash
-    - if: runner.os != 'darwin'
-      name: Run full tests
+    - if: runner.os != 'macOS'
+      name: Run minimum tests
       run: |
         python -c 'import torch; print(torch.__version__); print(torch.rand(5,3))'
         python -c "import monai; monai.config.print_config()"
-        python -m unittest -v
+        ./runtests.sh --min
       shell: bash
 
   packaging:  # Test package generation

--- a/.github/workflows/cicd_tests.yml
+++ b/.github/workflows/cicd_tests.yml
@@ -223,12 +223,12 @@ jobs:
         cat "requirements-dev.txt"
         python -m pip install --no-build-isolation -r requirements-dev.txt
         python -m pip list
-        python -m pip install -e .  # test no compile installation
+        python -m pip install --no-build-isolation -e .  # test no compile installation
       shell: bash
     - name: Run compiled (${{ runner.os }})
       run: |
         python -m pip uninstall -y monai
-        BUILD_MONAI=1 python -m pip install -e .  # compile the cpp extensions
+        BUILD_MONAI=1 python -m pip install --no-build-isolation -e .  # compile the cpp extensions
       shell: bash
     - if: runner.os != 'macOS'
       name: Run full tests


### PR DESCRIPTION


### Description

macOS tests are really slow and disabled for now in the CI system, see #8864. This change will enable most of the test again except for the actual unit tests, so this will test the build and install only. Subsequent changes will look into re-enabling a subset of tests for macOS. 

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
