### PR TITLE
Adding MedNeXt to documentation

### DIFF
--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -295,6 +295,11 @@ N-Dim Fourier Transform
 .. autofunction:: monai.networks.blocks.fft_utils_t.fftshift
 .. autofunction:: monai.networks.blocks.fft_utils_t.ifftshift
 
+`MedNeXtBlock`
+~~~~~~~~~~~~~~
+.. autoclass:: MedNeXtBlock
+    :members:
+
 Layers
 ------
 
@@ -793,6 +798,11 @@ Nets
    :members:
 
 .. autoclass:: VoxelMorph
+   :members:
+
+`MedNeXt`
+~~~~~~~~~~~~
+.. autoclass:: MedNeXt
    :members:
 
 Utilities

--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -99,6 +99,11 @@ Blocks
 .. autoclass:: DenseBlock
    :members:
 
+`MedNeXtBlock`
+~~~~~~~~~~~~~~
+.. autoclass:: MedNeXtBlock
+    :members:
+
 `SegResnet Block`
 ~~~~~~~~~~~~~~~~~
 .. autoclass:: ResBlock
@@ -294,11 +299,6 @@ N-Dim Fourier Transform
 .. autofunction:: monai.networks.blocks.fft_utils_t.roll_1d
 .. autofunction:: monai.networks.blocks.fft_utils_t.fftshift
 .. autofunction:: monai.networks.blocks.fft_utils_t.ifftshift
-
-`MedNeXtBlock`
-~~~~~~~~~~~~~~
-.. autoclass:: MedNeXtBlock
-    :members:
 
 Layers
 ------


### PR DESCRIPTION
MedNeXt implementation is missing from the documentation.
Small fix to add it to the docs so it's clear that it exists in the MONAI framework when using the API Documentation.

### Description

Small fix to the documentation to add the missing MedNeXt model architecture and the MedNeXt block.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [x] Documentation updated, tested `make html` command in the `docs/` folder.
