### PR TITLE
Fix ZarrAvgMerger under zarr 3.3: map chunks=True to auto-chunking

### DIFF
--- a/monai/inferers/merger.py
+++ b/monai/inferers/merger.py
@@ -307,7 +307,13 @@ class ZarrAvgMerger(Merger):
             self.value_store = zarr.storage.TempStore() if value_store is None else value_store  # type: ignore
             self.count_store = zarr.storage.TempStore() if count_store is None else count_store  # type: ignore
 
-        self.chunks = chunks
+        # zarr 3.3 rejects boolean chunk arguments; `None` there means auto-chunking,
+        # which is what `chunks=True` meant before. On zarr < 3.3 `None` instead means
+        # a single whole-shape chunk, so the substitution must not be applied there.
+        if chunks is True and version_geq(get_package_version("zarr"), "3.3.0"):
+            self.chunks: Sequence[int] | bool | None = None
+        else:
+            self.chunks = chunks
 
         # Initialize codecs/compressor attributes with proper types
         self.codecs: list | None = None

--- a/tests/inferers/test_zarr_avg_merger.py
+++ b/tests/inferers/test_zarr_avg_merger.py
@@ -195,11 +195,20 @@ TEST_CASE_12_CHUNKS = [
 ]
 
 # Define zarr v3 codec configurations with proper bytes codec
-ZARR_V3_LZ4_CODECS = [{"name": "bytes", "configuration": {}}, {"name": "blosc", "configuration": {"cname": "lz4"}}]
+ZARR_V3_LZ4_CODECS = [
+    {"name": "bytes", "configuration": {"endian": "little"}},
+    {"name": "blosc", "configuration": {"cname": "lz4"}},
+]
 
-ZARR_V3_PICKLE_CODECS = [{"name": "bytes", "configuration": {}}, {"name": "blosc", "configuration": {"cname": "zstd"}}]
+ZARR_V3_PICKLE_CODECS = [
+    {"name": "bytes", "configuration": {"endian": "little"}},
+    {"name": "blosc", "configuration": {"cname": "zstd"}},
+]
 
-ZARR_V3_LZMA_CODECS = [{"name": "bytes", "configuration": {}}, {"name": "blosc", "configuration": {"cname": "zlib"}}]
+ZARR_V3_LZMA_CODECS = [
+    {"name": "bytes", "configuration": {"endian": "little"}},
+    {"name": "blosc", "configuration": {"cname": "zlib"}},
+]
 
 # test for LZ4 compressor (zarr v2) or codecs (zarr v3)
 TEST_CASE_13_COMPRESSOR_LZ4 = [
@@ -289,7 +298,10 @@ TEST_CASE_18_CODECS = [
 TEST_CASE_19_VALUE_CODECS = [
     dict(
         merged_shape=TENSOR_4x4.shape,
-        value_codecs=[{"name": "bytes", "configuration": {}}, {"name": "blosc", "configuration": {"cname": "zstd"}}],
+        value_codecs=[
+            {"name": "bytes", "configuration": {"endian": "little"}},
+            {"name": "blosc", "configuration": {"cname": "zstd"}},
+        ],
     ),
     [
         (TENSOR_4x4[..., :2, :2], (0, 0)),
@@ -304,7 +316,10 @@ TEST_CASE_19_VALUE_CODECS = [
 TEST_CASE_20_COUNT_CODECS = [
     dict(
         merged_shape=TENSOR_4x4.shape,
-        count_codecs=[{"name": "bytes", "configuration": {}}, {"name": "blosc", "configuration": {"cname": "zlib"}}],
+        count_codecs=[
+            {"name": "bytes", "configuration": {"endian": "little"}},
+            {"name": "blosc", "configuration": {"cname": "zlib"}},
+        ],
     ),
     [
         (TENSOR_4x4[..., :2, :2], (0, 0)),
@@ -448,6 +463,11 @@ class ZarrAvgMergerTests(unittest.TestCase):
     def test_zarr_avg_merge_none_merged_shape_error(self):
         with self.assertRaises(ValueError):
             ZarrAvgMerger(merged_shape=None, store=self.merged_name)
+
+    def test_zarr_avg_merger_default_chunks_auto(self):
+        """chunks=True must mean auto-chunking, not one whole-shape chunk (zarr 3.3 removed boolean chunks)."""
+        merger = ZarrAvgMerger(merged_shape=(4096, 4096), store=self.merged_name)
+        self.assertNotEqual(merger.output.chunks, (4096, 4096))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes part of #9069 (the `zarr` row of the failure table: 20 errors in `tests/inferers/test_zarr_avg_merger.py` under zarr 3.3.0).

### Description

zarr 3.3 removed boolean chunk arguments. `ZarrAvgMerger`'s documented default is `chunks=True` ("chunk shape will be guessed from `shape` and `dtype`"), so on zarr 3.3 every construction with the default raises:

```
ValueError: True is not a valid chunk input. Use chunks=None or chunks="auto" ...
```

This isn't reachable in CI because `full-dep` pins Python 3.10, and zarr >= 3.0 requires Python >= 3.11 (3.3.0 resolves only on >= 3.12) — the version-resolution gap described in #9069.

I verified the chunk-argument semantics empirically across versions before choosing the fix:

| zarr | `chunks=True` | `chunks=None` | `chunks=False` |
|---|---|---|---|
| 3.0.0 | auto-chunking | **one whole-shape chunk** | one whole-shape chunk |
| 3.2.0 | auto-chunking | auto-chunking | one whole-shape chunk |
| 3.3.0 | `ValueError` | auto-chunking | one whole-shape chunk |

So the fix maps `True -> None` **only when zarr >= 3.3.0**. A blanket substitution would silently change zarr 3.0 behaviour from auto-chunking to a single whole-shape chunk, which for large merged volumes defeats the point of using zarr at all. `chunks=False` and explicit chunk shapes work on every version and pass through unchanged. The public API and documented semantics stay exactly as they are.

Note: the error message's own suggestion (`chunks="auto"`) does not work in the `zarr.empty`/`zarr.zeros` convenience API — the string is interpreted as a 4-element sequence and fails with a dimension mismatch. `None` is the spelling that works there, which is why the mapping targets it.

### Second, smaller breakage in the same suite

zarr 3.3 also requires the `bytes` codec to declare endianness for multi-byte dtypes. Five test fixtures used `{"name": "bytes", "configuration": {}}`, which now fails with `The 'endian' configuration needs to be specified for multi-byte data types.` The fixtures now set `{"endian": "little"}`, which is accepted from zarr 3.0 on (verified with a write/read round-trip on 3.0.0 and 3.3.0). This is a fixture fix, not a `merger.py` change — the codecs are caller-supplied, and callers hitting this get zarr's own clear error. The `count_codecs` case was already passing because `uint8` is single-byte.

### Regression test

The existing default-parameter tests only prove construction doesn't raise; none of them would catch `True` silently degrading to a whole-shape chunk, since at the fixtures' 4x4 size auto and whole-shape coincide. The added `test_zarr_avg_merger_default_chunks_auto` uses a 4096x4096 merged shape, where auto-chunking yields (512, 512), and asserts the default does **not** produce one whole-shape chunk.

### Verification

Full `tests/inferers/test_zarr_avg_merger.py` suite (24 tests) on Python 3.12 / torch 2.13.0:

| zarr | unpatched `dev` | with this PR |
|---|---|---|
| 3.0.0 | passes | 24 passed |
| 3.2.0 | passes | 24 passed |
| 3.3.0 | 20 errors / 5 failures | 24 passed |

Negative control: reverting only the `merger.py` change on zarr 3.3.0 fails 21 of 24.

zarr 2: not run locally, but both changes are structurally inert there — the mapping is gated on `version_geq(zarr, "3.3.0")`, and the fixture edits only touch configs selected when `version_geq(zarr, "3.0.0")`. CI's py3.10 job (zarr 2.18) exercises that path.

`black`, `isort`, and `flake8 --max-line-length=120` clean on both changed files (the one E501 in `merger.py` is pre-existing on `dev`, line 75).

Related: #8816 also touches `ZarrAvgMerger.__init__` (tmpdir GC on zarr v3) — different bug, no overlap in changed lines, but flagging it since both land in the same constructor.

### Types of changes
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.

<sub>On the unchecked test boxes: I ran the affected suite in full across three zarr versions rather than the whole `runtests.sh` matrix, since the change is confined to `ZarrAvgMerger`. Happy to run either in full if wanted before merge.</sub>
