### PR TITLE
Fix clipping boxes with large coordinates

### DIFF
--- a/monai/data/box_utils.py
+++ b/monai/data/box_utils.py
@@ -1035,8 +1035,8 @@ def spatial_crop_boxes(
     # convert to float32 since torch.clamp_ does not support float16
     boxes_t = boxes_t.to(dtype=COMPUTE_DTYPE)
 
-    roi_start_t = convert_to_dst_type(src=roi_start, dst=boxes_t, wrap_sequence=True)[0].to(torch.int16)
-    roi_end_t = convert_to_dst_type(src=roi_end, dst=boxes_t, wrap_sequence=True)[0].to(torch.int16)
+    roi_start_t = convert_to_dst_type(src=roi_start, dst=boxes_t, wrap_sequence=True)[0]
+    roi_end_t = convert_to_dst_type(src=roi_end, dst=boxes_t, wrap_sequence=True)[0]
     roi_end_t = torch.maximum(roi_end_t, roi_start_t)
 
     # makes sure the bounding boxes are within the patch

--- a/tests/data/test_box_utils.py
+++ b/tests/data/test_box_utils.py
@@ -271,6 +271,7 @@ class TestBoxUtilsDtype(unittest.TestCase):
         self.assertGreater(iou[0, 0], 0.0, "IoU should not be truncated to 0")
 
     def test_large_coordinates_are_not_dropped(self):
+        """Verify large-coordinate boxes are preserved by cropping and clipping."""
         boxes = torch.tensor([[41000.0, 5000.0, 45000.0, 15000.0]], dtype=torch.float32)
 
         cropped_boxes, keep = spatial_crop_boxes(

--- a/tests/data/test_box_utils.py
+++ b/tests/data/test_box_utils.py
@@ -35,6 +35,7 @@ from monai.data.box_utils import (
     convert_box_mode,
     convert_box_to_standard_mode,
     non_max_suppression,
+    spatial_crop_boxes,
 )
 from monai.utils.type_conversion import convert_data_type
 from tests.test_utils import TEST_NDARRAYS, assert_allclose
@@ -268,6 +269,19 @@ class TestBoxUtilsDtype(unittest.TestCase):
         iou = box_iou(boxes1, boxes2)
         self.assertTrue(np.issubdtype(iou.dtype, np.floating))
         self.assertGreater(iou[0, 0], 0.0, "IoU should not be truncated to 0")
+
+    def test_large_coordinates_are_not_dropped(self):
+        boxes = torch.tensor([[41000.0, 5000.0, 45000.0, 15000.0]], dtype=torch.float32)
+
+        cropped_boxes, keep = spatial_crop_boxes(
+            boxes=boxes, roi_start=[40000, 0], roi_end=[50000, 20000], remove_empty=True
+        )
+        assert_allclose(keep, torch.tensor([True]))
+        assert_allclose(cropped_boxes, torch.tensor([[1000.0, 5000.0, 5000.0, 15000.0]]))
+
+        clipped_boxes, keep = clip_boxes_to_image(boxes=boxes, spatial_size=[50000, 50000], remove_empty=True)
+        assert_allclose(keep, torch.tensor([True]))
+        assert_allclose(clipped_boxes, boxes)
 
 
 class TestBatchedNms(unittest.TestCase):


### PR DESCRIPTION
Fixes #9045.

### Description

`spatial_crop_boxes` converted crop ROI bounds to `torch.int16`, which overflows for coordinates above 32767. This could cause valid boxes in large images to be clamped incorrectly and silently removed when `remove_empty=True`.

This PR keeps the ROI bounds in the same tensor dtype as the boxes during clipping and adds a regression test covering both `spatial_crop_boxes` and the public `clip_boxes_to_image` path for large coordinates.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

Local validation:
- `python -m tests.data.test_box_utils`
- `python -m ruff check monai/data/box_utils.py tests/data/test_box_utils.py`

`black` and `isort` were not installed in my local Python environment, so I could not run those checks directly.