### PR TITLE
Clarify CUDA/CuPy install requirements in docs (#8106)

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -38,7 +38,7 @@ Ignite](https://pytorch.org/ignite/), please follow the instructions:
 The installation commands below usually end up installing the CPU variant of PyTorch. To install GPU-enabled PyTorch:
 
 1. Install the latest NVIDIA driver.
-1. Check [PyTorch Official Guide](https://pytorch.org/get-started/locally/) for the recommended CUDA versions. For Pip package, the user needs to download the CUDA manually, install it on the system, and ensure CUDA_PATH is set properly.
+1. Check the [PyTorch Official Guide](https://pytorch.org/get-started/locally/) for the recommended CUDA versions. For Pip packages, PyTorch wheels already bundle the CUDA runtime, so you only need to pick the CUDA version matching your driver from the selector and install with the provided command. You do not need to manually download CUDA or set `CUDA_PATH`.
 1. Continue to follow the guide and install PyTorch.
 1. Install MONAI using one of the ways described below.
 
@@ -47,15 +47,18 @@ however, additionally use [CuPy](https://cupy.dev/) for GPU-accelerated array op
 when a transform converts a CUDA tensor via `convert_to_cupy`). If CuPy is not installed, these code
 paths raise `OptionalImportError: import cupy (No module named 'cupy')`.
 
-CuPy is provided through the `cucim` extra, so installing MONAI with that extra pulls in a compatible
-CuPy build:
+MONAI provides a dedicated `cupy` extra that installs a compatible CuPy build:
 
 ```bash
-pip install 'monai[cucim]'
+pip install 'monai[cupy]'
 ```
 
+The `cucim` extra installs [cuCIM](https://github.com/rapidsai/cucim) (`cucim-cu12` or `cucim-cu13`
+depending on your Python version), which is a separate GPU image-processing library and does not
+install CuPy.
+
 If you prefer to install CuPy directly, note that the PyPI package name is CUDA-version specific
-(e.g. `cupy-cuda12x` for CUDA 12.x, `cupy-cuda11x` for CUDA 11.x) rather than plain `cupy`. See the
+(e.g. `cupy-cuda12x` for CUDA 12.x, `cupy-cuda13x` for CUDA 13.x) rather than plain `cupy`. See the
 [CuPy installation guide](https://docs.cupy.dev/en/stable/install.html) for the correct package for
 your CUDA toolkit.
 
@@ -206,7 +209,7 @@ You can install it by running:
 ```bash
 cd MONAI/
 pip install -e .
-# or pip install -e .[all,testing] to include most of the dependencies
+# or pip install -e '.[all,testing]' to include most of the dependencies
 ```
 
 or, to build with MONAI C++/CUDA extensions and install:
@@ -234,7 +237,7 @@ $env:BUILD_MONAI="1"
 pip install -e .
 ```
 
-If the compiled extensions were built by pip against a different version of PyTorch than the one in your environment, you may need to run the above with the `--no-build-isoloation` flag to force the use of that version, or use the `--build-constraint` method.
+If the compiled extensions were built by pip against a different version of PyTorch than the one in your environment, you may need to run the above with the `--no-build-isolation` flag to force the use of that version, or use the `--build-constraint` method.
 
 To uninstall the package please run:
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -4,6 +4,7 @@
 
 - [Installation Guide](#installation-guide)
 	- [Table of Contents](#table-of-contents)
+	- [GPU-enabled installation (CUDA and CuPy)](#gpu-enabled-installation-cuda-and-cupy)
 	- [From PyPI](#from-pypi)
 		- [Milestone release](#milestone-release)
 		- [Weekly preview release](#weekly-preview-release)
@@ -30,12 +31,33 @@ Ignite](https://pytorch.org/ignite/), please follow the instructions:
 
 - [Installing the recommended dependencies](#installing-the-recommended-dependencies)
 
-The installation commands below usually end up installing CPU variant of PyTorch. To install GPU-enabled PyTorch:
+---
+
+## GPU-enabled installation (CUDA and CuPy)
+
+The installation commands below usually end up installing the CPU variant of PyTorch. To install GPU-enabled PyTorch:
 
 1. Install the latest NVIDIA driver.
 1. Check [PyTorch Official Guide](https://pytorch.org/get-started/locally/) for the recommended CUDA versions. For Pip package, the user needs to download the CUDA manually, install it on the system, and ensure CUDA_PATH is set properly.
 1. Continue to follow the guide and install PyTorch.
-1. Install MONAI using one the ways described below.
+1. Install MONAI using one of the ways described below.
+
+Installing GPU-enabled PyTorch is enough to run models and transforms on the GPU. Some transforms,
+however, additionally use [CuPy](https://cupy.dev/) for GPU-accelerated array operations (for example
+when a transform converts a CUDA tensor via `convert_to_cupy`). If CuPy is not installed, these code
+paths raise `OptionalImportError: import cupy (No module named 'cupy')`.
+
+CuPy is provided through the `cucim` extra, so installing MONAI with that extra pulls in a compatible
+CuPy build:
+
+```bash
+pip install 'monai[cucim]'
+```
+
+If you prefer to install CuPy directly, note that the PyPI package name is CUDA-version specific
+(e.g. `cupy-cuda12x` for CUDA 12.x, `cupy-cuda11x` for CUDA 11.x) rather than plain `cupy`. See the
+[CuPy installation guide](https://docs.cupy.dev/en/stable/install.html) for the correct package for
+your CUDA toolkit.
 
 ---
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -4,6 +4,7 @@
 
 - [Installation Guide](#installation-guide)
 	- [Table of Contents](#table-of-contents)
+	- [GPU-enabled installation (CUDA and CuPy)](#gpu-enabled-installation-cuda-and-cupy)
 	- [From PyPI](#from-pypi)
 		- [Milestone release](#milestone-release)
 		- [Weekly preview release](#weekly-preview-release)
@@ -30,12 +31,33 @@ Ignite](https://pytorch.org/ignite/), please follow the instructions:
 
 - [Installing the recommended dependencies](#installing-the-recommended-dependencies)
 
-The installation commands below usually end up installing CPU variant of PyTorch. To install GPU-enabled PyTorch:
+---
+
+## GPU-enabled installation (CUDA and CuPy)
+
+The installation commands below usually end up installing the CPU variant of PyTorch. To install GPU-enabled PyTorch:
 
 1. Install the latest NVIDIA driver.
 1. Check [PyTorch Official Guide](https://pytorch.org/get-started/locally/) for the recommended CUDA versions. For Pip package, the user needs to download the CUDA manually, install it on the system, and ensure CUDA_PATH is set properly.
 1. Continue to follow the guide and install PyTorch.
-1. Install MONAI using one the ways described below.
+1. Install MONAI using one of the ways described below.
+
+Installing GPU-enabled PyTorch is enough to run models and transforms on the GPU. Some transforms,
+however, additionally use [CuPy](https://cupy.dev/) for GPU-accelerated array operations (for example
+when a transform converts a CUDA tensor via `convert_to_cupy`). If CuPy is not installed, these code
+paths raise `OptionalImportError: import cupy (No module named 'cupy')`.
+
+CuPy is provided through the `cucim` extra, so installing MONAI with that extra pulls in a compatible
+CuPy build:
+
+```bash
+pip install 'monai[cucim]'
+```
+
+If you prefer to install CuPy directly, note that the PyPI package name is CUDA-version specific
+(e.g. `cupy-cuda12x` for CUDA 12.x, `cupy-cuda11x` for CUDA 11.x) rather than plain `cupy`. See the
+[CuPy installation guide](https://docs.cupy.dev/en/stable/install.html) for the correct package for
+your CUDA toolkit.
 
 ---
 
@@ -298,3 +320,6 @@ O(N log N) alternatives to windowed self-attention). Install with
 `pip install 'monai[hyena]'`.
 
 - `pip install 'monai[all]'` installs all the optional dependencies.
+- The `cucim` extra also provides [CuPy](https://cupy.dev/), which is required by GPU-accelerated
+  transforms. See [GPU-enabled installation (CUDA and CuPy)](#gpu-enabled-installation-cuda-and-cupy)
+  for details.


### PR DESCRIPTION
Fixes #8106

### Description

The installation docs did not make it clear that some MONAI transforms require CuPy for GPU-accelerated array operations. Users who ran GPU inference hit `OptionalImportError: import cupy (No module named 'cupy')` with no obvious guidance — `pip install cupy` fails because the real package is CUDA-version specific (`cupy-cuda12x`), and it was not documented that the `cucim` extra provides CuPy.

This PR updates `docs/source/installation.md` to:
- Promote the GPU/CUDA setup steps into their own `## GPU-enabled installation (CUDA and CuPy)` section (with a Table of Contents entry) instead of an unlabeled paragraph.
- Explain that some transforms use CuPy (e.g. via `convert_to_cupy`), what error appears when it is missing, and that CuPy is installed through the `cucim` extra (`pip install 'monai[cucim]'`).
- Note that installing CuPy directly requires the CUDA-specific package name (`cupy-cuda12x` / `cupy-cuda11x`), linking to the CuPy installation guide.
- Add a cross-reference from the recommended-dependencies list.

Docs-only change; no code or public API is modified.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
