### PR TITLE
Fix double sharding in ShuffleBuffer

### DIFF
--- a/monai/data/grid_dataset.py
+++ b/monai/data/grid_dataset.py
@@ -218,6 +218,8 @@ class GridPatchDataset(IterableDataset):
 
     """
 
+    _shards_by_worker = True
+
     def __init__(
         self,
         data: Iterable | Sequence,
@@ -403,6 +405,8 @@ class PatchDataset(IterableDataset):
         >>> torch.Size([2, 1, 3, 3])
 
     """
+
+    _shards_by_worker = True
 
     def __init__(
         self, data: Sequence, patch_func: Callable, samples_per_image: int = 1, transform: Callable | None = None

--- a/monai/data/iterable_dataset.py
+++ b/monai/data/iterable_dataset.py
@@ -75,6 +75,11 @@ class ShuffleBuffer(Randomizable, IterableDataset):
             every iter() call, refer to the PyTorch idea:
             https://github.com/pytorch/pytorch/blob/v1.10.0/torch/utils/data/distributed.py#L98.
         epochs: number of epochs to iterate over the dataset, default to 1, -1 means infinite epochs.
+        source_shards_by_worker: whether ``data`` already partitions its stream
+            using ``torch.utils.data.get_worker_info``. ``None`` automatically
+            recognizes MONAI ``IterableDataset`` sources, ``True`` avoids a
+            second worker partition for any worker-aware source, and ``False``
+            preserves the outer partition for unsharded iterable datasets.
 
     Note:
         Both ``monai.data.DataLoader`` and ``torch.utils.data.DataLoader`` do not seed this class (as a subclass of
@@ -97,11 +102,22 @@ class ShuffleBuffer(Randomizable, IterableDataset):
 
     """
 
-    def __init__(self, data, transform=None, buffer_size: int = 512, seed: int = 0, epochs: int = 1) -> None:
+    def __init__(
+        self,
+        data,
+        transform=None,
+        buffer_size: int = 512,
+        seed: int = 0,
+        epochs: int = 1,
+        source_shards_by_worker: bool | None = None,
+    ) -> None:
         super().__init__(data=data, transform=transform)
         self.size = buffer_size
         self.seed = seed
         self.epochs = epochs
+        self.source_shards_by_worker = (
+            isinstance(data, IterableDataset) if source_shards_by_worker is None else source_shards_by_worker
+        )
         self._idx = 0
 
     def randomized_pop(self, buffer):
@@ -124,17 +140,13 @@ class ShuffleBuffer(Randomizable, IterableDataset):
     def __iter__(self):
         """Randomly pop buffered items from ``self.data``.
 
-        MONAI ``IterableDataset`` sources retain their existing worker
-        partition; other sources are partitioned after shuffling.
-
         Yields:
             Items from the shuffled source after applying the optional transform.
         """
         self.seed += 1
         super().set_random_state(seed=self.seed)  # make all workers in sync
         for _ in range(self.epochs) if self.epochs >= 0 else iter(int, 1):
-            if isinstance(self.data, IterableDataset):
-                # MONAI IterableDataset subclasses already partition their source per worker.
+            if self.source_shards_by_worker:
                 for item in self.generate_item():
                     if self.transform is not None:
                         item = apply_transform(self.transform, item)

--- a/monai/data/iterable_dataset.py
+++ b/monai/data/iterable_dataset.py
@@ -25,6 +25,14 @@ from monai.utils import optional_import
 pd, _ = optional_import("pandas")
 
 
+def _source_shards_by_worker(data: Iterable[Any]) -> bool:
+    """Return whether the source declares that its iterator partitions by worker."""
+    for source_type in type(data).__mro__:
+        if "__iter__" in source_type.__dict__:
+            return bool(source_type.__dict__.get("_shards_by_worker", False))
+    return False
+
+
 class IterableDataset(_TorchIterableDataset):
     """
     A generic dataset for iterable data source and an optional callable data transform
@@ -39,6 +47,8 @@ class IterableDataset(_TorchIterableDataset):
     process-safe from data source or DataLoader.
 
     """
+
+    _shards_by_worker = True
 
     def __init__(self, data: Iterable[Any], transform: Callable | None = None) -> None:
         """
@@ -77,9 +87,11 @@ class ShuffleBuffer(Randomizable, IterableDataset):
         epochs: number of epochs to iterate over the dataset, default to 1, -1 means infinite epochs.
         source_shards_by_worker: whether ``data`` already partitions its stream
             using ``torch.utils.data.get_worker_info``. ``None`` automatically
-            recognizes MONAI ``IterableDataset`` sources, ``True`` avoids a
-            second worker partition for any worker-aware source, and ``False``
-            preserves the outer partition for unsharded iterable datasets.
+            recognizes built-in MONAI sources that declare worker partitioning.
+            A subclass that overrides iteration without declaring that capability
+            is treated as unsharded. ``True`` avoids a second worker partition
+            for any worker-aware source, and ``False`` preserves the outer
+            partition for unsharded iterable datasets.
 
     Note:
         Both ``monai.data.DataLoader`` and ``torch.utils.data.DataLoader`` do not seed this class (as a subclass of
@@ -102,6 +114,8 @@ class ShuffleBuffer(Randomizable, IterableDataset):
 
     """
 
+    _shards_by_worker = True
+
     def __init__(
         self,
         data,
@@ -121,14 +135,15 @@ class ShuffleBuffer(Randomizable, IterableDataset):
             epochs: number of source iterations, where ``-1`` means infinite.
             source_shards_by_worker: whether ``data`` already partitions its
                 stream using ``torch.utils.data.get_worker_info``. ``None``
-                automatically recognizes MONAI ``IterableDataset`` sources.
+                automatically recognizes built-in MONAI sources that declare
+                worker partitioning.
         """
         super().__init__(data=data, transform=transform)
         self.size = buffer_size
         self.seed = seed
         self.epochs = epochs
         self.source_shards_by_worker = (
-            isinstance(data, IterableDataset) if source_shards_by_worker is None else source_shards_by_worker
+            _source_shards_by_worker(data) if source_shards_by_worker is None else source_shards_by_worker
         )
         self._idx = 0
 
@@ -231,6 +246,8 @@ class CSVIterableDataset(IterableDataset):
         kwargs: additional arguments for `pandas.merge()` API to join tables.
 
     """
+
+    _shards_by_worker = True
 
     def __init__(
         self,

--- a/monai/data/iterable_dataset.py
+++ b/monai/data/iterable_dataset.py
@@ -330,4 +330,5 @@ class CSVIterableDataset(IterableDataset):
                 data=self._flattened(), transform=self.transform, buffer_size=self.buffer_size, seed=self.seed
             )
             yield from buffer
-        yield from IterableDataset(data=self._flattened(), transform=self.transform)
+        else:
+            yield from IterableDataset(data=self._flattened(), transform=self.transform)

--- a/monai/data/iterable_dataset.py
+++ b/monai/data/iterable_dataset.py
@@ -178,6 +178,9 @@ class ShuffleBuffer(Randomizable, IterableDataset):
 
         Yields:
             Items from the shuffled source after applying the optional transform.
+
+        Raises:
+            RuntimeError: When the optional transform raises an exception.
         """
         self.seed += 1
         super().set_random_state(seed=self.seed)  # make all workers in sync

--- a/monai/data/iterable_dataset.py
+++ b/monai/data/iterable_dataset.py
@@ -26,7 +26,16 @@ pd, _ = optional_import("pandas")
 
 
 def _source_shards_by_worker(data: Iterable[Any]) -> bool:
-    """Return whether the source declares that its iterator partitions by worker."""
+    """Return whether the source declares that its iterator partitions by worker.
+
+    Args:
+        data: iterable source to inspect through its type's method resolution order.
+
+    Returns:
+        ``True`` if the first class defining ``__iter__`` declares a truthy
+        ``_shards_by_worker`` value on itself, or ``False`` if the declaration
+        is missing or false.
+    """
     for source_type in type(data).__mro__:
         if "__iter__" in source_type.__dict__:
             return bool(source_type.__dict__.get("_shards_by_worker", False))

--- a/monai/data/iterable_dataset.py
+++ b/monai/data/iterable_dataset.py
@@ -111,6 +111,18 @@ class ShuffleBuffer(Randomizable, IterableDataset):
         epochs: int = 1,
         source_shards_by_worker: bool | None = None,
     ) -> None:
+        """Initialize the shuffle buffer.
+
+        Args:
+            data: input data source to load, shuffle, and optionally transform.
+            transform: a callable data transform applied to each yielded item.
+            buffer_size: maximum number of items stored before random popping.
+            seed: random seed used to initialize the worker random states.
+            epochs: number of source iterations, where ``-1`` means infinite.
+            source_shards_by_worker: whether ``data`` already partitions its
+                stream using ``torch.utils.data.get_worker_info``. ``None``
+                automatically recognizes MONAI ``IterableDataset`` sources.
+        """
         super().__init__(data=data, transform=transform)
         self.size = buffer_size
         self.seed = seed

--- a/monai/data/iterable_dataset.py
+++ b/monai/data/iterable_dataset.py
@@ -122,14 +122,25 @@ class ShuffleBuffer(Randomizable, IterableDataset):
             yield self.randomized_pop(buffer)
 
     def __iter__(self):
-        """
-        Randomly pop buffered items from `self.data`.
-        Multiple dataloader workers sharing this dataset will generate identical item sequences.
+        """Randomly pop buffered items from ``self.data``.
+
+        MONAI ``IterableDataset`` sources retain their existing worker
+        partition; other sources are partitioned after shuffling.
+
+        Yields:
+            Items from the shuffled source after applying the optional transform.
         """
         self.seed += 1
         super().set_random_state(seed=self.seed)  # make all workers in sync
         for _ in range(self.epochs) if self.epochs >= 0 else iter(int, 1):
-            yield from IterableDataset(self.generate_item(), transform=self.transform)
+            if isinstance(self.data, IterableDataset):
+                # MONAI IterableDataset subclasses already partition their source per worker.
+                for item in self.generate_item():
+                    if self.transform is not None:
+                        item = apply_transform(self.transform, item)
+                    yield item
+            else:
+                yield from IterableDataset(self.generate_item(), transform=self.transform)
 
     def randomize(self, size: int) -> None:
         self._idx = self.R.randint(size)

--- a/tests/data/test_csv_iterable_dataset.py
+++ b/tests/data/test_csv_iterable_dataset.py
@@ -31,6 +31,14 @@ class _OneShotChunks:
         self.iterations = 0
 
     def __iter__(self):
+        """Yield the source's single DataFrame chunk.
+
+        Yields:
+            A DataFrame containing two test records.
+
+        Raises:
+            RuntimeError: When the source is iterated more than once.
+        """
         self.iterations += 1
         if self.iterations > 1:
             raise RuntimeError("one-shot source reused")

--- a/tests/data/test_csv_iterable_dataset.py
+++ b/tests/data/test_csv_iterable_dataset.py
@@ -24,8 +24,31 @@ from monai.transforms import ToNumpyd
 from tests.test_utils import skip_if_windows
 
 
+class _OneShotChunks:
+    """Yield one DataFrame chunk and reject a second iteration."""
+
+    def __init__(self):
+        self.iterations = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        if self.iterations > 1:
+            raise RuntimeError("one-shot source reused")
+        yield pd.DataFrame({"subject_id": ["s0", "s1"], "label": [0, 1]})
+
+
 @skip_if_windows
 class TestCSVIterableDataset(unittest.TestCase):
+    def test_shuffle_consumes_one_shot_source_once(self):
+        source = _OneShotChunks()
+        dataset = CSVIterableDataset(src=source, chunksize=2, buffer_size=2, shuffle=True, seed=7)
+
+        items = list(dataset)
+
+        self.assertEqual(source.iterations, 1)
+        self.assertEqual(len(items), 2)
+        self.assertEqual({item["subject_id"] for item in items}, {"s0", "s1"})
+
     def test_values(self):
         with tempfile.TemporaryDirectory() as tempdir:
             test_data1 = [

--- a/tests/data/test_shuffle_buffer.py
+++ b/tests/data/test_shuffle_buffer.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 
 import sys
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import numpy as np
 
-from monai.data import DataLoader, ShuffleBuffer
+from monai.data import DataLoader, IterableDataset, ShuffleBuffer
 from monai.utils import convert_data_type
 
 
@@ -36,6 +38,18 @@ class TestShuffleBuffer(unittest.TestCase):
         else:  # multiprocess shuffle
             np.testing.assert_allclose(output, [[2, 3], [1, 4]], err_msg=f"seed {buffer.seed}")
             np.testing.assert_allclose(output2, [[1, 4], [2, 3]], err_msg=f"seed {buffer.seed}")
+
+    def test_iterable_dataset_is_not_sharded_twice(self):
+        """Verify a MONAI iterable source is partitioned exactly once."""
+        worker_info = SimpleNamespace(num_workers=2, id=0)
+        source = IterableDataset(range(40))
+        buffer = ShuffleBuffer(source, transform=lambda item: item + 40, buffer_size=8, seed=7)
+
+        with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
+            output = list(buffer)
+
+        self.assertEqual(len(output), 20)
+        self.assertEqual(set(output), set(range(40, 80, 2)))
 
     def test_epochs(self):
         buffer = ShuffleBuffer([1, 2, 3, 4], seed=0, epochs=2)

--- a/tests/data/test_shuffle_buffer.py
+++ b/tests/data/test_shuffle_buffer.py
@@ -90,18 +90,24 @@ class TestShuffleBuffer(unittest.TestCase):
             self.assertEqual(len(outputs), 40)
             self.assertEqual(set(outputs), set(range(40, 80)))
 
-    def test_explicit_unsharded_source_keeps_outer_worker_partition(self):
-        """Verify explicit unsharded mode preserves outer worker partitioning."""
-        outputs = []
-        for worker_id in range(2):
-            source = _UnshardedMonaiIterable(range(40))
-            buffer = ShuffleBuffer(source, buffer_size=8, seed=7, source_shards_by_worker=False)
-            worker_info = SimpleNamespace(num_workers=2, id=worker_id)
-            with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
-                outputs.extend(buffer)
+    def test_unsharded_monai_subclass_keeps_outer_worker_partition(self):
+        """Verify default and explicit unsharded modes preserve outer partitioning."""
+        for source_shards_by_worker in (None, False):
+            outputs = []
+            for worker_id in range(2):
+                source = _UnshardedMonaiIterable(range(40))
+                buffer = ShuffleBuffer(
+                    source,
+                    buffer_size=8,
+                    seed=7,
+                    source_shards_by_worker=source_shards_by_worker,
+                )
+                worker_info = SimpleNamespace(num_workers=2, id=worker_id)
+                with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
+                    outputs.extend(buffer)
 
-        self.assertEqual(len(outputs), 40)
-        self.assertEqual(set(outputs), set(range(40)))
+            self.assertEqual(len(outputs), 40)
+            self.assertEqual(set(outputs), set(range(40)))
 
     def test_epochs(self):
         buffer = ShuffleBuffer([1, 2, 3, 4], seed=0, epochs=2)

--- a/tests/data/test_shuffle_buffer.py
+++ b/tests/data/test_shuffle_buffer.py
@@ -28,6 +28,11 @@ class _UnshardedMonaiIterable(IterableDataset):
     """MONAI iterable subclass that intentionally does not partition itself."""
 
     def __iter__(self):
+        """Yield every item from the unsharded source.
+
+        Yields:
+            Items from ``self.data``.
+        """
         yield from self.data
 
 
@@ -38,6 +43,11 @@ class _WorkerShardedTorchIterable(TorchIterableDataset):
         self.size = size
 
     def __iter__(self):
+        """Yield the integer indices assigned to the current worker.
+
+        Yields:
+            Integer indices from the worker's partition of ``range(self.size)``.
+        """
         worker_info = iterable_dataset_module.get_worker_info()
         num_workers = worker_info.num_workers if worker_info is not None else 1
         worker_id = worker_info.id if worker_info is not None else 0

--- a/tests/data/test_shuffle_buffer.py
+++ b/tests/data/test_shuffle_buffer.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 import numpy as np
 from torch.utils.data import IterableDataset as TorchIterableDataset
 
-from monai.data import DataLoader, IterableDataset, ShuffleBuffer
+from monai.data import DataLoader, GridPatchDataset, IterableDataset, PatchIter, ShuffleBuffer
 from monai.data import iterable_dataset as iterable_dataset_module
 from monai.utils import convert_data_type
 
@@ -90,18 +90,36 @@ class TestShuffleBuffer(unittest.TestCase):
             self.assertEqual(len(outputs), 40)
             self.assertEqual(set(outputs), set(range(40, 80)))
 
+    def test_grid_patch_dataset_is_not_sharded_twice(self):
+        """Verify every grid patch is yielded exactly once across workers."""
+        images = [np.arange(16).reshape(1, 4, 4), np.arange(16, 32).reshape(1, 4, 4)]
+        expected_patches = [
+            (0, 1, 4, 5),
+            (2, 3, 6, 7),
+            (8, 9, 12, 13),
+            (10, 11, 14, 15),
+            (16, 17, 20, 21),
+            (18, 19, 22, 23),
+            (24, 25, 28, 29),
+            (26, 27, 30, 31),
+        ]
+        outputs = []
+        for worker_id in range(2):
+            source = GridPatchDataset(data=images, patch_iter=PatchIter(patch_size=(2, 2)), with_coordinates=False)
+            buffer = ShuffleBuffer(source, buffer_size=3, seed=7)
+            worker_info = SimpleNamespace(num_workers=2, id=worker_id)
+            with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
+                outputs.extend(tuple(item.ravel().tolist()) for item in buffer)
+
+        self.assertCountEqual(outputs, expected_patches)
+
     def test_unsharded_monai_subclass_keeps_outer_worker_partition(self):
         """Verify default and explicit unsharded modes preserve outer partitioning."""
         for source_shards_by_worker in (None, False):
             outputs = []
             for worker_id in range(2):
                 source = _UnshardedMonaiIterable(range(40))
-                buffer = ShuffleBuffer(
-                    source,
-                    buffer_size=8,
-                    seed=7,
-                    source_shards_by_worker=source_shards_by_worker,
-                )
+                buffer = ShuffleBuffer(source, buffer_size=8, seed=7, source_shards_by_worker=source_shards_by_worker)
                 worker_info = SimpleNamespace(num_workers=2, id=worker_id)
                 with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
                     outputs.extend(buffer)

--- a/tests/data/test_shuffle_buffer.py
+++ b/tests/data/test_shuffle_buffer.py
@@ -17,9 +17,31 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+from torch.utils.data import IterableDataset as TorchIterableDataset
 
 from monai.data import DataLoader, IterableDataset, ShuffleBuffer
+from monai.data import iterable_dataset as iterable_dataset_module
 from monai.utils import convert_data_type
+
+
+class _UnshardedMonaiIterable(IterableDataset):
+    """MONAI iterable subclass that intentionally does not partition itself."""
+
+    def __iter__(self):
+        yield from self.data
+
+
+class _WorkerShardedTorchIterable(TorchIterableDataset):
+    """PyTorch iterable source that partitions itself across workers."""
+
+    def __init__(self, size):
+        self.size = size
+
+    def __iter__(self):
+        worker_info = iterable_dataset_module.get_worker_info()
+        num_workers = worker_info.num_workers if worker_info is not None else 1
+        worker_id = worker_info.id if worker_info is not None else 0
+        yield from range(worker_id, self.size, num_workers)
 
 
 class TestShuffleBuffer(unittest.TestCase):
@@ -39,17 +61,47 @@ class TestShuffleBuffer(unittest.TestCase):
             np.testing.assert_allclose(output, [[2, 3], [1, 4]], err_msg=f"seed {buffer.seed}")
             np.testing.assert_allclose(output2, [[1, 4], [2, 3]], err_msg=f"seed {buffer.seed}")
 
-    def test_iterable_dataset_is_not_sharded_twice(self):
-        """Verify a MONAI iterable source is partitioned exactly once."""
-        worker_info = SimpleNamespace(num_workers=2, id=0)
-        source = IterableDataset(range(40))
-        buffer = ShuffleBuffer(source, transform=lambda item: item + 40, buffer_size=8, seed=7)
+    def test_monai_iterable_source_is_detected_as_worker_sharded(self):
+        """Verify MONAI iterable sources avoid a second worker partition by default."""
+        outputs = []
+        for worker_id in range(2):
+            source = IterableDataset(range(40))
+            buffer = ShuffleBuffer(source, buffer_size=8, seed=7)
+            worker_info = SimpleNamespace(num_workers=2, id=worker_id)
+            with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
+                outputs.extend(buffer)
 
-        with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
-            output = list(buffer)
+        self.assertEqual(len(outputs), 40)
+        self.assertEqual(set(outputs), set(range(40)))
 
-        self.assertEqual(len(output), 20)
-        self.assertEqual(set(output), set(range(40, 80, 2)))
+    def test_worker_sharded_source_is_not_sharded_twice(self):
+        """Verify an explicitly worker-sharded source is not repartitioned."""
+        sources = [IterableDataset(range(40)), _WorkerShardedTorchIterable(40)]
+        for source in sources:
+            outputs = []
+            for worker_id in range(2):
+                buffer = ShuffleBuffer(
+                    source, transform=lambda item: item + 40, buffer_size=8, seed=7, source_shards_by_worker=True
+                )
+                worker_info = SimpleNamespace(num_workers=2, id=worker_id)
+                with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
+                    outputs.extend(buffer)
+
+            self.assertEqual(len(outputs), 40)
+            self.assertEqual(set(outputs), set(range(40, 80)))
+
+    def test_explicit_unsharded_source_keeps_outer_worker_partition(self):
+        """Verify explicit unsharded mode preserves outer worker partitioning."""
+        outputs = []
+        for worker_id in range(2):
+            source = _UnshardedMonaiIterable(range(40))
+            buffer = ShuffleBuffer(source, buffer_size=8, seed=7, source_shards_by_worker=False)
+            worker_info = SimpleNamespace(num_workers=2, id=worker_id)
+            with patch("monai.data.iterable_dataset.get_worker_info", return_value=worker_info):
+                outputs.extend(buffer)
+
+        self.assertEqual(len(outputs), 40)
+        self.assertEqual(set(outputs), set(range(40)))
 
     def test_epochs(self):
         buffer = ShuffleBuffer([1, 2, 3, 4], seed=0, epochs=2)


### PR DESCRIPTION
Fixes #7986.

### Description

`ShuffleBuffer` now distinguishes sources that already partition their stream using `torch.utils.data.get_worker_info`. MONAI `IterableDataset` sources are recognized automatically, while an explicit `source_shards_by_worker` override supports generic PyTorch or unusual custom iterable sources.

The default auto-detects MONAI iterable sources, so the `GridPatchDataset` pipeline reported in #7986 works without a caller change. `True` prevents a second partition for any worker-aware source; `False` preserves the outer worker partition for an explicitly unsharded iterable source.

This avoids using class identity as a proxy for sharding behavior: MONAI subclasses can be unsharded, while generic PyTorch iterable sources can shard themselves.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

### Validation

- the original double-sharding reproduction loses samples when an already-sharded source is partitioned again;
- tests cover both explicitly worker-sharded MONAI/PyTorch sources and an unsharded MONAI subclass whose default behavior must remain unchanged;
- affected data tests: 7 passed;
- real two-worker fork-context `DataLoader` contract: the default MONAI-source path returns all 40 inputs exactly once;
- Black, isort, Ruff, DCO, and `git diff --check` pass.
