### PR TITLE
Fix Warp reference grid caching

### DIFF
--- a/monai/networks/blocks/warp.py
+++ b/monai/networks/blocks/warp.py
@@ -109,13 +109,27 @@ class Warp(nn.Module):
             self._padding_mode = self._padding_mode_native
 
         self.ref_grid = None
+        self._ref_grid_params: tuple[bool, int | None] | None = None
         self.jitter = jitter
 
     def get_reference_grid(self, ddf: torch.Tensor, jitter: bool = False, seed: int = 0) -> torch.Tensor:
+        """Return a reference grid matching the displacement field and generation parameters.
+
+        Args:
+            ddf: Dense displacement field defining the grid shape, device, and dtype.
+            jitter: Whether to add deterministic random offsets to the grid.
+            seed: Random seed used when ``jitter`` is enabled.
+
+        Returns:
+            The cached or newly generated reference grid.
+        """
+        ref_grid_params = (jitter, seed if jitter else None)
         if (
             self.ref_grid is not None
-            and self.ref_grid.shape[0] == ddf.shape[0]
-            and self.ref_grid.shape[1:] == ddf.shape[2:]
+            and self.ref_grid.shape == ddf.shape
+            and self.ref_grid.device == ddf.device
+            and self.ref_grid.dtype == ddf.dtype
+            and self._ref_grid_params == ref_grid_params
         ):
             return self.ref_grid  # type: ignore
         mesh_points = [torch.arange(0, dim) for dim in ddf.shape[2:]]
@@ -128,6 +142,7 @@ class Warp(nn.Module):
                 torch.random.manual_seed(seed)
                 grid += torch.rand_like(grid)
         self.ref_grid = grid
+        self._ref_grid_params = ref_grid_params
         self.ref_grid.requires_grad = False
         return self.ref_grid
 

--- a/tests/networks/blocks/warp/test_warp.py
+++ b/tests/networks/blocks/warp/test_warp.py
@@ -154,6 +154,41 @@ class TestWarp(unittest.TestCase):
         self.assertTrue(torch.equal(same, repeat))
         self.assertFalse(torch.equal(same, other))
 
+    def test_reference_grid_cache(self):
+        """Verify reference-grid cache hits and invalidation across every key dimension."""
+        warp_layer = Warp()
+        ddf = torch.zeros(1, 2, 4, 5)
+
+        regular = warp_layer.get_reference_grid(ddf, jitter=False, seed=0)
+        self.assertIs(regular, warp_layer.get_reference_grid(ddf, jitter=False, seed=7))
+
+        float64 = warp_layer.get_reference_grid(ddf.to(torch.float64))
+        self.assertIsNot(float64, regular)
+        self.assertEqual(float64.dtype, torch.float64)
+
+        jitter_7 = warp_layer.get_reference_grid(ddf.to(torch.float64), jitter=True, seed=7)
+        self.assertIsNot(jitter_7, float64)
+        self.assertIs(jitter_7, warp_layer.get_reference_grid(ddf.to(torch.float64), jitter=True, seed=7))
+
+        jitter_8 = warp_layer.get_reference_grid(ddf.to(torch.float64), jitter=True, seed=8)
+        self.assertIsNot(jitter_8, jitter_7)
+        self.assertTrue(torch.equal(jitter_8, Warp().get_reference_grid(ddf.to(torch.float64), jitter=True, seed=8)))
+
+        regular = warp_layer.get_reference_grid(ddf.to(torch.float64))
+        self.assertIsNot(regular, jitter_8)
+
+        different_batch = warp_layer.get_reference_grid(torch.zeros(2, 2, 4, 5, dtype=torch.float64))
+        self.assertIsNot(different_batch, regular)
+
+        different_shape = warp_layer.get_reference_grid(torch.zeros(2, 2, 5, 4, dtype=torch.float64))
+        self.assertIsNot(different_shape, different_batch)
+
+        meta_ddf = torch.zeros(2, 2, 5, 4, dtype=torch.float64, device="meta")
+        meta = warp_layer.get_reference_grid(meta_ddf)
+        self.assertIsNot(meta, different_shape)
+        self.assertIs(meta, warp_layer.get_reference_grid(meta_ddf))
+        self.assertEqual(meta.device.type, "meta")
+
     @mock.patch("monai.networks.blocks.warp.USE_COMPILED", False)
     def test_singleton_spatial_dim(self):
         """


### PR DESCRIPTION
### Description

`Warp.get_reference_grid` is meant to reuse its coordinate grid, but the cached grid has shape `(batch, spatial_dims, *spatial)` while the existing check compares `ref_grid.shape[1:]` against `ddf.shape[2:]`. Those tuples cannot match for 2D or 3D fields, so the grid gets rebuilt on each call.

This change restores the cache and makes its key complete:

- full tensor shape, device and dtype;
- whether jitter is enabled;
- the seed when jitter is enabled (the seed cannot affect a regular grid).

A shape-only fix would make the cache reachable, but a stale grid could still pass after a dtype, device, jitter or jitter-seed change. So the key has to be complete, and the test covers a cache hit plus each of these invalidations.

This shows up the most in `DVF2DDF`, which reuses one `Warp` instance across the default seven scaling-and-squaring steps. I measured it with `tests/testing_data/anatomical.nii`, one Torch thread and interleaved baseline/candidate runs:

| CPU | Before | After | Paired improvement |
|---|---:|---:|---:|
| Intel Core i9-13900HX | 8.740 ms | 8.010 ms | 7.86% (6.14–12.46%, 21/21 groups) |
| ARM Neoverse-N1 | 29.043 ms | 26.988 ms | 6.92% (6.69–7.04%, 5/5 processes) |
| Intel Xeon Platinum 8481C | 16.421 ms | 14.750 ms | 9.98% (9.54–11.61%, 5/5 processes) |

Cache-miss and cache-hit outputs, image gradients, displacement gradients and the real anatomical volume output are bit-identical to the original grid construction, and the jitter path keeps the caller's RNG state untouched. I also checked memory with five fresh-process peak-RSS pairs at 64 cubed, there was no regression.

Validation:

- `python -m tests.networks.blocks.warp.test_warp`: 10 tests passed, 1 skipped.
- `python -m tests.networks.blocks.warp.test_dvf2ddf`: 4 tests passed.
- `python -m tests.networks.nets.test_voxelmorph`: 19 tests passed.
- The same three modules passed from the exact HEAD archive on an ephemeral Intel Sapphire Rapids
VM, Python 3.10.12, Torch 2.8.0+cpu.
- The new regression test fails on the same `origin/dev` revision and passes with this patch.
- `bin/monai_lint.sh --check --pyrefly .`: passed, including pyrefly with zero errors.
- The full quick unit phase ran 14822 tests. 35 nonpasses are confined to six unrelated modules and
reproduce with the same test identities and counts on pristine `origin/dev`. 31/31 remaining distributed tests pass, and the one LMDB distributed failure also reproduces on `origin/dev`.

### Types of changes

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests --disttests`.
