### PR TITLE
Accept torch tensors as DiNTS arch_code for weights_only=True checkpoints

### DIFF
--- a/monai/networks/nets/dints.py
+++ b/monai/networks/nets/dints.py
@@ -519,7 +519,8 @@ class TopologyConstruction(nn.Module):
     The base class for `TopologyInstance` and `TopologySearch`.
 
     Args:
-        arch_code: `[arch_code_a, arch_code_c]`, numpy arrays. The architecture codes defining the model.
+        arch_code: `[arch_code_a, arch_code_c]`, numpy arrays or torch tensors. The architecture codes defining
+            the model.
             For example, for a ``num_depths=4, num_blocks=12`` search space:
 
             - `arch_code_a` is a 12x10 (10 paths) binary matrix representing if a path is activated.
@@ -605,8 +606,8 @@ class TopologyConstruction(nn.Module):
             arch_code_a = torch.ones((self.num_blocks, len(self.arch_code2out))).to(self.device)
             arch_code_c = torch.ones((self.num_blocks, len(self.arch_code2out), self.num_cell_ops)).to(self.device)
         else:
-            arch_code_a = torch.from_numpy(arch_code[0]).to(self.device)
-            arch_code_c = F.one_hot(torch.from_numpy(arch_code[1]).to(torch.int64), self.num_cell_ops).to(self.device)
+            arch_code_a = torch.as_tensor(arch_code[0]).to(self.device)
+            arch_code_c = F.one_hot(torch.as_tensor(arch_code[1]).to(torch.int64), self.num_cell_ops).to(self.device)
 
         self.arch_code_a = arch_code_a
         self.arch_code_c = arch_code_c

--- a/tests/networks/nets/test_dints_network.py
+++ b/tests/networks/nets/test_dints_network.py
@@ -153,6 +153,48 @@ class TestDints(unittest.TestCase):
         self.assertTrue(isinstance(net.weight_parameters(), list))
 
 
+class TestDintsArchCode(unittest.TestCase):
+    """arch_code entries loaded with `torch.load(..., weights_only=True)` are tensors, not numpy arrays."""
+
+    def setUp(self):
+        self.grid_params = {
+            "channel_mul": 0.2,
+            "num_blocks": 6,
+            "num_depths": 3,
+            "device": "cpu",
+            "use_downsample": False,
+            "spatial_dims": 3,
+        }
+        _cell = Cell(1, 1, 0, spatial_dims=self.grid_params["spatial_dims"])
+        num_paths = 3 * self.grid_params["num_depths"] - 2
+        self.arch_code_a = np.ones((self.grid_params["num_blocks"], num_paths))
+        self.arch_code_c = np.random.randint(len(_cell.OPS), size=(self.grid_params["num_blocks"], num_paths))
+
+    def test_tensor_arch_code_matches_numpy(self):
+        grid_np = TopologyInstance(arch_code=[self.arch_code_a, self.arch_code_c], **self.grid_params)
+        grid_pt = TopologyInstance(
+            arch_code=[torch.as_tensor(self.arch_code_a), torch.as_tensor(self.arch_code_c)], **self.grid_params
+        )
+        torch.testing.assert_close(grid_pt.arch_code_a, grid_np.arch_code_a)
+        torch.testing.assert_close(grid_pt.arch_code_c, grid_np.arch_code_c)
+        self.assertEqual(set(grid_pt.cell_tree.keys()), set(grid_np.cell_tree.keys()))
+
+    def test_dints_forward_tensor_arch_code(self):
+        grid = TopologyInstance(
+            arch_code=[torch.as_tensor(self.arch_code_a), torch.as_tensor(self.arch_code_c)], **self.grid_params
+        )
+        net = DiNTS(
+            dints_space=grid,
+            in_channels=1,
+            num_classes=2,
+            spatial_dims=3,
+            use_downsample=False,
+            node_a=torch.ones((self.grid_params["num_blocks"] + 1, self.grid_params["num_depths"])),
+        )
+        result = net(torch.randn(1, 1, 16, 16, 16))
+        self.assertEqual(result.shape, (1, 2, 16, 16, 16))
+
+
 class TestDintsTS(unittest.TestCase):
     @parameterized.expand(TEST_CASES_3D + TEST_CASES_2D)
     def test_script(self, dints_grid_params, dints_params, input_shape, _):

--- a/tests/networks/nets/test_dints_network.py
+++ b/tests/networks/nets/test_dints_network.py
@@ -157,6 +157,12 @@ class TestDintsArchCode(unittest.TestCase):
     """arch_code entries loaded with `torch.load(..., weights_only=True)` are tensors, not numpy arrays."""
 
     def setUp(self):
+        """Create a small CPU search space and numpy architecture codes shared by the tests.
+
+        Builds ``grid_params`` for a ``num_blocks=6, num_depths=3`` topology, a binary
+        ``arch_code_a`` path-activation matrix of ones, and a random integer ``arch_code_c``
+        cell-operation matrix valid for the ``Cell`` operation set.
+        """
         self.grid_params = {
             "channel_mul": 0.2,
             "num_blocks": 6,
@@ -171,6 +177,11 @@ class TestDintsArchCode(unittest.TestCase):
         self.arch_code_c = np.random.randint(len(_cell.OPS), size=(self.grid_params["num_blocks"], num_paths))
 
     def test_tensor_arch_code_matches_numpy(self):
+        """Tensor arch codes yield the same topology as the equivalent numpy arch codes.
+
+        Constructs ``TopologyInstance`` from numpy and from tensor inputs and asserts that
+        ``arch_code_a``, ``arch_code_c``, and the instantiated cell tree are identical.
+        """
         grid_np = TopologyInstance(arch_code=[self.arch_code_a, self.arch_code_c], **self.grid_params)
         grid_pt = TopologyInstance(
             arch_code=[torch.as_tensor(self.arch_code_a), torch.as_tensor(self.arch_code_c)], **self.grid_params
@@ -180,6 +191,11 @@ class TestDintsArchCode(unittest.TestCase):
         self.assertEqual(set(grid_pt.cell_tree.keys()), set(grid_np.cell_tree.keys()))
 
     def test_dints_forward_tensor_arch_code(self):
+        """DiNTS built from tensor arch codes runs a forward pass with the expected output shape.
+
+        Feeds a random ``(1, 1, 16, 16, 16)`` volume through the network and asserts the
+        segmentation output shape is ``(1, 2, 16, 16, 16)``.
+        """
         grid = TopologyInstance(
             arch_code=[torch.as_tensor(self.arch_code_a), torch.as_tensor(self.arch_code_c)], **self.grid_params
         )


### PR DESCRIPTION
Addresses the MONAI-side portion of #9025. This PR does not fully resolve that issue
on its own — see "Follow-up required" below for the bundle-artifact half.

### Description

`TopologyConstruction.__init__` converted the `arch_code` entries with
`torch.from_numpy(...)`, which raises `TypeError: expected np.ndarray (got Tensor)`
when the architecture codes are already tensors. Checkpoints such as
`search_code_18590.pt` from the `pancreas_ct_dints_segmentation` and
`multi_organ_segmentation` bundles currently store numpy arrays, which
`torch.load(..., weights_only=True)` rejects; once those files are re-saved with
tensors, the DiNTS network must accept tensor arch codes to load them.

This PR replaces the two `torch.from_numpy(...)` calls with `torch.as_tensor(...)`
(`monai/networks/nets/dints.py`), which handles numpy arrays and tensors
identically:

- **numpy path unchanged**: `torch.as_tensor(ndarray)` is equivalent to
  `torch.from_numpy` — zero-copy (same `data_ptr()`), dtype preserved, followed by
  the same `.to(self.device)`.
- **tensor path**: `torch.as_tensor(tensor)` returns the input as-is (no copy,
  no warning), unlike `torch.tensor(...)` which always copies and warns.
- `arch_code_c` still goes through `.to(torch.int64)` before `F.one_hot`, so the
  one-hot output dtype (`int64`) is identical for both input types; all downstream
  consumers (`== 1` gates, `arch_c > 0` in `MixedOp`, forward-path activation
  checks) already operated on tensors after the conversion site, so their behavior
  is unchanged.

Credit where due: another contributor (@Theerth1) independently traced the same
root cause to `TopologyConstruction.__init__` in the issue discussion before this
PR was prepared.

### Follow-up required (not resolved by this PR)

This change alone does not make the affected bundles loadable with
`weights_only=True`: the shipped `search_code_18590.pt` files contain pickled
numpy arrays, which the `weights_only` unpickler rejects at `torch.load` time
regardless of this fix. The checkpoints for `pancreas_ct_dints_segmentation` and
`multi_organ_segmentation` (including their identical HuggingFace mirrors) need to
be re-saved with tensors and re-uploaded in Project-MONAI/model-zoo. This PR is
the prerequisite that lets those re-saved tensor checkpoints construct the
network. Per the investigation in #9025, no other model-zoo bundles are affected.

### Notes / disclosed risks

- `torch.as_tensor` also accepts Python lists/scalars, so the accepted input is
  slightly broader than the documented `numpy arrays or torch tensors`; this is
  benign.
- `arch_code_a`'s stored dtype now follows a tensor input's dtype (previously
  always the numpy dtype); all consumers are dtype-agnostic comparisons, and no
  functional difference was found.
- Verified locally (Windows, Python 3.11): full
  `tests/networks/nets/test_dints_network.py` module passes via unittest
  (including the TorchScript tests); the new `TestDintsArchCode` cases pass;
  `ruff check` clean on both changed files; `mypy monai/networks/nets/dints.py`
  clean. `black` was not available locally, so formatting is deferred to CI.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.