### PR TITLE
Improve missing image writer dependency hints

### DIFF
--- a/monai/data/image_writer.py
+++ b/monai/data/image_writer.py
@@ -103,6 +103,10 @@ def resolve_writer(ext_name, error_if_not_found=True) -> Sequence:
         error_if_not_found: whether to raise an error if no suitable image writer is found.
             if True , raise an ``OptionalImportError``, otherwise return an empty tuple. Default is ``True``.
 
+    Returns:
+        A tuple of available ``ImageWriter`` classes, or an empty tuple when ``error_if_not_found`` is ``False`` and
+            no writer is available.
+
     Raises:
         OptionalImportError: When no registered writer is available. If candidate writers require missing optional
             dependencies, the error includes commands for installing them.

--- a/monai/data/image_writer.py
+++ b/monai/data/image_writer.py
@@ -63,6 +63,9 @@ __all__ = [
 
 SUPPORTED_WRITERS: dict = {}
 
+# Map import names to their corresponding Python distribution names where they differ.
+_PACKAGE_INSTALL_NAMES = {"PIL": "pillow"}
+
 
 def register_writer(ext_name, *im_writers):
     """
@@ -99,6 +102,10 @@ def resolve_writer(ext_name, error_if_not_found=True) -> Sequence:
             As an indexing key it will be converted to a lower case string.
         error_if_not_found: whether to raise an error if no suitable image writer is found.
             if True , raise an ``OptionalImportError``, otherwise return an empty tuple. Default is ``True``.
+
+    Raises:
+        OptionalImportError: When no registered writer is available. If candidate writers require missing optional
+            dependencies, the error includes commands for installing them.
     """
     if not SUPPORTED_WRITERS:
         init()
@@ -106,17 +113,28 @@ def resolve_writer(ext_name, error_if_not_found=True) -> Sequence:
     if fmt.startswith("."):
         fmt = fmt[1:]
     avail_writers = []
+    missing_packages: set[str] = set()
     default_writers = SUPPORTED_WRITERS.get(EXT_WILDCARD, ())
     for _writer in look_up_option(fmt, SUPPORTED_WRITERS, default=default_writers):
         try:
             _writer()  # this triggers `monai.utils.module.require_pkg` to check the system availability
             avail_writers.append(_writer)
-        except OptionalImportError:
+        except OptionalImportError as error:
+            if error.name:
+                missing_packages.add(_PACKAGE_INSTALL_NAMES.get(error.name, error.name))
             continue
         except Exception:  # other writer init errors indicating it exists
             avail_writers.append(_writer)
     if not avail_writers and error_if_not_found:
-        raise OptionalImportError(f"No ImageWriter backend found for {fmt}.")
+        message = f"No ImageWriter backend found for {fmt}."
+        packages = sorted(missing_packages)
+        if len(packages) == 1:
+            package = packages[0]
+            message += f" Install `{package}` with `pip install {package}`."
+        elif packages:
+            hints = ", ".join(f"`{package}` (`pip install {package}`)" for package in packages)
+            message += f" Install one of the following packages: {hints}."
+        raise OptionalImportError(message)
     writer_tuple = ensure_tuple(avail_writers)
     SUPPORTED_WRITERS[fmt] = writer_tuple
     return writer_tuple

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -476,7 +476,7 @@ def require_pkg(
             if not has:
                 err_msg = f"required package `{pkg_name}` is not installed or the version doesn't match requirement."
                 if raise_error:
-                    raise OptionalImportError(err_msg)
+                    raise OptionalImportError(err_msg, name=pkg_name)
                 else:
                     warnings.warn(err_msg)
 

--- a/tests/data/test_image_rw.py
+++ b/tests/data/test_image_rw.py
@@ -16,13 +16,21 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import torch
 from parameterized import parameterized
 
 from monai.data.image_reader import ITKReader, NibabelReader, NrrdReader, PILReader
-from monai.data.image_writer import ITKWriter, NibabelWriter, PILWriter, register_writer, resolve_writer
+from monai.data.image_writer import (
+    SUPPORTED_WRITERS,
+    ITKWriter,
+    NibabelWriter,
+    PILWriter,
+    register_writer,
+    resolve_writer,
+)
 from monai.data.meta_tensor import MetaTensor
 from monai.transforms import LoadImage, SaveImage, moveaxis
 from monai.utils import MetaKeys, OptionalImportError, optional_import
@@ -149,6 +157,36 @@ class TestRegRes(unittest.TestCase):
         register_writer("new", lambda x: x + 1)
         register_writer("new2", lambda x: x + 1)
         self.assertEqual(resolve_writer("new")[0](0), 1)
+
+    def test_missing_writer_install_hint(self):
+        def missing_pillow():
+            raise OptionalImportError("PIL is unavailable", name="PIL")
+
+        with patch.dict(SUPPORTED_WRITERS, {"png": (missing_pillow,)}, clear=True):
+            with self.assertRaisesRegex(OptionalImportError, r"Install `pillow` with `pip install pillow`"):
+                resolve_writer(".PNG")
+
+    def test_multiple_missing_writer_install_hints(self):
+        def missing_itk():
+            raise OptionalImportError("ITK is unavailable", name="itk")
+
+        def missing_nibabel():
+            raise OptionalImportError("Nibabel is unavailable", name="nibabel")
+
+        with patch.dict(SUPPORTED_WRITERS, {"nii": (missing_nibabel, missing_itk)}, clear=True):
+            with self.assertRaises(OptionalImportError) as context:
+                resolve_writer("nii")
+        self.assertIn("Install one of the following packages", str(context.exception))
+        self.assertIn("`itk` (`pip install itk`)", str(context.exception))
+        self.assertIn("`nibabel` (`pip install nibabel`)", str(context.exception))
+
+    def test_missing_writer_without_package_name(self):
+        def missing_unknown():
+            raise OptionalImportError("Unknown dependency")
+
+        with patch.dict(SUPPORTED_WRITERS, {"unknown": (missing_unknown,)}, clear=True):
+            with self.assertRaisesRegex(OptionalImportError, r"^No ImageWriter backend found for unknown\.$"):
+                resolve_writer("unknown")
 
 
 @unittest.skipUnless(has_itk, "itk not installed")

--- a/tests/utils/test_require_pkg.py
+++ b/tests/utils/test_require_pkg.py
@@ -43,13 +43,14 @@ class TestRequirePkg(unittest.TestCase):
         test_func(x=None)
 
     def test_class_exception(self):
-        with self.assertRaises(OptionalImportError):
+        with self.assertRaises(OptionalImportError) as context:
 
             @require_pkg(pkg_name="test123")
             class TestClass:
                 pass
 
             TestClass()
+        self.assertEqual(context.exception.name, "test123")
 
     def test_class_version_exception(self):
         with self.assertRaises(OptionalImportError):


### PR DESCRIPTION
Fixes #7980.

### Description

Improve the error raised when `resolve_writer` cannot find an available image writer by including actionable installation commands for the actual candidate backends.

Rather than maintaining a separate extension-to-package table, this change records the missing dependency name on `OptionalImportError` in `require_pkg`. `resolve_writer` collects that information from its registered candidate writers and formats one or more installation hints. This keeps the guidance aligned with `SUPPORTED_WRITERS`, including wildcard formats and custom registrations that use `require_pkg`.

For example, saving PNG without Pillow now reports:

```text
No ImageWriter backend found for png. Install `pillow` with `pip install pillow`.
```

This is a non-breaking, error-message-only enhancement.

I am aware of the existing proposals for #7980, particularly #8761, #8625, and #8240. This draft uses the package metadata approach previously suggested in the review of #8240 and is opened for maintainer guidance on whether to proceed independently or coordinate with an existing PR.

### Changes

- Preserve the missing package name through `OptionalImportError.name`.
- Generate installation guidance from unavailable registered writers.
- Translate the `PIL` import name to the installable `pillow` distribution.
- Preserve the generic error when dependency metadata is unavailable.
- Add tests for single, multiple, and unknown dependency cases.
- Document the enhanced `OptionalImportError` behavior.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Focused unit tests passed locally.
- [x] Black, isort, Ruff, compilation, and whitespace checks passed.
- [x] In-line docstrings updated.
- [ ] Documentation pages updated.

### Test results

- `tests.utils.test_require_pkg`: 7 passed
- `tests.utils.test_optional_import`: 12 passed
- New writer dependency-hint tests: 3 passed

The complete `tests.data.test_image_rw` module requires optional image backends not installed in the minimal local environment. Its pre-existing NRRD assertion requires `itk` or `nibabel`; the new tests do not require those dependencies and pass independently.