### PR TITLE
Expand ONNX export test coverage to 12 network architectures

### DIFF
--- a/tests/networks/test_convert_to_onnx.py
+++ b/tests/networks/test_convert_to_onnx.py
@@ -19,7 +19,21 @@ import torch
 from parameterized import parameterized
 
 from monai.networks import convert_to_onnx
-from monai.networks.nets import SegResNet, UNet
+from monai.networks.nets import (
+    UNETR,
+    AttentionUnet,
+    BasicUNet,
+    BasicUNetPlusPlus,
+    DenseNet,
+    DynUNet,
+    FullyConnectedNet,
+    HighResNet,
+    SegResNet,
+    SEResNet50,
+    UNet,
+    VNet,
+    resnet10,
+)
 from tests.test_utils import SkipIfNoModule, optional_import, skip_if_quick
 
 onnx, _ = optional_import("onnx")
@@ -32,12 +46,28 @@ TORCH_DEVICE_OPTIONS = ["cpu"]
 
 TESTS = list(itertools.product(TORCH_DEVICE_OPTIONS, [True, False], [True, False]))
 TESTS_ORT = list(itertools.product(TORCH_DEVICE_OPTIONS, [True]))
+TESTS_TRACE = list(itertools.product(TORCH_DEVICE_OPTIONS, [True, False]))
 
 ON_AARCH64 = platform.machine() == "aarch64"
 if ON_AARCH64:
     rtol, atol = 1e-1, 1e-2
 else:
     rtol, atol = 1e-2, 1e-2
+
+
+def _check_ort_available(test_case):
+    """Skip the test if onnxruntime is not installed.
+
+    Args:
+        test_case: the ``unittest.TestCase`` instance to call ``skipTest`` on
+            when onnxruntime is unavailable.
+
+    Raises:
+        unittest.SkipTest: when onnxruntime cannot be imported.
+    """
+    _, has_onnxruntime = optional_import("onnxruntime")
+    if not has_onnxruntime:
+        test_case.skipTest("onnxruntime is not installed probably due to python version >= 3.11.")
 
 
 @SkipIfNoModule("onnx")
@@ -92,6 +122,323 @@ class TestConvertToOnnx(unittest.TestCase):
         onnx_model = convert_to_onnx(
             model=model,
             inputs=[torch.randn((1, 1, 24, 24, 24), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_dynunet(self, device, use_ort):
+        """Test converting DynUNet to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = DynUNet(
+            spatial_dims=3,
+            in_channels=1,
+            out_channels=2,
+            kernel_size=[3, 3, 3],
+            strides=[1, 2, 2],
+            upsample_kernel_size=[2, 2],
+        )
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 32, 32, 32), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_attention_unet(self, device, use_ort):
+        """Test converting AttentionUnet to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = AttentionUnet(spatial_dims=3, in_channels=1, out_channels=2, channels=(16, 32, 64), strides=(2, 2))
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 32, 32, 32), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_basic_unet(self, device, use_ort):
+        """Test converting BasicUNet to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = BasicUNet(spatial_dims=3, in_channels=1, out_channels=2, features=(8, 8, 16, 32, 64, 8))
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 32, 32, 32), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_basic_unet_plus_plus(self, device, use_ort):
+        """Test converting BasicUNetPlusPlus to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = BasicUNetPlusPlus(
+            spatial_dims=3, in_channels=1, out_channels=2, features=(8, 8, 16, 32, 64, 8), deep_supervision=False
+        )
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 32, 32, 32), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_vnet(self, device, use_ort):
+        """Test converting VNet to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = VNet(spatial_dims=3, in_channels=1, out_channels=1)
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 32, 32, 32), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_highresnet(self, device, use_ort):
+        """Test converting HighResNet to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = HighResNet(spatial_dims=3, in_channels=1, out_channels=2)
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 16, 16, 16), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_densenet(self, device, use_ort):
+        """Test converting DenseNet to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = DenseNet(
+            spatial_dims=3, in_channels=1, out_channels=2, init_features=16, growth_rate=8, block_config=(2, 2, 2, 2)
+        )
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 32, 32, 32), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_resnet(self, device, use_ort):
+        """Test converting ResNet to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = resnet10(pretrained=False, spatial_dims=3, n_input_channels=1, num_classes=2)
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 32, 32, 32), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_seresnet(self, device, use_ort):
+        """Test converting SEResNet50 to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = SEResNet50(layers=(1, 1, 1, 1), spatial_dims=3, in_channels=1, num_classes=2)
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 32, 32, 32), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_unetr(self, device, use_ort):
+        """Test converting UNETR to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = UNETR(
+            in_channels=1,
+            out_channels=2,
+            img_size=(32, 32, 32),
+            feature_size=8,
+            hidden_size=128,
+            mlp_dim=256,
+            num_heads=8,
+            spatial_dims=3,
+        )
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((1, 1, 32, 32, 32), requires_grad=False)],
+            input_names=["x"],
+            output_names=["y"],
+            verify=True,
+            device=device,
+            use_ort=use_ort,
+            use_trace=True,
+            rtol=rtol,
+            atol=atol,
+        )
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
+
+    @parameterized.expand(TESTS_TRACE)
+    def test_fully_connected_net(self, device, use_ort):
+        """Test converting FullyConnectedNet to ONNX with and without ORT verification.
+
+        Args:
+            device: torch device string (e.g. ``"cpu"``).
+            use_ort: if ``True``, verify via onnxruntime; if ``False``, verify
+                via ``onnx.reference.ReferenceEvaluator``. Skipped when
+                onnxruntime is unavailable.
+        """
+        if use_ort:
+            _check_ort_available(self)
+        model = FullyConnectedNet(in_channels=10, out_channels=2, hidden_channels=[20, 10])
+        onnx_model = convert_to_onnx(
+            model=model,
+            inputs=[torch.randn((4, 10), requires_grad=False)],
             input_names=["x"],
             output_names=["y"],
             verify=True,


### PR DESCRIPTION
Fixes #9072

### Description

The ONNX export test suite (`tests/networks/test_convert_to_onnx.py`) only covered **2 out of 40+ network architectures** (UNet 2D and SegResNet 3D). This leaves regressions in ONNX exportability for widely used architectures completely undetected.

This PR adds parameterized ONNX export tests for **10 additional networks**, bringing total coverage to 12 architectures:

| # | Network | Type | Spatial Dims |
|---|---|---|---|
| 1 | UNet | Segmentation | 2D *(existing)* |
| 2 | SegResNet | Segmentation | 3D *(existing)* |
| 3 | **DynUNet** | Segmentation | 3D |
| 4 | **AttentionUnet** | Segmentation | 3D |
| 5 | **BasicUNet** | Segmentation | 3D |
| 6 | **BasicUNetPlusPlus** | Segmentation | 3D |
| 7 | **VNet** | Segmentation | 3D |
| 8 | **HighResNet** | Segmentation | 3D |
| 9 | **DenseNet** | Classification | 3D |
| 10 | **ResNet** (resnet10) | Classification | 3D |
| 11 | **SEResNet50** | Classification | 3D |
| 12 | **UNETR** | Segmentation | 3D |
| 13 | **FullyConnectedNet** | Classification | 1D |

All new tests use small model configurations (small filter counts, minimal layers) and tiny input tensors to keep CI runtime low. Each test follows the existing `TESTS_ORT` parameterized pattern with `use_trace=True` and `verify=True`.

Networks with known ONNX-incompatible patterns (e.g., SwinUNETR, AHNet) were intentionally excluded and can be addressed in follow-up work.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.