### PR TITLE
fix(apps/nuclick): wire up unused `min_area` and `do_reconstruction` parameters

### DIFF
--- a/monai/apps/nuclick/transforms.py
+++ b/monai/apps/nuclick/transforms.py
@@ -597,6 +597,27 @@ class PostFilterLabeld(MapTransform):
         return d
 
     def post_processing(self, preds, thresh=0.33, min_size=10, min_hole=30, do_reconstruction=False, nuc_points=None):
+        """
+        Convert predicted probability maps into cleaned binary instance masks.
+
+        Each channel is thresholded at ``thresh``, small objects and holes are removed, and,
+        when enabled, the mask is morphologically reconstructed from the nuclear marker points.
+
+        Args:
+            preds: predicted probability maps, as an array of shape ``(n_instances, H, W)``.
+            thresh: threshold used to binarize the predictions.
+            min_size: minimum area for a connected component to be kept,
+                passed to ``morphology.remove_small_objects``.
+            min_hole: maximum area of the holes to be filled,
+                passed to ``morphology.remove_small_holes``.
+            do_reconstruction: whether to morphologically reconstruct each mask from the
+                corresponding nuclear marker points.
+            nuc_points: optional nuclear points, one entry per instance, used as
+                reconstruction markers when ``do_reconstruction`` is enabled.
+
+        Returns:
+            Binary masks with the same shape as ``preds``.
+        """
         masks = preds > thresh
         for i in range(preds.shape[0]):
             masks[i] = morphology.remove_small_objects(masks[i], min_size=min_size)

--- a/monai/apps/nuclick/transforms.py
+++ b/monai/apps/nuclick/transforms.py
@@ -137,7 +137,8 @@ class SplitLabeld(MapTransform):
         label: key of the label source
         others: other labels storage key, defaults to ``"others"``
         mask_value: the mask_value that will be kept for binarization of the label, defaults to ``"mask_value"``
-        min_area: The smallest allowable object size.
+        min_area: The smallest allowable object size. Connected components of ``others``
+            smaller than ``min_area`` pixels are discarded during relabeling.
         others_value: Value/class for other nuclei;  Use this to separate core nuclei vs others.
         to_binary_mask: Convert mask to binary;  Set it false to restore original class values
     """
@@ -184,6 +185,14 @@ class SplitLabeld(MapTransform):
             others[others > 0] = 1
             if torch.count_nonzero(others):
                 others = measure.label(convert_to_numpy(others)[0], connectivity=1)
+                # discard ``others`` components smaller than ``min_area`` pixels
+                # (bincount-based so the semantics stay identical across skimage
+                # versions: skimage 0.26 changed remove_small_objects' threshold
+                # from "smaller than" to "smaller than or equal to")
+                sizes = np.bincount(others.ravel())
+                too_small = sizes < self.min_area
+                too_small[0] = False
+                others = np.where(too_small[others], 0, others)
                 others = torch.from_numpy(others)[None]
 
             label = mask.type(torch.uint8) if isinstance(mask, torch.Tensor) else mask
@@ -525,10 +534,17 @@ class PostFilterLabeld(MapTransform):
     Performs Filtering of Labels on the predicted probability map
 
     Args:
+        nuc_points: key of the click-point maps, used as reconstruction markers when
+            ``do_reconstruction`` is True.
+        bounding_boxes: key of the bounding boxes for each predicted instance.
+        img_height: key of the output image height.
+        img_width: key of the output image width.
         thresh: probability threshold for classifying a pixel as a mask
         min_size: min_size objects that will be removed from the image, refer skimage remove_small_objects
         min_hole: min_hole that will be removed from the image, refer skimage remove_small_holes
-        do_reconstruction: Boolean Flag, Perform a morphological reconstruction of an image, refer skimage
+        do_reconstruction: Boolean Flag, Perform a morphological reconstruction of an image, refer skimage.
+            When enabled, only the mask components containing click points (from the ``nuc_points``
+            key) are kept and regrown; components without a click point are discarded.
         allow_missing_keys: don't raise exception if key is missing.
         pred_classes: List of Predicted class for each instance
     """
@@ -569,15 +585,30 @@ class PostFilterLabeld(MapTransform):
 
         for key in self.keys:
             label = d[key].astype(np.uint8)
-            masks = self.post_processing(label, self.thresh, self.min_size, self.min_hole)
+            masks = self.post_processing(
+                label,
+                self.thresh,
+                self.min_size,
+                self.min_hole,
+                do_reconstruction=self.do_reconstruction,
+                nuc_points=d.get(self.nuc_points) if self.do_reconstruction else None,
+            )
             d[key] = self.gen_instance_map(masks, bounding_boxes, x, y, pred_classes=pred_classes).astype(np.uint8)
         return d
 
-    def post_processing(self, preds, thresh=0.33, min_size=10, min_hole=30):
+    def post_processing(self, preds, thresh=0.33, min_size=10, min_hole=30, do_reconstruction=False, nuc_points=None):
         masks = preds > thresh
         for i in range(preds.shape[0]):
             masks[i] = morphology.remove_small_objects(masks[i], min_size=min_size)
             masks[i] = morphology.remove_small_holes(masks[i], area_threshold=min_hole)
+            if do_reconstruction and nuc_points is not None and i < len(nuc_points):
+                points = convert_to_numpy(nuc_points[i])
+                marker = points[0] > 0 if points.ndim == 3 else points > 0
+                # intersect with the filtered mask so that the marker always
+                # satisfies skimage's ``marker <= mask`` requirement
+                marker = np.logical_and(marker, masks[i])
+                if np.any(marker):
+                    masks[i] = morphology.reconstruction(marker, masks[i], footprint=morphology.disk(1))
         return masks
 
     def gen_instance_map(self, masks, bounding_boxes, x, y, flatten=True, pred_classes=None):

--- a/tests/apps/nuclick/test_nuclick_transforms.py
+++ b/tests/apps/nuclick/test_nuclick_transforms.py
@@ -307,6 +307,7 @@ class TestSplitLabelsd(unittest.TestCase):
 
     @parameterized.expand([SPLIT_MIN_AREA_CASE_1, SPLIT_MIN_AREA_CASE_2])
     def test_min_area_filters_others(self, arguments, input_data, expected_values):
+        """Test that ``others`` objects below ``min_area`` are dropped from the output."""
         result = SplitLabeld(**arguments)(input_data)
         np.testing.assert_equal(np.unique(result["others"]), expected_values)
 
@@ -336,6 +337,7 @@ class TestPostFilterLabel(unittest.TestCase):
 
     @parameterized.expand([LABEL_FILTER_TEST_CASE_2, LABEL_FILTER_TEST_CASE_3, LABEL_FILTER_TEST_CASE_4])
     def test_do_reconstruction(self, arguments, input_data, expected_count):
+        """Test that reconstruction keeps only the blob containing the click point."""
         result = PostFilterLabeld(**arguments)(input_data)
         np.testing.assert_equal(np.count_nonzero(result["pred"]), expected_count)
 

--- a/tests/apps/nuclick/test_nuclick_transforms.py
+++ b/tests/apps/nuclick/test_nuclick_transforms.py
@@ -65,6 +65,11 @@ LABEL_3 = np.array([[[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]], d
 
 LABEL_4 = np.array([[[4, 4, 4, 4], [4, 4, 4, 4], [4, 4, 4, 4], [4, 4, 4, 4]]], dtype=np.uint8)
 
+# mask_value block (class 1, area 9), a 1-pixel object (class 2), a 9-pixel object (class 3)
+LABEL_5 = np.array(
+    [[[1, 1, 1, 0, 2, 0, 3, 3, 3], [1, 1, 1, 0, 0, 0, 3, 3, 3], [1, 1, 1, 0, 0, 0, 3, 3, 3]]], dtype=np.uint8
+)
+
 IL_IMAGE_1 = np.array(
     [
         [[0, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 1, 1], [0, 0, 1, 1, 1], [0, 0, 1, 1, 1]],
@@ -125,6 +130,72 @@ DATA_LABEL_FILTER_1 = {
     "img_width": 6,
 }
 
+# two above-threshold blobs: a 3x3 block (area 9) and a 2x2 block (area 4)
+PRED_2 = np.array(
+    [
+        [
+            [1, 1, 1, 0, 0, 0, 0],
+            [1, 1, 1, 0, 0, 0, 0],
+            [1, 1, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 1, 0],
+            [0, 0, 0, 0, 1, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+        ]
+    ],
+    dtype=np.float32,
+)
+# click point inside the smaller blob
+NUC_POINTS_2 = np.array(
+    [
+        [
+            [
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+            ]
+        ]
+    ],
+    dtype=np.float32,
+)
+# click point on background (outside any mask component)
+NUC_POINTS_3 = np.array(
+    [
+        [
+            [
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0],
+            ]
+        ]
+    ],
+    dtype=np.float32,
+)
+BB_2 = np.array([[0, 0, 7, 7]], dtype=np.uint8)
+
+DATA_LABEL_FILTER_2 = {
+    "pred": PRED_2,
+    "nuc_points": NUC_POINTS_2,
+    "bounding_boxes": BB_2,
+    "img_height": 7,
+    "img_width": 7,
+}
+DATA_LABEL_FILTER_3 = {
+    "pred": PRED_2,
+    "nuc_points": NUC_POINTS_3,
+    "bounding_boxes": BB_2,
+    "img_height": 7,
+    "img_width": 7,
+}
+
 # Result Definitions
 EXTRACT_RESULT_TC1 = np.array([[[0, 0, 0], [0, 0, 0], [0, 0, 1]]], dtype=np.uint8)
 EXTRACT_RESULT_TC2 = np.array([[[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]], dtype=np.uint8)
@@ -155,6 +226,19 @@ EXTRACT_KW_TEST_CASE_1 = [
 SPLIT_TEST_CASE_1 = [{"keys": ["label"], "mask_value": "mask_value", "min_area": 1}, DATA_SPLIT_1, SPLIT_RESULT_TC1]
 SPLIT_TEST_CASE_2 = [{"keys": ["label"], "mask_value": "mask_value", "min_area": 3}, DATA_SPLIT_2, SPLIT_RESULT_TC2]
 
+# the 1-pixel "others" object is dropped with min_area=5 (the surviving object keeps
+# its original component label 2), kept with min_area=1
+SPLIT_MIN_AREA_CASE_1 = [
+    {"keys": ["label"], "mask_value": "mask_value", "min_area": 5},
+    {"label": LABEL_5, "mask_value": 1},
+    [0, 2],
+]
+SPLIT_MIN_AREA_CASE_2 = [
+    {"keys": ["label"], "mask_value": "mask_value", "min_area": 1},
+    {"label": LABEL_5, "mask_value": 1},
+    [0, 1, 2],
+]
+
 GUIDANCE_TEST_CASE_1 = [{"image": "image", "label": "label", "others": "others"}, DATA_GUIDANCE_1, [5, 5, 5]]
 GUIDANCE_TEST_CASE_2 = [
     {"image": "image", "label": "label", "others": "others", "gaussian": True, "use_distance": True},
@@ -170,6 +254,13 @@ CLICK_TEST_CASE_2 = [
 ]
 
 LABEL_FILTER_TEST_CASE_1 = [{"keys": ["pred"]}, DATA_LABEL_FILTER_1, [6, 6]]
+
+# without reconstruction both blobs survive (9 + 4 = 13 pixels); with reconstruction
+# only the blob containing the click point is kept (4 pixels)
+LABEL_FILTER_TEST_CASE_2 = [{"keys": ["pred"], "min_size": 3}, DATA_LABEL_FILTER_2, 13]
+LABEL_FILTER_TEST_CASE_3 = [{"keys": ["pred"], "min_size": 3, "do_reconstruction": True}, DATA_LABEL_FILTER_2, 4]
+# a click point outside every mask component leaves the filtered mask unchanged
+LABEL_FILTER_TEST_CASE_4 = [{"keys": ["pred"], "min_size": 3, "do_reconstruction": True}, DATA_LABEL_FILTER_3, 13]
 
 LABEL_GUIDANCE_TEST_CASE_1 = [{"keys": ["image"], "source": "label"}, DATA_GUIDANCE_1, [4, 5, 5]]
 
@@ -214,6 +305,11 @@ class TestSplitLabelsd(unittest.TestCase):
         result = SplitLabeld(**arguments)(input_data)
         np.testing.assert_equal(result["label"], expected_result)
 
+    @parameterized.expand([SPLIT_MIN_AREA_CASE_1, SPLIT_MIN_AREA_CASE_2])
+    def test_min_area_filters_others(self, arguments, input_data, expected_values):
+        result = SplitLabeld(**arguments)(input_data)
+        np.testing.assert_equal(np.unique(result["others"]), expected_values)
+
 
 class TestGuidanceSignal(unittest.TestCase):
 
@@ -237,6 +333,11 @@ class TestPostFilterLabel(unittest.TestCase):
     def test_correct_shape(self, arguments, input_data, expected_shape):
         result = PostFilterLabeld(**arguments)(input_data)
         np.testing.assert_equal(result["pred"].shape, expected_shape)
+
+    @parameterized.expand([LABEL_FILTER_TEST_CASE_2, LABEL_FILTER_TEST_CASE_3, LABEL_FILTER_TEST_CASE_4])
+    def test_do_reconstruction(self, arguments, input_data, expected_count):
+        result = PostFilterLabeld(**arguments)(input_data)
+        np.testing.assert_equal(np.count_nonzero(result["pred"]), expected_count)
 
 
 class TestAddLabelAsGuidance(unittest.TestCase):


### PR DESCRIPTION
Fixes #9083.

### Problem

Two documented parameters in `monai/apps/nuclick/transforms.py` were accepted and stored but never used, so setting them had no effect:

- `SplitLabeld.min_area` — documented as "the smallest allowable object size", never referenced outside `__init__`.
- `PostFilterLabeld.do_reconstruction` — documented as performing a morphological reconstruction, but `post_processing` neither accepted the flag nor received the `nuc_points` needed as reconstruction markers.

### Root cause

Both behaviors existed in the original NuClick transforms addition (#4266) and were accidentally dropped in the later NuClick transform fixes (#5563):

- the original `SplitLabeld._mask_relabeling` filtered `others` components by `stat.area > min_area`;
- the original `post_processing(..., do_reconstruction, nuc_points)` regrew each mask from its click points via `skimage.morphology.reconstruction`.

This PR restores both behaviors, adapted to the current code structure.

### Changes

**`SplitLabeld`** — after relabeling the `others` channel, connected components smaller than `min_area` pixels are discarded. Implemented with `np.bincount` rather than `skimage.morphology.remove_small_objects` on purpose: scikit-image 0.26 deprecated the `min_size` keyword and changed the threshold semantics from "smaller than" to "smaller than or equal to", so the bincount form keeps one well-defined behavior (discard `area < min_area`, matching the docstring "smallest allowable object size") on every skimage version.

**`PostFilterLabeld`** — `post_processing` again accepts `do_reconstruction` and `nuc_points`; when enabled, each instance mask is regrown from its click points (`morphology.reconstruction`), so only the mask component containing the user's click is kept. Two robustness improvements over the original implementation:

- the marker is intersected with the filtered mask, satisfying skimage's `marker <= mask` requirement by construction (the original relied on `try/except BaseException` for clicks outside the mask);
- an instance whose click point falls outside every mask component keeps its filtered mask instead of being silently emptied by an empty marker.

Docstrings for both parameters clarified (including that `do_reconstruction` consumes the `nuc_points` key).

### Tests

- `tests/apps/nuclick/test_nuclick_transforms.py`: 5 new cases —
  - `SplitLabeld`: a 1-pixel `others` object is dropped with `min_area=5` and kept with `min_area=1`;
  - `PostFilterLabeld`: without reconstruction both blobs survive (13 px); with reconstruction only the clicked blob remains (4 px); a click on background leaves the filtered mask unchanged (13 px).
- Full file: **24 passed** (19 pre-existing + 5 new) with torch CPU + scikit-image.

### Note for reviewers

- Unrelated pre-existing observation (not touched here): `PostFilterLabeld.gen_instance_map` is called as `(masks, bounding_boxes, x=img_width, y=img_height)` and indexes `instance_map[bb[0]:bb[2], bb[1]:bb[3]]`, so non-square `img_height`/`img_width` inputs broadcast-fail — the existing tests only use square shapes. Happy to file a separate issue if you agree it's a bug.
- Also pre-existing: `post_processing` still calls `remove_small_objects(min_size=...)`, which emits a `FutureWarning` and changed semantics under scikit-image 0.26 (see above). Can be addressed separately.
