### PR TITLE
Standardize crop size kwargs to spatial_size (#8432)

### DIFF
--- a/monai/apps/deepgrow/transforms.py
+++ b/monai/apps/deepgrow/transforms.py
@@ -440,7 +440,7 @@ class SpatialCropForegroundd(MapTransform):
         current_size = list(np.subtract(box_end, box_start).astype(int, copy=False))
 
         if np.all(np.less(current_size, self.spatial_size)):
-            cropper = SpatialCrop(roi_center=center, roi_size=self.spatial_size)
+            cropper = SpatialCrop(roi_center=center, spatial_size=self.spatial_size)
             box_start = [s.start for s in cropper.slices]
             box_end = [s.stop for s in cropper.slices]
         else:
@@ -677,7 +677,7 @@ class SpatialCropGuidanced(MapTransform):
             if len(center) == 3:
                 # 3D Deepgrow: set center to be middle of the depth dimension (D)
                 center[0] = spatial_size[0] // 2
-            cropper = SpatialCrop(roi_center=center, roi_size=spatial_size)
+            cropper = SpatialCrop(roi_center=center, spatial_size=spatial_size)
         else:
             cropper = SpatialCrop(roi_start=box_start, roi_end=box_end)
 

--- a/monai/apps/detection/transforms/dictionary.py
+++ b/monai/apps/detection/transforms/dictionary.py
@@ -882,7 +882,7 @@ class BoxToMaskd(MapTransform):
                         prob=0.2,range_x=np.pi/6,range_y=np.pi/6,range_z=np.pi/6,
                         keep_size=True,padding_mode="zeros"
                     ),
-                    RandSpatialCropd(keys=["image","box_mask"],roi_size=128, random_size=False),
+                    RandSpatialCropd(keys=["image","box_mask"],spatial_size=128, random_size=False),
                     MaskToBoxd(
                         box_mask_keys="box_mask", box_keys="boxes",
                         label_keys="labels", min_fg_label=0
@@ -965,7 +965,7 @@ class MaskToBoxd(MapTransform):
                         prob=0.2,range_x=np.pi/6,range_y=np.pi/6,range_z=np.pi/6,
                         keep_size=True,padding_mode="zeros"
                     ),
-                    RandSpatialCropd(keys=["image","box_mask"],roi_size=128, random_size=False),
+                    RandSpatialCropd(keys=["image","box_mask"],spatial_size=128, random_size=False),
                     MaskToBoxd(
                         box_mask_keys="box_mask", box_keys="boxes",
                         label_keys="labels", min_fg_label=0
@@ -1197,7 +1197,7 @@ class RandCropBoxByPosNegLabeld(Randomizable, MapTransform):
         for i, center in enumerate(self.centers):
             results[i] = deepcopy(d)
             # compute crop start and end, always crop, no padding
-            cropper = SpatialCrop(roi_center=tuple(center), roi_size=self.spatial_size)
+            cropper = SpatialCrop(roi_center=tuple(center), spatial_size=self.spatial_size)
             crop_start = [max(s.start, 0) for s in cropper.slices]
             crop_end = [min(s.stop, image_size_a) for s, image_size_a in zip(cropper.slices, image_size)]
             crop_slices = [slice(int(s), int(e)) for s, e in zip(crop_start, crop_end)]

--- a/monai/apps/reconstruction/transforms/dictionary.py
+++ b/monai/apps/reconstruction/transforms/dictionary.py
@@ -269,7 +269,7 @@ class ReferenceBasedSpatialCropd(MapTransform, InvertibleTransform):
         for key in self.key_iterator(d):
             image = d[key]
             roi_center = tuple(i // 2 for i in image.shape[1:])
-            cropper = SpatialCrop(roi_center=roi_center, roi_size=roi_size)
+            cropper = SpatialCrop(roi_center=roi_center, spatial_size=roi_size)
             d[key] = convert_to_tensor(cropper(d[key]))
         return d
 

--- a/monai/data/grid_dataset.py
+++ b/monai/data/grid_dataset.py
@@ -382,7 +382,7 @@ class PatchDataset(IterableDataset):
                   np.arange(16, dtype=float).reshape(1, 4, 4)]
         # image patch sampler
         n_samples = 5
-        sampler = RandSpatialCropSamples(roi_size=(3, 3), num_samples=n_samples,
+        sampler = RandSpatialCropSamples(spatial_size=(3, 3), num_samples=n_samples,
                                          random_center=True, random_size=False)
         # patch-level intensity shifts
         patch_intensity = RandShiftIntensity(offsets=1.0, prob=1.0)

--- a/monai/inferers/inferer.py
+++ b/monai/inferers/inferer.py
@@ -1206,7 +1206,7 @@ class LatentDiffusionInferer(DiffusionInferer):
         self.autoencoder_latent_shape = autoencoder_latent_shape
         if self.ldm_latent_shape is not None and self.autoencoder_latent_shape is not None:
             self.ldm_resizer = SpatialPad(spatial_size=self.ldm_latent_shape)
-            self.autoencoder_resizer = CenterSpatialCrop(roi_size=self.autoencoder_latent_shape)
+            self.autoencoder_resizer = CenterSpatialCrop(spatial_size=self.autoencoder_latent_shape)
 
     def __call__(  # type: ignore[override]
         self,
@@ -1777,7 +1777,7 @@ class ControlNetLatentDiffusionInferer(ControlNetDiffusionInferer):
         self.autoencoder_latent_shape = autoencoder_latent_shape
         if self.ldm_latent_shape is not None and self.autoencoder_latent_shape is not None:
             self.ldm_resizer = SpatialPad(spatial_size=self.ldm_latent_shape)
-            self.autoencoder_resizer = CenterSpatialCrop(roi_size=self.autoencoder_latent_shape)
+            self.autoencoder_resizer = CenterSpatialCrop(spatial_size=self.autoencoder_latent_shape)
 
     def __call__(  # type: ignore[override]
         self,

--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -51,6 +51,7 @@ from monai.utils import (
     TransformBackends,
     convert_data_type,
     convert_to_tensor,
+    deprecated_arg,
     ensure_tuple,
     ensure_tuple_rep,
     fall_back_tuple,
@@ -451,30 +452,44 @@ class SpatialCrop(Crop):
     for more information.
     """
 
+    @deprecated_arg(
+        name="roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="spatial_size",
+        msg_suffix="please use `spatial_size` instead.",
+    )
     def __init__(
         self,
         roi_center: Sequence[int] | int | NdarrayOrTensor | None = None,
-        roi_size: Sequence[int] | int | NdarrayOrTensor | None = None,
+        spatial_size: Sequence[int] | int | NdarrayOrTensor | None = None,
         roi_start: Sequence[int] | int | NdarrayOrTensor | None = None,
         roi_end: Sequence[int] | int | NdarrayOrTensor | None = None,
         roi_slices: Sequence[slice] | None = None,
         lazy: bool = False,
+        roi_size: Sequence[int] | int | NdarrayOrTensor | None = None,
     ) -> None:
         """
         Args:
             roi_center: voxel coordinates for center of the crop ROI.
-            roi_size: size of the crop ROI, if a dimension of ROI size is larger than image size,
+            spatial_size: size of the crop ROI, if a dimension of ROI size is larger than image size,
                 will not crop that dimension of the image.
             roi_start: voxel coordinates for start of the crop ROI.
             roi_end: voxel coordinates for end of the crop ROI, if a coordinate is out of image,
                 use the end coordinate of image.
             roi_slices: list of slices for each of the spatial dimensions.
             lazy: a flag to indicate whether this transform should execute lazily or not. Defaults to False.
+            roi_size: deprecated argument in favor of ``spatial_size``.
+
+        .. deprecated:: 1.6.0rc1
+            ``roi_size`` is deprecated, use ``spatial_size`` instead.
 
         """
+        if spatial_size is None:
+            spatial_size = roi_size
         super().__init__(lazy)
         self.slices = self.compute_slices(
-            roi_center=roi_center, roi_size=roi_size, roi_start=roi_start, roi_end=roi_end, roi_slices=roi_slices
+            roi_center=roi_center, roi_size=spatial_size, roi_start=roi_start, roi_end=roi_end, roi_slices=roi_slices
         )
 
     def __call__(self, img: torch.Tensor, lazy: bool | None = None) -> torch.Tensor:  # type: ignore[override]
@@ -498,20 +513,36 @@ class CenterSpatialCrop(Crop):
     for more information.
 
     Args:
-        roi_size: the spatial size of the crop region e.g. [224,224,128]
+        spatial_size: the spatial size of the crop region e.g. [224,224,128]
             if a dimension of ROI size is larger than image size, will not crop that dimension of the image.
             If its components have non-positive values, the corresponding size of input image will be used.
-            for example: if the spatial size of input data is [40, 40, 40] and `roi_size=[32, 64, -1]`,
+            for example: if the spatial size of input data is [40, 40, 40] and `spatial_size=[32, 64, -1]`,
             the spatial size of output data will be [32, 40, 40].
         lazy: a flag to indicate whether this transform should execute lazily or not. Defaults to False.
+        roi_size: deprecated argument in favor of ``spatial_size``.
+
+    .. deprecated:: 1.6.0rc1
+        ``roi_size`` is deprecated, use ``spatial_size`` instead.
     """
 
-    def __init__(self, roi_size: Sequence[int] | int, lazy: bool = False) -> None:
+    @deprecated_arg(
+        name="roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="spatial_size",
+        msg_suffix="please use `spatial_size` instead.",
+    )
+    def __init__(
+        self,
+        spatial_size: Sequence[int] | int,
+        lazy: bool = False,
+        roi_size: Sequence[int] | int | None = None,
+    ) -> None:
         super().__init__(lazy=lazy)
-        self.roi_size = roi_size
+        self.spatial_size = spatial_size
 
     def compute_slices(self, spatial_size: Sequence[int]) -> tuple[slice]:  # type: ignore[override]
-        roi_size = fall_back_tuple(self.roi_size, spatial_size)
+        roi_size = fall_back_tuple(self.spatial_size, spatial_size)
         roi_center = [i // 2 for i in spatial_size]
         return super().compute_slices(roi_center=roi_center, roi_size=roi_size)
 
@@ -549,9 +580,9 @@ class CenterScaleCrop(Crop):
     def __call__(self, img: torch.Tensor, lazy: bool | None = None) -> torch.Tensor:  # type: ignore[override]
         img_size = img.peek_pending_shape() if isinstance(img, MetaTensor) else img.shape[1:]
         ndim = len(img_size)
-        roi_size = [ceil(r * s) for r, s in zip(ensure_tuple_rep(self.roi_scale, ndim), img_size)]
+        crop_size = [ceil(r * s) for r, s in zip(ensure_tuple_rep(self.roi_scale, ndim), img_size)]
         lazy_ = self.lazy if lazy is None else lazy
-        cropper = CenterSpatialCrop(roi_size=roi_size, lazy=lazy_)
+        cropper = CenterSpatialCrop(spatial_size=crop_size, lazy=lazy_)
         return super().__call__(img=img, slices=cropper.compute_slices(img_size), lazy=lazy_)
 
 
@@ -568,41 +599,69 @@ class RandSpatialCrop(Randomizable, Crop):
     for more information.
 
     Args:
-        roi_size: if `random_size` is True, it specifies the minimum crop region.
+        spatial_size: if `random_size` is True, it specifies the minimum crop region.
             if `random_size` is False, it specifies the expected ROI size to crop. e.g. [224, 224, 128]
             if a dimension of ROI size is larger than image size, will not crop that dimension of the image.
             If its components have non-positive values, the corresponding size of input image will be used.
-            for example: if the spatial size of input data is [40, 40, 40] and `roi_size=[32, 64, -1]`,
+            for example: if the spatial size of input data is [40, 40, 40] and `spatial_size=[32, 64, -1]`,
             the spatial size of output data will be [32, 40, 40].
-        max_roi_size: if `random_size` is True and `roi_size` specifies the min crop region size, `max_roi_size`
-            can specify the max crop region size. if None, defaults to the input image size.
+        max_spatial_size: if `random_size` is True and `spatial_size` specifies the min crop region size,
+            `max_spatial_size` can specify the max crop region size. if None, defaults to the input image size.
             if its components have non-positive values, the corresponding size of input image will be used.
         random_center: crop at random position as center or the image center.
         random_size: crop with random size or specific size ROI.
-            if True, the actual size is sampled from `randint(roi_size, max_roi_size + 1)`.
+            if True, the actual size is sampled from `randint(spatial_size, max_spatial_size + 1)`.
         lazy: a flag to indicate whether this transform should execute lazily or not. Defaults to False.
+        roi_size: deprecated argument in favor of ``spatial_size``.
+        max_roi_size: deprecated argument in favor of ``max_spatial_size``.
+
+    .. deprecated:: 1.6.0rc1
+        ``roi_size`` and ``max_roi_size`` are deprecated, use ``spatial_size`` and ``max_spatial_size`` instead.
     """
 
+    @deprecated_arg(
+        name="max_roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="max_spatial_size",
+        msg_suffix="please use `max_spatial_size` instead.",
+    )
+    @deprecated_arg(
+        name="roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="spatial_size",
+        msg_suffix="please use `spatial_size` instead.",
+    )
     def __init__(
         self,
-        roi_size: Sequence[int] | int,
-        max_roi_size: Sequence[int] | int | None = None,
+        spatial_size: Sequence[int] | int | None = None,
+        max_spatial_size: Sequence[int] | int | None = None,
         random_center: bool = True,
         random_size: bool = False,
         lazy: bool = False,
+        roi_size: Sequence[int] | int | None = None,
+        max_roi_size: Sequence[int] | int | None = None,
     ) -> None:
+        # Defaults are None so stacked ``deprecated_arg`` remaps can bind before validation.
+        if spatial_size is None:
+            spatial_size = roi_size
+        if spatial_size is None:
+            raise ValueError("`spatial_size` must be provided.")
+        if max_spatial_size is None:
+            max_spatial_size = max_roi_size
         super().__init__(lazy)
-        self.roi_size = roi_size
-        self.max_roi_size = max_roi_size
+        self.spatial_size = spatial_size
+        self.max_spatial_size = max_spatial_size
         self.random_center = random_center
         self.random_size = random_size
         self._size: Sequence[int] | None = None
         self._slices: tuple[slice, ...]
 
     def randomize(self, img_size: Sequence[int]) -> None:
-        self._size = fall_back_tuple(self.roi_size, img_size)
+        self._size = fall_back_tuple(self.spatial_size, img_size)
         if self.random_size:
-            max_size = img_size if self.max_roi_size is None else fall_back_tuple(self.max_roi_size, img_size)
+            max_size = img_size if self.max_spatial_size is None else fall_back_tuple(self.max_spatial_size, img_size)
             if any(i > j for i, j in zip(self._size, max_size)):
                 raise ValueError(f"min ROI size: {self._size} is larger than max ROI size: {max_size}.")
             self._size = tuple(self.R.randint(low=self._size[i], high=max_size[i] + 1) for i in range(len(img_size)))
@@ -662,18 +721,20 @@ class RandScaleCrop(RandSpatialCrop):
         lazy: bool = False,
     ) -> None:
         super().__init__(
-            roi_size=-1, max_roi_size=None, random_center=random_center, random_size=random_size, lazy=lazy
+            spatial_size=-1, max_spatial_size=None, random_center=random_center, random_size=random_size, lazy=lazy
         )
         self.roi_scale = roi_scale
         self.max_roi_scale = max_roi_scale
 
     def get_max_roi_size(self, img_size):
         ndim = len(img_size)
-        self.roi_size = [ceil(r * s) for r, s in zip(ensure_tuple_rep(self.roi_scale, ndim), img_size)]
+        self.spatial_size = [ceil(r * s) for r, s in zip(ensure_tuple_rep(self.roi_scale, ndim), img_size)]
         if self.max_roi_scale is not None:
-            self.max_roi_size = [ceil(r * s) for r, s in zip(ensure_tuple_rep(self.max_roi_scale, ndim), img_size)]
+            self.max_spatial_size = [
+                ceil(r * s) for r, s in zip(ensure_tuple_rep(self.max_roi_scale, ndim), img_size)
+            ]
         else:
-            self.max_roi_size = None
+            self.max_spatial_size = None
 
     def randomize(self, img_size: Sequence[int]) -> None:
         self.get_max_roi_size(img_size)
@@ -705,42 +766,70 @@ class RandSpatialCropSamples(Randomizable, TraceableTransform, LazyTransform, Mu
     for more information.
 
     Args:
-        roi_size: if `random_size` is True, it specifies the minimum crop region.
+        spatial_size: if `random_size` is True, it specifies the minimum crop region.
             if `random_size` is False, it specifies the expected ROI size to crop. e.g. [224, 224, 128]
             if a dimension of ROI size is larger than image size, will not crop that dimension of the image.
             If its components have non-positive values, the corresponding size of input image will be used.
-            for example: if the spatial size of input data is [40, 40, 40] and `roi_size=[32, 64, -1]`,
+            for example: if the spatial size of input data is [40, 40, 40] and `spatial_size=[32, 64, -1]`,
             the spatial size of output data will be [32, 40, 40].
         num_samples: number of samples (crop regions) to take in the returned list.
-        max_roi_size: if `random_size` is True and `roi_size` specifies the min crop region size, `max_roi_size`
-            can specify the max crop region size. if None, defaults to the input image size.
+        max_spatial_size: if `random_size` is True and `spatial_size` specifies the min crop region size,
+            `max_spatial_size` can specify the max crop region size. if None, defaults to the input image size.
             if its components have non-positive values, the corresponding size of input image will be used.
         random_center: crop at random position as center or the image center.
         random_size: crop with random size or specific size ROI.
-            The actual size is sampled from `randint(roi_size, img_size)`.
+            The actual size is sampled from `randint(spatial_size, img_size)`.
         lazy: a flag to indicate whether this transform should execute lazily or not. Defaults to False.
+        roi_size: deprecated argument in favor of ``spatial_size``.
+        max_roi_size: deprecated argument in favor of ``max_spatial_size``.
 
     Raises:
         ValueError: When ``num_samples`` is nonpositive.
+
+    .. deprecated:: 1.6.0rc1
+        ``roi_size`` and ``max_roi_size`` are deprecated, use ``spatial_size`` and ``max_spatial_size`` instead.
 
     """
 
     backend = RandSpatialCrop.backend
 
+    @deprecated_arg(
+        name="max_roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="max_spatial_size",
+        msg_suffix="please use `max_spatial_size` instead.",
+    )
+    @deprecated_arg(
+        name="roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="spatial_size",
+        msg_suffix="please use `spatial_size` instead.",
+    )
     def __init__(
         self,
-        roi_size: Sequence[int] | int,
-        num_samples: int,
-        max_roi_size: Sequence[int] | int | None = None,
+        spatial_size: Sequence[int] | int | None = None,
+        num_samples: int = 1,
+        max_spatial_size: Sequence[int] | int | None = None,
         random_center: bool = True,
         random_size: bool = False,
         lazy: bool = False,
+        roi_size: Sequence[int] | int | None = None,
+        max_roi_size: Sequence[int] | int | None = None,
     ) -> None:
         LazyTransform.__init__(self, lazy)
+        # Defaults are None so stacked ``deprecated_arg`` remaps can bind before validation.
+        if spatial_size is None:
+            spatial_size = roi_size
+        if spatial_size is None:
+            raise ValueError("`spatial_size` must be provided.")
+        if max_spatial_size is None:
+            max_spatial_size = max_roi_size
         if num_samples < 1:
             raise ValueError(f"num_samples must be positive, got {num_samples}.")
         self.num_samples = num_samples
-        self.cropper = RandSpatialCrop(roi_size, max_roi_size, random_center, random_size, lazy)
+        self.cropper = RandSpatialCrop(spatial_size, max_spatial_size, random_center, random_size, lazy)
 
     def set_random_state(
         self, seed: int | None = None, state: np.random.RandomState | None = None
@@ -1028,7 +1117,7 @@ class RandWeightedCrop(Randomizable, TraceableTransform, LazyTransform, MultiSam
         results: list[torch.Tensor] = []
         lazy_ = self.lazy if lazy is None else lazy
         for i, center in enumerate(self.centers):
-            cropper = SpatialCrop(roi_center=center, roi_size=_spatial_size, lazy=lazy_)
+            cropper = SpatialCrop(roi_center=center, spatial_size=_spatial_size, lazy=lazy_)
             cropped = cropper(img)
             if get_track_meta():
                 ret_: MetaTensor = cropped  # type: ignore
@@ -1207,7 +1296,7 @@ class RandCropByPosNegLabel(Randomizable, TraceableTransform, LazyTransform, Mul
             roi_size = fall_back_tuple(self.spatial_size, default=img_shape)
             lazy_ = self.lazy if lazy is None else lazy
             for i, center in enumerate(self.centers):
-                cropper = SpatialCrop(roi_center=center, roi_size=roi_size, lazy=lazy_)
+                cropper = SpatialCrop(roi_center=center, spatial_size=roi_size, lazy=lazy_)
                 cropped = cropper(img)
                 if get_track_meta():
                     ret_: MetaTensor = cropped  # type: ignore
@@ -1383,7 +1472,7 @@ class RandCropByLabelClasses(Randomizable, TraceableTransform, LazyTransform, Mu
             roi_size = fall_back_tuple(self.spatial_size, default=img_shape)
             lazy_ = self.lazy if lazy is None else lazy
             for i, center in enumerate(self.centers):
-                cropper = SpatialCrop(roi_center=tuple(center), roi_size=roi_size, lazy=lazy_)
+                cropper = SpatialCrop(roi_center=tuple(center), spatial_size=roi_size, lazy=lazy_)
                 cropped = cropper(img)
                 if get_track_meta():
                     ret_: MetaTensor = cropped  # type: ignore
@@ -1434,7 +1523,7 @@ class ResizeWithPadOrCrop(InvertibleTransform, LazyTransform):
     ):
         LazyTransform.__init__(self, lazy)
         self.padder = SpatialPad(spatial_size=spatial_size, method=method, mode=mode, lazy=lazy, **pad_kwargs)
-        self.cropper = CenterSpatialCrop(roi_size=spatial_size, lazy=lazy)
+        self.cropper = CenterSpatialCrop(spatial_size=spatial_size, lazy=lazy)
 
     @LazyTransform.lazy.setter  # type: ignore
     def lazy(self, val: bool):

--- a/monai/transforms/croppad/dictionary.py
+++ b/monai/transforms/croppad/dictionary.py
@@ -50,7 +50,7 @@ from monai.transforms.inverse import InvertibleTransform
 from monai.transforms.traits import LazyTrait, MultiSampleTrait
 from monai.transforms.transform import LazyTransform, MapTransform, Randomizable
 from monai.transforms.utils import is_positive
-from monai.utils import MAX_SEED, Method, PytorchPadMode, TraceKeys, ensure_tuple_rep
+from monai.utils import MAX_SEED, Method, PytorchPadMode, TraceKeys, deprecated_arg, ensure_tuple_rep
 
 __all__ = [
     "Padd",
@@ -431,7 +431,7 @@ class SpatialCropd(Cropd):
         - a spatial center and size
         - the start and end coordinates of the ROI
 
-    ROI parameters (``roi_center``, ``roi_size``, ``roi_start``, ``roi_end``) can also be specified as
+    ROI parameters (``roi_center``, ``spatial_size``, ``roi_start``, ``roi_end``) can also be specified as
     string dictionary keys. When a string is provided, the actual coordinate values are read from the
     data dictionary at call time. This enables pipelines where coordinates are computed by earlier
     transforms (e.g., :py:class:`monai.transforms.TransformPointsWorldToImaged`) and stored in the
@@ -451,16 +451,24 @@ class SpatialCropd(Cropd):
     for more information.
     """
 
+    @deprecated_arg(
+        name="roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="spatial_size",
+        msg_suffix="please use `spatial_size` instead.",
+    )
     def __init__(
         self,
         keys: KeysCollection,
         roi_center: Sequence[int] | int | str | None = None,
-        roi_size: Sequence[int] | int | str | None = None,
+        spatial_size: Sequence[int] | int | str | None = None,
         roi_start: Sequence[int] | int | str | None = None,
         roi_end: Sequence[int] | int | str | None = None,
         roi_slices: Sequence[slice] | None = None,
         allow_missing_keys: bool = False,
         lazy: bool = False,
+        roi_size: Sequence[int] | int | str | None = None,
     ) -> None:
         """
         Args:
@@ -468,7 +476,7 @@ class SpatialCropd(Cropd):
                 See also: :py:class:`monai.transforms.compose.MapTransform`
             roi_center: voxel coordinates for center of the crop ROI, or a string key to look up
                 the coordinates from the data dictionary.
-            roi_size: size of the crop ROI, if a dimension of ROI size is larger than image size,
+            spatial_size: size of the crop ROI, if a dimension of ROI size is larger than image size,
                 will not crop that dimension of the image. Can also be a string key.
             roi_start: voxel coordinates for start of the crop ROI, or a string key to look up
                 the coordinates from the data dictionary.
@@ -477,19 +485,25 @@ class SpatialCropd(Cropd):
             roi_slices: list of slices for each of the spatial dimensions.
             allow_missing_keys: don't raise exception if key is missing.
             lazy: a flag to indicate whether this transform should execute lazily or not. Defaults to False.
+            roi_size: deprecated argument in favor of ``spatial_size``.
+
+        .. deprecated:: 1.6.0rc1
+            ``roi_size`` is deprecated, use ``spatial_size`` instead.
         """
+        if spatial_size is None:
+            spatial_size = roi_size
         self._roi_center = roi_center
-        self._roi_size = roi_size
+        self._spatial_size = spatial_size
         self._roi_start = roi_start
         self._roi_end = roi_end
         self._roi_slices = roi_slices
-        self._has_str_roi = any(isinstance(v, str) for v in [roi_center, roi_size, roi_start, roi_end])
+        self._has_str_roi = any(isinstance(v, str) for v in [roi_center, spatial_size, roi_start, roi_end])
 
         if not self._has_str_roi:
             _roi_t: TypeAlias = Sequence[int] | int | None
             cropper = SpatialCrop(
                 cast(_roi_t, roi_center),
-                cast(_roi_t, roi_size),
+                cast(_roi_t, spatial_size),
                 cast(_roi_t, roi_start),
                 cast(_roi_t, roi_end),
                 roi_slices,
@@ -551,14 +565,14 @@ class SpatialCropd(Cropd):
 
         d = dict(data)
         roi_center = self._resolve_roi_param(self._roi_center, d)
-        roi_size = self._resolve_roi_param(self._roi_size, d)
+        spatial_size = self._resolve_roi_param(self._spatial_size, d)
         roi_start = self._resolve_roi_param(self._roi_start, d)
         roi_end = self._resolve_roi_param(self._roi_end, d)
 
         lazy_ = self.lazy if lazy is None else lazy
         cropper = SpatialCrop(
             roi_center=roi_center,
-            roi_size=roi_size,
+            spatial_size=spatial_size,
             roi_start=roi_start,
             roi_end=roi_end,
             roi_slices=self._roi_slices,
@@ -608,19 +622,35 @@ class CenterSpatialCropd(Cropd):
     Args:
         keys: keys of the corresponding items to be transformed.
             See also: monai.transforms.MapTransform
-        roi_size: the size of the crop region e.g. [224,224,128]
+        spatial_size: the size of the crop region e.g. [224,224,128]
             if a dimension of ROI size is larger than image size, will not crop that dimension of the image.
             If its components have non-positive values, the corresponding size of input image will be used.
-            for example: if the spatial size of input data is [40, 40, 40] and `roi_size=[32, 64, -1]`,
+            for example: if the spatial size of input data is [40, 40, 40] and `spatial_size=[32, 64, -1]`,
             the spatial size of output data will be [32, 40, 40].
         allow_missing_keys: don't raise exception if key is missing.
         lazy: a flag to indicate whether this transform should execute lazily or not. Defaults to False.
+        roi_size: deprecated argument in favor of ``spatial_size``.
+
+    .. deprecated:: 1.6.0rc1
+        ``roi_size`` is deprecated, use ``spatial_size`` instead.
     """
 
+    @deprecated_arg(
+        name="roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="spatial_size",
+        msg_suffix="please use `spatial_size` instead.",
+    )
     def __init__(
-        self, keys: KeysCollection, roi_size: Sequence[int] | int, allow_missing_keys: bool = False, lazy: bool = False
+        self,
+        keys: KeysCollection,
+        spatial_size: Sequence[int] | int,
+        allow_missing_keys: bool = False,
+        lazy: bool = False,
+        roi_size: Sequence[int] | int | None = None,
     ) -> None:
-        cropper = CenterSpatialCrop(roi_size, lazy=lazy)
+        cropper = CenterSpatialCrop(spatial_size, lazy=lazy)
         super().__init__(keys, cropper=cropper, allow_missing_keys=allow_missing_keys, lazy=lazy)
 
 
@@ -670,14 +700,14 @@ class RandSpatialCropd(RandCropd):
     Args:
         keys: keys of the corresponding items to be transformed.
             See also: monai.transforms.MapTransform
-        roi_size: if `random_size` is True, it specifies the minimum crop region.
+        spatial_size: if `random_size` is True, it specifies the minimum crop region.
             if `random_size` is False, it specifies the expected ROI size to crop. e.g. [224, 224, 128]
             if a dimension of ROI size is larger than image size, will not crop that dimension of the image.
             If its components have non-positive values, the corresponding size of input image will be used.
-            for example: if the spatial size of input data is [40, 40, 40] and `roi_size=[32, 64, -1]`,
+            for example: if the spatial size of input data is [40, 40, 40] and `spatial_size=[32, 64, -1]`,
             the spatial size of output data will be [32, 40, 40].
-        max_roi_size: if `random_size` is True and `roi_size` specifies the min crop region size, `max_roi_size`
-            can specify the max crop region size. if None, defaults to the input image size.
+        max_spatial_size: if `random_size` is True and `spatial_size` specifies the min crop region size,
+            `max_spatial_size` can specify the max crop region size. if None, defaults to the input image size.
             if its components have non-positive values, the corresponding size of input image will be used.
         random_center: crop at random position as center or the image center.
         random_size: crop with random size or specific size ROI.
@@ -685,19 +715,46 @@ class RandSpatialCropd(RandCropd):
             `randint(roi_scale * image spatial size, max_roi_scale * image spatial size + 1)`.
         allow_missing_keys: don't raise exception if key is missing.
         lazy: a flag to indicate whether this transform should execute lazily or not. Defaults to False.
+        roi_size: deprecated argument in favor of ``spatial_size``.
+        max_roi_size: deprecated argument in favor of ``max_spatial_size``.
+
+    .. deprecated:: 1.6.0rc1
+        ``roi_size`` and ``max_roi_size`` are deprecated, use ``spatial_size`` and ``max_spatial_size`` instead.
     """
 
+    @deprecated_arg(
+        name="max_roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="max_spatial_size",
+        msg_suffix="please use `max_spatial_size` instead.",
+    )
+    @deprecated_arg(
+        name="roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="spatial_size",
+        msg_suffix="please use `spatial_size` instead.",
+    )
     def __init__(
         self,
         keys: KeysCollection,
-        roi_size: Sequence[int] | int,
-        max_roi_size: Sequence[int] | int | None = None,
+        spatial_size: Sequence[int] | int | None = None,
+        max_spatial_size: Sequence[int] | int | None = None,
         random_center: bool = True,
         random_size: bool = False,
         allow_missing_keys: bool = False,
         lazy: bool = False,
+        roi_size: Sequence[int] | int | None = None,
+        max_roi_size: Sequence[int] | int | None = None,
     ) -> None:
-        cropper = RandSpatialCrop(roi_size, max_roi_size, random_center, random_size, lazy=lazy)
+        if spatial_size is None:
+            spatial_size = roi_size
+        if spatial_size is None:
+            raise ValueError("`spatial_size` must be provided.")
+        if max_spatial_size is None:
+            max_spatial_size = max_roi_size
+        cropper = RandSpatialCrop(spatial_size, max_spatial_size, random_center, random_size, lazy=lazy)
         super().__init__(keys, cropper=cropper, allow_missing_keys=allow_missing_keys, lazy=lazy)
 
 
@@ -763,44 +820,71 @@ class RandSpatialCropSamplesd(Randomizable, MapTransform, LazyTransform, MultiSa
     Args:
         keys: keys of the corresponding items to be transformed.
             See also: monai.transforms.MapTransform
-        roi_size: if `random_size` is True, it specifies the minimum crop region.
+        spatial_size: if `random_size` is True, it specifies the minimum crop region.
             if `random_size` is False, it specifies the expected ROI size to crop. e.g. [224, 224, 128]
             if a dimension of ROI size is larger than image size, will not crop that dimension of the image.
             If its components have non-positive values, the corresponding size of input image will be used.
-            for example: if the spatial size of input data is [40, 40, 40] and `roi_size=[32, 64, -1]`,
+            for example: if the spatial size of input data is [40, 40, 40] and `spatial_size=[32, 64, -1]`,
             the spatial size of output data will be [32, 40, 40].
         num_samples: number of samples (crop regions) to take in the returned list.
-        max_roi_size: if `random_size` is True and `roi_size` specifies the min crop region size, `max_roi_size`
-            can specify the max crop region size. if None, defaults to the input image size.
+        max_spatial_size: if `random_size` is True and `spatial_size` specifies the min crop region size,
+            `max_spatial_size` can specify the max crop region size. if None, defaults to the input image size.
             if its components have non-positive values, the corresponding size of input image will be used.
         random_center: crop at random position as center or the image center.
         random_size: crop with random size or specific size ROI.
-            The actual size is sampled from `randint(roi_size, img_size)`.
+            The actual size is sampled from `randint(spatial_size, img_size)`.
         allow_missing_keys: don't raise exception if key is missing.
         lazy: a flag to indicate whether this transform should execute lazily or not. Defaults to False.
+        roi_size: deprecated argument in favor of ``spatial_size``.
+        max_roi_size: deprecated argument in favor of ``max_spatial_size``.
 
     Raises:
         ValueError: When ``num_samples`` is nonpositive.
+
+    .. deprecated:: 1.6.0rc1
+        ``roi_size`` and ``max_roi_size`` are deprecated, use ``spatial_size`` and ``max_spatial_size`` instead.
 
     """
 
     backend = RandSpatialCropSamples.backend
 
+    @deprecated_arg(
+        name="max_roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="max_spatial_size",
+        msg_suffix="please use `max_spatial_size` instead.",
+    )
+    @deprecated_arg(
+        name="roi_size",
+        since="1.6.0rc1",
+        removed="1.8.0",
+        new_name="spatial_size",
+        msg_suffix="please use `spatial_size` instead.",
+    )
     def __init__(
         self,
         keys: KeysCollection,
-        roi_size: Sequence[int] | int,
-        num_samples: int,
-        max_roi_size: Sequence[int] | int | None = None,
+        spatial_size: Sequence[int] | int | None = None,
+        num_samples: int = 1,
+        max_spatial_size: Sequence[int] | int | None = None,
         random_center: bool = True,
         random_size: bool = False,
         allow_missing_keys: bool = False,
         lazy: bool = False,
+        roi_size: Sequence[int] | int | None = None,
+        max_roi_size: Sequence[int] | int | None = None,
     ) -> None:
         MapTransform.__init__(self, keys, allow_missing_keys)
         LazyTransform.__init__(self, lazy)
+        if spatial_size is None:
+            spatial_size = roi_size
+        if spatial_size is None:
+            raise ValueError("`spatial_size` must be provided.")
+        if max_spatial_size is None:
+            max_spatial_size = max_roi_size
         self.cropper = RandSpatialCropSamples(
-            roi_size, num_samples, max_roi_size, random_center, random_size, lazy=lazy
+            spatial_size, num_samples, max_spatial_size, random_center, random_size, lazy=lazy
         )
 
     @LazyTransform.lazy.setter  # type: ignore

--- a/monai/transforms/spatial/array.py
+++ b/monai/transforms/spatial/array.py
@@ -2861,7 +2861,7 @@ class Rand2DElastic(RandomizableTransform):
                 mode=InterpolateMode.BICUBIC.value,
                 align_corners=False,
             )
-            grid = CenterSpatialCrop(roi_size=sp_size)(grid[0])
+            grid = CenterSpatialCrop(spatial_size=sp_size)(grid[0])
         else:
             _device = img.device if isinstance(img, torch.Tensor) else self.device
             grid = cast(torch.Tensor, create_grid(spatial_size=sp_size, device=_device, backend="torch"))

--- a/monai/transforms/spatial/dictionary.py
+++ b/monai/transforms/spatial/dictionary.py
@@ -1353,7 +1353,7 @@ class Rand2DElasticd(RandomizableTransform, MapTransform):
                 mode=InterpolateMode.BICUBIC.value,
                 align_corners=False,
             )
-            grid = CenterSpatialCrop(roi_size=sp_size)(grid[0])
+            grid = CenterSpatialCrop(spatial_size=sp_size)(grid[0])
         else:
             grid = cast(torch.Tensor, create_grid(spatial_size=sp_size, device=device, backend="torch"))
 

--- a/monai/transforms/utils_create_transform_ims.py
+++ b/monai/transforms/utils_create_transform_ims.py
@@ -621,15 +621,15 @@ if __name__ == "__main__":
     create_transform_im(SpatialPadd, dict(keys=keys, spatial_size=(300, 300, 300)), data)
     create_transform_im(BorderPad, dict(spatial_border=10), data)
     create_transform_im(BorderPadd, dict(keys=keys, spatial_border=10), data)
-    create_transform_im(SpatialCrop, dict(roi_center=(75, 75, 75), roi_size=(100, 100, 100)), data)
-    create_transform_im(SpatialCropd, dict(keys=keys, roi_center=(75, 75, 75), roi_size=(100, 100, 100)), data)
-    create_transform_im(CenterSpatialCrop, dict(roi_size=(100, 100, 100)), data)
-    create_transform_im(CenterSpatialCropd, dict(keys=keys, roi_size=(100, 100, 100)), data)
-    create_transform_im(RandSpatialCrop, dict(roi_size=(100, 100, 100), random_size=False), data)
-    create_transform_im(RandSpatialCropd, dict(keys=keys, roi_size=(100, 100, 100), random_size=False), data)
-    create_transform_im(RandSpatialCropSamples, dict(num_samples=4, roi_size=(100, 100, 100), random_size=False), data)
+    create_transform_im(SpatialCrop, dict(roi_center=(75, 75, 75), spatial_size=(100, 100, 100)), data)
+    create_transform_im(SpatialCropd, dict(keys=keys, roi_center=(75, 75, 75), spatial_size=(100, 100, 100)), data)
+    create_transform_im(CenterSpatialCrop, dict(spatial_size=(100, 100, 100)), data)
+    create_transform_im(CenterSpatialCropd, dict(keys=keys, spatial_size=(100, 100, 100)), data)
+    create_transform_im(RandSpatialCrop, dict(spatial_size=(100, 100, 100), random_size=False), data)
+    create_transform_im(RandSpatialCropd, dict(keys=keys, spatial_size=(100, 100, 100), random_size=False), data)
+    create_transform_im(RandSpatialCropSamples, dict(num_samples=4, spatial_size=(100, 100, 100), random_size=False), data)
     create_transform_im(
-        RandSpatialCropSamplesd, dict(keys=keys, num_samples=4, roi_size=(100, 100, 100), random_size=False), data
+        RandSpatialCropSamplesd, dict(keys=keys, num_samples=4, spatial_size=(100, 100, 100), random_size=False), data
     )
     create_transform_im(
         RandWeightedCrop, dict(spatial_size=(100, 100, 100), num_samples=4, weight_map=data[CommonKeys.IMAGE] > 0), data

--- a/tests/transforms/inverse/test_inverse.py
+++ b/tests/transforms/inverse/test_inverse.py
@@ -89,14 +89,14 @@ for name in ("1D even", "1D odd"):
             partial(BorderPadd, spatial_border=[val, val + 1]),
             partial(DivisiblePadd, k=val),
             partial(ResizeWithPadOrCropd, spatial_size=20 + val),
-            partial(CenterSpatialCropd, roi_size=10 + val),
+            partial(CenterSpatialCropd, spatial_size=10 + val),
             partial(CenterScaleCropd, roi_scale=0.8),
             partial(CropForegroundd, source_key="label"),
-            partial(SpatialCropd, roi_center=10, roi_size=10 + val),
-            partial(SpatialCropd, roi_center=11, roi_size=10 + val),
+            partial(SpatialCropd, roi_center=10, spatial_size=10 + val),
+            partial(SpatialCropd, roi_center=11, spatial_size=10 + val),
             partial(SpatialCropd, roi_start=val, roi_end=17),
             partial(SpatialCropd, roi_start=val, roi_end=16),
-            partial(RandSpatialCropd, roi_size=12 + val),
+            partial(RandSpatialCropd, spatial_size=12 + val),
             partial(ResizeWithPadOrCropd, spatial_size=21 - val),
         ):
             TESTS.append((t.func.__name__ + name, name, 0, True, t(KEYS)))  # type: ignore
@@ -104,12 +104,12 @@ for name in ("1D even", "1D odd"):
 # non-sensical tests: crop bigger or pad smaller or -ve values
 for t in (
     partial(DivisiblePadd, k=-3),
-    partial(CenterSpatialCropd, roi_size=-3),
-    partial(RandSpatialCropd, roi_size=-3),
+    partial(CenterSpatialCropd, spatial_size=-3),
+    partial(RandSpatialCropd, spatial_size=-3),
     partial(SpatialPadd, spatial_size=15),
     partial(BorderPadd, spatial_border=[15, 16]),
-    partial(CenterSpatialCropd, roi_size=30),
-    partial(SpatialCropd, roi_center=10, roi_size=100),
+    partial(CenterSpatialCropd, spatial_size=30),
+    partial(SpatialCropd, roi_center=10, spatial_size=100),
     partial(SpatialCropd, roi_start=3, roi_end=100),
 ):
     TESTS.append((t.func.__name__ + "bad 1D even", "1D even", 0, True, t(KEYS)))  # type: ignore
@@ -157,9 +157,9 @@ TESTS.append(("DivisiblePadd 2d", "2D", 0, True, DivisiblePadd(KEYS, k=4)))
 
 TESTS.append(("DivisiblePadd 3d", "3D", 0, True, DivisiblePadd(KEYS, k=[4, 8, 11])))
 
-TESTS.append(("CenterSpatialCropd 2d", "2D", 0, True, CenterSpatialCropd(KEYS, roi_size=95)))
+TESTS.append(("CenterSpatialCropd 2d", "2D", 0, True, CenterSpatialCropd(KEYS, spatial_size=95)))
 
-TESTS.append(("CenterSpatialCropd 3d", "3D", 0, True, CenterSpatialCropd(KEYS, roi_size=[95, 97, 98])))
+TESTS.append(("CenterSpatialCropd 3d", "3D", 0, True, CenterSpatialCropd(KEYS, spatial_size=[95, 97, 98])))
 
 TESTS.append(("CropForegroundd 2d", "2D", 0, True, CropForegroundd(KEYS, source_key="label", margin=2)))
 

--- a/tests/transforms/test_center_spatial_crop.py
+++ b/tests/transforms/test_center_spatial_crop.py
@@ -20,15 +20,15 @@ from monai.transforms import CenterSpatialCrop
 from tests.croppers import CropTest
 
 TEST_SHAPES = [
-    [{"roi_size": [2, 2, -1]}, (3, 3, 3, 3), (3, 2, 2, 3), True],
-    [{"roi_size": [2, 2, 2]}, (3, 3, 3, 3), (3, 2, 2, 2), True],
-    [{"roi_size": [2, 1, 2]}, (3, 3, 3, 3), (3, 2, 1, 2), False],
-    [{"roi_size": [2, 1, 3]}, (3, 3, 1, 3), (3, 2, 1, 3), True],
+    [{"spatial_size": [2, 2, -1]}, (3, 3, 3, 3), (3, 2, 2, 3), True],
+    [{"spatial_size": [2, 2, 2]}, (3, 3, 3, 3), (3, 2, 2, 2), True],
+    [{"spatial_size": [2, 1, 2]}, (3, 3, 3, 3), (3, 2, 1, 2), False],
+    [{"spatial_size": [2, 1, 3]}, (3, 3, 1, 3), (3, 2, 1, 3), True],
 ]
 
 TEST_VALUES = [
     [
-        {"roi_size": [2, 2]},
+        {"spatial_size": [2, 2]},
         np.array([[[0, 0, 0, 0, 0], [0, 1, 2, 1, 0], [0, 2, 3, 2, 0], [0, 1, 2, 1, 0], [0, 0, 0, 0, 0]]]),
         np.array([[[1, 2], [2, 3]]]),
     ]
@@ -49,6 +49,13 @@ class TestCenterSpatialCrop(CropTest):
     @parameterized.expand(TEST_SHAPES)
     def test_pending_ops(self, input_param, input_shape, _, align_corners):
         self.crop_test_pending_ops(input_param, input_shape, align_corners)
+
+
+    def test_deprecated_roi_size(self):
+        with self.assertWarns(FutureWarning):
+            cropper = CenterSpatialCrop(roi_size=[2, 2, 2])
+        self.assertEqual(cropper.spatial_size, [2, 2, 2])
+        self.assertFalse(hasattr(cropper, "roi_size"))
 
 
 if __name__ == "__main__":

--- a/tests/transforms/test_center_spatial_cropd.py
+++ b/tests/transforms/test_center_spatial_cropd.py
@@ -21,13 +21,13 @@ from tests.croppers import CropTest
 
 TEST_SHAPES = [
     [
-        {"keys": "img", "roi_size": [2, -1, -1]},
+        {"keys": "img", "spatial_size": [2, -1, -1]},
         (3, 3, 3, 3),
         (3, 2, 3, 3),
         (slice(None), slice(None, -1), slice(None), slice(None)),
     ],
     [
-        {"keys": "img", "roi_size": [2, 2, 2]},
+        {"keys": "img", "spatial_size": [2, 2, 2]},
         (3, 3, 3, 3),
         (3, 2, 2, 2),
         (slice(None), slice(None, -1), slice(None, -1), slice(None, -1)),
@@ -36,7 +36,7 @@ TEST_SHAPES = [
 
 TEST_CASES = [
     [
-        {"keys": "img", "roi_size": [2, 2]},
+        {"keys": "img", "spatial_size": [2, 2]},
         np.array([[[0, 0, 0, 0, 0], [0, 1, 2, 1, 0], [0, 2, 3, 2, 0], [0, 1, 2, 1, 0], [0, 0, 0, 0, 0]]]),
         np.array([[[1, 2], [2, 3]]]),
     ]
@@ -57,6 +57,11 @@ class TestCenterSpatialCropd(CropTest):
     @parameterized.expand(TEST_SHAPES)
     def test_pending_ops(self, input_param, input_shape, _expected_shape, _same_area):
         self.crop_test_pending_ops(input_param, input_shape)
+
+
+    def test_deprecated_roi_size(self):
+        with self.assertWarns(FutureWarning):
+            CenterSpatialCropd(keys=["img"], roi_size=[2, 2, 2])
 
 
 if __name__ == "__main__":

--- a/tests/transforms/test_rand_spatial_crop.py
+++ b/tests/transforms/test_rand_spatial_crop.py
@@ -23,29 +23,29 @@ from tests.croppers import CropTest
 from tests.test_utils import TEST_NDARRAYS_ALL, assert_allclose
 
 TEST_SHAPES = [
-    [{"roi_size": [3, 3, -1], "random_center": True}, (3, 3, 3, 4), (3, 3, 3, 4)],
-    [{"roi_size": [3, 3, 3], "random_center": True}, (3, 3, 3, 3), (3, 3, 3, 3)],
-    [{"roi_size": [3, 3, 3], "random_center": False}, (3, 3, 3, 3), (3, 3, 3, 3)],
-    [{"roi_size": [3, 3, 2], "random_center": False, "random_size": False}, (3, 3, 3, 3), (3, 3, 3, 2)],
+    [{"spatial_size": [3, 3, -1], "random_center": True}, (3, 3, 3, 4), (3, 3, 3, 4)],
+    [{"spatial_size": [3, 3, 3], "random_center": True}, (3, 3, 3, 3), (3, 3, 3, 3)],
+    [{"spatial_size": [3, 3, 3], "random_center": False}, (3, 3, 3, 3), (3, 3, 3, 3)],
+    [{"spatial_size": [3, 3, 2], "random_center": False, "random_size": False}, (3, 3, 3, 3), (3, 3, 3, 2)],
 ]
 
 TEST_VALUES = [
     [
-        {"roi_size": [3, 3], "random_center": False},
+        {"spatial_size": [3, 3], "random_center": False},
         np.array([[[0, 0, 0, 0, 0], [0, 1, 2, 1, 0], [0, 2, 3, 2, 0], [0, 1, 2, 1, 0], [0, 0, 0, 0, 0]]]),
     ]
 ]
 
 TEST_RANDOM_SHAPES = [
     [
-        {"roi_size": [3, 3, 3], "max_roi_size": [5, -1, 4], "random_center": True, "random_size": True},
+        {"spatial_size": [3, 3, 3], "max_spatial_size": [5, -1, 4], "random_center": True, "random_size": True},
         (1, 4, 5, 6),
         (1, 4, 4, 3),
     ],
-    [{"roi_size": 3, "max_roi_size": 4, "random_center": True, "random_size": True}, (1, 4, 5, 6), (1, 3, 4, 3)],
+    [{"spatial_size": 3, "max_spatial_size": 4, "random_center": True, "random_size": True}, (1, 4, 5, 6), (1, 3, 4, 3)],
 ]
 
-func1 = {RandSpatialCrop: {"roi_size": [8, 7, -1], "random_center": True, "random_size": False}}
+func1 = {RandSpatialCrop: {"spatial_size": [8, 7, -1], "random_center": True, "random_size": False}}
 func2 = {RandScaleCrop: {"roi_scale": [0.5, 0.6, -1.0], "random_center": True, "random_size": True}}
 func3 = {RandScaleCrop: {"roi_scale": [1.0, 0.5, -1.0], "random_center": False, "random_size": False}}
 
@@ -101,6 +101,15 @@ class TestRandSpatialCrop(CropTest):
     @parameterized.expand(TESTS_COMBINE)
     def test_combine_ops(self, funcs, input_shape):
         self.crop_test_combine_ops(funcs, input_shape)
+
+
+    def test_deprecated_roi_size(self):
+        with self.assertWarns(FutureWarning):
+            cropper = RandSpatialCrop(roi_size=[3, 3, 3], max_roi_size=[4, 4, 4], random_size=True)
+        self.assertEqual(cropper.spatial_size, [3, 3, 3])
+        self.assertEqual(cropper.max_spatial_size, [4, 4, 4])
+        self.assertFalse(hasattr(cropper, "roi_size"))
+        self.assertFalse(hasattr(cropper, "max_roi_size"))
 
 
 if __name__ == "__main__":

--- a/tests/transforms/test_rand_spatial_crop_samples.py
+++ b/tests/transforms/test_rand_spatial_crop_samples.py
@@ -23,7 +23,7 @@ from tests.croppers import CropTest
 from tests.test_utils import TEST_NDARRAYS_ALL, assert_allclose
 
 TEST_CASE_1 = [
-    {"roi_size": [3, 3, 3], "num_samples": 4, "random_center": True, "random_size": False},
+    {"spatial_size": [3, 3, 3], "num_samples": 4, "random_center": True, "random_size": False},
     (3, 4, 4, 4),
     [(3, 3, 3, 3), (3, 3, 3, 3), (3, 3, 3, 3), (3, 3, 3, 3)],
     np.array(
@@ -48,7 +48,7 @@ TEST_CASE_1 = [
 ]
 
 TEST_CASE_2 = [
-    {"roi_size": [3, 3, 3], "num_samples": 8, "random_center": False, "random_size": True},
+    {"spatial_size": [3, 3, 3], "num_samples": 8, "random_center": False, "random_size": True},
     (3, 4, 4, 4),
     [(3, 4, 4, 3), (3, 4, 3, 3), (3, 3, 4, 4), (3, 4, 4, 4), (3, 3, 3, 4), (3, 3, 3, 3), (3, 3, 3, 3), (3, 3, 3, 3)],
     np.array(
@@ -73,11 +73,11 @@ TEST_CASE_2 = [
 ]
 
 TEST_INVERSE_LIST = [
-    [(1, 2, 2), {"roi_size": (1, 1), "num_samples": 4, "random_size": False}],
-    [(1, 3, 2), {"roi_size": (1, 1), "num_samples": 100, "random_size": False}],
-    [(3, 10, 11, 12), {"roi_size": (3, 5, 4), "num_samples": 7, "random_size": False}],
-    [(3, 10, 11, 12), {"roi_size": (10, 11, 12), "num_samples": 3, "random_size": False}],
-    [(3, 10, 11, 12), {"roi_size": (3, 4, 5), "num_samples": 100, "random_size": False}],
+    [(1, 2, 2), {"spatial_size": (1, 1), "num_samples": 4, "random_size": False}],
+    [(1, 3, 2), {"spatial_size": (1, 1), "num_samples": 100, "random_size": False}],
+    [(3, 10, 11, 12), {"spatial_size": (3, 5, 4), "num_samples": 7, "random_size": False}],
+    [(3, 10, 11, 12), {"spatial_size": (10, 11, 12), "num_samples": 3, "random_size": False}],
+    [(3, 10, 11, 12), {"spatial_size": (3, 4, 5), "num_samples": 100, "random_size": False}],
 ]
 
 
@@ -122,6 +122,12 @@ class TestRandSpatialCropSamples(CropTest):
                 result = apply_pending(_pending_result, overrides={"mode": "nearest", "align_corners": False})[0]
                 # compare
                 assert_allclose(result, expected[i], rtol=1e-5)
+
+
+    def test_deprecated_roi_size(self):
+        with self.assertWarns(FutureWarning):
+            sampler = RandSpatialCropSamples(roi_size=[3, 3, 3], num_samples=2, random_size=False)
+        self.assertEqual(sampler.cropper.spatial_size, [3, 3, 3])
 
 
 if __name__ == "__main__":

--- a/tests/transforms/test_rand_spatial_crop_samplesd.py
+++ b/tests/transforms/test_rand_spatial_crop_samplesd.py
@@ -22,7 +22,7 @@ from monai.transforms.lazy.functional import apply_pending
 from tests.test_utils import TEST_NDARRAYS_ALL, assert_allclose
 
 TEST_CASE_1 = [
-    {"keys": ["img", "seg"], "num_samples": 4, "roi_size": [2, 2, 2], "random_center": True, "random_size": True},
+    {"keys": ["img", "seg"], "num_samples": 4, "spatial_size": [2, 2, 2], "random_center": True, "random_size": True},
     {"img": np.arange(81).reshape(3, 3, 3, 3), "seg": np.arange(81, 0, -1).reshape(3, 3, 3, 3)},
     [(3, 2, 2, 2), (3, 2, 3, 3), (3, 2, 3, 2), (3, 2, 3, 2)],
     {
@@ -50,7 +50,7 @@ for p in TEST_NDARRAYS_ALL:
             {
                 "keys": ["img", "seg"],
                 "num_samples": 8,
-                "roi_size": [2, 2, 3],
+                "spatial_size": [2, 2, 3],
                 "random_center": False,
                 "random_size": True,
             },
@@ -110,7 +110,7 @@ class TestRandSpatialCropSamplesd(unittest.TestCase):
         data = {"img": np.ones((1, 10, 11, 12))}
         num_samples = 3
         sampler = RandSpatialCropSamplesd(
-            keys=["img"], roi_size=(3, 3, 3), num_samples=num_samples, random_center=True, random_size=False
+            keys=["img"], spatial_size=(3, 3, 3), num_samples=num_samples, random_center=True, random_size=False
         )
         transform = Compose([DivisiblePadd(keys="img", k=5), sampler])
         samples = transform(data)
@@ -141,6 +141,11 @@ class TestRandSpatialCropSamplesd(unittest.TestCase):
             # compare
             assert_allclose(result_img, expected[i]["img"], rtol=1e-5)
             assert_allclose(result_seg, expected[i]["seg"], rtol=1e-5)
+
+
+    def test_deprecated_roi_size(self):
+        with self.assertWarns(FutureWarning):
+            RandSpatialCropSamplesd(keys=["img"], roi_size=[3, 3, 3], num_samples=2, random_size=False)
 
 
 if __name__ == "__main__":

--- a/tests/transforms/test_rand_spatial_cropd.py
+++ b/tests/transforms/test_rand_spatial_cropd.py
@@ -23,33 +23,33 @@ from tests.croppers import CropTest
 from tests.test_utils import TEST_NDARRAYS_ALL, assert_allclose
 
 TEST_SHAPES = [
-    [{"keys": "img", "roi_size": [3, 3, -1], "random_center": True}, (3, 3, 3, 5), (3, 3, 3, 5)],
-    [{"keys": "img", "roi_size": [3, 3, 3], "random_center": True}, (3, 3, 3, 3), (3, 3, 3, 3)],
-    [{"keys": "img", "roi_size": [3, 3, 3], "random_center": False}, (3, 3, 3, 3), (3, 3, 3, 3)],
-    [{"keys": "img", "roi_size": [3, 2, 3], "random_center": False, "random_size": False}, (3, 3, 3, 3), (3, 3, 2, 3)],
+    [{"keys": "img", "spatial_size": [3, 3, -1], "random_center": True}, (3, 3, 3, 5), (3, 3, 3, 5)],
+    [{"keys": "img", "spatial_size": [3, 3, 3], "random_center": True}, (3, 3, 3, 3), (3, 3, 3, 3)],
+    [{"keys": "img", "spatial_size": [3, 3, 3], "random_center": False}, (3, 3, 3, 3), (3, 3, 3, 3)],
+    [{"keys": "img", "spatial_size": [3, 2, 3], "random_center": False, "random_size": False}, (3, 3, 3, 3), (3, 3, 2, 3)],
 ]
 
 TEST_VALUES = [
     [
-        {"keys": "img", "roi_size": [3, 3], "random_center": False},
+        {"keys": "img", "spatial_size": [3, 3], "random_center": False},
         np.array([[[0, 0, 0, 0, 0], [0, 1, 2, 1, 0], [0, 2, 3, 2, 0], [0, 1, 2, 1, 0], [0, 0, 0, 0, 0]]]),
     ]
 ]
 
 TEST_RANDOM_SHAPES = [
     [
-        {"keys": "img", "roi_size": [3, 3, 3], "max_roi_size": [5, -1, 4], "random_center": True, "random_size": True},
+        {"keys": "img", "spatial_size": [3, 3, 3], "max_spatial_size": [5, -1, 4], "random_center": True, "random_size": True},
         (1, 4, 5, 6),
         (1, 4, 4, 3),
     ],
     [
-        {"keys": "img", "roi_size": 3, "max_roi_size": 4, "random_center": True, "random_size": True},
+        {"keys": "img", "spatial_size": 3, "max_spatial_size": 4, "random_center": True, "random_size": True},
         (1, 4, 5, 6),
         (1, 3, 4, 3),
     ],
 ]
 
-func1 = {RandSpatialCropd: {"keys": "img", "roi_size": [8, 7, -1], "random_center": True, "random_size": False}}
+func1 = {RandSpatialCropd: {"keys": "img", "spatial_size": [8, 7, -1], "random_center": True, "random_size": False}}
 func2 = {RandScaleCropd: {"keys": "img", "roi_scale": [0.5, 0.6, -1.0], "random_center": True, "random_size": True}}
 func3 = {RandScaleCropd: {"keys": "img", "roi_scale": [1.0, 0.5, -1.0], "random_center": False, "random_size": False}}
 
@@ -106,6 +106,11 @@ class TestRandSpatialCropd(CropTest):
     @parameterized.expand(TESTS_COMBINE)
     def test_combine_ops(self, funcs, input_shape):
         self.crop_test_combine_ops(funcs, input_shape)
+
+
+    def test_deprecated_roi_size(self):
+        with self.assertWarns(FutureWarning):
+            RandSpatialCropd(keys=["img"], roi_size=[3, 3, 3], max_roi_size=[4, 4, 4], random_size=True)
 
 
 if __name__ == "__main__":

--- a/tests/transforms/test_spatial_crop.py
+++ b/tests/transforms/test_spatial_crop.py
@@ -19,8 +19,8 @@ from monai.transforms import CenterScaleCrop, CenterSpatialCrop, SpatialCrop
 from tests.croppers import CropTest
 
 TESTS = [
-    [{"roi_center": [1, 1, 1], "roi_size": [2, 2, 2]}, (3, 3, 3, 3), (3, 2, 2, 2)],
-    [{"roi_center": [1, 1, 1], "roi_size": [2, 2, 2]}, (3, 1, 1, 1), (3, 1, 1, 1)],
+    [{"roi_center": [1, 1, 1], "spatial_size": [2, 2, 2]}, (3, 3, 3, 3), (3, 2, 2, 2)],
+    [{"roi_center": [1, 1, 1], "spatial_size": [2, 2, 2]}, (3, 1, 1, 1), (3, 1, 1, 1)],
     [{"roi_start": [0, 0, 0], "roi_end": [2, 2, 2]}, (3, 3, 3, 3), (3, 2, 2, 2)],
     [{"roi_start": [0, 0], "roi_end": [2, 2]}, (3, 3, 3, 3), (3, 2, 2, 3)],
     [{"roi_start": [0, 0, 0, 0, 0], "roi_end": [2, 2, 2, 2, 2]}, (3, 3, 3, 3), (3, 2, 2, 2)],
@@ -42,8 +42,8 @@ TEST_ERRORS = [[{"roi_slices": [slice(s, e, 2) for s, e in zip([-1, -2, 0], [Non
 
 TEST_LAZY_ERRORS = [[{"roi_start": [1, 0, 0], "roi_end": [1, 8, 8]}, (3, 3, 3, 3), (3, 0, 3, 3)]]
 
-func1 = {CenterSpatialCrop: {"roi_size": [8, 8, 6]}}
-func2 = {SpatialCrop: {"roi_center": [1, 1, 1], "roi_size": [3, 4, 3]}}
+func1 = {CenterSpatialCrop: {"spatial_size": [8, 8, 6]}}
+func2 = {SpatialCrop: {"roi_center": [1, 1, 1], "spatial_size": [3, 4, 3]}}
 func3 = {CenterScaleCrop: {"roi_scale": [0.6, 0.3, -1]}}
 
 TESTS_COMBINE = []
@@ -76,6 +76,13 @@ class TestSpatialCrop(CropTest):
     @parameterized.expand(TESTS_COMBINE)
     def test_combine_ops(self, funcs, input_shape):
         self.crop_test_combine_ops(funcs, input_shape)
+
+
+    def test_deprecated_roi_size(self):
+        with self.assertWarns(FutureWarning):
+            cropper = SpatialCrop(roi_center=[1, 1, 1], roi_size=[2, 2, 2])
+        # slices computed at init; no stored size attribute
+        self.assertIsNotNone(cropper.slices)
 
 
 if __name__ == "__main__":

--- a/tests/transforms/test_spatial_cropd.py
+++ b/tests/transforms/test_spatial_cropd.py
@@ -23,13 +23,13 @@ from tests.croppers import CropTest
 
 TESTS = [
     [
-        {"keys": ["img"], "roi_center": [1, 1], "roi_size": [2, 2]},
+        {"keys": ["img"], "roi_center": [1, 1], "spatial_size": [2, 2]},
         (1, 3, 3),
         (1, 2, 2),
         (slice(None), slice(None, 2), slice(None, 2)),
     ],
     [
-        {"keys": ["img"], "roi_center": [1, 1, 1], "roi_size": [2, 2, 2]},
+        {"keys": ["img"], "roi_center": [1, 1, 1], "spatial_size": [2, 2, 2]},
         (3, 3, 3, 3),
         (3, 2, 2, 2),
         (slice(None), slice(None, 2), slice(None, 2), slice(None, 2)),
@@ -85,10 +85,10 @@ class TestSpatialCropdStringKeys(unittest.TestCase):
         self.assertEqual(result["img"].shape, (3, 5, 5, 5))
 
     def test_string_roi_center_size(self):
-        """String keys for roi_center and roi_size should resolve from data dict."""
+        """String keys for roi_center and spatial_size should resolve from data dict."""
         img = MetaTensor(torch.rand(1, 20, 20, 20))
         data = {"img": img, "center_key": [10, 10, 10], "size_key": [6, 6, 6]}
-        cropper = SpatialCropd(keys="img", roi_center="center_key", roi_size="size_key")
+        cropper = SpatialCropd(keys="img", roi_center="center_key", spatial_size="size_key")
         result = cropper(data)
         self.assertEqual(result["img"].shape, (1, 6, 6, 6))
 
@@ -96,7 +96,7 @@ class TestSpatialCropdStringKeys(unittest.TestCase):
         """Mix of string key and direct value for ROI params."""
         img = MetaTensor(torch.rand(1, 20, 20, 20))
         data = {"img": img, "center_key": [10, 10, 10]}
-        cropper = SpatialCropd(keys="img", roi_center="center_key", roi_size=[4, 4, 4])
+        cropper = SpatialCropd(keys="img", roi_center="center_key", spatial_size=[4, 4, 4])
         result = cropper(data)
         self.assertEqual(result["img"].shape, (1, 4, 4, 4))
 
@@ -216,6 +216,11 @@ class TestSpatialCropdStringKeys(unittest.TestCase):
         inverted = cropper.inverse(result)
         self.assertEqual(inverted["img1"].shape, (1, 20, 20, 20))
         self.assertEqual(inverted["img2"].shape, (3, 20, 20, 20))
+
+
+    def test_deprecated_roi_size(self):
+        with self.assertWarns(FutureWarning):
+            SpatialCropd(keys=["img"], roi_center=[1, 1, 1], roi_size=[2, 2, 2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #8432 .

### Description

Standardizes crop-size keyword arguments across spatial crop transforms to `spatial_size` (and `max_spatial_size` where applicable), aligning them with pad/resize and label-based crop APIs.

`roi_size` / `max_roi_size` remain accepted via `@deprecated_arg` (`since=1.6.0rc1`, `removed=1.8.0`) and emit `FutureWarning`. Public attributes are stored only under the canonical names. Dictionary transforms mirror the array APIs. Internal call sites were updated to the new names to avoid warning noise. `RandScaleCrop` keeps `roi_scale` / `max_roi_scale`; `ResizeWithPadOrCrop` already used `spatial_size`.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

### Test plan
- [x] `python -m tests.transforms.test_spatial_crop`
- [x] `python -m tests.transforms.test_spatial_cropd`
- [x] `python -m tests.transforms.test_center_spatial_crop`
- [x] `python -m tests.transforms.test_center_spatial_cropd`
- [x] `python -m tests.transforms.test_rand_spatial_crop`
- [x] `python -m tests.transforms.test_rand_spatial_cropd`
- [x] `python -m tests.transforms.test_rand_spatial_crop_samples`
- [x] `python -m tests.transforms.test_rand_spatial_crop_samplesd`
- [x] `python -m tests.transforms.test_rand_scale_crop`
- [x] Deprecation cases assert `FutureWarning` for `roi_size` / `max_roi_size`


Made with [Cursor](https://cursor.com)