### PR TITLE
docs: correct pip extras in installation guide to match setup.cfg

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -286,11 +286,11 @@ Since MONAI v0.2.0, the extras syntax such as `pip install 'monai[nibabel]'` is 
 - The options are
 
 ```
-[nibabel, skimage, scipy, pillow, tensorboard, gdown, ignite, torchvision, itk, tqdm, lmdb, psutil, cucim, openslide, pandas, einops, transformers, mlflow, clearml, matplotlib, tensorboardX, tifffile, imagecodecs, pyyaml, fire, jsonschema, ninja, pynrrd, pydicom, h5py, nni, optuna, onnx, onnxruntime, zarr, lpips, pynvml, huggingface_hub, hyena]
+[nibabel, skimage, scipy, pillow, tensorboard, gdown, ignite, torchio, torchvision, itk, tqdm, lmdb, psutil, cucim, openslide, pandas, einops, transformers, mlflow, clearml, matplotlib, tensorboardX, tifffile, imagecodecs, pyyaml, fire, packaging, jsonschema, ninja, pynrrd, pydicom, h5py, nni, optuna, onnx, zarr, lpips, pynvml, polygraphy, huggingface_hub, pyamg, hyena]
 ```
 
-which correspond to `nibabel`, `scikit-image`,`scipy`, `pillow`, `tensorboard`,
-`gdown`, `pytorch-ignite`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas`, `einops`, `transformers`, `mlflow`, `clearml`, `matplotlib`, `tensorboardX`, `tifffile`, `imagecodecs`, `pyyaml`, `fire`, `jsonschema`, `ninja`, `pynrrd`, `pydicom`, `h5py`, `nni`, `optuna`, `onnx`, `onnxruntime`, `zarr`, `lpips`, `nvidia-ml-py`, `huggingface_hub`, `pyamg`, and `nvsubquadratic` respectively.
+which correspond to `nibabel`, `scikit-image`, `scipy`, `pillow`, `tensorboard`,
+`gdown`, `pytorch-ignite`, `torchio`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas`, `einops`, `transformers`, `mlflow`, `clearml`, `matplotlib`, `tensorboardX`, `tifffile`, `imagecodecs`, `pyyaml`, `fire`, `packaging`, `jsonschema`, `ninja`, `pynrrd`, `pydicom`, `h5py`, `nni`, `optuna`, `onnx` (which also installs `onnxruntime`), `zarr`, `lpips`, `nvidia-ml-py`, `polygraphy`, `huggingface_hub`, `pyamg`, and `nvsubquadratic` respectively.
 
 The `hyena` extra pulls in [`nvsubquadratic`](https://github.com/NVIDIA-BioNeMo/nvSubquadratic),
 required by `HyenaNDUNETR` / `HyenaMixer` / `HyenaTransformerBlock` (subquadratic

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -290,7 +290,7 @@ Since MONAI v0.2.0, the extras syntax such as `pip install 'monai[nibabel]'` is 
 ```
 
 which correspond to `nibabel`, `scikit-image`, `scipy`, `pillow`, `tensorboard`,
-`gdown`, `pytorch-ignite`, `torchio`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas`, `einops`, `transformers`, `mlflow`, `clearml`, `matplotlib`, `tensorboardX`, `tifffile`, `imagecodecs`, `pyyaml`, `fire`, `packaging`, `jsonschema`, `ninja`, `pynrrd`, `pydicom`, `h5py`, `nni`, `optuna`, `onnx` (which also installs `onnxruntime`), `zarr`, `lpips`, `nvidia-ml-py`, `polygraphy`, `huggingface_hub`, `pyamg`, and `nvsubquadratic` respectively.
+`gdown`, `pytorch-ignite`, `torchio`, `torchvision`, `itk`, `tqdm`, `lmdb`, `psutil`, `cucim`, `openslide-python`, `pandas`, `einops`, `transformers`, `mlflow`, `clearml`, `matplotlib`, `tensorboardX`, `tifffile`, `imagecodecs`, `pyyaml`, `fire`, `packaging`, `jsonschema`, `ninja`, `pynrrd`, `pydicom`, `h5py`, `nni`, `optuna`, `onnx` (which also installs `onnxruntime` on Python <= 3.10), `zarr`, `lpips`, `nvidia-ml-py`, `polygraphy`, `huggingface_hub`, `pyamg`, and `nvsubquadratic` respectively.
 
 The `hyena` extra pulls in [`nvsubquadratic`](https://github.com/NVIDIA-BioNeMo/nvSubquadratic),
 required by `HyenaNDUNETR` / `HyenaMixer` / `HyenaTransformerBlock` (subquadratic


### PR DESCRIPTION
### Description

The extras list in the installation guide (`docs/source/installation.md`) has drifted from the actual `[options.extras_require]` section of `setup.cfg`:

1. **`onnxruntime` is documented as an extra, but no such extra exists.** `onnxruntime` is a dependency *installed by* the `onnx` extra. As a result, `pip install 'monai[onnxruntime]'` currently succeeds but silently installs nothing (pip only warns that the extra is unknown), which is misleading for users following the docs.
2. **Four real, functional extras are undocumented:** `torchio`, `packaging`, `polygraphy`, and `pyamg`.
3. The "which correspond to" package list was misaligned with the bracket list (40 vs 39 entries, out of step from `transformers` onward).

This PR updates only the documentation so the bracket list and the corresponding package list match `setup.cfg` exactly (42 extras, one prose entry per extra, same order), and notes that the `onnx` extra also installs `onnxruntime`. Verified programmatically: 0 missing, 0 extra, 0 nonexistent after the edit. No changes to `setup.cfg`.

### Types of changes

- [x] Non-breaking change (documentation only)

DCO: commit is signed off (`Signed-off-by: ymxlx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
