### PR TITLE
Fix ResidualUnit padding override for explicit padding=0

### DIFF
--- a/monai/networks/blocks/convolutions.py
+++ b/monai/networks/blocks/convolutions.py
@@ -231,7 +231,7 @@ class ResidualUnit(nn.Module):
             - When dropout_dim = 2, Randomly zero out entire channels (a channel is a 2D feature map).
             - When dropout_dim = 3, Randomly zero out entire channels (a channel is a 3D feature map).
 
-            The value of dropout_dim should be no larger than the value of `dimensions`.
+            The value of dropout_dim should be no larger than the value of `spatial_dims`.
         dilation: dilation rate. Defaults to 1.
         bias: whether to have a bias term. Defaults to True.
         last_conv_only: for the last subunit, whether to use the convolutional layer only.
@@ -269,7 +269,7 @@ class ResidualUnit(nn.Module):
         self.out_channels = out_channels
         self.conv = nn.Sequential()
         self.residual = nn.Identity()
-        if not padding:
+        if padding is None:
             padding = same_padding(kernel_size, dilation)
         schannels = in_channels
         sstrides = strides

--- a/tests/networks/blocks/test_convolutions.py
+++ b/tests/networks/blocks/test_convolutions.py
@@ -152,7 +152,7 @@ class TestResidualUnit2D(TorchImageTestCase2D):
         self.assertEqual(out.shape, expected_shape)
 
     def test_padding1(self):
-        conv = ResidualUnit(2, 1, self.output_channels, kernel_size=3, padding=0)
+        conv = ResidualUnit(2, 1, self.output_channels, kernel_size=1, padding=0)
         self.assertEqual(conv.conv.unit0.conv.padding, (0, 0))
 
 

--- a/tests/networks/blocks/test_convolutions.py
+++ b/tests/networks/blocks/test_convolutions.py
@@ -151,6 +151,10 @@ class TestResidualUnit2D(TorchImageTestCase2D):
         expected_shape = (1, self.output_channels, self.im_shape[0], self.im_shape[1])
         self.assertEqual(out.shape, expected_shape)
 
+    def test_padding1(self):
+        conv = ResidualUnit(2, 1, self.output_channels, kernel_size=3, padding=0)
+        self.assertEqual(conv.conv.unit0.conv.padding, (0, 0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix ResidualUnit padding override for explicit padding=0

### Description

ResidualUnit used `if not padding:` to decide whether to compute default same-padding, which treats an explicitly passed `padding=0` as falsy and silently overrides it with the auto-computed value. This is inconsistent with the Convolution class in the same file, which correctly checks `if padding is None:`.

Also fixes a stale docstring reference to a parameter named `dimensions`, which was renamed to `spatial_dims` in this class but never updated in the dropout_dim docstring.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
