### PR TITLE
Perf: faster get_largest_connected_component_mask (bincount + LUT gather)

### DIFF
--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1224,15 +1224,15 @@ def get_largest_connected_component_mask(
     if num_features <= num_components:
         out = img_.astype(bool)
     else:
-        # ignore background
-        nonzeros = features[lib.nonzero(features)]
-        # get number voxels per feature (bincount). argsort[::-1] to get indices
-        # of largest components.
-        features_to_keep = lib.argsort(lib.bincount(nonzeros))[::-1]
-        # only keep the first n non-background indices
-        features_to_keep = features_to_keep[:num_components]
-        # generate labelfield. True if in list of features to keep
-        out = lib.isin(features, features_to_keep)
+        # bincount counts every label; index 0 is background, so drop it before ranking
+        counts = lib.bincount(features.reshape(-1))
+        counts[0] = 0
+        # argsort[::-1] gives labels of the largest components; keep the first n
+        features_to_keep = lib.argsort(counts)[::-1][:num_components]
+        # boolean lookup-table gather over the label field, cheaper than isin
+        keep = lib.zeros(counts.shape[0], dtype=bool)
+        keep[features_to_keep] = True
+        out = keep[features]
 
     return convert_to_dst_type(out, dst=img, dtype=out.dtype)[0]
 


### PR DESCRIPTION
Fixes #8974 .

### Description

`get_largest_connected_component_mask` (`monai/transforms/utils.py`) ranked component sizes by gathering every non-background voxel through `lib.nonzero(features)` and then built the mask with `lib.isin` over the whole label field. Both allocate large transient arrays. This counts labels with a single full-field `lib.bincount` (zeroing index 0 to drop background), and builds the mask with a boolean lookup-table gather (`keep[features]`) instead of `isin`. Output is bit-identical, verified across 2D and 3D at several foreground fractions and component counts, and the numpy and cupy/cucim paths are covered unchanged.

The `isin` replacement is the dominant win on both time and peak memory; the `bincount` change removes the redundant `nonzero` index arrays and gathered copy on top.

| case | metric | before | after | improvement |
|---|---|---|---|---|
| 3D 192^3, fg 50% | time | 82.0 ms | 8.6 ms | 9.5x |
| 3D 192^3, fg 50% | peak transient mem | 108.0 MB | 7.2 MB | 15x |
| 2D 1024^2, fg 60% | time | 21.5 ms | 1.8 ms | 11.7x |
| 2D 1024^2, fg 60% | peak transient mem | 18.0 MB | 1.4 MB | 12.9x |
| 3D 128^3, fg 5% (48k comps) | time | 10.7 ms | 6.2 ms | 1.7x |

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
