### PR TITLE
Route runtests.sh ruff invocations through PY_EXE

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -595,13 +595,13 @@ then
     then
         install_deps
     fi
-    ruff --version
+    "${PY_EXE}" -m ruff --version
 
     if [ $doRuffFix = true ]
     then
-        ruff check --fix --unsafe-fixes --exclude versioneer.py --exclude "monai/_version.py" "$homedir"
+        "${PY_EXE}" -m ruff check --fix --unsafe-fixes --exclude versioneer.py --exclude "monai/_version.py" "$homedir"
     else
-        ruff check --exclude versioneer.py --exclude "monai/_version.py" "$homedir"
+        "${PY_EXE}" -m ruff check --exclude versioneer.py --exclude "monai/_version.py" "$homedir"
     fi
 
     ruff_status=$?


### PR DESCRIPTION
`runtests.sh` calls every other formatter (black, isort, pylint, pytype) through `"${PY_EXE}" -m`; the ruff invocations still called a bare `ruff` off `PATH`. `is_pip_installed ruff` checks `$PY_EXE`, so the guard and the invocation could disagree — in a clean venv built per `CONTRIBUTING.md` with no editable `PATH` entry, `./runtests.sh --codeformat` fails with `ruff: command not found` even though ruff is installed and importable from `$PY_EXE`.

No behavior change when `ruff` happens to already be on `PATH` (the common case in an activated venv); this only fixes the case where it isn't.

<details>
<summary>Reproduced before/after</summary>

With `$PY_EXE` pointed at a venv holding ruff, and that venv absent from `PATH`:

```
$ MONAI_PY_EXE=/path/to/venv/bin/python bash -c 'PY_EXE=$MONAI_PY_EXE; ruff --version'
bash: line 1: ruff: command not found

$ MONAI_PY_EXE=/path/to/venv/bin/python bash -c 'PY_EXE=$MONAI_PY_EXE; "${PY_EXE}" -m ruff --version'
ruff 0.16.5
```

`./runtests.sh --ruff` with `$PY_EXE` set and the venv not on `PATH` now reaches `All checks passed!` instead of failing at the version check.

</details>

<!--
provenance: claude-code session 2026-09-03, branch mono-runtests-ruff-pyexe off dev @ 9ea04d41a
related: split out of #9067 (closed) as one of three narrower follow-ups; see #9067 for the fuller
  ODR investigation. Sibling PRs: pyproject extend-exclude + drop duplicated runtests.sh excludes
  (stacked on this branch), and cross-reference comments for ruff/black/isort pins (independent).
-->
