### PR TITLE
Perf(test): shrink synthetic volumes in image loading and dataset tests

### DIFF
--- a/tests/data/test_arraydataset.py
+++ b/tests/data/test_arraydataset.py
@@ -28,14 +28,14 @@ TEST_CASE_1 = [
     Compose([LoadImage(image_only=True), EnsureChannelFirst(channel_dim="no_channel"), RandGaussianNoise(prob=1.0)]),
     Compose([LoadImage(image_only=True), EnsureChannelFirst(channel_dim="no_channel"), RandGaussianNoise(prob=1.0)]),
     (0, 1),
-    (1, 128, 128, 128),
+    (1, 32, 32, 32),
 ]
 
 TEST_CASE_2 = [
     Compose([LoadImage(image_only=True), EnsureChannelFirst(channel_dim="no_channel"), RandAdjustContrast(prob=1.0)]),
     Compose([LoadImage(image_only=True), EnsureChannelFirst(channel_dim="no_channel"), RandAdjustContrast(prob=1.0)]),
     (0, 1),
-    (1, 128, 128, 128),
+    (1, 32, 32, 32),
 ]
 
 
@@ -69,12 +69,12 @@ TEST_CASE_3 = [
         ]
     ),
     (0, 2),
-    (1, 64, 64, 33),
+    (1, 16, 16, 9),
 ]
 
 TEST_CASE_4 = [
     Compose([LoadImage(image_only=True), EnsureChannelFirst(channel_dim="no_channel"), RandGaussianNoise(prob=1.0)]),
-    (1, 128, 128, 128),
+    (1, 32, 32, 32),
 ]
 
 
@@ -82,7 +82,7 @@ class TestArrayDataset(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2, TEST_CASE_3])
     def test_shape(self, img_transform, label_transform, indices, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(128, 128, 128)).astype(float), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(32, 32, 32)).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             test_image1 = os.path.join(tempdir, "test_image1.nii.gz")
             test_seg1 = os.path.join(tempdir, "test_seg1.nii.gz")
@@ -116,7 +116,7 @@ class TestArrayDataset(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_4])
     def test_default_none(self, img_transform, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(128, 128, 128)).astype(float), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(32, 32, 32)).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             test_image1 = os.path.join(tempdir, "test_image1.nii.gz")
             test_image2 = os.path.join(tempdir, "test_image2.nii.gz")
@@ -139,7 +139,7 @@ class TestArrayDataset(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_4])
     def test_dataloading_img(self, img_transform, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(128, 128, 128)).astype(float), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(32, 32, 32)).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             test_image1 = os.path.join(tempdir, "test_image1.nii.gz")
             test_image2 = os.path.join(tempdir, "test_image2.nii.gz")
@@ -160,7 +160,7 @@ class TestArrayDataset(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_4])
     def test_dataloading_img_label(self, img_transform, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(128, 128, 128)).astype(float), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=(32, 32, 32)).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             test_image1 = os.path.join(tempdir, "test_image1.nii.gz")
             test_image2 = os.path.join(tempdir, "test_image2.nii.gz")

--- a/tests/data/test_cachedataset.py
+++ b/tests/data/test_cachedataset.py
@@ -23,9 +23,9 @@ from parameterized import parameterized
 from monai.data import CacheDataset, DataLoader, PersistentDataset, SmartCacheDataset
 from monai.transforms import Compose, Lambda, LoadImaged, RandLambda, ThreadUnsafe, Transform
 
-TEST_CASE_1 = [Compose([LoadImaged(keys=["image", "label", "extra"])]), (128, 128, 128)]
+TEST_CASE_1 = [Compose([LoadImaged(keys=["image", "label", "extra"])]), (32, 32, 32)]
 
-TEST_CASE_2 = [None, (128, 128, 128)]
+TEST_CASE_2 = [None, (32, 32, 32)]
 
 TEST_DS = []
 for c in (0, 1, 2):
@@ -41,7 +41,7 @@ class TestCacheDataset(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     def test_shape(self, transform, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[32, 32, 32]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             test_data = []
             for i in ["1", "2"]:
@@ -192,7 +192,7 @@ class TestCacheThread(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     def test_hash_as_key(self, transform, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[32, 32, 32]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             test_data = []
             for i in ["1", "2", "2", "3", "3"]:

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -26,13 +26,13 @@ from monai.data import Dataset
 from monai.transforms import Compose, Lambda, LoadImage, LoadImaged, SimulateDelay, SimulateDelayd
 from tests.transforms.compose.test_compose import TEST_COMPOSE_LAZY_ON_CALL_LOGGING_TEST_CASES, data_from_keys
 
-TEST_CASE_1 = [(128, 128, 128)]
+TEST_CASE_1 = [(32, 32, 32)]
 
 
 class TestDataset(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1])
     def test_shape(self, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[32, 32, 32]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
             nib.save(test_image, os.path.join(tempdir, "test_label1.nii.gz"))
@@ -101,7 +101,7 @@ class TestDataset(unittest.TestCase):
 class TestTupleDataset(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1])
     def test_shape(self, expected_shape):
-        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[128, 128, 128]).astype(float), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.randint(0, 2, size=[32, 32, 32]).astype(float), np.eye(4))
         with tempfile.TemporaryDirectory() as tempdir:
             nib.save(test_image, os.path.join(tempdir, "test_image1.nii.gz"))
             nib.save(test_image, os.path.join(tempdir, "test_label1.nii.gz"))

--- a/tests/data/test_mapping_file.py
+++ b/tests/data/test_mapping_file.py
@@ -28,7 +28,7 @@ nib, has_nib = optional_import("nibabel")
 
 
 def create_input_file(temp_dir, name):
-    test_image = np.random.rand(128, 128, 128)
+    test_image = np.random.rand(16, 16, 16)
     output_ext = ".nii.gz"
     input_file = os.path.join(temp_dir, name + output_ext)
     nib.save(nib.Nifti1Image(test_image, np.eye(4)), input_file)

--- a/tests/transforms/test_load_image.py
+++ b/tests/transforms/test_load_image.py
@@ -52,64 +52,64 @@ class _MiniReader:
         return np.zeros((1, 1, 1)), {"name": "my test"}
 
 
-TEST_CASE_1 = [{}, ["test_image.nii.gz"], (128, 128, 128)]
+TEST_CASE_1 = [{}, ["test_image.nii.gz"], (32, 32, 32)]
 
-TEST_CASE_2 = [{}, ["test_image.nii.gz"], (128, 128, 128)]
+TEST_CASE_2 = [{}, ["test_image.nii.gz"], (32, 32, 32)]
 
-TEST_CASE_3 = [{}, ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"], (3, 128, 128, 128)]
+TEST_CASE_3 = [{}, ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"], (3, 32, 32, 32)]
 
 TEST_CASE_3_1 = [  # .mgz format
     {"reader": "nibabelreader"},
     ["test_image.mgz", "test_image2.mgz", "test_image3.mgz"],
-    (3, 128, 128, 128),
+    (3, 32, 32, 32),
 ]
 
-TEST_CASE_4 = [{}, ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"], (3, 128, 128, 128)]
+TEST_CASE_4 = [{}, ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"], (3, 32, 32, 32)]
 
 TEST_CASE_4_1 = [  # additional parameter
     {"mmap": False},
     ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"],
-    (3, 128, 128, 128),
+    (3, 32, 32, 32),
 ]
 
-TEST_CASE_5 = [{"reader": NibabelReader(mmap=False)}, ["test_image.nii.gz"], (128, 128, 128)]
+TEST_CASE_5 = [{"reader": NibabelReader(mmap=False)}, ["test_image.nii.gz"], (32, 32, 32)]
 
-TEST_CASE_GPU_1 = [{"reader": "nibabelreader", "to_gpu": True}, ["test_image.nii.gz"], (128, 128, 128)]
+TEST_CASE_GPU_1 = [{"reader": "nibabelreader", "to_gpu": True}, ["test_image.nii.gz"], (32, 32, 32)]
 
-TEST_CASE_GPU_2 = [{"reader": "nibabelreader", "to_gpu": True}, ["test_image.nii"], (128, 128, 128)]
+TEST_CASE_GPU_2 = [{"reader": "nibabelreader", "to_gpu": True}, ["test_image.nii"], (32, 32, 32)]
 
 TEST_CASE_GPU_3 = [
     {"reader": "nibabelreader", "to_gpu": True},
     ["test_image.nii", "test_image2.nii", "test_image3.nii"],
-    (3, 128, 128, 128),
+    (3, 32, 32, 32),
 ]
 
 TEST_CASE_GPU_4 = [
     {"reader": "nibabelreader", "to_gpu": True},
     ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"],
-    (3, 128, 128, 128),
+    (3, 32, 32, 32),
 ]
 
-TEST_CASE_6 = [{"reader": ITKReader() if has_itk else "itkreader"}, ["test_image.nii.gz"], (128, 128, 128)]
+TEST_CASE_6 = [{"reader": ITKReader() if has_itk else "itkreader"}, ["test_image.nii.gz"], (32, 32, 32)]
 
-TEST_CASE_7 = [{"reader": ITKReader() if has_itk else "itkreader"}, ["test_image.nii.gz"], (128, 128, 128)]
+TEST_CASE_7 = [{"reader": ITKReader() if has_itk else "itkreader"}, ["test_image.nii.gz"], (32, 32, 32)]
 
 TEST_CASE_8 = [
     {"reader": ITKReader() if has_itk else "itkreader"},
     ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"],
-    (3, 128, 128, 128),
+    (3, 32, 32, 32),
 ]
 
 TEST_CASE_8_1 = [
     {"reader": ITKReader(channel_dim=0) if has_itk else "itkreader"},
     ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"],
-    (384, 128, 128),
+    (96, 32, 32),
 ]
 
 TEST_CASE_9 = [
     {"reader": ITKReader() if has_itk else "itkreader"},
     ["test_image.nii.gz", "test_image2.nii.gz", "test_image3.nii.gz"],
-    (3, 128, 128, 128),
+    (3, 32, 32, 32),
 ]
 
 TEST_CASE_10 = [
@@ -128,24 +128,24 @@ TEST_CASE_12 = [
     (4, 16, 16),
 ]
 
-TEST_CASE_13 = [{"reader": "nibabelreader", "channel_dim": 0}, "test_image.nii.gz", (3, 128, 128, 128)]
+TEST_CASE_13 = [{"reader": "nibabelreader", "channel_dim": 0}, "test_image.nii.gz", (3, 32, 32, 32)]
 
 TEST_CASE_14 = [
     {"reader": "nibabelreader", "channel_dim": -1, "ensure_channel_first": True},
     "test_image.nii.gz",
-    (128, 128, 128, 3),
+    (32, 32, 32, 3),
 ]
 
-TEST_CASE_15 = [{"reader": "nibabelreader", "channel_dim": 2}, "test_image.nii.gz", (128, 128, 3, 128)]
+TEST_CASE_15 = [{"reader": "nibabelreader", "channel_dim": 2}, "test_image.nii.gz", (32, 32, 3, 32)]
 
-TEST_CASE_16 = [{"reader": "itkreader", "channel_dim": 0}, "test_image.nii.gz", (3, 128, 128, 128)]
+TEST_CASE_16 = [{"reader": "itkreader", "channel_dim": 0}, "test_image.nii.gz", (3, 32, 32, 32)]
 
-TEST_CASE_17 = [{"reader": "monai.data.ITKReader", "channel_dim": -1}, "test_image.nii.gz", (128, 128, 128, 3)]
+TEST_CASE_17 = [{"reader": "monai.data.ITKReader", "channel_dim": -1}, "test_image.nii.gz", (32, 32, 32, 3)]
 
 TEST_CASE_18 = [
     {"reader": "ITKReader", "channel_dim": 2, "ensure_channel_first": True},
     "test_image.nii.gz",
-    (128, 128, 3, 128),
+    (32, 32, 3, 32),
 ]
 
 # test same dicom data with PydicomReader
@@ -180,8 +180,8 @@ TEST_CASE_GPU_6 = [
 
 TESTS_META = []
 for track_meta in (False, True):
-    TESTS_META.append([{}, (128, 128, 128), track_meta])
-    TESTS_META.append([{"reader": "ITKReader", "fallback_only": False}, (128, 128, 128), track_meta])
+    TESTS_META.append([{}, (32, 32, 32), track_meta])
+    TESTS_META.append([{"reader": "ITKReader", "fallback_only": False}, (32, 32, 32), track_meta])
 
 
 @unittest.skipUnless(has_itk, "itk not installed")
@@ -209,7 +209,7 @@ class TestLoadImage(unittest.TestCase):
         [TEST_CASE_1, TEST_CASE_2, TEST_CASE_3, TEST_CASE_3_1, TEST_CASE_4, TEST_CASE_4_1, TEST_CASE_5]
     )
     def test_nibabel_reader(self, input_param, filenames, expected_shape):
-        test_image = np.random.rand(128, 128, 128)
+        test_image = np.random.rand(32, 32, 32)
         with tempfile.TemporaryDirectory() as tempdir:
             for i, name in enumerate(filenames):
                 filenames[i] = os.path.join(tempdir, name)
@@ -229,9 +229,9 @@ class TestLoadImage(unittest.TestCase):
         if torch.__version__.endswith("nv24.8"):
             # related issue: https://github.com/Project-MONAI/MONAI/issues/8274
             # for this version, use randint test case to avoid the issue
-            test_image = torch.randint(0, 256, (128, 128, 128), dtype=torch.uint8).numpy()
+            test_image = torch.randint(0, 256, (32, 32, 32), dtype=torch.uint8).numpy()
         else:
-            test_image = np.random.rand(128, 128, 128)
+            test_image = np.random.rand(32, 32, 32)
         with tempfile.TemporaryDirectory() as tempdir:
             for i, name in enumerate(filenames):
                 filenames[i] = os.path.join(tempdir, name)
@@ -251,7 +251,7 @@ class TestLoadImage(unittest.TestCase):
 
     @parameterized.expand([TEST_CASE_6, TEST_CASE_7, TEST_CASE_8, TEST_CASE_8_1, TEST_CASE_9])
     def test_itk_reader(self, input_param, filenames, expected_shape):
-        test_image = torch.randint(0, 256, (128, 128, 128), dtype=torch.uint8).numpy()
+        test_image = torch.randint(0, 256, (32, 32, 32), dtype=torch.uint8).numpy()
         print("Test image value range:", test_image.min(), test_image.max())
         with tempfile.TemporaryDirectory() as tempdir:
             for i, name in enumerate(filenames):
@@ -462,7 +462,7 @@ class TestLoadImage(unittest.TestCase):
             result = LoadImage(image_only=True, **input_param)(filename)  # with itk, meta has 'qto_xyz': itkMatrixF44
 
         self.assertTupleEqual(
-            result.shape, (3, 128, 128, 128) if input_param.get("ensure_channel_first", False) else expected_shape
+            result.shape, (3, 32, 32, 32) if input_param.get("ensure_channel_first", False) else expected_shape
         )
         self.assertEqual(result.meta["original_channel_dim"], input_param["channel_dim"])
 
@@ -473,7 +473,7 @@ class TestLoadImageMeta(unittest.TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.tmpdir = tempfile.mkdtemp()
-        test_image = nib.Nifti1Image(np.random.rand(128, 128, 128), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.rand(32, 32, 32), np.eye(4))
         nib.save(test_image, os.path.join(cls.tmpdir, "im.nii.gz"))
         cls.test_data = os.path.join(cls.tmpdir, "im.nii.gz")
 
@@ -502,7 +502,7 @@ class TestLoadImageMeta(unittest.TestCase):
         try:
             set_track_meta(False)
             r = LoadImage(image_only=True, ensure_channel_first=True)(self.test_data)
-            self.assertTupleEqual(r.shape, (1, 128, 128, 128))
+            self.assertTupleEqual(r.shape, (1, 32, 32, 32))
             self.assertIsInstance(r, torch.Tensor)
             self.assertNotIsInstance(r, MetaTensor)
         finally:

--- a/tests/transforms/test_load_imaged.py
+++ b/tests/transforms/test_load_imaged.py
@@ -34,21 +34,21 @@ itk, has_itk = optional_import("itk", allow_namespace_pkg=True)
 
 KEYS = ["image", "label", "extra"]
 
-TEST_CASE_1 = [{"keys": KEYS}, (128, 128, 128)]
+TEST_CASE_1 = [{"keys": KEYS}, (32, 32, 32)]
 
-TEST_CASE_2 = [{"keys": KEYS, "reader": "ITKReader", "fallback_only": False}, (128, 128, 128)]
+TEST_CASE_2 = [{"keys": KEYS, "reader": "ITKReader", "fallback_only": False}, (32, 32, 32)]
 
 TESTS_META = []
 for track_meta in (False, True):
-    TESTS_META.append([{"keys": KEYS}, (128, 128, 128), track_meta])
-    TESTS_META.append([{"keys": KEYS, "reader": "ITKReader", "fallback_only": False}, (128, 128, 128), track_meta])
+    TESTS_META.append([{"keys": KEYS}, (32, 32, 32), track_meta])
+    TESTS_META.append([{"keys": KEYS, "reader": "ITKReader", "fallback_only": False}, (32, 32, 32), track_meta])
 
 
 @unittest.skipUnless(has_itk, "itk not installed")
 class TestLoadImaged(unittest.TestCase):
     @parameterized.expand([TEST_CASE_1, TEST_CASE_2])
     def test_shape(self, input_param, expected_shape):
-        test_image = nib.Nifti1Image(np.random.rand(128, 128, 128), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.rand(32, 32, 32), np.eye(4))
         test_data = {}
         with tempfile.TemporaryDirectory() as tempdir:
             for key in KEYS:
@@ -159,7 +159,7 @@ class TestLoadImagedMeta(unittest.TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.tmpdir = tempfile.mkdtemp()
-        test_image = nib.Nifti1Image(np.random.rand(128, 128, 128), np.eye(4))
+        test_image = nib.Nifti1Image(np.random.rand(32, 32, 32), np.eye(4))
         cls.test_data = {}
         for key in KEYS:
             nib.save(test_image, os.path.join(cls.tmpdir, key + ".nii.gz"))


### PR DESCRIPTION
### Description

Shrinks the synthetic volumes these six test files generate, so each test still exercises the same code paths in a fraction of the runtime. Pure test-fixture change: no production code touched, no test logic altered:

- `tests/transforms/test_load_image.py`, `tests/transforms/test_load_imaged.py`: 128³ volumes → 32³; multi-image cases 3×128³ → 3×32³; the 384×128³ channel-dim case scales to 96×32³.
- `tests/data/test_arraydataset.py`, `test_cachedataset.py`, `test_dataset.py`: 128³ → 32³; the Spacing case 64×64×33 → 16×16×9.
- `tests/data/test_mapping_file.py`: 128³ → 16³.

The 128³ sizes were an unexamined default; nothing depends on the magnitude, only that shapes round-trip through `.nii.gz` I/O. Expected shapes were updated in lockstep, so the assertions still verify the same behaviour.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
