### PR TITLE
Adding Temporary Directory Routine

### DIFF
--- a/docs/source/apps.rst
+++ b/docs/source/apps.rst
@@ -43,6 +43,8 @@ Applications
 
 .. autofunction:: download_and_extract
 
+.. autofunction:: create_temp_dir
+
 `Deepgrow`
 ----------
 

--- a/monai/apps/__init__.py
+++ b/monai/apps/__init__.py
@@ -13,4 +13,13 @@ from __future__ import annotations
 
 from .datasets import CrossValidation, DecathlonDataset, MedNISTDataset, TciaDataset
 from .mmars import MODEL_DESC, RemoteMMARKeys, download_mmar, get_model_spec, load_from_mmar
-from .utils import SUPPORTED_HASH_TYPES, check_hash, download_and_extract, download_url, extractall, get_logger, logger
+from .utils import (
+    SUPPORTED_HASH_TYPES,
+    check_hash,
+    create_temp_dir,
+    download_and_extract,
+    download_url,
+    extractall,
+    get_logger,
+    logger,
+)

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -459,6 +459,6 @@ def create_temp_dir(directory: str | None = None, delete_on_finalise: bool = Fal
     os.makedirs(directory, exist_ok=True)
 
     if delete_on_finalise:
-        atexit.register(shutil.rmtree, directory)
+        atexit.register(shutil.rmtree, directory, ignore_errors=True)
 
     return directory

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import atexit
 import hashlib
 import json
 import logging
@@ -29,7 +30,7 @@ from urllib.parse import urlparse
 from urllib.request import urlopen, urlretrieve
 
 from monai.config.type_definitions import PathLike
-from monai.utils import look_up_option, min_version, optional_import
+from monai.utils import MONAIEnvVars, look_up_option, min_version, optional_import
 
 requests, has_requests = optional_import("requests")
 gdown, has_gdown = optional_import("gdown", "4.7.3")
@@ -42,7 +43,15 @@ if TYPE_CHECKING:
 else:
     tqdm, has_tqdm = optional_import("tqdm", "4.47.0", min_version, "tqdm")
 
-__all__ = ["check_hash", "download_url", "extractall", "download_and_extract", "get_logger", "SUPPORTED_HASH_TYPES"]
+__all__ = [
+    "check_hash",
+    "download_url",
+    "extractall",
+    "download_and_extract",
+    "get_logger",
+    "SUPPORTED_HASH_TYPES",
+    "create_temp_dir",
+]
 
 DEFAULT_FMT = "%(asctime)s - %(levelname)s - %(message)s"
 SUPPORTED_HASH_TYPES = {"md5": hashlib.md5, "sha1": hashlib.sha1, "sha256": hashlib.sha256, "sha512": hashlib.sha512}
@@ -422,3 +431,34 @@ def download_and_extract(
         filename = filepath or Path(tmp_dir, get_filename_from_url(url)).resolve()
         download_url(url=url, filepath=filename, hash_val=hash_val, hash_type=hash_type, progress=progress)
         extractall(filepath=filename, output_dir=output_dir, file_type=file_type, has_base=has_base)
+
+
+def create_temp_dir(directory: str | None = None, delete_on_finalise: bool = False) -> str:
+    """
+    Creates or uses an existing temporary directory. If `directory` is given, this is used as the path to a directory
+    which is created if it doesn't exist already. If `directory` is None, the value of the environment variable
+    `MONAI_DATA_DIRECTORY` is used instead, if this is not present then a random temporary directory is chosen. If
+    `delete_on_finalise` is True, or a random temp directory was created, the directory and its contents will be deleted
+    when the process exits.
+
+    Args:
+        directory: path to desired temporary directory, or None to use MONAI_DATA_DIRECTORY or choose a random one.
+        delete_on_finalise: if True, the directory and its contents will be deleted when the process exits.
+
+    Returns:
+        The path to the existing or new temporary directory, if `directory` is given this will be returned, otherwise it
+        will be the value of MONAI_DATA_DIRECTORY if present or the chosen random directory. This directory will exist.
+
+    """
+    if directory is None:
+        directory = MONAIEnvVars.data_dir()
+        if directory is None:
+            directory = tempfile.mkdtemp()
+            delete_on_finalise = True
+
+    os.makedirs(directory, exist_ok=True)
+
+    if delete_on_finalise:
+        atexit.register(shutil.rmtree, directory)
+
+    return directory

--- a/monai/apps/utils.py
+++ b/monai/apps/utils.py
@@ -433,7 +433,7 @@ def download_and_extract(
         extractall(filepath=filename, output_dir=output_dir, file_type=file_type, has_base=has_base)
 
 
-def create_temp_dir(directory: str | None = None, delete_on_finalise: bool = False) -> str:
+def create_temp_dir(directory: PathLike | None = None, delete_on_finalise: bool = False) -> str:
     """
     Creates or uses an existing temporary directory. If `directory` is given, this is used as the path to a directory
     which is created if it doesn't exist already. If `directory` is None, the value of the environment variable
@@ -455,6 +455,8 @@ def create_temp_dir(directory: str | None = None, delete_on_finalise: bool = Fal
         if directory is None:
             directory = tempfile.mkdtemp()
             delete_on_finalise = True
+    else:
+        directory = str(directory)  # convert Path if given
 
     os.makedirs(directory, exist_ok=True)
 

--- a/tests/apps/test_create_temp_dir.py
+++ b/tests/apps/test_create_temp_dir.py
@@ -62,30 +62,26 @@ class TestCreateTempDir(unittest.TestCase):
             self.assertTrue(os.path.isdir(selected_dir))
             self.assertEqual(test_dir, selected_dir)
 
-    @skip_if_quick
     def test_finalisation(self):
         """Test the temporary directory is deleted by finalisation using a subprocess."""
-        # this writes a script to a temporary directory which uses create_temp_dir, this is then called in a subprocess
-        # to verify the finalising behaviour
-        with tempfile.TemporaryDirectory() as temp_dir:
+        self.finaliser = None
+
+        def _register(func, /, *args, **kwargs):
+            self.finaliser = (func, args, kwargs)
+
+        with patch("atexit.register", new=_register), tempfile.TemporaryDirectory() as temp_dir:
             selected_dir = f"{temp_dir}/test_inner_dir"
-            script = f"""
-                import os
-                from monai.apps import create_temp_dir
-                test_dir = create_temp_dir({selected_dir!r}, True)
-                with open(test_dir+"/test_file", "w") as o:
-                    o.write("Test file data")
-                assert os.path.isdir(test_dir)
-            """
-            script_file = f"{temp_dir}/script.py"
-            with open(script_file, "w") as o:
-                o.write(dedent(script))
+            test_dir = create_temp_dir(selected_dir, True)
 
-            # add a PYTHONPATH value to the environment to find the current MONAI install
-            env = {**os.environ, "PYTHONPATH": f"{os.path.dirname(monai.__file__)}/.."}
-            retcode = call([sys.executable, "script.py"], cwd=temp_dir, env=env)
+            self.assertTrue(os.path.isdir(selected_dir))
+            self.assertIsNotNone(self.finaliser)
 
-            self.assertEqual(0, retcode)
+            with open(test_dir + "/test_file", "w") as o:
+                o.write("Test file data")
+
+            func, args, kwargs = self.finaliser
+            func(*args, **kwargs)
+
             self.assertFalse(os.path.exists(selected_dir))
 
 

--- a/tests/apps/test_create_temp_dir.py
+++ b/tests/apps/test_create_temp_dir.py
@@ -12,17 +12,12 @@
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 import unittest
-from subprocess import call
-from textwrap import dedent
 from unittest.mock import patch
 
-import monai
 from monai.apps import create_temp_dir
 from monai.utils import MONAIEnvVars
-from tests.test_utils import skip_if_quick
 
 MONAI_DATA_DIRECTORY = "MONAI_DATA_DIRECTORY"
 

--- a/tests/apps/test_create_temp_dir.py
+++ b/tests/apps/test_create_temp_dir.py
@@ -64,7 +64,6 @@ class TestCreateTempDir(unittest.TestCase):
 
             self.assertTrue(os.path.isdir(selected_dir))
             self.assertEqual(test_dir, selected_dir)
-            self.assertEqual(test_dir, selected_dir)
 
     def test_given_dir_path(self):
         """Test giving a directory as a Path object to the function, ensuring it creates the directory."""

--- a/tests/apps/test_create_temp_dir.py
+++ b/tests/apps/test_create_temp_dir.py
@@ -1,0 +1,93 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from subprocess import call
+from textwrap import dedent
+from unittest.mock import patch
+
+import monai
+from monai.apps import create_temp_dir
+from monai.utils import MONAIEnvVars
+from tests.test_utils import skip_if_quick
+
+MONAI_DATA_DIRECTORY = "MONAI_DATA_DIRECTORY"
+
+
+class TestCreateTempDir(unittest.TestCase):
+    def test_basic_use(self):
+        """Test basic usage which should create a new random temporary directory."""
+        try:
+            data_dir = os.environ.pop(MONAI_DATA_DIRECTORY, None)  # ignore the environment variable if present
+
+            test_dir = create_temp_dir()
+
+            self.assertTrue(os.path.isdir(test_dir))
+
+        finally:
+            if data_dir is not None:
+                os.environ[MONAI_DATA_DIRECTORY] = data_dir
+
+    def test_data_dir(self):
+        """Test using a mocked MONAI_DATA_DIRECTORY, which should be returned by the function."""
+        with patch("monai.utils.MONAIEnvVars.data_dir") as data_dir, tempfile.TemporaryDirectory() as fake_data_dir:
+            data_dir.return_value = fake_data_dir
+
+            self.assertEqual(fake_data_dir, MONAIEnvVars.data_dir())
+
+            test_dir = create_temp_dir()
+
+            self.assertTrue(os.path.isdir(test_dir))
+            self.assertEqual(test_dir, fake_data_dir)
+
+    def test_given_dir(self):
+        """Test giving a directory to the function, ensuring it creates the directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            selected_dir = f"{temp_dir}/test_inner_dir"
+            test_dir = create_temp_dir(selected_dir)
+
+            self.assertTrue(os.path.isdir(selected_dir))
+            self.assertEqual(test_dir, selected_dir)
+
+    @skip_if_quick
+    def test_finalisation(self):
+        """Test the temporary directory is deleted by finalisation using a subprocess."""
+        # this writes a script to a temporary directory which uses create_temp_dir, this is then called in a subprocess
+        # to verify the finalising behaviour
+        with tempfile.TemporaryDirectory() as temp_dir:
+            selected_dir = f"{temp_dir}/test_inner_dir"
+            script = f"""
+                import os
+                from monai.apps import create_temp_dir
+                test_dir = create_temp_dir({selected_dir!r}, True)
+                with open(test_dir+"/test_file", "w") as o:
+                    o.write("Test file data")
+                assert os.path.isdir(test_dir)
+            """
+            script_file = f"{temp_dir}/script.py"
+            with open(script_file, "w") as o:
+                o.write(dedent(script))
+
+            # add a PYTHONPATH value to the environment to find the current MONAI install
+            env = {**os.environ, "PYTHONPATH": f"{os.path.dirname(monai.__file__)}/.."}
+            retcode = call([sys.executable, "script.py"], cwd=temp_dir, env=env)
+
+            self.assertEqual(0, retcode)
+            self.assertFalse(os.path.exists(selected_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/apps/test_create_temp_dir.py
+++ b/tests/apps/test_create_temp_dir.py
@@ -12,8 +12,10 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from monai.apps import create_temp_dir
@@ -25,13 +27,15 @@ MONAI_DATA_DIRECTORY = "MONAI_DATA_DIRECTORY"
 class TestCreateTempDir(unittest.TestCase):
     def test_basic_use(self):
         """Test basic usage which should create a new random temporary directory."""
+
+        data_dir = os.environ.pop(MONAI_DATA_DIRECTORY, None)  # ignore the environment variable if present
         try:
-            data_dir = os.environ.pop(MONAI_DATA_DIRECTORY, None)  # ignore the environment variable if present
+            with patch("atexit.register") as mock_reg:
+                test_dir = create_temp_dir()
 
-            test_dir = create_temp_dir()
+                self.assertTrue(os.path.isdir(test_dir))
 
-            self.assertTrue(os.path.isdir(test_dir))
-
+                mock_reg.assert_called_once_with(shutil.rmtree, test_dir, ignore_errors=True)
         finally:
             if data_dir is not None:
                 os.environ[MONAI_DATA_DIRECTORY] = data_dir
@@ -51,21 +55,33 @@ class TestCreateTempDir(unittest.TestCase):
     def test_given_dir(self):
         """Test giving a directory to the function, ensuring it creates the directory."""
         with tempfile.TemporaryDirectory() as temp_dir:
-            selected_dir = f"{temp_dir}/test_inner_dir"
+            selected_dir = f"{temp_dir}{os.path.sep}test_inner_dir"
+
             test_dir = create_temp_dir(selected_dir)
+
+            self.assertTrue(os.path.isdir(selected_dir))
+            self.assertEqual(test_dir, selected_dir)
+            self.assertEqual(test_dir, selected_dir)
+
+    def test_given_dir_path(self):
+        """Test giving a directory as a Path object to the function, ensuring it creates the directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            selected_dir = f"{temp_dir}{os.path.sep}test_inner_dir"
+
+            test_dir = create_temp_dir(Path(selected_dir))
 
             self.assertTrue(os.path.isdir(selected_dir))
             self.assertEqual(test_dir, selected_dir)
 
     def test_finalisation(self):
-        """Test the temporary directory is deleted by finalisation using a subprocess."""
+        """Test the temporary directory is deleted by finalisation."""
         self.finaliser = None
 
         def _register(func, /, *args, **kwargs):
             self.finaliser = (func, args, kwargs)
 
         with patch("atexit.register", new=_register), tempfile.TemporaryDirectory() as temp_dir:
-            selected_dir = f"{temp_dir}/test_inner_dir"
+            selected_dir = f"{temp_dir}{os.path.sep}test_inner_dir"
             test_dir = create_temp_dir(selected_dir, True)
 
             self.assertTrue(os.path.isdir(selected_dir))

--- a/tests/apps/test_create_temp_dir.py
+++ b/tests/apps/test_create_temp_dir.py
@@ -29,6 +29,7 @@ class TestCreateTempDir(unittest.TestCase):
         """Test basic usage which should create a new random temporary directory."""
 
         data_dir = os.environ.pop(MONAI_DATA_DIRECTORY, None)  # ignore the environment variable if present
+        test_dir = None
         try:
             with patch("atexit.register") as mock_reg:
                 test_dir = create_temp_dir()
@@ -39,6 +40,8 @@ class TestCreateTempDir(unittest.TestCase):
         finally:
             if data_dir is not None:
                 os.environ[MONAI_DATA_DIRECTORY] = data_dir
+            if test_dir is not None:
+                shutil.rmtree(test_dir, ignore_errors=True)
 
     def test_data_dir(self):
         """Test using a mocked MONAI_DATA_DIRECTORY, which should be returned by the function."""


### PR DESCRIPTION
### Description

This adds a temporary directory creation routine to replace the following cell in many tutorial notebooks:

```python
# Set data directory
directory = os.environ.get("MONAI_DATA_DIRECTORY")
if directory is not None:
    os.makedirs(directory, exist_ok=True)
root_dir = tempfile.mkdtemp() if directory is None else directory
print(root_dir)
```

This should be functionally equivalent, but can also add a finaliser function to delete the directory when the notebook closes. The notebooks can then be updated to reduce the amount of code.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
