### PR TITLE
Fix type hints for pad functions to use Sequence[tuple[int, int]]

### DIFF
--- a/monai/transforms/croppad/array.py
+++ b/monai/transforms/croppad/array.py
@@ -108,7 +108,7 @@ class Pad(InvertibleTransform, LazyTransform):
 
     def __init__(
         self,
-        to_pad: tuple[tuple[int, int]] | None = None,
+        to_pad: Sequence[tuple[int, int]] | None = None,
         mode: str = PytorchPadMode.CONSTANT,
         lazy: bool = False,
         **kwargs,
@@ -118,7 +118,7 @@ class Pad(InvertibleTransform, LazyTransform):
         self.mode = mode
         self.kwargs = kwargs
 
-    def compute_pad_width(self, spatial_shape: Sequence[int]) -> tuple[tuple[int, int]]:
+    def compute_pad_width(self, spatial_shape: Sequence[int]) -> tuple[tuple[int, int], ...]:
         """
         dynamically compute the pad width according to the spatial shape.
         the output is the amount of padding for all dimensions including the channel.
@@ -132,7 +132,7 @@ class Pad(InvertibleTransform, LazyTransform):
     def __call__(  # type: ignore[override]
         self,
         img: torch.Tensor,
-        to_pad: tuple[tuple[int, int]] | None = None,
+        to_pad: Sequence[tuple[int, int]] | None = None,
         mode: str | None = None,
         lazy: bool | None = None,
         **kwargs,
@@ -218,7 +218,7 @@ class SpatialPad(Pad):
         self.method: Method = look_up_option(method, Method)
         super().__init__(mode=mode, lazy=lazy, **kwargs)
 
-    def compute_pad_width(self, spatial_shape: Sequence[int]) -> tuple[tuple[int, int]]:
+    def compute_pad_width(self, spatial_shape: Sequence[int]) -> tuple[tuple[int, int], ...]:
         """
         dynamically compute the pad width according to the spatial shape.
 
@@ -273,7 +273,7 @@ class BorderPad(Pad):
         self.spatial_border = spatial_border
         super().__init__(mode=mode, lazy=lazy, **kwargs)
 
-    def compute_pad_width(self, spatial_shape: Sequence[int]) -> tuple[tuple[int, int]]:
+    def compute_pad_width(self, spatial_shape: Sequence[int]) -> tuple[tuple[int, int], ...]:
         spatial_border = ensure_tuple(self.spatial_border)
         if not all(isinstance(b, int) for b in spatial_border):
             raise ValueError(f"self.spatial_border must contain only ints, got {spatial_border}.")
@@ -336,7 +336,7 @@ class DivisiblePad(Pad):
         self.method: Method = Method(method)
         super().__init__(mode=mode, lazy=lazy, **kwargs)
 
-    def compute_pad_width(self, spatial_shape: Sequence[int]) -> tuple[tuple[int, int]]:
+    def compute_pad_width(self, spatial_shape: Sequence[int]) -> tuple[tuple[int, int], ...]:
         new_size = compute_divisible_spatial_size(spatial_shape=spatial_shape, k=self.k)
         spatial_pad = SpatialPad(spatial_size=new_size, method=self.method)
         return spatial_pad.compute_pad_width(spatial_shape)

--- a/monai/transforms/croppad/functional.py
+++ b/monai/transforms/croppad/functional.py
@@ -15,6 +15,7 @@ A collection of "functional" transforms for spatial operations.
 from __future__ import annotations
 
 import warnings
+from collections.abc import Sequence
 
 import numpy as np
 import torch
@@ -154,7 +155,7 @@ def crop_or_pad_nd(img: torch.Tensor, translation_mat, spatial_size: tuple[int, 
 
 def pad_func(
     img: torch.Tensor,
-    to_pad: tuple[tuple[int, int]],
+    to_pad: Sequence[tuple[int, int]],
     transform_info: dict,
     mode: str = PytorchPadMode.CONSTANT,
     lazy: bool = False,


### PR DESCRIPTION
The to_pad parameter and compute_pad_width return types used tuple[tuple[int, int]] which restricts to a single inner tuple. Changed to_pad to Sequence[tuple[int, int]] and compute_pad_width returns to tuple[tuple[int, int], ...] to correctly allow padding tuples for every dimension. Fixes #9026

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
