### PR TITLE
Count components via bincount over full field in get_largest_connected_component_mask

### DIFF
--- a/monai/transforms/utils.py
+++ b/monai/transforms/utils.py
@@ -1224,11 +1224,15 @@ def get_largest_connected_component_mask(
     if num_features <= num_components:
         out = img_.astype(bool)
     else:
-        # ignore background
-        nonzeros = features[lib.nonzero(features)]
-        # get number voxels per feature (bincount). argsort[::-1] to get indices
-        # of largest components.
-        features_to_keep = lib.argsort(lib.bincount(nonzeros))[::-1]
+        # count voxels per feature directly over the whole field; background is
+        # label 0. This avoids materializing the ``nonzero`` index arrays (one per
+        # spatial dim) and the gathered copy of every foreground voxel that
+        # ``features[lib.nonzero(features)]`` would create.
+        counts = lib.bincount(features.reshape(-1))
+        # ignore background so it is never selected as a component to keep.
+        counts[0] = 0
+        # argsort[::-1] to get indices of the largest components.
+        features_to_keep = lib.argsort(counts)[::-1]
         # only keep the first n non-background indices
         features_to_keep = features_to_keep[:num_components]
         # generate labelfield. True if in list of features to keep

--- a/tests/transforms/test_keep_largest_connected_component.py
+++ b/tests/transforms/test_keep_largest_connected_component.py
@@ -19,6 +19,7 @@ import torch.nn.functional as F
 from parameterized import parameterized
 
 from monai.transforms import KeepLargestConnectedComponent
+from monai.transforms.utils import get_largest_connected_component_mask
 from monai.transforms.utils_pytorch_numpy_unification import moveaxis
 from monai.utils.type_conversion import convert_to_dst_type
 from tests.test_utils import TEST_NDARRAYS, assert_allclose
@@ -413,6 +414,34 @@ class TestKeepLargestConnectedComponent(unittest.TestCase):
             img = input_image.argmax(0)[None]
             result2 = KeepLargestConnectedComponent(**args)(img)
             assert_allclose(result.argmax(0)[None], result2, type_test="tensor")
+
+
+class TestGetLargestConnectedComponentMask(unittest.TestCase):
+    @parameterized.expand([(p,) for p in TEST_NDARRAYS])
+    def test_num_components_selection(self, in_type):
+        # a field with four separate foreground blobs of sizes 6, 4, 3 and 1
+        # voxels (plus background). Selecting the ``num_components`` largest must
+        # keep exactly the largest ``num_components`` blobs, regardless of label
+        # order. This guards the bincount-based ranking in
+        # ``get_largest_connected_component_mask``.
+        img = in_type(
+            torch.tensor(
+                [[1, 1, 0, 2, 2, 0], [1, 1, 0, 2, 2, 0], [1, 1, 0, 0, 0, 0], [0, 0, 0, 3, 3, 0], [4, 0, 0, 3, 0, 0]]
+            )
+        )
+
+        # sizes: blob A=6, B=4, C=3, D=1 -> expected kept voxels for each n
+        expected_counts = {1: 6, 2: 10, 3: 13, 4: 14}
+        for num_components, expected in expected_counts.items():
+            mask = get_largest_connected_component_mask(img, num_components=num_components)
+            assert_allclose(mask.sum(), torch.tensor(expected), type_test=False)
+
+    @parameterized.expand([(p,) for p in TEST_NDARRAYS])
+    def test_background_never_selected(self, in_type):
+        # background (label 0) dominates by voxel count but must never be kept.
+        img = in_type(torch.tensor([[0, 0, 0, 0], [0, 1, 1, 0], [0, 0, 0, 0]]))
+        mask = get_largest_connected_component_mask(img, num_components=1)
+        assert_allclose(mask.sum(), torch.tensor(2), type_test=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #8974.

### Summary

`get_largest_connected_component_mask` (`monai/transforms/utils.py`) ranked component sizes with:

```python
nonzeros = features[lib.nonzero(features)]
features_to_keep = lib.argsort(lib.bincount(nonzeros))[::-1][:num_components]
```

`lib.nonzero(features)` materializes one full index array **per spatial dim**, and `features[...]` then gathers a full copy of every non-background voxel — all purely to drop background before `bincount`. That is unnecessary: a `bincount` over the whole field already counts every label, and background is label `0`.

This PR counts directly over the field and masks background out:

```python
counts = lib.bincount(features.reshape(-1))
counts[0] = 0  # ignore background
features_to_keep = lib.argsort(counts)[::-1][:num_components]
```

This avoids both the `nonzero` index arrays and the gathered copy, so it lowers peak memory and runtime on large volumes. The change applies to both the NumPy and CuPy (`lib`) paths.

### Why the output is unchanged (bit-identical)

- Background is label `0`; setting `counts[0] = 0` guarantees it is never selected.
- Every foreground label keeps the exact same voxel count as before (the old code excluded background from `bincount`, which only affected bin `0`, whose count was already `0`).
- This branch only runs when `num_features > num_components`, so all foreground labels have count `>= 1` and the `num_components` largest selected by `argsort(...)[::-1]` are identical. `isin` membership is order-independent.

### Tests

Existing `test_keep_largest_connected_component[d]` suites (174 cases) still pass. Added direct `get_largest_connected_component_mask` tests across `TEST_NDARRAYS` backends:

- `test_num_components_selection`: a field with four blobs (6/4/3/1 voxels) keeps exactly the largest `num_components` for `n = 1..4`.
- `test_background_never_selected`: background dominates by voxel count but is never kept.