### PR TITLE
fix(metrics): stop passing deprecated always_return_as_numpy internally (Fixes #9059)

### DIFF
--- a/monai/metrics/utils.py
+++ b/monai/metrics/utils.py
@@ -359,9 +359,7 @@ def get_edge_surface_distance(
     edges_spacing = None
     if use_subvoxels:
         edges_spacing = spacing if spacing is not None else ([1] * len(y_pred.shape))
-    edges_pred, edges_gt, *areas = get_mask_edges(
-        y_pred, y, crop=True, spacing=edges_spacing, always_return_as_numpy=False
-    )
+    edges_pred, edges_gt, *areas = get_mask_edges(y_pred, y, crop=True, spacing=edges_spacing)
     if not edges_gt.any():
         warnings.warn(
             f"the ground truth of class {class_index if class_index != -1 else 'Unknown'} is all 0,"

--- a/tests/metrics/test_metrics_internal_deprecation.py
+++ b/tests/metrics/test_metrics_internal_deprecation.py
@@ -19,6 +19,9 @@ import torch
 
 import monai
 from monai.metrics import HausdorffDistanceMetric, SurfaceDistanceMetric
+from monai.utils import optional_import
+
+binary_erosion, has_scipy = optional_import("scipy.ndimage", name="binary_erosion")
 
 _MONAI_ROOT = str(pathlib.Path(monai.__file__).parent.resolve())
 
@@ -48,6 +51,7 @@ def _internal_deprecation_warnings(fn):
     ]
 
 
+@unittest.skipUnless(has_scipy, "Requires scipy.")
 class TestMetricsNoInternalDeprecationWarnings(unittest.TestCase):
     """Metrics must not trigger MONAI's own deprecation warnings via internal call sites.
 
@@ -55,6 +59,9 @@ class TestMetricsNoInternalDeprecationWarnings(unittest.TestCase):
     `monai.metrics.utils.get_edge_surface_distance`. If that helper passes a deprecated
     argument to `get_mask_edges`, every metric computation emits a warning that the caller
     never triggered and cannot suppress.
+
+    Both metrics compute mask edges via `scipy.ndimage`, so this test is skipped when
+    scipy is unavailable.
     """
 
     def test_surface_and_hausdorff_emit_no_internal_deprecation_warnings(self):

--- a/tests/metrics/test_metrics_internal_deprecation.py
+++ b/tests/metrics/test_metrics_internal_deprecation.py
@@ -1,0 +1,69 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+import warnings
+
+import torch
+
+import monai
+from monai.metrics import HausdorffDistanceMetric, SurfaceDistanceMetric
+
+_MONAI_ROOT = str(pathlib.Path(monai.__file__).parent.resolve())
+
+
+def _internal_deprecation_warnings(fn):
+    """Collect deprecation-style warnings raised from inside the MONAI package itself.
+
+    Warnings originating in third-party packages are ignored, so this is not affected by
+    unrelated deprecations in torch or numpy.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn()
+    return [
+        w
+        for w in caught
+        if issubclass(w.category, (DeprecationWarning, FutureWarning))
+        and _MONAI_ROOT in str(pathlib.Path(w.filename).resolve())
+    ]
+
+
+class TestMetricsNoInternalDeprecationWarnings(unittest.TestCase):
+    """Metrics must not trigger MONAI's own deprecation warnings via internal call sites.
+
+    `SurfaceDistanceMetric` and `HausdorffDistanceMetric` both route through
+    `monai.metrics.utils.get_edge_surface_distance`. If that helper passes a deprecated
+    argument to `get_mask_edges`, every metric computation emits a warning that the caller
+    never triggered and cannot suppress.
+    """
+
+    def test_surface_and_hausdorff_emit_no_internal_deprecation_warnings(self):
+        pred = torch.zeros(1, 1, 32, 32)
+        pred[..., :16, :] = 1
+        gt = torch.zeros(1, 1, 32, 32)
+        gt[..., :20, :] = 1
+
+        for metric in (SurfaceDistanceMetric(), HausdorffDistanceMetric()):
+            with self.subTest(metric=type(metric).__name__):
+                found = _internal_deprecation_warnings(lambda m=metric: m(pred, gt))
+                self.assertEqual(
+                    [str(w.message) for w in found],
+                    [],
+                    f"{type(metric).__name__} raised MONAI-internal deprecation warning(s)",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/metrics/test_metrics_internal_deprecation.py
+++ b/tests/metrics/test_metrics_internal_deprecation.py
@@ -28,6 +28,14 @@ def _internal_deprecation_warnings(fn):
 
     Warnings originating in third-party packages are ignored, so this is not affected by
     unrelated deprecations in torch or numpy.
+
+    Args:
+        fn: zero-argument callable to invoke while warnings are being recorded.
+
+    Returns:
+        list of `warnings.WarningMessage`: the recorded `DeprecationWarning` and
+        `FutureWarning` entries whose originating file lies inside the MONAI package.
+        Empty when the call raised no MONAI-internal deprecation warnings.
     """
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -50,6 +58,11 @@ class TestMetricsNoInternalDeprecationWarnings(unittest.TestCase):
     """
 
     def test_surface_and_hausdorff_emit_no_internal_deprecation_warnings(self):
+        """Assert neither metric raises a MONAI-internal deprecation warning.
+
+        Computes each metric on a fixed pair of 2D binary masks and fails if any
+        `DeprecationWarning` or `FutureWarning` originating inside MONAI is recorded.
+        """
         pred = torch.zeros(1, 1, 32, 32)
         pred[..., :16, :] = 1
         gt = torch.zeros(1, 1, 32, 32)


### PR DESCRIPTION
Fixes #9059 .

### Description

`get_mask_edges()` is decorated with `@deprecated_arg(name="always_return_as_numpy", since="1.5.0", removed="1.7.0")`, but `get_edge_surface_distance()` in the same module called it with `always_return_as_numpy=False` (`monai/metrics/utils.py:363`).

`SurfaceDistanceMetric` and `HausdorffDistanceMetric` both route through that helper, so every metric computation emitted a `FutureWarning` about an argument the caller never passed and could not suppress. It surfaces in ordinary validation loops. Separately, the argument is scheduled for removal in 1.7.0, and this internal call site would have blocked that removal.

`False` is already the parameter default, so the keyword is simply dropped:

```python
-    edges_pred, edges_gt, *areas = get_mask_edges(
-        y_pred, y, crop=True, spacing=edges_spacing, always_return_as_numpy=False
-    )
+    edges_pred, edges_gt, *areas = get_mask_edges(y_pred, y, crop=True, spacing=edges_spacing)
```

This adds `tests/metrics/test_metrics_internal_deprecation.py`, asserting that neither metric raises a MONAI-internal `DeprecationWarning` or `FutureWarning`. The test filters warnings by originating file, so unrelated deprecations from torch or numpy cannot make it pass or fail spuriously. Note the warning raised here is a `FutureWarning`, not a `DeprecationWarning` - a test checking only the latter would pass vacuously.

**Verification**

The new test fails against unpatched `dev` on **both** metrics, confirming they share the helper:

```
$ python tests/metrics/test_metrics_internal_deprecation.py -v
  ... (metric='SurfaceDistanceMetric')   ... FAIL
  ... (metric='HausdorffDistanceMetric') ... FAIL
Ran 1 test in 0.033s
FAILED (failures=2)
```

and passes with the fix applied:

```
$ python tests/metrics/test_metrics_internal_deprecation.py -v
test_surface_and_hausdorff_emit_no_internal_deprecation_warnings ... ok
OK
```

Existing metric suites:

```
$ python -m pytest tests/metrics/test_surface_distance.py tests/metrics/test_hausdorff_distance.py -q
71 passed, 38 warnings in 7.05s
```

`./runtests.sh --codeformat` passes (copyright headers 1354 files, isort, black 1317 files unchanged, ruff).

Numerical results are unchanged - measured over three metric calls on identical inputs:

| | deprecation warnings | SurfaceDistance | Hausdorff | SurfaceDistance reversed |
|---|---|---|---|---|
| before | 3 | 1.173913 | 4.000000 | 1.400000 |
| after | 0 | 1.173913 | 4.000000 | 1.400000 |

**Note on scope:** this deliberately does not remove the `always_return_as_numpy` parameter itself, since it is documented as removed in 1.7.0 and external callers may still be passing it. Happy to extend this PR to the full removal if you would prefer to land it now.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
