### PR TITLE
Make Fuzzy Gdown Argument Version-dependent

### DIFF
--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -240,7 +240,7 @@ def download_url(
             if urlparse(url).netloc == "drive.google.com":
                 if not has_gdown:
                     raise RuntimeError("To download files from Google Drive, please install the gdown dependency.")
-                if "fuzzy" not in gdown_kwargs and not min_version(gdown,"6.0.0"):  # "fuzzy" dropped in gdown 6.0.0
+                if "fuzzy" not in gdown_kwargs and not min_version(gdown, "6.0.0"):  # "fuzzy" dropped in gdown 6.0.0
                     gdown_kwargs["fuzzy"] = True  # default to true for flexible url
                 gdown.download(url, f"{tmp_name}", quiet=not progress, **gdown_kwargs)
             elif urlparse(url).netloc == "cloud-api.yandex.net":

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -240,7 +240,7 @@ def download_url(
             if urlparse(url).netloc == "drive.google.com":
                 if not has_gdown:
                     raise RuntimeError("To download files from Google Drive, please install the gdown dependency.")
-                if "fuzzy" not in gdown_kwargs:
+                if "fuzzy" not in gdown_kwargs and not min_version(gdown,"6.0.0"):  # "fuzzy" dropped in gdown 6.0.0
                     gdown_kwargs["fuzzy"] = True  # default to true for flexible url
                 gdown.download(url, f"{tmp_name}", quiet=not progress, **gdown_kwargs)
             elif urlparse(url).netloc == "cloud-api.yandex.net":

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -59,7 +59,6 @@ Checkpoint, has_ignite = optional_import("ignite.handlers", IgniteInfo.OPT_IMPOR
 requests, has_requests = optional_import("requests")
 onnx, _ = optional_import("onnx")
 huggingface_hub, _ = optional_import("huggingface_hub")
-gdown, _ = optional_import("gdown", "4.7.3")
 
 logger = get_logger(module_name=__name__)
 

--- a/monai/bundle/scripts.py
+++ b/monai/bundle/scripts.py
@@ -59,6 +59,7 @@ Checkpoint, has_ignite = optional_import("ignite.handlers", IgniteInfo.OPT_IMPOR
 requests, has_requests = optional_import("requests")
 onnx, _ = optional_import("onnx")
 huggingface_hub, _ = optional_import("huggingface_hub")
+gdown, _ = optional_import("gdown", "4.7.3")
 
 logger = get_logger(module_name=__name__)
 
@@ -2005,7 +2006,6 @@ def download_large_files(bundle_path: str | None = None, large_file_name: str | 
     parser.read_config(large_file_path)
     large_files_list = parser.get()["large_files"]
     for lf_data in large_files_list:
-        lf_data["fuzzy"] = True
         if "hash_val" in lf_data and lf_data.get("hash_val", "") == "":
             lf_data.pop("hash_val")
         if "hash_type" in lf_data and lf_data.get("hash_type", "") == "":

--- a/monai/networks/nets/hovernet.py
+++ b/monai/networks/nets/hovernet.py
@@ -632,7 +632,7 @@ def _remap_preact_resnet_model(model_url: str):
     pattern_bna = re.compile(r"^(.+\.d\d+)\.blk_bna\.(.+)")
     # download the pretrained weights into torch hub's default dir
     weights_dir = os.path.join(torch.hub.get_dir(), "preact-resnet50.pth")
-    download_url(model_url, fuzzy=True, filepath=weights_dir, progress=False)
+    download_url(model_url, filepath=weights_dir, progress=False)
     map_location = None if torch.cuda.is_available() else torch.device("cpu")
     state_dict = torch.load(weights_dir, map_location=map_location, weights_only=True)["desc"]
 
@@ -667,7 +667,7 @@ def _remap_standard_resnet_model(model_url: str, state_dict_key: str | None = No
     pattern_downsample1 = re.compile(r"^(res_blocks.d\d+).+\.downsample\.1\.(.+)")
     # download the pretrained weights into torch hub's default dir
     weights_dir = os.path.join(torch.hub.get_dir(), "resnet50.pth")
-    download_url(model_url, fuzzy=True, filepath=weights_dir, progress=False)
+    download_url(model_url, filepath=weights_dir, progress=False)
     map_location = None if torch.cuda.is_available() else torch.device("cpu")
     state_dict = torch.load(weights_dir, map_location=map_location, weights_only=True)
     if state_dict_key is not None:


### PR DESCRIPTION
### Description

Gdown has dropped the "fuzzy" argument in version 6.0.0. This PR makes the argument dependent on the Gdown version being below this, and removes it where it's not needed.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
