### PR TITLE
Make pyproject.toml the single definition for lint tool versions and settings

### DIFF
--- a/.github/workflows/cicd_tests.yml
+++ b/.github/workflows/cicd_tests.yml
@@ -52,6 +52,34 @@ env:
 # When support is dropped for a version it is important to update these as appropriate.
 
 jobs:
+  pre-commit:  # Run the hooks pre-commit.ci skips, using the tools pyproject.toml pins
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    # This job executes the hooks named by a PR's own .pre-commit-config.yaml, so
+    # it must not leave a usable token in .git/config for those hooks to reach.
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    # reads the pins below with tomllib, which needs 3.11+; the hooks take their
+    # target from pyproject.toml, so the interpreter version does not affect them
+    - name: Set up Python ${{ env.PYTHON_VER3 }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ env.PYTHON_VER3 }}
+        cache: 'pip'
+    - name: Install lint tools
+      run: |
+        # the lint extra alone, so this job needs neither torch nor the optional dependencies
+        python -m pip install --upgrade pip
+        python -c "import tomllib; print('\n'.join(tomllib.load(open('pyproject.toml','rb'))['project']['optional-dependencies']['lint']))" > lint-requirements.txt
+        cat lint-requirements.txt
+        python -m pip install -r lint-requirements.txt
+        rm lint-requirements.txt
+    - name: Run pre-commit
+      run: python -m pre_commit run --all-files --show-diff-on-failure
+
   static-checks:  # Perform static type and other checks using runtests.sh
     runs-on: ubuntu-latest
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,9 @@ ci:
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'
   autoupdate_schedule: quarterly
   # submodules: true
+  # The hooks below run the tools from the environment pyproject.toml defines, which
+  # pre-commit.ci does not build; the pre-commit job in cicd_tests.yml runs them instead.
+  skip: [black, isort, pycln, ruff-check]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -26,19 +29,33 @@ repos:
         args: ['--autofix', '--no-sort-keys', '--indent=4']
       - id: end-of-file-fixer
       - id: mixed-line-ending
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
-    hooks:
-    -   id: ruff-check
-        args: ["--fix"]
-        exclude: |
-          (?x)(
-              ^versioneer.py|
-              ^monai/_version.py
-          )
 
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.6.0
+  # Versions come from [project.optional-dependencies].lint and settings from the
+  # [tool.*] tables, so these hooks and runtests.sh cannot resolve a different tool.
+  # The --force-exclude/--filter-files flags apply those settings to the explicit
+  # filenames pre-commit passes.
+  - repo: local
     hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: python -m ruff check --force-exclude --fix
+        language: system
+        types_or: [python, pyi]
+
+      - id: isort
+        name: isort
+        entry: python -m isort --filter-files
+        language: system
+        types_or: [python, pyi]
+
+      - id: black
+        name: black
+        entry: python -m black
+        language: system
+        types_or: [python, pyi]
+
       - id: pycln
-        args: [--config=pyproject.toml]
+        name: pycln
+        entry: python -m pycln --config=pyproject.toml
+        language: system
+        types_or: [python, pyi]

--- a/monai/config/print_dependencies.py
+++ b/monai/config/print_dependencies.py
@@ -18,6 +18,7 @@ assumes the pyproject.toml file is in the current working directory.
 
 from __future__ import annotations
 
+import re
 import sys
 from collections.abc import Collection
 
@@ -25,8 +26,63 @@ BUILD_SYSTEM_KEY = "build-system"
 PROJ_KEY = "project"
 OPTS_KEY = "optional-dependencies"
 DEP_KEY = "dependencies"
+NAME_KEY = "name"
 REQ_KEY = "requires"
 TOML_FILE = "pyproject.toml"
+
+
+# a requirement of the form "<name>[<extra>,...]" and nothing else; a version specifier or an
+# environment marker after the brackets makes it something other than a bare self-reference
+SELF_REF_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*\[([^\]]+)\]$")
+
+
+def _normalize_name(name: str) -> str:
+    """
+    Normalize a project or extra name so case and ``-``/``_``/``.`` spellings compare equal.
+
+    PEP 503 (project names) and PEP 685 (extra names) specify the same rule, so one function
+    serves both sides of the comparison.
+    """
+    return re.sub(r"[-_.]+", "-", name.strip()).lower()
+
+
+def _expand_self_extras(dependencies: list[str], name: str, opts: dict) -> list[str]:
+    """
+    Replace self-referential requirements such as ``monai[lint]`` with the contents of that group.
+
+    pip resolves such a requirement against the package index, so leaving one in a generated
+    requirements file installs the published release instead of the checkout being worked on.
+
+    Args:
+        dependencies: requirement strings, some of which may be self-references.
+        name: this project's name, the only one treated as a self-reference.
+        opts: the "optional-dependencies" table the groups are read from.
+
+    Returns:
+        List of requirements with every self-reference replaced by the group it names.
+
+    Raises:
+        KeyError: If a self-reference names a group absent from `opts`.
+    """
+    self_name = _normalize_name(name)
+    groups = {_normalize_name(key): value for key, value in opts.items()}
+    expanded: list[str] = []
+    pending = list(dependencies)
+    seen: set[str] = set()
+
+    while pending:
+        req = pending.pop(0)
+        match = SELF_REF_RE.match(req.strip())
+        if match is None or _normalize_name(match.group(1)) != self_name:
+            expanded.append(req)
+            continue
+        for group in (_normalize_name(g) for g in match.group(2).split(",")):
+            if group in seen:  # a group already expanded, or a cycle
+                continue
+            seen.add(group)
+            pending.extend(groups[group])
+
+    return expanded
 
 
 def parse_dependencies(filename: str | None = None, sections: Collection[str] | None = None) -> list[str]:
@@ -67,6 +123,8 @@ def parse_dependencies(filename: str | None = None, sections: Collection[str] | 
     else:
         for s in sections:
             dependencies += opts[s]
+
+    dependencies = _expand_self_extras(dependencies, proj[NAME_KEY], opts)
 
     return sorted(set(dependencies))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,20 +157,25 @@ torchvision = ["torchvision"]
 tqdm = ["tqdm>=4.47.0"]
 transformers = ["transformers>=5.5.0"]  # 5.x needs the transchex BertLayer/BertConfig updates; re-verify the NGC image float8 concern
 zarr = ["zarr"]
+# the tools .pre-commit-config.yaml and runtests.sh invoke; installable without torch
+lint = [
+  "black>=26.3.1",
+  "isort>=5.1,<6,!=6.0.0",
+  "pre-commit",
+  "pycln==2.6.0",
+  "ruff==0.16.4"
+]
 # these dependencies are for testing/building only, they aren't needed for regular use so don't appear in "all"
 testing = [
-  "black>=26.3.1",
+  "monai[lint]",
   "coverage>=5.5",
-  "isort>=5.1,<6,!=6.0.0",
   "mccabe",
   "packaging",
   "parameterized",
   "pep8-naming",
-  "pre-commit",
   "pycodestyle",
   "pyflakes",
   "pyrefly>=1.0.0",
-  "ruff>=0.14.11,<0.15",
   "tomli",  # used in print_dependencies.py for Python<3.11
   "typeguard<3",  # https://github.com/microsoft/nni/issues/5457
   "types-PyYAML",
@@ -266,7 +271,9 @@ line-length = 120
 target-version = ['py310']
 skip-magic-trailing-comma = true
 include = '\.pyi?$'
-exclude = '''
+# force-exclude, not exclude: black ignores exclude for filenames passed explicitly,
+# which is how pre-commit invokes it.
+force-exclude = '''
 (
   /(
     # exclude a few common directories in the root of the project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,6 +296,8 @@ exclude = "monai/bundle/__main__.py"
 [tool.ruff]
 line-length = 120
 target-version = "py310"
+# Vendored/generated; matches [tool.black] exclude and [tool.pyrefly] project-excludes.
+extend-exclude = ["versioneer.py", "monai/_version.py"]
 
 [tool.ruff.lint]
 select = [

--- a/runtests.sh
+++ b/runtests.sh
@@ -595,13 +595,13 @@ then
     then
         install_deps
     fi
-    ruff --version
+    ${cmdPrefix}"${PY_EXE}" -m ruff --version
 
     if [ $doRuffFix = true ]
     then
-        ruff check --fix --unsafe-fixes --exclude versioneer.py --exclude "monai/_version.py" "$homedir"
+        ${cmdPrefix}"${PY_EXE}" -m ruff check --fix --unsafe-fixes "$homedir"
     else
-        ruff check --exclude versioneer.py --exclude "monai/_version.py" "$homedir"
+        ${cmdPrefix}"${PY_EXE}" -m ruff check "$homedir"
     fi
 
     ruff_status=$?

--- a/tests/config/test_print_dependencies.py
+++ b/tests/config/test_print_dependencies.py
@@ -32,14 +32,52 @@ dependencies = ["torch", "numpy"]
 
 [project.optional-dependencies]
 all = ["something", "another"]
-testing = ["coverage", "black"]
+lint = ["ruff", "black"]
+testing = ["test[lint]", "coverage"]
+cyclic = ["test[cyclic]", "spam"]
+spell_check = ["eggs"]
+mixed = ["Test[Spell.Check]", "ham"]
+other_pkg = ["versioneer[toml]", "bacon"]
+"""
+
+# a project whose name needs normalizing before a self-reference spelled differently can match it
+PUNCTUATED_NAME_TOML = """
+[project]
+name = "My_Project"
+dependencies = ["torch"]
+
+[project.optional-dependencies]
+lint = ["ruff"]
+testing = ["my-project[lint]", "coverage"]
 """
 
 PARSE_CASES = [
     ([], ["numpy", "torch"]),
-    (["testing"], ["black", "coverage", "numpy", "torch"]),
+    # "test[lint]" expands rather than reaching pip as a requirement on the published package
+    (["testing"], ["black", "coverage", "numpy", "ruff", "torch"]),
     (["build-system"], ["numpy", "setuptools", "torch", "wheel"]),
-    (["*"], ["another", "black", "coverage", "numpy", "something", "torch"]),
+    (
+        ["*"],
+        [
+            "another",
+            "bacon",
+            "black",
+            "coverage",
+            "eggs",
+            "ham",
+            "numpy",
+            "ruff",
+            "something",
+            "spam",
+            "torch",
+            "versioneer[toml]",
+        ],
+    ),
+    (["cyclic"], ["numpy", "spam", "torch"]),
+    # PEP 685: extra names compare equal across case and "-"/"_"/"." spellings
+    (["mixed"], ["eggs", "ham", "numpy", "torch"]),
+    # another project's extra is not a self-reference and passes through untouched
+    (["other_pkg"], ["bacon", "numpy", "torch", "versioneer[toml]"]),
 ]
 
 
@@ -56,6 +94,15 @@ class TestPrintDependencies(unittest.TestCase):
     def test_parse_dependencies(self, sections, outputs):
         deps = parse_dependencies(self.toml.name, sections)
         self.assertEqual(outputs, deps)
+
+    def test_self_reference_spelled_differently(self):
+        """PEP 503: "my-project[lint]" is a self-reference to a project named "My_Project"."""
+        toml = NamedTemporaryFile("w", delete=False)
+        toml.write(PUNCTUATED_NAME_TOML)
+        toml.close()
+        self.addCleanup(os.unlink, toml.name)
+
+        self.assertEqual(["coverage", "ruff", "torch"], parse_dependencies(toml.name, ["testing"]))
 
     def test_missing_section(self):
         with self.assertRaises(KeyError):


### PR DESCRIPTION
Several people have converged on the same goal from different directions: @Borda opened #8683 asking that linting "rely solely on the repository's `pre-commit` configuration ... the exact same versions and rules are applied everywhere", @ericspod listed "Move black and isort formatting into pre-commit" in #9058 and raised the tool-version concern on #8683, and @aymuos15 prototyped a "remove everything and only do ruff" branch off that thread. This PR implements the shared requirement — one definition per tool — without changing a single source file.

Concretely: `pyproject.toml` becomes the only place a lint tool's version or settings are declared, and a CI job runs `pre-commit` on a lint-only environment.

**For reviewers:** this does not compete with #9061. #9061 adds black and isort hooks and notes that their versions "need to be set in the `.pre-commit-config.yaml` file separately from wherever else they're specified, so when versions are changed they need to be synced between files." This removes that requirement, so the two can be rebased onto each other in either order.

It also fills the gap left when the Pre-Commit-Lite approach was struck from the #9058 checklist. That approach existed to "ensure the versions of black and isort match what would be used locally"; with it withdrawn in favour of "regular pre-commit may just be fine", nothing currently makes those versions match. Declaring them once is the smaller way to get the same guarantee.

<details>
<summary>The drift is already real, not hypothetical</summary>

On `dev` today:

| Setting | `pyproject.toml` | elsewhere |
|---|---|---|
| ruff version | `ruff>=0.14.11,<0.15` | `.pre-commit-config.yaml` → `rev: v0.15.20` |
| pycln version | *absent* | `.pre-commit-config.yaml` → `rev: v2.6.0` |
| ruff excludes | *absent* | `runtests.sh:602,604` **and** the ruff hook |

The two ruff ranges are disjoint, so a contributor following `CONTRIBUTING.md` and pre-commit.ci could not run the same linter even in principle. Building an environment from `pyproject.toml` on this machine gives **ruff 0.14.14**; pre-commit.ci runs **0.15.20**.

Because the excludes live in the callers, a plain `ruff check --fix .` — what an editor or a one-off invocation runs — does not get them, and rewrites `versioneer.py` and `monai/_version.py`. Before this PR that command reports 111 violations (84 UP031, 11 N806, 7 N801, 6 UP035, 2 N818, 1 B904), every one inside those two files.

`runtests.sh` also called `ruff` as a bare PATH executable while `isort`, `black`, `pylint` and `pytype` all go through `"${PY_EXE}" -m`. The guard above it, `is_pip_installed ruff`, tests `importlib.util.find_spec` using `PY_EXE` — so the check interrogated one environment and the invocation ran whatever `ruff` PATH happened to offer. In a clean virtualenv built per `CONTRIBUTING.md`, `./runtests.sh --codeformat` fails outright with `ruff: command not found`.

</details>

<details>
<summary>What changed</summary>

**`pyproject.toml`** — a `lint` optional-dependency group holds the tools that `.pre-commit-config.yaml` and `runtests.sh` both invoke; `testing` pulls it in via `monai[lint]` so developers still have one install. The group excludes torch and the optional dependencies, so a lint-only environment can be built from it alone.

- `extend-exclude` added to `[tool.ruff]` for the two vendored files
- ruff pinned to `0.16.4`, the newest release that leaves this codebase unchanged
- `pycln==2.6.0` added — it was pinned only in the hook and never installed by `runtests.sh`
- `[tool.black]` switches from `exclude` to `force-exclude`, same regex

**`.pre-commit-config.yaml`** — ruff and pycln become `repo: local` hooks with `language: system`, and black and isort join them, so pre-commit runs the tools from that environment instead of building its own from a second set of pins. There is no `rev:` left to keep in sync. The hygiene hooks from `pre-commit-hooks` keep theirs — they have no `pyproject.toml` counterpart and are already single-definition.

**`runtests.sh`** — ruff goes through `"${PY_EXE}" -m` like every other tool; its duplicated `--exclude` flags are dropped.

**`monai/config/print_dependencies.py`** — `parse_dependencies()` expands self-referential requirements, normalizing both the project name and the extra names so case and `-`/`_`/`.` spellings resolve to one group; PEP 503 and PEP 685 specify the same rule. A requirement naming a different project, such as `versioneer[toml]` in `build-system.requires`, passes through untouched. `install_deps` feeds its output to `pip install -r`, where an unexpanded `monai[lint]` would resolve against the package index rather than the checkout. This is the only Python change; no source file is reformatted.

**`.github/workflows/cicd_tests.yml`** — a `pre-commit` job. pre-commit has never run in GitHub Actions; only the external pre-commit.ci service ran it, and the hooks above need an environment that service does not build, so they are listed under `ci.skip` and this job runs them. It reads the `lint` extra out of `pyproject.toml` at run time rather than restating versions in YAML. `static-checks` is left unchanged, so its copyright and pyrefly coverage is kept and CI fails if the two routes ever disagree.

</details>

<details>
<summary>Why each exclusion flag on the hook entries is load-bearing</summary>

`language: system` hooks receive explicit filenames, and most tools ignore their configured excludes in that mode. Run directly against the two vendored files:

| tool | with the flag | without |
|---|---|---|
| black (`force-exclude`) | nothing to do | 2 files would be reformatted |
| ruff (`--force-exclude`) | no files found | 200 errors |
| isort (`--filter-files`) | skipped 2 files | 2 sort errors |

This is also why `[tool.black]` moves from `exclude` to `force-exclude`: black ignores `exclude` for filenames given on the command line, which is exactly how pre-commit calls it.

</details>

<details>
<summary>Verification</summary>

Ruff 0.16.4 was chosen by sweeping every release from 0.14.11 to 0.16.4 against `dev`. They are indistinguishable on this codebase — same violations before, same files touched by `--fix` — so the bump carries no lint-behaviour change.

| check | result |
|---|---|
| `pre-commit run --all-files`, full environment | all hooks pass, tree unmodified |
| `pre-commit run --all-files`, torch-free lint env (as CI) | all hooks pass, tree unmodified |
| `./runtests.sh --codeformat`, venv not on PATH | copyright 1360 files, isort, black, ruff 0.16.4, pyrefly 0 errors |
| `./runtests.sh --autofix` | 0 Python files changed |
| `./runtests.sh -u --net --coverage` | 18196 tests, failure set identical to unmodified `dev` |

Both routes now resolve the same ruff, 0.16.4, which is the point of the change.

The full suite was run twice from separate worktrees, once on this branch and once on unmodified `dev`, so the comparison is a controlled one. Both report 18196 tests and the same 39 failures, from pre-existing dependency incompatibilities unrelated to this PR (`zarr` 3.x, `scipy` 1.18 dropping `sqrtm(disp=)`, matplotlib baseline images, and a `None` reaching a numeric comparison in `fall_back_tuple`). The `dev` run additionally failed `test_optim_novograd` `test_step_6` and `test_step_7`, which pass in isolation on both trees across repeated runs and appear to be order-dependent flakes.

Note for anyone reproducing: use Python 3.10, matching `PYTHON_VER1`. The `all` extra has no upper bounds, so Python 3.12 resolves `zarr` 3.3.0, `scipy` 1.18.1 and `matplotlib` 3.11.1 — versions that Python 3.10 cannot reach and that CI therefore never sees. Rebuilding on 3.10 clears most of the failures above.

</details>

Nothing here changes which tools are used. Whether `ruff` should replace `black` and `isort` outright is a separate question with its own trade-offs, raised in #9066; this PR is a prerequisite for that either way, since otherwise such a swap has to be made in `pyproject.toml`, `.pre-commit-config.yaml` and `runtests.sh` simultaneously and kept in sync.

<!--
provenance: claude-code session 2026-08-22, branch ruff-odr-exclude off dev @ c1240a2d4
commits (rewritten since opening; rebased onto dev @ 605611ba9; current tip a07ad283b):
  dc261459d pyproject [tool.ruff] extend-exclude
  cf130300a lint extra + local/system hooks + black force-exclude + parse_dependencies self-extra
            expansion; project and extra names both normalized (PEP 503 / PEP 685 share the rule)
  202e87378 runtests.sh ruff via PY_EXE, drop duplicated excludes
  a07ad283b cicd_tests.yml pre-commit job (persist-credentials: false, permissions: contents: read)
measurements re-derived this session, not inherited:
  ruff sweep 0.14.11..0.16.4 -> identical on dev (111 violations, 2 files, all in versioneer.py + monai/_version.py)
  extend-exclude -> "All checks passed!", --fix a no-op, on 0.14.14 and 0.16.4
  formatter-swap evidence moved out of this PR body into issue #9066 (measurements, caveats, open questions)
corrections to earlier analysis, do not reuse:
  CONTRIBUTING.md does NOT still mention mypy/pytype - that was fixed on dev
  runtests.sh --pytype is explicitly deprecated with warnings, not dead code
  [tool.mypy] has 3 override tables, not 4
related: #8683 (parent), #9058, #9061, #8694, #8692, #8606
aymuos15/MONAI:fix/ci-lint-typing returns 404 - branch deleted, never opened as a PR
separate branch fix-malformed-error-messages holds the 3 message bugs surfaced by the ruff-format experiment
post_merge_action: revisit black/isort -> ruff format as its own PR; chatops /black dispatches to
  project-monai/monai-code-formatter and would need repointing or retiring first
-->



