### PR TITLE
Handle constant B-spline mutual information inputs

### DIFF
--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -294,10 +294,10 @@ class GlobalMutualInformationLoss(_Loss):
         interior_bins = self.num_bins - 2 * padding
         value_range = _max - _min
         raw_bin_size = value_range / interior_bins
-        # Smaller bins either underflow the compute dtype or require a
-        # normalization slope that cannot be represented by the input dtype.
-        minimum_bin_size = max(torch.finfo(compute_img.dtype).tiny, 1.0 / torch.finfo(img.dtype).max)
-        bin_size = torch.where(raw_bin_size >= minimum_bin_size, raw_bin_size, torch.ones_like(raw_bin_size))
+        # Fall back only when the promoted bin size is non-finite or too small
+        # to remain a nonzero normal value in the compute dtype.
+        valid_bin_size = torch.isfinite(raw_bin_size) & (raw_bin_size >= torch.finfo(compute_img.dtype).tiny)
+        bin_size = torch.where(valid_bin_size, raw_bin_size, torch.ones_like(raw_bin_size))
         norm_min = torch.div(_min, bin_size) - padding
 
         # assign bin/window index to each voxel

--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -214,7 +214,8 @@ class GlobalMutualInformationLoss(_Loss):
                       IEEE Transactions in Medical Imaging. Vol.22, No.1,
                       January 2003. pp.120-128.
 
-            num_bins: number of bins for intensity. The B-spline kernel requires more than 4 bins.
+            num_bins: number of bins for intensity. The Gaussian kernel requires
+                more than 1 bin, and the B-spline kernel requires more than 4 bins.
             sigma_ratio: a hyper param for gaussian function
             reduction: {``"none"``, ``"mean"``, ``"sum"``}
                 Specifies the reduction to apply to the output. Defaults to ``"mean"``.
@@ -226,15 +227,15 @@ class GlobalMutualInformationLoss(_Loss):
             smooth_dr: a small constant added to the denominator to avoid nan.
 
         Raises:
-            ValueError: if ``num_bins`` is not positive, or if a B-spline
-                kernel is configured with four or fewer bins.
+            ValueError: if a Gaussian kernel is configured with one or fewer
+                bins, or if a B-spline kernel is configured with four or fewer bins.
         """
         super().__init__(reduction=LossReduction(reduction).value)
         if num_bins <= 0:
             raise ValueError(f"num_bins must > 0, got {num_bins}")
-        bin_centers = torch.linspace(0.0, 1.0, num_bins)  # (num_bins,)
-        sigma = torch.mean(bin_centers[1:] - bin_centers[:-1]) * sigma_ratio
         self.kernel_type = look_up_option(kernel_type, ["gaussian", "b-spline"])
+        if self.kernel_type == "gaussian" and num_bins <= 1:
+            raise ValueError(f"num_bins must be greater than 1 for gaussian kernel, got {num_bins}")
         # B-spline windowing reserves two padding bins at each boundary.
         if self.kernel_type == "b-spline" and num_bins <= 4:
             raise ValueError(f"num_bins must be greater than 4 for b-spline kernel, got {num_bins}")
@@ -246,6 +247,8 @@ class GlobalMutualInformationLoss(_Loss):
         self.register_buffer("preterm", None, persistent=False)
         self.register_buffer("bin_centers", None, persistent=False)
         if self.kernel_type == "gaussian":
+            bin_centers = torch.linspace(0.0, 1.0, num_bins)  # (num_bins,)
+            sigma = torch.mean(bin_centers[1:] - bin_centers[:-1]) * sigma_ratio
             self.register_buffer("preterm", 1 / (2 * sigma**2), persistent=False)
             self.register_buffer("bin_centers", bin_centers[None, None, ...], persistent=False)
         self.smooth_nr = float(smooth_nr)

--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -214,7 +214,7 @@ class GlobalMutualInformationLoss(_Loss):
                       IEEE Transactions in Medical Imaging. Vol.22, No.1,
                       January 2003. pp.120-128.
 
-            num_bins: number of bins for intensity. The b-spline kernel requires more than 4 bins.
+            num_bins: number of bins for intensity. The B-spline kernel requires more than 4 bins.
             sigma_ratio: a hyper param for gaussian function
             reduction: {``"none"``, ``"mean"``, ``"sum"``}
                 Specifies the reduction to apply to the output. Defaults to ``"mean"``.
@@ -288,22 +288,25 @@ class GlobalMutualInformationLoss(_Loss):
         # Note that there can still be non-zero bin values in the padded region,
         # it's just that these bins will never be a central bin for the Parzen
         # window.
-        _max, _min = torch.max(img), torch.min(img)
+        compute_img = img.float() if img.dtype in (torch.float16, torch.bfloat16) else img
+        _max, _min = torch.max(compute_img), torch.min(compute_img)
         padding = 2
+        interior_bins = self.num_bins - 2 * padding
         value_range = _max - _min
-        bin_size = value_range / (self.num_bins - 2 * padding)
-        bin_size = torch.where(value_range > 0, bin_size, torch.ones_like(bin_size))
+        raw_bin_size = value_range / interior_bins
+        # Smaller bins either underflow the compute dtype or require a
+        # normalization slope that cannot be represented by the input dtype.
+        minimum_bin_size = max(torch.finfo(compute_img.dtype).tiny, 1.0 / torch.finfo(img.dtype).max)
+        bin_size = torch.where(raw_bin_size >= minimum_bin_size, raw_bin_size, torch.ones_like(raw_bin_size))
         norm_min = torch.div(_min, bin_size) - padding
 
         # assign bin/window index to each voxel
-        window_term = torch.div(img, bin_size) - norm_min  # B[NDHW]
+        window_term = torch.div(compute_img, bin_size) - norm_min  # B[NDHW]
         # make sure the extreme values are in valid (non-padded) bins
         window_term = torch.clamp(window_term, padding, self.num_bins - padding - 1)  # B[NDHW]
         window_term = window_term.reshape(window_term.shape[0], -1, 1)  # (batch, num_sample, 1)
         bins = torch.arange(self.num_bins, device=window_term.device).reshape(1, 1, -1)  # (1, 1, num_bins)
         sample_bin_matrix = torch.abs(bins - window_term)  # (batch, num_sample, num_bins)
-        if sample_bin_matrix.dtype == torch.float16:
-            sample_bin_matrix = sample_bin_matrix.float()  # avoid overflow in the cubic polynomial
 
         # b-spleen kernel
         # (4 - 6 * abs ** 2 + 3 * abs ** 3) / 6 when 0 <= abs < 1

--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -291,7 +291,9 @@ class GlobalMutualInformationLoss(_Loss):
         # Note that there can still be non-zero bin values in the padded region,
         # it's just that these bins will never be a central bin for the Parzen
         # window.
-        compute_img = img.float() if img.dtype in (torch.float16, torch.bfloat16) else img
+        compute_img = (
+            img.float() if not torch.is_floating_point(img) or img.dtype in (torch.float16, torch.bfloat16) else img
+        )
         _max, _min = torch.max(compute_img), torch.min(compute_img)
         padding = 2
         interior_bins = self.num_bins - 2 * padding

--- a/monai/losses/image_dissimilarity.py
+++ b/monai/losses/image_dissimilarity.py
@@ -214,7 +214,7 @@ class GlobalMutualInformationLoss(_Loss):
                       IEEE Transactions in Medical Imaging. Vol.22, No.1,
                       January 2003. pp.120-128.
 
-            num_bins: number of bins for intensity
+            num_bins: number of bins for intensity. The b-spline kernel requires more than 4 bins.
             sigma_ratio: a hyper param for gaussian function
             reduction: {``"none"``, ``"mean"``, ``"sum"``}
                 Specifies the reduction to apply to the output. Defaults to ``"mean"``.
@@ -224,6 +224,10 @@ class GlobalMutualInformationLoss(_Loss):
                 - ``"sum"``: the output will be summed.
             smooth_nr: a small constant added to the numerator to avoid nan.
             smooth_dr: a small constant added to the denominator to avoid nan.
+
+        Raises:
+            ValueError: if ``num_bins`` is not positive, or if a B-spline
+                kernel is configured with four or fewer bins.
         """
         super().__init__(reduction=LossReduction(reduction).value)
         if num_bins <= 0:
@@ -231,6 +235,9 @@ class GlobalMutualInformationLoss(_Loss):
         bin_centers = torch.linspace(0.0, 1.0, num_bins)  # (num_bins,)
         sigma = torch.mean(bin_centers[1:] - bin_centers[:-1]) * sigma_ratio
         self.kernel_type = look_up_option(kernel_type, ["gaussian", "b-spline"])
+        # B-spline windowing reserves two padding bins at each boundary.
+        if self.kernel_type == "b-spline" and num_bins <= 4:
+            raise ValueError(f"num_bins must be greater than 4 for b-spline kernel, got {num_bins}")
         self.num_bins = num_bins
         # declared as buffers so they move with the module (e.g. ``.to(device)``); only populated for the
         # gaussian kernel, hence the ``Tensor`` annotation reflects the type at the use sites in that path.
@@ -283,7 +290,9 @@ class GlobalMutualInformationLoss(_Loss):
         # window.
         _max, _min = torch.max(img), torch.min(img)
         padding = 2
-        bin_size = (_max - _min) / (self.num_bins - 2 * padding)
+        value_range = _max - _min
+        bin_size = value_range / (self.num_bins - 2 * padding)
+        bin_size = torch.where(value_range > 0, bin_size, torch.ones_like(bin_size))
         norm_min = torch.div(_min, bin_size) - padding
 
         # assign bin/window index to each voxel
@@ -293,6 +302,8 @@ class GlobalMutualInformationLoss(_Loss):
         window_term = window_term.reshape(window_term.shape[0], -1, 1)  # (batch, num_sample, 1)
         bins = torch.arange(self.num_bins, device=window_term.device).reshape(1, 1, -1)  # (1, 1, num_bins)
         sample_bin_matrix = torch.abs(bins - window_term)  # (batch, num_sample, num_bins)
+        if sample_bin_matrix.dtype == torch.float16:
+            sample_bin_matrix = sample_bin_matrix.float()  # avoid overflow in the cubic polynomial
 
         # b-spleen kernel
         # (4 - 6 * abs ** 2 + 3 * abs ** 3) / 6 when 0 <= abs < 1

--- a/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
+++ b/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
@@ -172,11 +172,30 @@ class TestGlobalMutualInformationLossIll(unittest.TestCase):
 class TestGlobalMutualInformationLossBSpline(unittest.TestCase):
     """Test B-spline mutual information on degenerate intensity ranges."""
 
-    def test_b_spline_constant_images_are_finite(self):
-        """Verify constant float32 inputs yield finite loss and gradients."""
-        pred = torch.zeros((1, 1, 8, 8), requires_grad=True)
-        target = torch.ones_like(pred)
+    @parameterized.expand(["prediction", "target"])
+    def test_b_spline_single_constant_input_is_finite(self, constant_input):
+        """Verify either independently constant input yields finite gradients."""
+        varying = torch.linspace(0.0, 1.0, 64).reshape(1, 1, 8, 8)
+        if constant_input == "prediction":
+            pred = torch.zeros_like(varying, requires_grad=True)
+            target = varying
+        else:
+            pred = varying.clone().requires_grad_()
+            target = torch.ones_like(varying)
         loss = GlobalMutualInformationLoss(kernel_type="b-spline")
+
+        result = loss(pred, target)
+
+        self.assertTrue(torch.isfinite(result))
+        result.backward()
+        self.assertIsNotNone(pred.grad)
+        self.assertTrue(torch.isfinite(pred.grad).all())
+
+    def test_b_spline_constant_half_precision_images_are_finite(self):
+        """Verify constant float16 inputs survive overflow-sized bin distances."""
+        pred = torch.zeros((1, 1, 8, 8), dtype=torch.float16, requires_grad=True)
+        target = torch.ones_like(pred)
+        loss = GlobalMutualInformationLoss(kernel_type="b-spline", num_bins=64)
 
         result = loss(pred, target)
 
@@ -186,16 +205,24 @@ class TestGlobalMutualInformationLossBSpline(unittest.TestCase):
         self.assertIsNotNone(pred.grad)
         self.assertTrue(torch.isfinite(pred.grad).all())
 
-    def test_b_spline_constant_half_precision_images_are_finite(self):
-        """Verify constant float16 inputs yield finite loss and gradients."""
-        pred = torch.zeros((1, 1, 8, 8), dtype=torch.float16, requires_grad=True)
-        target = torch.ones_like(pred)
-        loss = GlobalMutualInformationLoss(kernel_type="b-spline", num_bins=32)
+    @parameterized.expand(
+        [
+            ("float16_tiny", torch.float16, torch.finfo(torch.float16).tiny / 2),
+            ("bfloat16_tiny", torch.bfloat16, torch.finfo(torch.bfloat16).tiny / 2),
+            ("float32_tiny", torch.float32, torch.finfo(torch.float32).tiny / 2),
+            ("float16_large", torch.float16, 65000.0),
+        ]
+    )
+    def test_b_spline_nonzero_ranges_are_finite(self, _, dtype, maximum):
+        """Verify extreme nonzero ranges yield finite loss and gradients."""
+        values = torch.tensor([0.0, maximum, maximum, 0.0], dtype=dtype).reshape(1, 1, 2, 2)
+        pred = values.clone().requires_grad_()
+        target = torch.flip(values, dims=(-1,))
+        loss = GlobalMutualInformationLoss(kernel_type="b-spline", num_bins=64)
 
         result = loss(pred, target)
 
         self.assertTrue(torch.isfinite(result))
-        self.assertAlmostEqual(result.item(), 0.0, places=6)
         result.backward()
         self.assertIsNotNone(pred.grad)
         self.assertTrue(torch.isfinite(pred.grad).all())

--- a/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
+++ b/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
@@ -174,7 +174,12 @@ class TestGlobalMutualInformationLossBSpline(unittest.TestCase):
 
     @parameterized.expand(["prediction", "target"])
     def test_b_spline_single_constant_input_is_finite(self, constant_input):
-        """Verify either independently constant input yields finite gradients."""
+        """Verify either independently constant input yields finite gradients.
+
+        Args:
+            constant_input: Which input (``"prediction"`` or ``"target"``)
+                is held constant.
+        """
         varying = torch.linspace(0.0, 1.0, 64).reshape(1, 1, 8, 8)
         if constant_input == "prediction":
             pred = torch.zeros_like(varying, requires_grad=True)
@@ -213,8 +218,14 @@ class TestGlobalMutualInformationLossBSpline(unittest.TestCase):
             ("float16_large", torch.float16, 65000.0),
         ]
     )
-    def test_b_spline_nonzero_ranges_are_finite(self, _, dtype, maximum):
-        """Verify extreme nonzero ranges yield finite loss and gradients."""
+    def test_b_spline_nonzero_ranges_are_finite(self, case_name, dtype, maximum):
+        """Verify extreme nonzero ranges yield finite loss and gradients.
+
+        Args:
+            case_name: Descriptive label for the parameterized range case.
+            dtype: Tensor dtype used for the prediction and target.
+            maximum: Nonzero upper endpoint of the tested intensity range.
+        """
         values = torch.tensor([0.0, maximum, maximum, 0.0], dtype=dtype).reshape(1, 1, 2, 2)
         pred = values.clone().requires_grad_()
         target = torch.flip(values, dims=(-1,))

--- a/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
+++ b/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
@@ -135,6 +135,11 @@ class TestGlobalMutualInformationLossIll(unittest.TestCase):
 
         self.assertIsNone(loss.bin_centers)
 
+    def test_b_spline_num_bins_must_allow_padding(self):
+        """Verify B-spline bin counts leave room for boundary padding."""
+        with self.assertRaisesRegex(ValueError, "num_bins must be greater than 4"):
+            GlobalMutualInformationLoss(kernel_type="b-spline", num_bins=4)
+
     @parameterized.expand(
         [
             (torch.ones((1, 2), dtype=torch.float), torch.ones((1, 3), dtype=torch.float)),  # mismatched_simple_dims
@@ -162,6 +167,38 @@ class TestGlobalMutualInformationLossIll(unittest.TestCase):
         target = torch.ones((1, 3, 3, 3, 3), dtype=torch.float, device=device)
         with self.assertRaisesRegex(expected_exception, expected_message):
             GlobalMutualInformationLoss(num_bins=num_bins, reduction=reduction)(pred, target)
+
+
+class TestGlobalMutualInformationLossBSpline(unittest.TestCase):
+    """Test B-spline mutual information on degenerate intensity ranges."""
+
+    def test_b_spline_constant_images_are_finite(self):
+        """Verify constant float32 inputs yield finite loss and gradients."""
+        pred = torch.zeros((1, 1, 8, 8), requires_grad=True)
+        target = torch.ones_like(pred)
+        loss = GlobalMutualInformationLoss(kernel_type="b-spline")
+
+        result = loss(pred, target)
+
+        self.assertTrue(torch.isfinite(result))
+        self.assertAlmostEqual(result.item(), 0.0, places=6)
+        result.backward()
+        self.assertIsNotNone(pred.grad)
+        self.assertTrue(torch.isfinite(pred.grad).all())
+
+    def test_b_spline_constant_half_precision_images_are_finite(self):
+        """Verify constant float16 inputs yield finite loss and gradients."""
+        pred = torch.zeros((1, 1, 8, 8), dtype=torch.float16, requires_grad=True)
+        target = torch.ones_like(pred)
+        loss = GlobalMutualInformationLoss(kernel_type="b-spline", num_bins=32)
+
+        result = loss(pred, target)
+
+        self.assertTrue(torch.isfinite(result))
+        self.assertAlmostEqual(result.item(), 0.0, places=6)
+        result.backward()
+        self.assertIsNotNone(pred.grad)
+        self.assertTrue(torch.isfinite(pred.grad).all())
 
 
 class TestGlobalMutualInformationLossBuffers(unittest.TestCase):

--- a/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
+++ b/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
@@ -210,6 +210,21 @@ class TestGlobalMutualInformationLossBSpline(unittest.TestCase):
         self.assertIsNotNone(pred.grad)
         self.assertTrue(torch.isfinite(pred.grad).all())
 
+    def test_b_spline_float16_small_range_preserves_signal(self):
+        """Verify a small nonzero float16 range retains loss and gradient signal."""
+        values = torch.linspace(0.0, 5e-4, 64, dtype=torch.float16).reshape(1, 1, 8, 8)
+        pred = values.clone().requires_grad_()
+        loss = GlobalMutualInformationLoss(kernel_type="b-spline", num_bins=64)
+
+        result = loss(pred, values)
+
+        self.assertTrue(torch.isfinite(result))
+        self.assertLess(result.item(), -1.0)
+        result.backward()
+        self.assertIsNotNone(pred.grad)
+        self.assertTrue(torch.isfinite(pred.grad).all())
+        self.assertGreater(torch.count_nonzero(pred.grad).item(), 0)
+
     @parameterized.expand(
         [
             ("float16_tiny", torch.float16, torch.finfo(torch.float16).tiny / 2),

--- a/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
+++ b/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
@@ -140,6 +140,11 @@ class TestGlobalMutualInformationLossIll(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "num_bins must be greater than 4"):
             GlobalMutualInformationLoss(kernel_type="b-spline", num_bins=4)
 
+    def test_gaussian_num_bins_must_allow_spacing(self):
+        """Verify Gaussian bin counts allow a finite bin-centre spacing."""
+        with self.assertRaisesRegex(ValueError, "num_bins must be greater than 1"):
+            GlobalMutualInformationLoss(kernel_type="gaussian", num_bins=1)
+
     @parameterized.expand(
         [
             (torch.ones((1, 2), dtype=torch.float), torch.ones((1, 3), dtype=torch.float)),  # mismatched_simple_dims

--- a/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
+++ b/tests/losses/image_dissimilarity/test_global_mutual_information_loss.py
@@ -215,6 +215,19 @@ class TestGlobalMutualInformationLossBSpline(unittest.TestCase):
         self.assertIsNotNone(pred.grad)
         self.assertTrue(torch.isfinite(pred.grad).all())
 
+    def test_b_spline_integer_target_is_supported(self):
+        """Verify integer targets do not fail floating-point range validation."""
+        pred = torch.linspace(0.0, 1.0, 64).reshape(1, 1, 8, 8).requires_grad_()
+        target = torch.arange(64, dtype=torch.int64).reshape(1, 1, 8, 8)
+        loss = GlobalMutualInformationLoss(kernel_type="b-spline")
+
+        result = loss(pred, target)
+
+        self.assertTrue(torch.isfinite(result))
+        result.backward()
+        self.assertIsNotNone(pred.grad)
+        self.assertTrue(torch.isfinite(pred.grad).all())
+
     def test_b_spline_float16_small_range_preserves_signal(self):
         """Verify a small nonzero float16 range retains loss and gradient signal."""
         values = torch.linspace(0.0, 5e-4, 64, dtype=torch.float16).reshape(1, 1, 8, 8)


### PR DESCRIPTION
Fixes #9018.

### Description

B-spline global mutual information now remains finite when either prediction or target has a constant intensity range and for float16, bfloat16, or float32 inputs with tiny nonzero ranges. B-spline configurations with four or fewer bins are rejected because the implementation reserves two padding bins at each boundary. Gaussian configurations with one or fewer bins are rejected before bin-centre spacing is computed.

The fix performs reduced-precision range, bin-width, and B-spline coordinate arithmetic in float32. Bin widths too small to be represented safely by the compute or input dtype are treated as a degenerate range. This prevents zero-range division, tiny-range underflow, unrepresentable normalization slopes, and cubic-distance overflow while preserving autograd back to the original input.

### Types of changes

- [x] A Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

### Validation

- zero-range and tiny-range regressions fail before the follow-up fix;
- prediction-constant and target-constant paths are covered independently;
- extreme-range coverage includes float16, bfloat16, and float32 tiny ranges plus a large float16 range with `num_bins=64`;
- a one-bin Gaussian constructor regression verifies invalid spacing is rejected;
- exact final head `354e5975` affected loss module: 24 passed, 1 skipped;
- ordinary float32/float64 outputs and gradients remain unchanged in differential checks;
- Black, isort, Ruff, DCO, and `git diff --check` pass.