### PR TITLE
Fix FID metric for scipy >= 1.18: sqrtm no longer accepts disp

### DIFF
--- a/monai/metrics/fid.py
+++ b/monai/metrics/fid.py
@@ -82,7 +82,7 @@ def _cov(input_data: torch.Tensor, rowvar: bool = True) -> torch.Tensor:
 
 def _sqrtm(input_data: torch.Tensor) -> torch.Tensor:
     """Compute the square root of a matrix."""
-    scipy_res, _ = scipy.linalg.sqrtm(input_data.detach().cpu().numpy().astype(np.float64), disp=False)
+    scipy_res = scipy.linalg.sqrtm(input_data.detach().cpu().numpy().astype(np.float64))
     return torch.from_numpy(scipy_res)
 
 

--- a/tests/metrics/test_compute_fid_metric.py
+++ b/tests/metrics/test_compute_fid_metric.py
@@ -17,6 +17,7 @@ import numpy as np
 import torch
 
 from monai.metrics import FIDMetric
+from monai.metrics.fid import _sqrtm
 from monai.utils import optional_import
 
 _, has_scipy = optional_import("scipy")
@@ -24,6 +25,12 @@ _, has_scipy = optional_import("scipy")
 
 @unittest.skipUnless(has_scipy, "Requires scipy")
 class TestFIDMetric(unittest.TestCase):
+
+    def test_sqrtm_returns_tensor(self):
+        """``scipy.linalg.sqrtm`` dropped its ``disp`` argument, and with it the 2-tuple return."""
+        result = _sqrtm(torch.tensor([[4.0, 0.0], [0.0, 9.0]], dtype=torch.float64))
+        self.assertIsInstance(result, torch.Tensor)
+        np.testing.assert_allclose(result.cpu().numpy(), np.array([[2.0, 0.0], [0.0, 3.0]]), atol=1e-6)
 
     def test_results(self):
         x = torch.Tensor([[1, 2], [1, 2], [1, 2]])


### PR DESCRIPTION
Fixes part of #9069 (the `scipy` row of the failure table).

### Description

`scipy` 1.18 removed the `disp` parameter from `scipy.linalg.sqrtm`, and with it the 2-tuple `(matrix, errest)` return that `disp=False` produced. `monai/metrics/fid.py:85` still called it as:

```python
scipy_res, _ = scipy.linalg.sqrtm(..., disp=False)
```

so on `scipy >= 1.18` every FID computation fails:

```
TypeError: sqrtm() got an unexpected keyword argument 'disp'
```

This is not reachable in CI today because `full-dep` pins `PYTHON_VER1: '3.10'`, and `scipy >= 1.18` requires Python >= 3.12 — so CI never resolves the breaking version, while a contributor on a current interpreter hits it immediately. That resolution gap is the subject of #9069; this PR fixes just the `scipy` breakage itself.

The fix drops `disp` and uses the return value directly. That is correct across MONAI's entire supported range (`scipy>=1.12.0`): older versions return the matrix alone when `disp` is left at its default.

| scipy | signature | `sqrtm(A)` | `sqrtm(A, disp=False)` |
|---|---|---|---|
| 1.12.0 | `(A, disp=True, blocksize=64)` | ndarray | tuple of 2 |
| 1.18.1 | `(A)` | ndarray | `TypeError` |

### One behavioural note

Omitting `disp` means it reverts to its `True` default on `scipy < 1.18`, so a matrix with no computable square root now prints scipy's `"Failed to find a square root."` to stdout rather than being silent. On `scipy >= 1.18` the same case emits a `LinAlgWarning`.

Downstream behaviour is unchanged either way: both versions return non-finite values, and `compute_frechet_distance` already branches on `torch.isfinite(covmean).all()` and prints its own message for the singular case.

I judged that preferable to version-gating the call site, but happy to switch to an explicit `scipy` version check or to suppress the message if you'd rather keep that path quiet.

### Verification

Run on unmodified `dev` and with the fix, in two environments:

| | scipy 1.18.1 / py3.12 / torch 2.13.0 | scipy 1.12.0 / py3.11 / torch 2.13.0 |
|---|---|---|
| `dev`, unpatched | `test_results` **fails** (`TypeError`) | passes |
| with this PR | 3 passed | 3 passed |

- `tests/metrics/` in full on scipy 1.18.1: **383 passed, 41 skipped**.
- The added `test_sqrtm_returns_tensor` fails on unpatched `dev` under scipy 1.18.1 and passes with the fix, so it genuinely guards the regression. Under scipy 1.12 it passes either way — the bug is version-gated, and the test asserts the contract (`_sqrtm` returns a tensor, not a tuple) rather than the version.
- `black` and `isort` clean; `flake8 --max-line-length=120` clean on both changed files. The one remaining `E501` in `fid.py` is pre-existing on `dev` (line 66, a docstring) and left untouched.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.

<sub>On the two unchecked test boxes: I ran `pytest tests/metrics/` in full on both scipy versions rather than the full `runtests.sh` suites, since the change is confined to one function. Happy to run either in full if you want it before merge.</sub>
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
