### PR TITLE
Warn when lazy resampling upcasts non-float input to float32 (#6713)

### DIFF
--- a/monai/transforms/lazy/utils.py
+++ b/monai/transforms/lazy/utils.py
@@ -192,6 +192,12 @@ def resample(data: torch.Tensor, matrix: NdarrayOrTensor, kwargs: dict | None = 
     }
     ndim = len(matrix) - 1
     img = convert_to_tensor(data=data, track_meta=monai.data.get_track_meta())
+    if not (torch.is_floating_point(img) or torch.is_complex(img)):
+        warnings.warn(
+            f"Lazy resampling computes in floating point and converts the input of dtype {img.dtype} to "
+            "float32; the original data type is not preserved. For integer data such as label maps, set "
+            "`lazy=False` for the affected transforms (or cast back afterwards) if the data type must be preserved."
+        )
     init_affine = monai.data.to_affine_nd(ndim, img.affine)
     spatial_size = kwargs.get(LazyAttr.SHAPE, None)
     out_spatial_size = img.peek_pending_shape() if spatial_size is None else spatial_size

--- a/monai/transforms/lazy/utils.py
+++ b/monai/transforms/lazy/utils.py
@@ -196,7 +196,8 @@ def resample(data: torch.Tensor, matrix: NdarrayOrTensor, kwargs: dict | None = 
         warnings.warn(
             f"Lazy resampling computes in floating point and converts the input of dtype {img.dtype} to "
             "float32; the original data type is not preserved. For integer data such as label maps, set "
-            "`lazy=False` for the affected transforms (or cast back afterwards) if the data type must be preserved."
+            "`lazy=False` for the affected transforms (or cast back afterwards) if the data type must be preserved.",
+            stacklevel=2,
         )
     init_affine = monai.data.to_affine_nd(ndim, img.affine)
     spatial_size = kwargs.get(LazyAttr.SHAPE, None)

--- a/tests/transforms/functional/test_resample.py
+++ b/tests/transforms/functional/test_resample.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import unittest
+import warnings
 
 import torch
 from parameterized import parameterized
@@ -44,6 +45,20 @@ class TestResampleFunction(unittest.TestCase):
         out = resample(img, matrix, {"lazy_resample_mode": "auto", "lazy_dtype": torch.float})
         out_1 = resample(img, matrix, {"lazy_resample_mode": "other value", "lazy_dtype": torch.float})
         self.assertIs(out.dtype, out_1.dtype)  # testing dtype in different lazy_resample_mode
+
+    def test_resample_warns_on_non_float_dtype(self):
+        """Lazy resampling upcasts non-floating-point inputs to float32; the user should be warned (see issue #6713)."""
+        img = convert_to_tensor(get_arange_img((3, 3)), dtype=torch.uint8)
+        with self.assertWarns(Warning):
+            out = resample(img, torch.eye(3), {"lazy_resample_mode": "auto"})
+        self.assertIs(out.dtype, torch.float32)
+
+    def test_resample_no_warning_for_float_dtype(self):
+        """Floating-point inputs are not upcast, so no dtype warning should be emitted."""
+        img = convert_to_tensor(get_arange_img((3, 3)), dtype=torch.float32)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # turn any warning into an error
+            resample(img, torch.eye(3), {"lazy_resample_mode": "auto"})
 
 
 if __name__ == "__main__":

--- a/tests/transforms/functional/test_resample.py
+++ b/tests/transforms/functional/test_resample.py
@@ -52,9 +52,10 @@ class TestResampleFunction(unittest.TestCase):
         with self.assertWarns(Warning):
             out = resample(img, torch.eye(3), {"lazy_resample_mode": "auto"})
         self.assertIs(out.dtype, torch.float32)
+        self.assertIs(img.dtype, torch.uint8)  # the input tensor itself is not mutated
 
     def test_resample_no_warning_for_float_dtype(self):
-        """Floating-point inputs are not upcast, so no dtype warning should be emitted."""
+        """Float32 inputs do not trigger the lazy resampling dtype warning."""
         img = convert_to_tensor(get_arange_img((3, 3)), dtype=torch.float32)
         with warnings.catch_warnings():
             warnings.simplefilter("error")  # turn any warning into an error


### PR DESCRIPTION
Fixes #6713

### Summary
When integer data (e.g. a `uint8` label map) is passed through a **lazy** `Compose`, the lazy resampling path silently converts it to `float32`. The same pipeline with `lazy=False` preserves the original dtype. This mismatch is surprising and can corrupt integer label data downstream with no indication.

### Root cause
Lazy resampling always computes in floating point:
- `torch.nn.functional.grid_sample` only supports floating point, and
- even the "auto" array-slicing fast path in `monai/transforms/lazy/utils.py::resample` casts to `float32` (`img.to(torch.float32)`) for collate robustness.

As discussed in #6713, preserving the dtype in the fast path was intentionally **ruled out** by maintainers (float32 is used "even if some specific cases are achievable by simple array slicing ... to ensure the preprocessing collate can work robustly"). The agreed resolution in the thread was to **warn** the user when this conversion happens (@wyli: *"marking this as a feature request"* in response to the request for a check/warning).

### Change
`resample()` now emits a `UserWarning` when the input tensor has a non-floating-point, non-complex dtype (i.e. it will be upcast to `float32`), pointing users to `lazy=False` if the dtype must be preserved.

### Before → after
```python
import torch
from monai.transforms import DivisiblePadd, Compose
inp = {"x": torch.arange(0, 27, dtype=torch.uint8).reshape(3, 3, 3)}
Compose([DivisiblePadd(k=5, keys=["x"])], lazy=True)(inp)
# before: dtype silently becomes float32, no warning
# after:  dtype still float32 (by design), but a UserWarning is now emitted
```

### Tests
Added to `tests/transforms/functional/test_resample.py`:
- `test_resample_warns_on_non_float_dtype` — warning is emitted for `uint8` input (fails before this change, passes after).
- `test_resample_no_warning_for_float_dtype` — no warning for `float32` input.

Verified locally: targeted + `tests/transforms/functional` and the pad transform suites pass; `ruff`/`black`/`isort` clean; `mypy` clean on the changed module.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
