### PR TITLE
Fix tracing-state leak after transform exceptions

### DIFF
--- a/monai/transforms/inverse.py
+++ b/monai/transforms/inverse.py
@@ -402,11 +402,20 @@ class TraceableTransform(Transform):
 
     @contextmanager
     def trace_transform(self, to_trace: bool):
-        """Temporarily set the tracing status of a transform with a context manager."""
+        """Temporarily set the tracing status of a transform.
+
+        The previous tracing state is restored when the context exits normally
+        or because of an exception.
+
+        Args:
+            to_trace: tracing state to use within the context.
+        """
         prev = self.tracing
         self.tracing = to_trace
-        yield
-        self.tracing = prev
+        try:
+            yield
+        finally:
+            self.tracing = prev
 
 
 class InvertibleTransform(TraceableTransform, InvertibleTrait):

--- a/tests/transforms/inverse/test_traceable_transform.py
+++ b/tests/transforms/inverse/test_traceable_transform.py
@@ -29,6 +29,18 @@ class _TraceTest(TraceableTransform):
 
 class TestTraceable(unittest.TestCase):
 
+    def test_trace_transform_restores_state_after_exception(self):
+        """Verify tracing state is restored after an exception."""
+        transform = _TraceTest()
+        transform.tracing = True
+
+        with self.assertRaisesRegex(RuntimeError, "expected failure"):
+            with transform.trace_transform(False):
+                self.assertFalse(transform.tracing)
+                raise RuntimeError("expected failure")
+
+        self.assertTrue(transform.tracing)
+
     def test_default(self):
         expected_key = "_transforms"
         a = _TraceTest()


### PR DESCRIPTION
Closes #7701.

### Description

`TraceableTransform.trace_transform()` now restores the previous tracing state even when code inside the context manager raises. The original exception still propagates unchanged.

The previous implementation restored `self.tracing` only after a normal `yield`, so an exception permanently leaked the temporary tracing value into the transform. This caused later inverse transforms to fail with `Transform Tracing must be enabled` after a caught CUDA OOM or other runtime exception.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

### Validation

- regression fails on `upstream/dev` with leaked tracing state;
- `python -m pytest tests/transforms/inverse/test_traceable_transform.py -q`: 2 passed;
- `ruff check` on both touched files;
- `git diff --check`.

