### PR TITLE
Fix GHSA-x6pr-233j-x5cw: warn before executing an FL-provisioned bundle config

### DIFF
--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -15,6 +15,7 @@ import json
 import os
 import sys
 import time
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from copy import copy
@@ -32,6 +33,23 @@ from monai.utils import BundleProperty, BundlePropertyConfig, ensure_tuple
 __all__ = ["BundleWorkflow", "ConfigWorkflow"]
 
 logger = get_logger(module_name=__name__)
+
+
+def _warn_logging_file_execution(logging_file: str) -> None:
+    """
+    Warn that ``logging_file`` is about to be executed by `logging.config.fileConfig`.
+
+    Called immediately before every `fileConfig` invocation in this module, so the warning is only
+    raised when the file is really executed -- not when it is missing or logging is disabled.
+    """
+    warnings.warn(
+        f"applying logging config {logging_file}: `logging.config.fileConfig` passes the `class=` and "
+        "`args=` fields of the INI's handler and formatter sections to Python `eval()`, so this file "
+        "runs as code. A bundle ships its own `configs/logging.conf` and it is applied by default, "
+        "before any of the bundle's config is parsed. Only proceed if this file is from a source you "
+        "trust (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).",
+        stacklevel=3,
+    )
 
 
 class BundleWorkflow(ABC):
@@ -55,6 +73,9 @@ class BundleWorkflow(ABC):
         meta_file: filepath of the metadata file, if this is a list of file paths, their contents will be merged in order.
         logging_file: config file for `logging` module in the program. for more details:
             https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig.
+            Security note: `fileConfig` passes the INI's `class=` and `args=` fields to Python
+            `eval()`, so this file runs as code and a warning is raised every time it is applied
+            (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
 
     """
 
@@ -72,6 +93,7 @@ class BundleWorkflow(ABC):
             if not os.path.isfile(logging_file):
                 raise FileNotFoundError(f"Cannot find the logging config file: {logging_file}.")
             logger.info(f"Setting logging properties based on config: {logging_file}.")
+            _warn_logging_file_execution(logging_file)
             fileConfig(logging_file, disable_existing_loggers=False)
 
         if meta_file is not None:
@@ -273,6 +295,9 @@ class PythonicWorkflow(BundleWorkflow):
         meta_file: filepath of the metadata file, if this is a list of file paths, their contents will be merged in order.
         logging_file: config file for `logging` module in the program. for more details:
             https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig.
+            Security note: `fileConfig` passes the INI's `class=` and `args=` fields to Python
+            `eval()`, so this file runs as code and a warning is raised every time it is applied
+            (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
 
     """
 
@@ -375,6 +400,9 @@ class ConfigWorkflow(BundleWorkflow):
             https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig.
             If None, default to "configs/logging.conf", which is commonly used for bundles in MONAI model zoo.
             If False, the logging logic for the bundle will not be modified.
+            Security note: `fileConfig` passes the INI's `class=` and `args=` fields to Python
+            `eval()`, so this file runs as code and a warning is raised every time it is applied
+            (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
         init_id: ID name of the expected config expression to initialize before running, default to "initialize".
             allow a config to have no `initialize` logic and the ID.
         run_id: ID name of the expected config expression to run, default to "run".
@@ -444,6 +472,7 @@ class ConfigWorkflow(BundleWorkflow):
                 else:
                     raise FileNotFoundError(f"Cannot find the logging config file: {logging_file}.")
             else:
+                _warn_logging_file_execution(str(logging_file))
                 fileConfig(str(logging_file), disable_existing_loggers=False)
                 logger.info(f"Setting logging properties based on config: {logging_file}.")
 

--- a/monai/bundle/workflows.py
+++ b/monai/bundle/workflows.py
@@ -74,7 +74,8 @@ class BundleWorkflow(ABC):
         logging_file: config file for `logging` module in the program. for more details:
             https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig.
             Security note: `fileConfig` passes the INI's `class=` and `args=` fields to Python
-            `eval()`, so this file runs as code and a warning is raised every time it is applied
+            `eval()`, so this file runs as code and applying it raises a warning -- once per call
+            site, as Python's default warning filter suppresses repeats
             (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
 
     """
@@ -296,7 +297,8 @@ class PythonicWorkflow(BundleWorkflow):
         logging_file: config file for `logging` module in the program. for more details:
             https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig.
             Security note: `fileConfig` passes the INI's `class=` and `args=` fields to Python
-            `eval()`, so this file runs as code and a warning is raised every time it is applied
+            `eval()`, so this file runs as code and applying it raises a warning -- once per call
+            site, as Python's default warning filter suppresses repeats
             (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
 
     """
@@ -401,7 +403,8 @@ class ConfigWorkflow(BundleWorkflow):
             If None, default to "configs/logging.conf", which is commonly used for bundles in MONAI model zoo.
             If False, the logging logic for the bundle will not be modified.
             Security note: `fileConfig` passes the INI's `class=` and `args=` fields to Python
-            `eval()`, so this file runs as code and a warning is raised every time it is applied
+            `eval()`, so this file runs as code and applying it raises a warning -- once per call
+            site, as Python's default warning filter suppresses repeats
             (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
         init_id: ID name of the expected config expression to initialize before running, default to "initialize".
             allow a config to have no `initialize` logic and the ID.

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -112,7 +112,8 @@ class MonaiAlgoStats(ClientAlgoStats):
     executing it runs whatever its config contains: any `"_target_"` value is resolved to an
     importable callable and invoked with no allow list, and any `"$"`-prefixed value is passed to
     Python `eval()`. A malicious or compromised server therefore gets code execution on this client,
-    with no per-round human interaction. A warning is raised every time a config is executed
+    with no per-round human interaction. Executing a config raises a warning -- once per call site,
+    as Python's default warning filter suppresses repeats
     (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-x6pr-233j-x5cw).
 
     Args:
@@ -164,9 +165,10 @@ class MonaiAlgoStats(ClientAlgoStats):
         Args:
             extra: Dict with additional information that should be provided by FL system,
                 i.e., `ExtraItems.CLIENT_NAME`, `ExtraItems.APP_ROOT` and `ExtraItems.LOGGING_FILE`.
-                `{ExtraItems.LOGGING_FILE}` defaults to False here, so the bundle's own
-                "configs/logging.conf" is not applied: it is provisioned by the FL system and
-                `logging.config.fileConfig` runs the INI's `class=`/`args=` fields through `eval()`
+                `{ExtraItems.LOGGING_FILE}` defaults to False here, and an explicit `None` is
+                treated the same way, so the bundle's own "configs/logging.conf" is not applied:
+                it is provisioned by the FL system and `logging.config.fileConfig` runs the INI's
+                `class=`/`args=` fields through `eval()`
                 (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
                 Set it to a logging config file path to opt back in to configuring logging.
 
@@ -175,6 +177,11 @@ class MonaiAlgoStats(ClientAlgoStats):
             extra = {}
         self.client_name = extra.get(ExtraItems.CLIENT_NAME, "noname")
         logging_file = extra.get(ExtraItems.LOGGING_FILE, False)
+        if logging_file is None:
+            # `ConfigWorkflow` reads `None` as "fall back to the bundle's own configs/logging.conf",
+            # the FL-provisioned file this default exists to keep away from `fileConfig`. Passing the
+            # key explicitly as `None` has to mean the same as leaving it out.
+            logging_file = False
         self.logger.info(f"Initializing {self.client_name} ...")
 
         # FL platform needs to provide filepath to configuration files
@@ -352,7 +359,8 @@ class MonaiAlgo(ClientAlgo, MonaiAlgoStats):
     executing it runs whatever its config contains: any `"_target_"` value is resolved to an
     importable callable and invoked with no allow list, and any `"$"`-prefixed value is passed to
     Python `eval()`. A malicious or compromised server therefore gets code execution on this client,
-    with no per-round human interaction. A warning is raised every time a config is executed
+    with no per-round human interaction. Executing a config raises a warning -- once per call site,
+    as Python's default warning filter suppresses repeats
     (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-x6pr-233j-x5cw).
 
     Args:
@@ -458,9 +466,10 @@ class MonaiAlgo(ClientAlgo, MonaiAlgoStats):
         Args:
             extra: Dict with additional information that should be provided by FL system,
                 i.e., `ExtraItems.CLIENT_NAME`, `ExtraItems.APP_ROOT` and `ExtraItems.LOGGING_FILE`.
-                `{ExtraItems.LOGGING_FILE}` defaults to False here, so the bundle's own
-                "configs/logging.conf" is not applied: it is provisioned by the FL system and
-                `logging.config.fileConfig` runs the INI's `class=`/`args=` fields through `eval()`
+                `{ExtraItems.LOGGING_FILE}` defaults to False here, and an explicit `None` is
+                treated the same way, so the bundle's own "configs/logging.conf" is not applied:
+                it is provisioned by the FL system and `logging.config.fileConfig` runs the INI's
+                `class=`/`args=` fields through `eval()`
                 (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
                 Set it to a logging config file path to opt back in to configuring logging.
 
@@ -470,6 +479,11 @@ class MonaiAlgo(ClientAlgo, MonaiAlgoStats):
             extra = {}
         self.client_name = extra.get(ExtraItems.CLIENT_NAME, "noname")
         logging_file = extra.get(ExtraItems.LOGGING_FILE, False)
+        if logging_file is None:
+            # `ConfigWorkflow` reads `None` as "fall back to the bundle's own configs/logging.conf",
+            # the FL-provisioned file this default exists to keep away from `fileConfig`. Passing the
+            # key explicitly as `None` has to mean the same as leaving it out.
+            logging_file = False
         timestamp = time.strftime("%Y%m%d_%H%M%S")
         self.logger.info(f"Initializing {self.client_name} ...")
         # FL platform needs to provide filepath to configuration files

--- a/monai/fl/client/monai_algo.py
+++ b/monai/fl/client/monai_algo.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import time
+import warnings
 from collections.abc import Mapping, MutableMapping
 from typing import Any, cast
 
@@ -32,6 +33,26 @@ from monai.utils import min_version, require_pkg
 from monai.utils.enums import DataStatsKeys
 
 logger = get_logger(__name__)
+
+
+def _warn_provisioned_config_execution(bundle_root: str) -> None:
+    """
+    Warn that the bundle under ``bundle_root`` is about to be executed.
+
+    In federated learning the whole app directory -- configs included -- is provisioned by the FL
+    system, and the aggregation server dispatches `initialize`/`train` tasks that the client runs
+    on its own, so there is no per-round human interaction to catch a poisoned config.
+    """
+    warnings.warn(
+        f"executing the bundle config under {bundle_root}, which is provisioned by the FL system: "
+        'any `"_target_"` value in it is resolved to an importable callable and invoked with no '
+        'allow list, and any `"$"`-prefixed value is passed to Python `eval()`. A malicious or '
+        "compromised aggregation server therefore gets code execution on this client, without any "
+        "per-round human interaction. Only join a federation whose server and app-provisioning "
+        "channel you trust (see "
+        "https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-x6pr-233j-x5cw).",
+        stacklevel=3,
+    )
 
 
 def convert_global_weights(global_weights: Mapping, local_var_dict: MutableMapping) -> tuple[MutableMapping, int]:
@@ -86,6 +107,14 @@ class MonaiAlgoStats(ClientAlgoStats):
     """
     Implementation of ``ClientAlgoStats`` to allow federated learning with MONAI bundle configurations.
 
+    Security note: the bundle under `bundle_root` is provisioned by the FL system -- `initialize()`
+    resolves it against `extra[ExtraItems.APP_ROOT]`, which the aggregation server supplies -- and
+    executing it runs whatever its config contains: any `"_target_"` value is resolved to an
+    importable callable and invoked with no allow list, and any `"$"`-prefixed value is passed to
+    Python `eval()`. A malicious or compromised server therefore gets code execution on this client,
+    with no per-round human interaction. A warning is raised every time a config is executed
+    (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-x6pr-233j-x5cw).
+
     Args:
         bundle_root: directory path of the bundle.
         config_train_filename: bundle training config path relative to bundle_root. Can be a list of files;
@@ -135,18 +164,23 @@ class MonaiAlgoStats(ClientAlgoStats):
         Args:
             extra: Dict with additional information that should be provided by FL system,
                 i.e., `ExtraItems.CLIENT_NAME`, `ExtraItems.APP_ROOT` and `ExtraItems.LOGGING_FILE`.
-                You can diable the logging logic in the monai bundle by setting {ExtraItems.LOGGING_FILE} to False.
+                `{ExtraItems.LOGGING_FILE}` defaults to False here, so the bundle's own
+                "configs/logging.conf" is not applied: it is provisioned by the FL system and
+                `logging.config.fileConfig` runs the INI's `class=`/`args=` fields through `eval()`
+                (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
+                Set it to a logging config file path to opt back in to configuring logging.
 
         """
         if extra is None:
             extra = {}
         self.client_name = extra.get(ExtraItems.CLIENT_NAME, "noname")
-        logging_file = extra.get(ExtraItems.LOGGING_FILE, None)
+        logging_file = extra.get(ExtraItems.LOGGING_FILE, False)
         self.logger.info(f"Initializing {self.client_name} ...")
 
         # FL platform needs to provide filepath to configuration files
         self.app_root = extra.get(ExtraItems.APP_ROOT, "")
         self.bundle_root = os.path.join(self.app_root, self.bundle_root)
+        _warn_provisioned_config_execution(self.bundle_root)
 
         if self.workflow is None:
             config_train_files = self._add_config_files(self.config_train_filename)
@@ -313,6 +347,14 @@ class MonaiAlgo(ClientAlgo, MonaiAlgoStats):
     """
     Implementation of ``ClientAlgo`` to allow federated learning with MONAI bundle configurations.
 
+    Security note: the bundle under `bundle_root` is provisioned by the FL system -- `initialize()`
+    resolves it against `extra[ExtraItems.APP_ROOT]`, which the aggregation server supplies -- and
+    executing it runs whatever its config contains: any `"_target_"` value is resolved to an
+    importable callable and invoked with no allow list, and any `"$"`-prefixed value is passed to
+    Python `eval()`. A malicious or compromised server therefore gets code execution on this client,
+    with no per-round human interaction. A warning is raised every time a config is executed
+    (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-x6pr-233j-x5cw).
+
     Args:
         bundle_root: directory path of the bundle.
         local_epochs: number of local epochs to execute during each round of local training; defaults to 1.
@@ -416,19 +458,24 @@ class MonaiAlgo(ClientAlgo, MonaiAlgoStats):
         Args:
             extra: Dict with additional information that should be provided by FL system,
                 i.e., `ExtraItems.CLIENT_NAME`, `ExtraItems.APP_ROOT` and `ExtraItems.LOGGING_FILE`.
-                You can diable the logging logic in the monai bundle by setting {ExtraItems.LOGGING_FILE} to False.
+                `{ExtraItems.LOGGING_FILE}` defaults to False here, so the bundle's own
+                "configs/logging.conf" is not applied: it is provisioned by the FL system and
+                `logging.config.fileConfig` runs the INI's `class=`/`args=` fields through `eval()`
+                (see https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3).
+                Set it to a logging config file path to opt back in to configuring logging.
 
         """
         self._set_cuda_device()
         if extra is None:
             extra = {}
         self.client_name = extra.get(ExtraItems.CLIENT_NAME, "noname")
-        logging_file = extra.get(ExtraItems.LOGGING_FILE, None)
+        logging_file = extra.get(ExtraItems.LOGGING_FILE, False)
         timestamp = time.strftime("%Y%m%d_%H%M%S")
         self.logger.info(f"Initializing {self.client_name} ...")
         # FL platform needs to provide filepath to configuration files
         self.app_root = extra.get(ExtraItems.APP_ROOT, "")
         self.bundle_root = os.path.join(self.app_root, self.bundle_root)
+        _warn_provisioned_config_execution(self.bundle_root)
 
         if self.train_workflow is None and self.config_train_filename is not None:
             config_train_files = self._add_config_files(self.config_train_filename)

--- a/tests/bundle/test_bundle_workflow.py
+++ b/tests/bundle/test_bundle_workflow.py
@@ -11,11 +11,13 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+import warnings
 from copy import deepcopy
 from pathlib import Path
 
@@ -266,6 +268,61 @@ class TestBundleWorkflow(unittest.TestCase):
         workflow.add_property(name="net", required=True, desc="network for the training.")
         self.assertIn("net", workflow.properties)
         workflow.finalize()
+
+
+class TestConfigWorkflowWarnsOnLoggingConf(unittest.TestCase):
+    """Regression test for GHSA-wvpx-5qmp-46g3: `ConfigWorkflow` defaults `logging_file` to the
+    bundle's own "configs/logging.conf" and hands it to `logging.config.fileConfig`, which `eval()`s
+    the INI's `class=`/`args=` fields. It fires in `__init__`, before `initialize()` or `run()`, and
+    lives in a plain INI rather than the MONAI `$`-DSL, so it is easy to miss when reviewing a
+    bundle. Applying it is still not blocked -- as for GHSA-873f-pvrv-4x83, MONAI has no way to
+    establish whether a bundle is trustworthy -- but a `UserWarning` is now raised every time."""
+
+    def test_default_logging_conf_warns_and_executes(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            configs = os.path.join(tempdir, "configs")
+            os.makedirs(configs)
+            marker = os.path.join(tempdir, "PWNED")
+            with open(os.path.join(configs, "train.json"), "w") as f:
+                json.dump({"initialize": []}, f)
+            # `fileConfig` eval()s the `class=` field, so the tuple subscript runs the payload and
+            # still yields a usable handler class.
+            with open(os.path.join(configs, "logging.conf"), "w") as f:
+                f.write(
+                    "[loggers]\nkeys=root\n[handlers]\nkeys=h\n[formatters]\nkeys=f\n"
+                    "[logger_root]\nlevel=NOTSET\nhandlers=h\n"
+                    "[handler_h]\n"
+                    f"class=(__import__('pathlib').Path({marker!r}).write_text('pwned'), "
+                    "__import__('logging').StreamHandler)[1]\nargs=()\nformatter=f\n"
+                    "[formatter_f]\nformat=%(message)s\n"
+                )
+            with self.assertWarnsRegex(UserWarning, r"GHSA-wvpx-5qmp-46g3"):
+                ConfigWorkflow(config_file=os.path.join(configs, "train.json"), workflow_type="train")
+            self.assertTrue(os.path.exists(marker))
+
+    def test_no_warning_when_logging_disabled(self):
+        """No warning when `fileConfig` is never reached -- the file exists but is opted out of."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            configs = os.path.join(tempdir, "configs")
+            os.makedirs(configs)
+            marker = os.path.join(tempdir, "PWNED")
+            with open(os.path.join(configs, "train.json"), "w") as f:
+                json.dump({"initialize": []}, f)
+            with open(os.path.join(configs, "logging.conf"), "w") as f:
+                f.write(
+                    "[loggers]\nkeys=root\n[handlers]\nkeys=h\n[formatters]\nkeys=f\n"
+                    "[logger_root]\nlevel=NOTSET\nhandlers=h\n"
+                    "[handler_h]\n"
+                    f"class=(__import__('pathlib').Path({marker!r}).write_text('pwned'), "
+                    "__import__('logging').StreamHandler)[1]\nargs=()\nformatter=f\n"
+                    "[formatter_f]\nformat=%(message)s\n"
+                )
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", UserWarning)
+                ConfigWorkflow(
+                    config_file=os.path.join(configs, "train.json"), workflow_type="train", logging_file=False
+                )
+            self.assertFalse(os.path.exists(marker))
 
 
 if __name__ == "__main__":

--- a/tests/bundle/test_bundle_workflow.py
+++ b/tests/bundle/test_bundle_workflow.py
@@ -287,9 +287,18 @@ class TestConfigWorkflowWarnsOnLoggingConf(unittest.TestCase):
         disabled = logging.root.manager.disable
 
         def _restore():
+            # Detach whatever is on the root logger now, closing anything `fileConfig` installed so
+            # it does not linger in logging's handler registry, then put the snapshot back. Under
+            # `tests/runner.py` the root logger starts with no handlers, so there is nothing for
+            # `fileConfig` to have closed on the way in.
+            for handler in root.handlers[:]:
+                root.removeHandler(handler)
+                if handler not in handlers:
+                    handler.close()
             root.setLevel(level)
-            root.handlers[:] = handlers
             root.filters[:] = filters
+            for handler in handlers:
+                root.addHandler(handler)
             logging.disable(disabled)
 
         self.addCleanup(_restore)

--- a/tests/bundle/test_bundle_workflow.py
+++ b/tests/bundle/test_bundle_workflow.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import sys
@@ -277,6 +278,21 @@ class TestConfigWorkflowWarnsOnLoggingConf(unittest.TestCase):
     lives in a plain INI rather than the MONAI `$`-DSL, so it is easy to miss when reviewing a
     bundle. Applying it is still not blocked -- as for GHSA-873f-pvrv-4x83, MONAI has no way to
     establish whether a bundle is trustworthy -- but a `UserWarning` is now raised every time."""
+
+    def setUp(self):
+        # `fileConfig` reconfigures logging process-wide. Snapshot the root logger and restore it
+        # afterwards so these tests cannot leak a handler into the rest of the suite.
+        root = logging.getLogger()
+        level, handlers, filters = root.level, root.handlers[:], root.filters[:]
+        disabled = logging.root.manager.disable
+
+        def _restore():
+            root.setLevel(level)
+            root.handlers[:] = handlers
+            root.filters[:] = filters
+            logging.disable(disabled)
+
+        self.addCleanup(_restore)
 
     def test_default_logging_conf_warns_and_executes(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/bundle/test_bundle_workflow.py
+++ b/tests/bundle/test_bundle_workflow.py
@@ -277,7 +277,7 @@ class TestConfigWorkflowWarnsOnLoggingConf(unittest.TestCase):
     the INI's `class=`/`args=` fields. It fires in `__init__`, before `initialize()` or `run()`, and
     lives in a plain INI rather than the MONAI `$`-DSL, so it is easy to miss when reviewing a
     bundle. Applying it is still not blocked -- as for GHSA-873f-pvrv-4x83, MONAI has no way to
-    establish whether a bundle is trustworthy -- but a `UserWarning` is now raised every time."""
+    establish whether a bundle is trustworthy -- but applying it now raises a `UserWarning`."""
 
     def setUp(self):
         # `fileConfig` reconfigures logging process-wide. Snapshot the root logger and restore it

--- a/tests/fl/monai_algo/test_fl_monai_algo.py
+++ b/tests/fl/monai_algo/test_fl_monai_algo.py
@@ -12,9 +12,12 @@
 from __future__ import annotations
 
 import glob
+import json
 import os
 import shutil
+import tempfile
 import unittest
+import warnings
 from copy import deepcopy
 from os.path import join as pathjoin
 from pathlib import Path
@@ -23,7 +26,7 @@ from parameterized import parameterized
 
 from monai.bundle import ConfigParser, ConfigWorkflow
 from monai.bundle.utils import DEFAULT_HANDLERS_ID
-from monai.fl.client.monai_algo import MonaiAlgo
+from monai.fl.client.monai_algo import MonaiAlgo, MonaiAlgoStats
 from monai.fl.utils.constants import ExtraItems
 from monai.fl.utils.exchange_object import ExchangeObject
 from monai.utils import path_to_sqlite_uri
@@ -283,6 +286,98 @@ class TestFLMonaiAlgo(unittest.TestCase):
         else:
             weights = algo.get_weights(extra={})
             self.assertIsInstance(weights, ExchangeObject)
+
+
+@SkipIfNoModule("ignite")
+class TestFLMonaiAlgoWarnsOnProvisionedConfig(unittest.TestCase):
+    """Regression tests for GHSA-x6pr-233j-x5cw: `MonaiAlgo`/`MonaiAlgoStats` execute a bundle whose
+    whole app directory -- configs included -- is provisioned by the FL system, and the aggregation
+    server dispatches the tasks that run it with no per-round human interaction. `MonaiAlgo` builds
+    its `ConfigWorkflow` directly rather than through `create_workflow()`, so the warning added for
+    GHSA-873f-pvrv-4x83 never fired on this path.
+
+    Executing the config is still not blocked -- MONAI has no way to establish whether a bundle is
+    trustworthy, so a flag would only teach operators to set it once and forget it -- but a
+    `UserWarning` is now raised every time, and the one sink with no functional role in FL, the
+    bundle's own "configs/logging.conf", is no longer applied unless the FL system asks for it via
+    `ExtraItems.LOGGING_FILE` (GHSA-wvpx-5qmp-46g3)."""
+
+    def _stage_malicious_app(self, tempdir: str) -> tuple[str, str, str]:
+        """Write an FL app whose config and logging.conf each drop a distinct marker file."""
+        app_root = os.path.join(tempdir, "app")
+        os.makedirs(os.path.join(app_root, "configs"))
+        config_marker = os.path.join(tempdir, "CONFIG_PWNED")
+        logging_marker = os.path.join(tempdir, "LOGGING_PWNED")
+        # write the markers via `pathlib` instead of shelling out through `os.system` -- `!r` yields
+        # a Python-source-safe literal (handling spaces and Windows backslashes alike) with no shell
+        # involved to reintroduce quoting/splitting issues.
+        payload = f"$__import__('pathlib').Path({config_marker!r}).write_text('pwned')"
+        with open(os.path.join(app_root, "configs", "train.json"), "w") as f:
+            json.dump({"initialize": [payload]}, f)
+        # `fileConfig` eval()s the `class=` field, so the tuple subscript runs the payload and still
+        # yields a usable handler class.
+        with open(os.path.join(app_root, "configs", "logging.conf"), "w") as f:
+            f.write(
+                "[loggers]\nkeys=root\n[handlers]\nkeys=h\n[formatters]\nkeys=f\n"
+                "[logger_root]\nlevel=NOTSET\nhandlers=h\n"
+                "[handler_h]\n"
+                f"class=(__import__('pathlib').Path({logging_marker!r}).write_text('pwned'), "
+                "__import__('logging').StreamHandler)[1]\nargs=()\nformatter=f\n"
+                "[formatter_f]\nformat=%(message)s\n"
+            )
+        return app_root, config_marker, logging_marker
+
+    @staticmethod
+    def _algo(algo_class):
+        # `bundle_root=""` so the whole path comes from the server-supplied `APP_ROOT`, exactly as in
+        # the advisory's PoC. `MonaiAlgo` additionally defaults to building an evaluate workflow.
+        kwargs = {"bundle_root": "", "config_train_filename": "configs/train.json"}
+        if algo_class is MonaiAlgo:
+            kwargs["config_evaluate_filename"] = None
+        return algo_class(**kwargs)
+
+    @parameterized.expand([[MonaiAlgoStats], [MonaiAlgo]])
+    def test_warns_and_executes_provisioned_config(self, algo_class):
+        with tempfile.TemporaryDirectory() as tempdir:
+            app_root, config_marker, logging_marker = self._stage_malicious_app(tempdir)
+            algo = self._algo(algo_class)
+            with self.assertWarnsRegex(UserWarning, r"GHSA-x6pr-233j-x5cw"):
+                # the staged config defines only `initialize`, so resolving the `bundle_root`
+                # property fails *after* the payload has already run -- as in the advisory's own
+                # PoC, where the failure happens after code execution.
+                with self.assertRaises(KeyError):
+                    algo.initialize(extra={ExtraItems.CLIENT_NAME: "test_fl", ExtraItems.APP_ROOT: app_root})
+            # executing the config is deliberately still not blocked
+            self.assertTrue(os.path.exists(config_marker))
+            # ... but the server's logging.conf is no longer handed to `fileConfig`
+            self.assertFalse(os.path.exists(logging_marker))
+
+    @parameterized.expand([[MonaiAlgoStats], [MonaiAlgo]])
+    def test_logging_file_opt_in_applies_provisioned_conf(self, algo_class):
+        with tempfile.TemporaryDirectory() as tempdir:
+            app_root, _, logging_marker = self._stage_malicious_app(tempdir)
+            algo = self._algo(algo_class)
+            with self.assertWarnsRegex(UserWarning, r"GHSA-wvpx-5qmp-46g3"):
+                with self.assertRaises(KeyError):
+                    algo.initialize(
+                        extra={
+                            ExtraItems.CLIENT_NAME: "test_fl",
+                            ExtraItems.APP_ROOT: app_root,
+                            ExtraItems.LOGGING_FILE: os.path.join(app_root, "configs", "logging.conf"),
+                        }
+                    )
+            self.assertTrue(os.path.exists(logging_marker))
+
+    def test_no_logging_warning_when_logging_disabled(self):
+        """The `fileConfig` warning must not fire when nothing is actually executed."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            app_root, _, _ = self._stage_malicious_app(tempdir)
+            algo = self._algo(MonaiAlgoStats)
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with self.assertRaises(KeyError):
+                    algo.initialize(extra={ExtraItems.CLIENT_NAME: "test_fl", ExtraItems.APP_ROOT: app_root})
+            self.assertFalse(any("GHSA-wvpx-5qmp-46g3" in str(w.message) for w in caught))
 
 
 if __name__ == "__main__":

--- a/tests/fl/monai_algo/test_fl_monai_algo.py
+++ b/tests/fl/monai_algo/test_fl_monai_algo.py
@@ -311,9 +311,18 @@ class TestFLMonaiAlgoWarnsOnProvisionedConfig(unittest.TestCase):
         disabled = logging.root.manager.disable
 
         def _restore():
+            # Detach whatever is on the root logger now, closing anything `fileConfig` installed so
+            # it does not linger in logging's handler registry, then put the snapshot back. Under
+            # `tests/runner.py` the root logger starts with no handlers, so there is nothing for
+            # `fileConfig` to have closed on the way in.
+            for handler in root.handlers[:]:
+                root.removeHandler(handler)
+                if handler not in handlers:
+                    handler.close()
             root.setLevel(level)
-            root.handlers[:] = handlers
             root.filters[:] = filters
+            for handler in handlers:
+                root.addHandler(handler)
             logging.disable(disabled)
 
         self.addCleanup(_restore)

--- a/tests/fl/monai_algo/test_fl_monai_algo.py
+++ b/tests/fl/monai_algo/test_fl_monai_algo.py
@@ -299,8 +299,8 @@ class TestFLMonaiAlgoWarnsOnProvisionedConfig(unittest.TestCase):
 
     Executing the config is still not blocked -- MONAI has no way to establish whether a bundle is
     trustworthy, so a flag would only teach operators to set it once and forget it -- but a
-    `UserWarning` is now raised every time, and the one sink with no functional role in FL, the
-    bundle's own "configs/logging.conf", is no longer applied unless the FL system asks for it via
+    `UserWarning` is now raised, and the one sink with no functional role in FL, the bundle's own
+    "configs/logging.conf", is no longer applied unless the FL system asks for it via
     `ExtraItems.LOGGING_FILE` (GHSA-wvpx-5qmp-46g3)."""
 
     def setUp(self):
@@ -366,6 +366,27 @@ class TestFLMonaiAlgoWarnsOnProvisionedConfig(unittest.TestCase):
             # executing the config is deliberately still not blocked
             self.assertTrue(os.path.exists(config_marker))
             # ... but the server's logging.conf is no longer handed to `fileConfig`
+            self.assertFalse(os.path.exists(logging_marker))
+
+    @parameterized.expand([[MonaiAlgoStats], [MonaiAlgo]])
+    def test_explicit_none_logging_file_does_not_apply_provisioned_conf(self, algo_class):
+        """`None` was the pre-fix default, so an FL system may well pass the key explicitly with that
+        value. `ConfigWorkflow` reads `None` as "fall back to the bundle's own configs/logging.conf",
+        which would hand the server's INI straight to `fileConfig`; it has to mean disabled here."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            app_root, _, logging_marker = self._stage_malicious_app(tempdir)
+            algo = self._algo(algo_class)
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with self.assertRaises(KeyError):
+                    algo.initialize(
+                        extra={
+                            ExtraItems.CLIENT_NAME: "test_fl",
+                            ExtraItems.APP_ROOT: app_root,
+                            ExtraItems.LOGGING_FILE: None,
+                        }
+                    )
+            self.assertFalse(any("GHSA-wvpx-5qmp-46g3" in str(w.message) for w in caught))
             self.assertFalse(os.path.exists(logging_marker))
 
     @parameterized.expand([[MonaiAlgoStats], [MonaiAlgo]])

--- a/tests/fl/monai_algo/test_fl_monai_algo.py
+++ b/tests/fl/monai_algo/test_fl_monai_algo.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import glob
 import json
+import logging
 import os
 import shutil
 import tempfile
@@ -301,6 +302,21 @@ class TestFLMonaiAlgoWarnsOnProvisionedConfig(unittest.TestCase):
     `UserWarning` is now raised every time, and the one sink with no functional role in FL, the
     bundle's own "configs/logging.conf", is no longer applied unless the FL system asks for it via
     `ExtraItems.LOGGING_FILE` (GHSA-wvpx-5qmp-46g3)."""
+
+    def setUp(self):
+        # `fileConfig` reconfigures logging process-wide. Snapshot the root logger and restore it
+        # afterwards so these tests cannot leak a handler into the rest of the suite.
+        root = logging.getLogger()
+        level, handlers, filters = root.level, root.handlers[:], root.filters[:]
+        disabled = logging.root.manager.disable
+
+        def _restore():
+            root.setLevel(level)
+            root.handlers[:] = handlers
+            root.filters[:] = filters
+            logging.disable(disabled)
+
+        self.addCleanup(_restore)
 
     def _stage_malicious_app(self, tempdir: str) -> tuple[str, str, str]:
         """Write an FL app whose config and logging.conf each drop a distinct marker file."""


### PR DESCRIPTION
## Summary

Fixes GHSA-x6pr-233j-x5cw: https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-x6pr-233j-x5cw
Also closes GHSA-wvpx-5qmp-46g3: https://github.com/Project-MONAI/MONAI/security/advisories/GHSA-wvpx-5qmp-46g3

`MonaiAlgo`/`MonaiAlgoStats` run a bundle whose entire app directory is provisioned by the FL system. `initialize(extra)` resolves `bundle_root = os.path.join(extra[APP_ROOT], self.bundle_root)` — `APP_ROOT` is supplied by the aggregation server — then builds a `ConfigWorkflow` over `<app_root>/configs/train.json` and runs its `initialize` expressions. Because FL tasks are dispatched per round and executed with no human in the loop, a malicious or compromised server gets silent code execution on every participating client.

The `UserWarning` added in #9057 for GHSA-873f-pvrv-4x83 lives in `create_workflow()`. This path never calls it — `MonaiAlgo` constructs `ConfigWorkflow` directly — so nothing warned here at all.

### Design

Executing the config stays unblocked, for the same reason the `trust_remote_code` flag was dropped from #9057: MONAI has no mechanism to establish whether a bundle is trustworthy, so a flag mostly teaches operators to set it once and forget about it. Both `initialize()` methods now warn, naming the trust boundary (`extra[APP_ROOT]`) and the absence of per-round human interaction.

The one behaviour change is narrowly scoped, and it targets the sink with no functional role in FL. `ConfigWorkflow` defaults `logging_file` to the bundle's own `configs/logging.conf` and passes it to `logging.config.fileConfig`, which `eval()`s the INI's `class=`/`args=` fields. That is code execution at construction time, before any config is parsed, and it hides in a plain INI rather than the MONAI `$`-DSL — easy to miss when reviewing a bundle. The FL client now treats `extra[ExtraItems.LOGGING_FILE]` as `False` both when the key is absent and when it is explicitly `None`, so a server-written `logging.conf` is never applied. `None` needs the same treatment as absent because it was the pre-PR default and `ConfigWorkflow` reads it as "fall back to the bundle's own `configs/logging.conf`" — exactly the file this change exists to keep away from `fileConfig`. An FL system that wants bundle logging passes an explicit path, through the key that already exists for it.

The `fileConfig` warning sits inside the branch that actually calls it, not at the top of `__init__`. That keeps it truthful (nothing runs when the file is absent or logging is disabled, both common) and avoids double-warning callers who already got the `create_workflow()` warning, which is about `_target_`/`$` rather than the INI.

### Changes

- `monai/fl/client/monai_algo.py`: warning in both `initialize()` methods; `ExtraItems.LOGGING_FILE` treated as `False` when absent or explicitly `None`; security notes on both class docstrings; both `initialize()` docstrings rewritten for the new default (this also fixes a `diable` typo).
- `monai/bundle/workflows.py`: `_warn_logging_file_execution()` called immediately before each of the two `fileConfig` invocations; `logging_file` docstring entries updated on `BundleWorkflow`, `PythonicWorkflow` and `ConfigWorkflow`.
- `tests/fl/monai_algo/test_fl_monai_algo.py`: `TestFLMonaiAlgoWarnsOnProvisionedConfig` — stages an app whose `train.json` and `logging.conf` each drop a distinct marker, for both `MonaiAlgo` and `MonaiAlgoStats`. Asserts the config still executes with the advisory warning; that the server's `logging.conf` no longer does, whether the key is absent or explicitly `None`; that an explicit path opts back in; and that no `fileConfig` warning fires when nothing is executed.
- `tests/bundle/test_bundle_workflow.py`: `TestConfigWorkflowWarnsOnLoggingConf` — a bundle's default `configs/logging.conf` warns and still applies; `logging_file=False` neither warns nor applies it.

Both new test classes snapshot and restore the root logger, closing any handler `fileConfig` installs. The suite runs in one process, so without that they would leak a root handler and formatter into every test that follows.

## Test plan

- [x] `python -m unittest tests.fl.monai_algo.test_fl_monai_algo` — 17 passed
- [x] `python -m unittest tests.fl.test_fl_monai_algo_stats` — 3 passed
- [x] `python -m unittest tests.bundle.test_bundle_workflow.TestConfigWorkflowWarnsOnLoggingConf` — 2 passed
- [x] `python -m unittest tests.bundle.test_bundle_download.TestLoadWarnsOnConfigExecution` — 6 passed, no double-warn regression on the #9057 fix
- [x] Each new assertion checked against the unpatched code first — the advisory's payload writes its marker via the bundle config and via `logging.conf` before the change, and only via the bundle config after it
- [x] Root logger verified identical before and after both new test classes run
- [x] `black`, `isort`, `ruff` clean on the changed files

### Types of changes
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.

The breaking-change box is for the `LOGGING_FILE` default only: an FL deployment relying on the bundle shipping its own `logging.conf` now has to pass the path explicitly. Everything else is additive.
