### PR TITLE
Raise OptionalImportError when user-specified reader is not installed

### DIFF
--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -166,7 +166,7 @@ class LoadImage(Transform):
          Raises:
             OptionalImportError: If an explicitly selected reader dependency is unavailable.
 
-        
+
 
         Note:
 

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -163,6 +163,10 @@ class LoadImage(Transform):
             expanduser: if True cast filename to Path and call .expanduser on it, otherwise keep filename as is.
             args: additional parameters for reader if providing a reader name.
             kwargs: additional parameters for reader if providing a reader name.
+         Raises:
+            OptionalImportError: If an explicitly selected reader dependency is unavailable.
+
+        
 
         Note:
 

--- a/monai/transforms/io/array.py
+++ b/monai/transforms/io/array.py
@@ -209,10 +209,10 @@ class LoadImage(Transform):
                     the_reader = look_up_option(_r.lower(), SUPPORTED_READERS)
                 try:
                     self.register(the_reader(*args, **kwargs))
-                except OptionalImportError:
-                    warnings.warn(
+                except OptionalImportError as e:
+                    raise OptionalImportError(
                         f"required package for reader {_r} is not installed, or the version doesn't match requirement."
-                    )
+                    ) from e
                 except TypeError:  # the reader doesn't have the corresponding args/kwargs
                     warnings.warn(f"{_r} is not supported with the given parameters {args} {kwargs}.")
                     self.register(the_reader())

--- a/tests/transforms/test_load_image.py
+++ b/tests/transforms/test_load_image.py
@@ -221,9 +221,14 @@ class TestLoadImage(unittest.TestCase):
             assert_allclose(result.affine, torch.eye(4))
             self.assertTupleEqual(result.shape, expected_shape)
 
-    @SkipIfNoModule("nibabel")
-    @SkipIfNoModule("cupy")
-    @SkipIfNoModule("kvikio")
+
+    def test_reader_not_installed_raises(self):
+        from unittest.mock import patch
+        from monai.utils import OptionalImportError
+
+        with patch("monai.data.ITKReader", side_effect=OptionalImportError("itk not installed")):
+            with self.assertRaises(OptionalImportError):
+                LoadImage(reader="ITKReader")
     @parameterized.expand([TEST_CASE_GPU_1, TEST_CASE_GPU_2, TEST_CASE_GPU_3, TEST_CASE_GPU_4])
     def test_nibabel_reader_gpu(self, input_param, filenames, expected_shape):
         if torch.__version__.endswith("nv24.8"):

--- a/tests/transforms/test_load_image.py
+++ b/tests/transforms/test_load_image.py
@@ -226,9 +226,11 @@ class TestLoadImage(unittest.TestCase):
         from unittest.mock import patch
         from monai.utils import OptionalImportError
 
-        with patch("monai.data.ITKReader", side_effect=OptionalImportError("itk not installed")):
-            with self.assertRaises(OptionalImportError):
+        original_error = OptionalImportError("itk not installed")
+        with patch("monai.data.ITKReader", side_effect=original_error):
+            with self.assertRaises(OptionalImportError) as context:
                 LoadImage(reader="ITKReader")
+        self.assertIs(context.exception.__cause__, original_error)
     @parameterized.expand([TEST_CASE_GPU_1, TEST_CASE_GPU_2, TEST_CASE_GPU_3, TEST_CASE_GPU_4])
     def test_nibabel_reader_gpu(self, input_param, filenames, expected_shape):
         if torch.__version__.endswith("nv24.8"):


### PR DESCRIPTION
(fixes #7437)

Fixes

Description

A few sentences describing the changes proposed in this pull request.

 Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
