### PR TITLE
Fix double sharding in ShuffleBuffer

### DIFF
--- a/monai/data/iterable_dataset.py
+++ b/monai/data/iterable_dataset.py
@@ -122,14 +122,25 @@ class ShuffleBuffer(Randomizable, IterableDataset):
             yield self.randomized_pop(buffer)
 
     def __iter__(self):
-        """
-        Randomly pop buffered items from `self.data`.
-        Multiple dataloader workers sharing this dataset will generate identical item sequences.
+        """Randomly pop buffered items from ``self.data``.
+
+        MONAI ``IterableDataset`` sources retain their existing worker
+        partition; other sources are partitioned after shuffling.
+
+        Yields:
+            Items from the shuffled source after applying the optional transform.
         """
         self.seed += 1
         super().set_random_state(seed=self.seed)  # make all workers in sync
         for _ in range(self.epochs) if self.epochs >= 0 else iter(int, 1):
-            yield from IterableDataset(self.generate_item(), transform=self.transform)
+            if isinstance(self.data, IterableDataset):
+                # MONAI IterableDataset subclasses already partition their source per worker.
+                for item in self.generate_item():
+                    if self.transform is not None:
+                        item = apply_transform(self.transform, item)
+                    yield item
+            else:
+                yield from IterableDataset(self.generate_item(), transform=self.transform)
 
     def randomize(self, size: int) -> None:
         self._idx = self.R.randint(size)

--- a/tests/data/test_shuffle_buffer.py
+++ b/tests/data/test_shuffle_buffer.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 
 import sys
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import numpy as np
 
-from monai.data import DataLoader, ShuffleBuffer
+from monai.data import DataLoader, IterableDataset, ShuffleBuffer
 from monai.utils import convert_data_type
 
 
@@ -36,6 +38,18 @@ class TestShuffleBuffer(unittest.TestCase):
         else:  # multiprocess shuffle
             np.testing.assert_allclose(output, [[2, 3], [1, 4]], err_msg=f"seed {buffer.seed}")
             np.testing.assert_allclose(output2, [[1, 4], [2, 3]], err_msg=f"seed {buffer.seed}")
+
+    def test_iterable_dataset_is_not_sharded_twice(self):
+        """Verify a MONAI iterable source is partitioned exactly once."""
+        worker_info = SimpleNamespace(num_workers=2, id=0)
+        source = IterableDataset(range(40))
+        buffer = ShuffleBuffer(source, transform=lambda item: item + 40, buffer_size=8, seed=7)
+
+        with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
+            output = list(buffer)
+
+        self.assertEqual(len(output), 20)
+        self.assertEqual(set(output), set(range(40, 80, 2)))
 
     def test_epochs(self):
         buffer = ShuffleBuffer([1, 2, 3, 4], seed=0, epochs=2)


### PR DESCRIPTION
Closes #7986.

### Description

`ShuffleBuffer` no longer applies worker partitioning twice when its source is already a PyTorch/MONAI `IterableDataset`.

A MONAI `IterableDataset` shards its source in its own iterator. `ShuffleBuffer` then wrapped that already-sharded generator in another `IterableDataset`, which sharded it again. With two workers this reduced 40 unique source items to 20 outputs. Ordinary iterable sources retain the existing shuffle-then-partition path, and transforms remain exactly-once.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

### Validation

- deterministic regression fails on `upstream/dev` due to double sharding;
- `python -m pytest tests/data/test_shuffle_buffer.py tests/data/test_iterable_dataset.py -q`: 5 passed;
- real two-worker reproduction: 40 inputs, 40 unique outputs;
- `ruff check` on both touched files;
- `git diff --check`.

