### PR TITLE
Cross-reference ruff/black/isort version pins between the two files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.5
+    rev: v0.16.5  # ruff version, keep synced with the ruff pin in pyproject.toml's testing extra
     hooks:
     -   id: ruff-check
         args: ["--fix"]
@@ -43,7 +43,7 @@ repos:
           )
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.1  # Black version, keep synced with MONAI requirements
+    rev: 26.5.1  # Black version, keep synced with the black pin in pyproject.toml's testing extra
     hooks:
       - id: black
         language_version: python3
@@ -55,7 +55,7 @@ repos:
           )
 
   - repo: https://github.com/pycqa/isort
-    rev: 9.0.1  # isort version, keep synced with MONAI requirements
+    rev: 9.0.1  # isort version, keep synced with the isort pin in pyproject.toml's testing extra
     hooks:
       - id: isort
         name: isort (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,9 +162,9 @@ transformers = ["transformers>=5.5.0"]  # 5.x needs the transchex BertLayer/Bert
 zarr = ["zarr"]
 # these dependencies are for testing/building only, they aren't needed for regular use so don't appear in "all"
 testing = [
-  "black>=26.5.1",
+  "black>=26.5.1",  # keep in sync with the black rev in .pre-commit-config.yaml
   "coverage>=5.5",
-  "isort>9.0.0",
+  "isort>9.0.0",  # keep in sync with the isort rev in .pre-commit-config.yaml
   "mccabe",
   "packaging",
   "parameterized",
@@ -173,7 +173,7 @@ testing = [
   "pycodestyle",
   "pyflakes",
   "pyrefly>=1.0.0",
-  "ruff>=0.16.5",
+  "ruff>=0.16.5",  # keep in sync with the ruff rev in .pre-commit-config.yaml
   "tomli",  # used in print_dependencies.py for Python<3.11
   "types-PyYAML",
   "types-setuptools"


### PR DESCRIPTION
ruff, black and isort are each pinned twice: once in `pyproject.toml`'s `testing` extra (the range a developer installs from) and once in `.pre-commit-config.yaml` (the exact `rev` pre-commit builds its environment from). Only black and isort carried a one-sided "keep synced" comment, in `.pre-commit-config.yaml` only; ruff had none anywhere. A contributor editing one pin had no in-file pointer to the other.

Adds a same-line comment at each of the six pin sites naming the file holding its counterpart. No version or behavior change — verified `pyproject.toml` still parses as TOML and `.pre-commit-config.yaml` still parses as YAML, and `pre-commit run --all-files` passes with the tree unmodified.

Independent of #9089 / #9090 — different lines, no overlap; can land in any order.

<!--
provenance: claude-code session 2026-09-03, branch mono-lint-pin-cross-ref off dev @ 9ea04d41a
related: split out of #9067 (closed) as one of three narrower follow-ups. Siblings: #9089
  (runtests.sh PY_EXE), #9090 (pyproject extend-exclude, stacked on #9089).
-->
